### PR TITLE
fix(dependencies): Fix PatternFly peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "semantic-release": "^6.3.6"
   },
   "peerDependencies": {
-    "patternfly": "~3.3",
+    "patternfly": "^3.27.4",
     "prop-types": "^15.5.10",
     "react": "^15.5.0"
   },


### PR DESCRIPTION
 

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
PatternFly peer dependency is incorrectly specified, so it always fails.

<!-- Why are these changes necessary? -->
**Why**:

<!-- How were these changes implemented? -->
**How**:
This changes fixes it so that peer dependency is met if installed patternfly is ^3.27.4


<!-- feel free to add additional comments -->