### PR TITLE
Fix transpiling tests with Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,6 @@
   "presets": ["es2015", "stage-0", "react"],
   "ignore": [
     "src/**/__snapshots__",
-    "src/**/*.test.js",
     "src/**/*.stories.js"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "patternfly": "~3.3"
   },
   "scripts": {
-    "build": "babel src --out-dir lib",
+    "build": "babel src --out-dir lib --ignore test.js",
     "lint": "standard",
     "prepublish": "npm run build",
     "test": "standard && jest",


### PR DESCRIPTION
Don't ignore tests with babel, so it is possible to run them during
development. Ignore tests only during build.