### PR TITLE
feat(alert): Adding mouse events to alerts

### DIFF
--- a/src/Alert/Alert.js
+++ b/src/Alert/Alert.js
@@ -6,8 +6,8 @@ import { ALERT_TYPES } from '../common/constants'
 /**
  * Alert Component for Patternfly React
  */
-const Alert = ({ children, onDismiss, type }) => {
-  const alertClass = ClassNames({
+const Alert = ({ children, className, onDismiss, type, ...props }) => {
+  const alertClass = ClassNames(className, {
     alert: true,
     'alert-danger': type === 'danger' || type === 'error',
     'alert-warning': type === 'warning',
@@ -24,7 +24,7 @@ const Alert = ({ children, onDismiss, type }) => {
   })
 
   return (
-    <div className={alertClass}>
+    <div className={alertClass} {...props}>
       {onDismiss && (
         <button
           type="button"
@@ -41,6 +41,8 @@ const Alert = ({ children, onDismiss, type }) => {
   )
 }
 Alert.propTypes = {
+  /** additional alert classes */
+  className: PropTypes.string,
   /** callback when alert is dismissed  */
   onDismiss: PropTypes.func,
   /** the type of alert  */

--- a/src/ToastNotification/ToastNotification.js
+++ b/src/ToastNotification/ToastNotification.js
@@ -11,8 +11,6 @@ const ToastNotification = ({
   className,
   onDismiss,
   type,
-  onMouseEnter,
-  onMouseLeave,
   children,
   ...props
 }) => {
@@ -37,12 +35,7 @@ const ToastNotification = ({
   })
 
   return (
-    <div
-      className={notificationClasses}
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
-      {...props}
-    >
+    <div className={notificationClasses} {...props}>
       {onDismiss && (
         <Button bsClass="close" aria-hidden="true" onClick={onDismiss}>
           <span className="pficon pficon-close" />
@@ -60,10 +53,6 @@ ToastNotification.propTypes = {
   onDismiss: PropTypes.func,
   /** the type of alert  */
   type: PropTypes.oneOf(TOAST_NOTIFICATION_TYPES).isRequired,
-  /** onMouseEnter callback */
-  onMouseEnter: PropTypes.func,
-  /** onMouseLeave callback */
-  onMouseLeave: PropTypes.func,
   /** children nodes  */
   children: PropTypes.node
 }


### PR DESCRIPTION
#61

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Adding mouse events to the `Alert` component

<!-- Why are these changes necessary? -->
**Why**: to support apps adding their own mouse events to the `Alert` component

<!-- How were these changes implemented? -->
**How**: Changed the `Alert` component to a class and added the handlers.


<!-- feel free to add additional comments -->