### PR TITLE
feat(toastNotification): adds toast notification component

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "scripts": {
     "commit": "git-cz",
-    "build": "babel src --out-dir lib --ignore test.js,__mocks__  && less",
+    "build": "babel src --out-dir lib --ignore test.js,__mocks__  && npm run less",
     "less": "mkdir -p lib/styles/less && cp -r less/ lib/styles/less",
     "lint": "eslint --max-warnings 0 src storybook",
     "prettier": "prettier --write --single-quote --no-semi '{src,storybook}/**/*.js'",

--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -1,6 +1,7 @@
 import ClassNames from 'classnames'
 import React from 'react'
 import PropTypes from 'prop-types'
+import { ALERT_TYPES } from '../common/constants'
 
 /**
  * Alert Component for Patternfly React
@@ -42,8 +43,7 @@ Alert.propTypes = {
   /** callback when alert is dismissed  */
   onDismiss: PropTypes.func,
   /** the type of alert  */
-  type: PropTypes.oneOf(['danger', 'error', 'warning', 'success', 'info'])
-    .isRequired,
+  type: PropTypes.oneOf(ALERT_TYPES).isRequired,
   /** children nodes  */
   children: PropTypes.node
 }

--- a/src/DropdownKebab/DropdownKebab.js
+++ b/src/DropdownKebab/DropdownKebab.js
@@ -1,22 +1,30 @@
 import { Dropdown } from 'react-bootstrap'
