### PR TITLE
Changes PropTypes on `id` to match react-bootstrap

### DIFF
--- a/src/DropdownKebab/DropdownKebab.js
+++ b/src/DropdownKebab/DropdownKebab.js
@@ -23,7 +23,7 @@ DropdownKebab.propTypes = {
   /** children nodes  */
   children: PropTypes.node,
   /** kebab dropdown id */
-  id: PropTypes.string.isRequired,
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   /** menu right aligned */
   pullRight: PropTypes.bool
 }


### PR DESCRIPTION
The PropTypes should support a number in addition to a string
just like the react-bootstrap repo does.

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Fixing the prop-types to align with the `react-bootstrap` changes found [here](https://github.com/react-bootstrap/react-bootstrap/blob/502fe0044e5edef530f944953154a85e9daaebeb/src/Dropdown.js#L36).

<!-- Why are these changes necessary? -->
**Why**: To support an integer as a valid id.

<!-- How were these changes implemented? -->
**How**: Updating the prop-types object to use `oneOfType`


<!-- feel free to add additional comments -->