### PR TITLE
Fixes #28 - npm install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "prettier": "prettier --write --single-quote --no-semi '{src,storybook}/**/*.js'",
     "prepublish": "npm run build",
     "test": "npm run lint && jest",
+    "prepublish": "npm install --ignore-scripts && npm run build",
     "test:watch": "jest --watchAll",
     "storybook": "start-storybook -c storybook -p 6006",
     "build-storybook": "build-storybook -c storybook -o .out",


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Trying to npm install patternfly-react currently fails unless babel-cli, babel-presets-stage2 are globally installed

<!-- Why are these changes necessary? -->
running build on **prepublish** executes before any devDependencies are installed, and so babel-cli is not found.

<!-- How were these changes implemented? -->
as a workaround, running npm install before build (--no-scripts prevents recursion) fixes it.


<!-- feel free to add additional comments -->