+import ClassNames from 'classnames'
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const DropdownKebab = ({ children, id, pullRight }) => {
+/**
+ * DropdownKebab Component for Patternfly React
+ */
+const DropdownKebab = ({ className, children, id, pullRight }) => {
+  const kebabClass = ClassNames('dropdown-kebab-pf', className)
   return (
-    <Dropdown className="dropdown-kebab-pf" id={id} pullRight={pullRight}>
+    <Dropdown className={kebabClass} id={id} pullRight={pullRight}>
       <Dropdown.Toggle bsStyle="link" noCaret>
         <span className="fa fa-ellipsis-v" />
       </Dropdown.Toggle>
-      <Dropdown.Menu>
-        {children}
-      </Dropdown.Menu>
+      <Dropdown.Menu>{children}</Dropdown.Menu>
     </Dropdown>
   )
 }
 DropdownKebab.propTypes = {
+  /** additional kebab dropdown classes */
+  className: PropTypes.string,
+  /** children nodes  */
   children: PropTypes.node,
+  /** kebab dropdown id */
   id: PropTypes.string.isRequired,
+  /** menu right aligned */
   pullRight: PropTypes.bool
 }
 export default DropdownKebab

--- a/src/ToastNotification/TimedToastNotification.js
+++ b/src/ToastNotification/TimedToastNotification.js
@@ -1,0 +1,98 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import helpers from '../common/helpers'
+import Timer from '../common/Timer'
+import { TOAST_NOTIFICATION_TYPES } from '../common/constants'
+import { ToastNotification } from '../index.js'
+
+/**
+ * TimedToastNotification Component for Patternfly React
+ */
+class TimedToastNotification extends React.Component {
+  constructor(props) {
+    super(props)
+    helpers.bindMethods(this, ['onMouseEnter', 'onMouseLeave'])
+  }
+
+  componentDidMount() {
+    const { paused, persistent, onDismiss, timerdelay } = this.props
+
+    if (!persistent) {
+      this.timer = new Timer(onDismiss, timerdelay)
+      this.timer.startTimer()
+    }
+
+    /** if we are paused on mount, then clear the timer
+     * after having initialized with the correct delay */
+    if (paused) {
+      this.timer && this.timer.clearTimer()
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    /**
+     * If paused prop changes, update our timer
+     */
+    if (nextProps.paused !== this.props.paused) {
+      if (nextProps.paused) {
+        this.timer && this.timer.clearTimer()
+      } else {
+        this.timer && this.timer.startTimer()
+      }
+    }
+  }
+
+  componentWillUnmount() {
+    this.timer && this.timer.clearTimer()
+  }
+
+  onMouseEnter() {
+    const { onMouseEnter } = this.props
+    onMouseEnter && onMouseEnter()
+  }
+
+  onMouseLeave() {
+    const { onMouseLeave } = this.props
+    onMouseLeave && onMouseLeave()
+  }
+  render() {
+    const { children } = this.props
+    return (
+      <ToastNotification
+        {...this.props}
+        onMouseEnter={this.onMouseEnter}
+        onMouseLeave={this.onMouseLeave}
+      >
+        {children}
+      </ToastNotification>
+    )
+  }
+}
+
+TimedToastNotification.propTypes = {
+  /** pauses notification from dismissing */
+  paused: PropTypes.bool,
+  /** persistent keeps the notification up endlessly until closed */
+  persistent: PropTypes.bool,
+  /** timer delay until dismiss */
+  timerdelay: PropTypes.number,
+  /** additional notification classes */
+  className: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
+  /** callback when alert is dismissed  */
+  onDismiss: PropTypes.func,
+  /** onMouseEnter callback */
+  onMouseEnter: PropTypes.func,
+  /** onMouseLeave callback */
+  onMouseLeave: PropTypes.func,
+  /** the type of alert  */
+  type: PropTypes.oneOf(TOAST_NOTIFICATION_TYPES).isRequired, // eslint-disable-line react/no-unused-prop-types
+  /** children nodes  */
+  children: PropTypes.node
+}
+TimedToastNotification.defaultProps = {
+  paused: false,
+  type: 'error',
+  timerdelay: 8000
+}
+
+export default TimedToastNotification

--- a/src/ToastNotification/ToastNotification.js
+++ b/src/ToastNotification/ToastNotification.js
@@ -1,0 +1,73 @@
+import ClassNames from 'classnames'
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button } from '../index'
+import { TOAST_NOTIFICATION_TYPES } from '../common/constants'
+
+/**
+ * ToastNotification Component for Patternfly React
+ */
+const ToastNotification = ({
+  className,
+  onDismiss,
+  type,
+  onMouseEnter,
+  onMouseLeave,
+  children,
+  ...props
+}) => {
+  const notificationClasses = ClassNames(
+    {
+      alert: true,
+      'toast-pf': true,
+      'alert-danger': type === 'danger' || type === 'error',
+      'alert-warning': type === 'warning',
+      'alert-success': type === 'success',
+      'alert-info': type === 'info',
+      'alert-dismissable': onDismiss
+    },
+    className
+  )
+  const iconClass = ClassNames({
+    pficon: true,
+    'pficon-error-circle-o': type === 'danger' || type === 'error',
+    'pficon-warning-triangle-o': type === 'warning',
+    'pficon-ok': type === 'success',
+    'pficon-info': type === 'info'
+  })
+
+  return (
+    <div
+      className={notificationClasses}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      {...props}
+    >
+      {onDismiss &&
+        <Button bsClass="close" aria-hidden="true" onClick={onDismiss}>
+          <span className="pficon pficon-close" />
+        </Button>}
+      <span className={iconClass} />
+      {children}
+    </div>
+  )
+}
+ToastNotification.propTypes = {
+  /** additional notification classes */
+  className: PropTypes.string,
+  /** callback when alert is dismissed  */
+  onDismiss: PropTypes.func,
+  /** the type of alert  */
+  type: PropTypes.oneOf(TOAST_NOTIFICATION_TYPES).isRequired,
+  /** onMouseEnter callback */
+  onMouseEnter: PropTypes.func,
+  /** onMouseLeave callback */
+  onMouseLeave: PropTypes.func,
+  /** children nodes  */
+  children: PropTypes.node
+}
+ToastNotification.defaultProps = {
+  type: 'error'
+}
+
+export default ToastNotification

--- a/src/ToastNotification/ToastNotification.stories.js
+++ b/src/ToastNotification/ToastNotification.stories.js
@@ -1,0 +1,171 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
+import { withKnobs, text, select, boolean } from '@storybook/addon-knobs'
+import { defaultTemplate } from '../../storybook/decorators/storyTemplates'
+import {
+  Button,
+  DropdownKebab,
+  MenuItem,
+  ToastNotification,
+  TimedToastNotification,
+  ToastNotificationList
+} from '../index.js'
+
+const stories = storiesOf('ToastNotification', module)
+stories.addDecorator(withKnobs)
+stories.addDecorator(
+  defaultTemplate({
+    title: 'Toast Notification',
+    documentationLink:
+      'http://www.patternfly.org/pattern-library/communication/toast-notifications/'
+  })
+)
+
+stories.addWithInfo(
+  'Toast Notification',
+  `Toast Notifications pop onto the screen to notify the user of a system occurrence`,
+  () => {
+    const header = text('Header', 'Great job!')
+    const message = text('Message', 'This is really working out.')
+    const type = select(
+      'Type',
+      ['success', 'danger', 'warning', 'info'],
+      'success'
+    )
+    const dismissEnabled = boolean('Dismiss', false)
+    const menuEnabled = boolean('Menu', true)
+    const actionEnabled = boolean('Action', true)
+    return (
+      <div>
+        <ToastNotification
+          type={type}
+          onDismiss={
+            dismissEnabled && !menuEnabled ? action('onDismiss') : null
+          }
+        >
+          {menuEnabled &&
+            <DropdownKebab id="dropdownKebab" pullRight className="pull-right">
+              <MenuItem>Action</MenuItem>
+              <MenuItem>Another Action</MenuItem>
+              <MenuItem>Something else here</MenuItem>
+              <MenuItem divider />
+              <MenuItem>Separated link</MenuItem>
+              {dismissEnabled && <MenuItem>Close</MenuItem>}
+            </DropdownKebab>}
+          {actionEnabled &&
+            <div className="pull-right toast-pf-action">
+              <a href="#">Start Server</a>
+            </div>}
+          <span>
+            <strong>{header}</strong> &nbsp;
+            {message}
+          </span>
+        </ToastNotification>
+      </div>
+    )
+  }
+)
+
+class ToastNotificationStoryWrapper extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      infoNotificationDismissed: false,
+      warningNotificationDismissed: false,
+      successNotificationDismissed: false
+    }
+
+    this.infoNotificationDismissed = () => {
+      action('info notification: onDismiss fired')()
+      this.setState({ infoNotificationDismissed: true })
+    }
+
+    this.warningNotificationDismissed = () => {
+      action('warning notification: onDismiss fired')()
+      this.setState({ warningNotificationDismissed: true })
+    }
+
+    this.persistentNotificationDismissed = () => {
+      action('persistent notification: onDismiss fired')()
+      this.setState({ persistentNotificationDismissed: true })
+    }
+
+    this.resetStateClicked = () => {
+      this.setState({
+        infoNotificationDismissed: false,
+        warningNotificationDismissed: false,
+        persistentNotificationDismissed: false
+      })
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <Button bsStyle="primary" onClick={this.resetStateClicked}>
+          Reset Notification State
+        </Button>
+        <ToastNotificationList
+          onMouseEnter={action('notification list: onMouseEnter fired')}
+          onMouseLeave={action('notification list: onMouseLeave fired')}
+        >
+          {!this.state.infoNotificationDismissed &&
+            <TimedToastNotification
+              timerdelay={8000}
+              type="info"
+              onDismiss={this.infoNotificationDismissed}
+              onMouseEnter={action('info notification: onMouseEnter fired')}
+              onMouseLeave={action('info notification: onMouseLeave fired')}
+            >
+              <span>
+                {text(
+                  'Message',
+                  "By default, a toast notification's timer expires after eight seconds."
+                )}
+              </span>
+            </TimedToastNotification>}
+          <br />
+          {!this.state.warningNotificationDismissed &&
+            <TimedToastNotification
+              timerdelay={8000}
+              type="warning"
+              onDismiss={this.warningNotificationDismissed}
+              onMouseEnter={action('warning notification: onMouseEnter fired')}
+              onMouseLeave={action('warning notification: onMouseLeave fired')}
+            >
+              <span>
+                Additionally, if the user hovers any toast notification each
+                timer is reset.
+              </span>
+            </TimedToastNotification>}
+          {!this.state.persistentNotificationDismissed &&
+            <TimedToastNotification
+              persistent
+              type="success"
+              onDismiss={this.persistentNotificationDismissed}
+              onMouseEnter={action(
+                'persistent notification: onMouseEnter fired'
+              )}
+              onMouseLeave={action(
+                'persistent notification: onMouseLeave fired'
+              )}
+            >
+              <span>
+                A persistent notification will remain on the screen until
+                closed.
+              </span>
+            </TimedToastNotification>}
+        </ToastNotificationList>
+      </div>
+    )
+  }
+}
+
+stories.addWithInfo(
+  'Toast Notification List',
+  `This is the Toast Notification List with a custom timer delay supplied.`,
+  () => {
+    return <ToastNotificationStoryWrapper />
+  }
+)

--- a/src/ToastNotification/ToastNotification.test.js
+++ b/src/ToastNotification/ToastNotification.test.js
@@ -1,0 +1,44 @@
+/* eslint-env jest */
+
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+import ToastNotification from './ToastNotification'
+import TimedToastNotification from './TimedToastNotification'
+
+test('ToastNotification renders properly', () => {
+  const handleNotificationClose = jest.fn()
+  const handleOnMouseEnter = jest.fn()
+  const handleOnMouseLeave = jest.fn()
+  const component = renderer.create(
+    <ToastNotification
+      type="danger"
+      onDismiss={handleNotificationClose}
+      onMouseEnter={handleOnMouseEnter}
+      onMouseLeave={handleOnMouseLeave}
+    >
+      <span>Danger Will Robinson!</span>
+    </ToastNotification>
+  )
+  let tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})
+
+test('TimedToastNotification renders properly', () => {
+  const handleNotificationClose = jest.fn()
+  const handleOnMouseEnter = jest.fn()
+  const handleOnMouseLeave = jest.fn()
+  const component = renderer.create(
+    <TimedToastNotification
+      type="danger"
+      onDismiss={handleNotificationClose}
+      onMouseEnter={handleOnMouseEnter}
+      onMouseLeave={handleOnMouseLeave}
+      paused={false}
+    >
+      <span>Danger Will Robinson!</span>
+    </TimedToastNotification>
+  )
+  let tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/ToastNotification/ToastNotificationList.js
+++ b/src/ToastNotification/ToastNotificationList.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import helpers from '../common/helpers'
+import { TimedToastNotification } from '../index'
+
+/**
+ * ToastNotificationList Component for Patternfly React
+ */
+class ToastNotificationList extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { paused: false }
+    helpers.bindMethods(this, ['onMouseEnter', 'onMouseLeave'])
+  }
+  onMouseEnter() {
+    this.setState({ paused: true })
+    const { onMouseEnter } = this.props
+    onMouseEnter && onMouseEnter()
+  }
+
+  onMouseLeave() {
+    this.setState({ paused: false })
+    const { onMouseLeave } = this.props
+    onMouseLeave && onMouseLeave()
+  }
+
+  renderChildren() {
+    const paused = this.state.paused
+    return React.Children.map(this.props.children, child => {
+      if (child && child.type === TimedToastNotification) {
+        /**
+         * If any of the notifications are hovered, pause
+         * all child notifications from dismissing
+         */
+        return React.cloneElement(child, {
+          paused: paused
+        })
+      } else {
+        return child
+      }
+    })
+  }
+  render() {
+    const { className } = this.props
+    return (
+      <div
+        onMouseEnter={this.onMouseEnter}
+        onMouseLeave={this.onMouseLeave}
+        className={className}
+      >
+        {this.renderChildren()}
+      </div>
+    )
+  }
+}
+ToastNotificationList.propTypes = {
+  /** additional notification list classes */
+  className: PropTypes.string,
+  /** onMouseEnter callback */
+  onMouseEnter: PropTypes.func,
+  /** onMouseLeave callback */
+  onMouseLeave: PropTypes.func,
+  /** children nodes  */
+  children: PropTypes.node
+}
+ToastNotificationList.defaultProps = {
+  className: 'toast-notifications-list-pf'
+}
+
+export default ToastNotificationList

--- a/src/ToastNotification/__snapshots__/ToastNotification.test.js.snap
+++ b/src/ToastNotification/__snapshots__/ToastNotification.test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TimedToastNotification renders properly 1`] = `
+<div
+  className="alert toast-pf alert-danger alert-dismissable"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  paused={false}
+  timerdelay={8000}
+>
+  <button
+    aria-hidden="true"
+    className="close close-default"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    <span
+      className="pficon pficon-close"
+    />
+  </button>
+  <span
+    className="pficon pficon-error-circle-o"
+  />
+  <span>
+    Danger Will Robinson!
+  </span>
+</div>
+`;
+
+exports[`ToastNotification renders properly 1`] = `
+<div
+  className="alert toast-pf alert-danger alert-dismissable"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <button
+    aria-hidden="true"
+    className="close close-default"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    <span
+      className="pficon pficon-close"
+    />
+  </button>
+  <span
+    className="pficon pficon-error-circle-o"
+  />
+  <span>
+    Danger Will Robinson!
+  </span>
+</div>
+`;

--- a/src/common/Timer.js
+++ b/src/common/Timer.js
@@ -1,0 +1,23 @@
+/**
+ * Timer class implements a simple timeout mechanism
+ */
+class Timer {
+  constructor(func, delay) {
+    this.timer = null
+    this.delay = delay
+    this.execute = func
+  }
+
+  startTimer() {
+    this.clearTimer()
+
+    this.timer = setTimeout(this.execute, this.delay)
+  }
+  clearTimer() {
+    if (this.timer) {
+      clearTimeout(this.timer)
+    }
+  }
+}
+
+export default Timer

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,0 +1,9 @@
+export const TOAST_NOTIFICATION_TYPES = [
+  'danger',
+  'error',
+  'warning',
+  'success',
+  'info'
+]
+
+export const ALERT_TYPES = ['danger', 'error', 'warning', 'success', 'info']

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -1,0 +1,8 @@
+export default {
+  bindMethods: function(context, methods) {
+    methods.forEach(method => {
+      context[method] = context[method].bind(context)
+    })
+  },
+  noop: Function.prototype // empty function
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 export { default as Alert } from './Alert/Alert'
-export { default as DropdownKebab } from './DropdownKebab/DropdownKebab'
-export { default as MenuItem } from './MenuItem/MenuItem'
 export { default as Button } from './Button/Button'
+export { default as DropdownKebab } from './DropdownKebab/DropdownKebab'
 export {
   ListView,
   ListGroupItem,
@@ -22,3 +21,13 @@ export {
 } from './ListView'
 export { default as ListViewItem } from './ListView/ListViewItem'
 export { default as ListViewRow } from './ListView/ListViewRow'
+export { default as MenuItem } from './MenuItem/MenuItem'
+export {
+  default as ToastNotification
+} from './ToastNotification/ToastNotification'
+export {
+  default as TimedToastNotification
+} from './ToastNotification/TimedToastNotification'
+export {
+  default as ToastNotificationList
+} from './ToastNotification/ToastNotificationList'


### PR DESCRIPTION
Closes #47

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
* adds `ToastNotification` and `ToastNotificationList` React component and toast notification stories to Storybook.
* fixes some formatting generated by prettier and updates prettier to latest
* adds optional `dropdownClass` to `DropdownKebab` component
* adds `TimedToastNotification` stateful component for consumers using a timer component

Storybook:
https://rawgit.com/priley86/patternfly-react/toast-notification/index.html