### PR TITLE
feat(modal) - adds the pf modal patterns

### DIFF
--- a/src/components/Modal/InnerComponents/CustomModalDialog.js
+++ b/src/components/Modal/InnerComponents/CustomModalDialog.js
@@ -1,0 +1,85 @@
+/**
+ * CustomModalDialog creates custom ReactBootstrap ModalDialog
+ * https://github.com/react-bootstrap/react-bootstrap/blob/master/src/ModalDialog.js
+ *
+ * This extends ModalDialog and adds contentClassName prop for setting
+ * `modal-content` div's class
+ */
+import classNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { utils } from 'react-bootstrap';
+
+const bsClass = utils.bootstrapUtils.bsClass;
+const bsSizes = utils.bootstrapUtils.bsSizes;
+const getClassSet = utils.bootstrapUtils.getClassSet;
+const prefix = utils.bootstrapUtils.prefix;
+const splitBsProps = utils.bootstrapUtils.splitBsProps;
+
+// React Bootstrap utils/StyleConfig Size is currently not exported
+const Size = {
+  LARGE: 'large',
+  SMALL: 'small',
+};
+
+class CustomModalDialog extends React.Component {
+  render() {
+    const {
+      dialogClassName,
+      contentClassName,
+      className,
+      style,
+      children,
+      ...props
+    } = this.props;
+    const [bsProps, elementProps] = splitBsProps(props);
+
+    const bsClassName = prefix(bsProps);
+
+    const modalStyle = { display: 'block', ...style };
+
+    const dialogClasses = {
+      ...getClassSet(bsProps),
+      [bsClassName]: false,
+      [prefix(bsProps, 'dialog')]: true,
+    };
+
+    return (
+      <div
+        {...elementProps}
+        tabIndex="-1"
+        role="dialog"
+        style={modalStyle}
+        className={classNames(className, bsClassName)}
+      >
+        <div className={classNames(dialogClassName, dialogClasses)}>
+          <div
+            className={classNames(prefix(bsProps, 'content'), contentClassName)}
+            role="document"
+          >
+            {children}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+CustomModalDialog.propTypes = {
+  /** A css class to apply to the Modal dialog DOM node. */
+  dialogClassName: PropTypes.string,
+  /** custom modal-content class added to the content DOM node */
+  contentClassName: PropTypes.string,
+  /** base modal class name */
+  className: PropTypes.string,
+  /** additional modal styles */
+  style: PropTypes.object,
+  /** Children nodes */
+  children: PropTypes.node,
+};
+
+export default bsClass(
+  'modal',
+  bsSizes([Size.LARGE, Size.SMALL], CustomModalDialog),
+);

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,0 +1,17 @@
+import CustomModalDialog from './InnerComponents/CustomModalDialog';
+import { Modal as BsModal } from 'react-bootstrap';
+
+/**
+ * Modal Component for Patternfly React
+ */
+class Modal extends BsModal {
+  render() {
+    return super.render();
+  }
+}
+
+Modal.defaultProps = Object.assign(BsModal.defaultProps, {
+  dialogComponentClass: CustomModalDialog,
+});
+
+export default Modal;

--- a/src/components/Modal/Modal.stories.js
+++ b/src/components/Modal/Modal.stories.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { defaultTemplate } from '../../../storybook/decorators/storyTemplates';
+
+import {
+  MockModalManager,
+  basicExampleSource,
+} from './__mocks__/mockModalManager';
+
+import {
+  MockAboutModalManager,
+  aboutExampleSource,
+} from './__mocks__/mockAboutModalManager';
+
+const stories = storiesOf('Modal Overlay', module);
+
+const description = (
+  <p>
+    This component is based on React Bootstrap Modal component. See{' '}
+    <a href="https://react-bootstrap.github.io/components.html#modals">
+      React Bootstrap Docs
+    </a>{' '}
+    for complete Modal component documentation.
+  </p>
+);
+
+stories.addDecorator(
+  defaultTemplate({
+    title: 'Modal Overlay',
+    documentationLink:
+      'http://www.patternfly.org/pattern-library/forms-and-controls/modal-overlay/',
+    description: description,
+  }),
+);
+
+stories.add(
+  'Basic example',
+  withInfo({
+    source: false,
+    propTablesExclude: [MockModalManager],
+    text: (
+      <div>
+        <h1>Story Source</h1>
+        <pre>{basicExampleSource}</pre>
+      </div>
+    ),
+  })(() => <MockModalManager />),
+);
+
+stories.add(
+  'About Modal',
+  withInfo({
+    source: false,
+    propTablesExclude: [MockAboutModalManager],
+    text: (
+      <div>
+        <h1>Story Source</h1>
+        <pre>{aboutExampleSource}</pre>
+      </div>
+    ),
+  })(() => <MockAboutModalManager />),
+);

--- a/src/components/Modal/__mocks__/mockAboutModalManager.js
+++ b/src/components/Modal/__mocks__/mockAboutModalManager.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import { Button } from '../../Button';
+import { Icon } from '../../Icon';
+import { Modal } from '../index';
+import logo from 'patternfly/dist/img/logo-alt.svg';
+
+export class MockAboutModalManager extends React.Component {
+  constructor() {
+    super();
+    this.state = { showModal: false };
+    this.open = this.open.bind(this);
+    this.close = this.close.bind(this);
+  }
+  open() {
+    this.setState({ showModal: true });
+  }
+  close() {
+    this.setState({ showModal: false });
+  }
+  render() {
+    return (
+      <div>
+        <Button bsStyle="primary" bsSize="large" onClick={this.open}>
+          Launch about modal
+        </Button>
+
+        <Modal
+          contentClassName="about-modal-pf"
+          show={this.state.showModal}
+          onHide={this.close}
+        >
+          <Modal.Header>
+            <button
+              className="close"
+              onClick={this.close}
+              aria-hidden="true"
+              aria-label="Close"
+            >
+              <Icon type="pf" name="close" />
+            </button>
+          </Modal.Header>
+          <Modal.Body>
+            <h1>Product Title</h1>
+            <div className="product-versions-pf">
+              <ul className="list-unstyled">
+                <li>
+                  <strong>Label</strong> Version
+                </li>
+                <li>
+                  <strong>Label</strong> Version
+                </li>
+                <li>
+                  <strong>Label</strong> Version
+                </li>
+                <li>
+                  <strong>Label</strong> Version
+                </li>
+                <li>
+                  <strong>Label</strong> Version
+                </li>
+                <li>
+                  <strong>Label</strong> Version
+                </li>
+              </ul>
+            </div>
+            <div className="trademark-pf">
+              Trademark and Copyright Information
+            </div>
+          </Modal.Body>
+          <Modal.Footer>
+            <img src={logo} alt="Patternfly Logo" />
+          </Modal.Footer>
+        </Modal>
+      </div>
+    );
+  }
+}
+
+export const aboutExampleSource = `
+  <Button bsStyle="primary" bsSize="large" onClick={this.open}>
+  Launch about modal
+  </Button>
+
+  <Modal
+  contentClassName="about-modal-pf"
+  show={this.state.showModal}
+  onHide={this.close}
+  >
+    <Modal.Header>
+      <button
+        className="close"
+        onClick={this.close}
+        aria-hidden="true"
+        aria-label="Close"
+      >
+        <Icon type="pf" name="close" />
+      </button>
+    </Modal.Header>
+    <Modal.Body>
+      <h1>Product Title</h1>
+      <div className="product-versions-pf">
+        <ul className="list-unstyled">
+          <li>
+            <strong>Label</strong> Version
+          </li>
+          <li>
+            <strong>Label</strong> Version
+          </li>
+          <li>
+            <strong>Label</strong> Version
+          </li>
+          <li>
+            <strong>Label</strong> Version
+          </li>
+          <li>
+            <strong>Label</strong> Version
+          </li>
+          <li>
+            <strong>Label</strong> Version
+          </li>
+        </ul>
+      </div>
+      <div className="trademark-pf">
+        Trademark and Copyright Information
+      </div>
+    </Modal.Body>
+    <Modal.Footer>
+      <img src={logo} alt="Patternfly Logo" />
+    </Modal.Footer>
+  </Modal>
+`;

--- a/src/components/Modal/__mocks__/mockModalManager.js
+++ b/src/components/Modal/__mocks__/mockModalManager.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import { Button } from '../../Button';
+import { Icon } from '../../Icon';
+import { Modal } from '../index';
+
+export class MockModalManager extends React.Component {
+  constructor() {
+    super();
+    this.state = { showModal: false };
+    this.open = this.open.bind(this);
+    this.close = this.close.bind(this);
+  }
+  open() {
+    this.setState({ showModal: true });
+  }
+  close() {
+    this.setState({ showModal: false });
+  }
+  render() {
+    return (
+      <div>
+        <Button bsStyle="primary" bsSize="large" onClick={this.open}>
+          Launch basic modal
+        </Button>
+
+        <Modal show={this.state.showModal} onHide={this.close}>
+          <Modal.Header>
+            <button
+              className="close"
+              onClick={this.close}
+              aria-hidden="true"
+              aria-label="Close"
+            >
+              <Icon type="pf" name="close" />
+            </button>
+            <Modal.Title>Modal Overlay Title</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <form className="form-horizontal">
+              <div className="form-group">
+                <label className="col-sm-3 control-label" htmlFor="textInput">
+                  Field One
+                </label>
+                <div className="col-sm-9">
+                  <input type="text" id="textInput" className="form-control" />
+                </div>
+              </div>
+              <div className="form-group">
+                <label className="col-sm-3 control-label" htmlFor="textInput2">
+                  Field Two
+                </label>
+                <div className="col-sm-9">
+                  <input type="text" id="textInput2" className="form-control" />
+                </div>
+              </div>
+              <div className="form-group">
+                <label className="col-sm-3 control-label" htmlFor="textInput3">
+                  Field Three
+                </label>
+                <div className="col-sm-9">
+                  <input type="text" id="textInput3" className="form-control" />
+                </div>
+              </div>
+            </form>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button
+              bsStyle="default"
+              className="btn-cancel"
+              onClick={this.close}
+            >
+              Cancel
+            </Button>
+            <Button bsStyle="primary" onClick={this.close}>
+              Save
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      </div>
+    );
+  }
+}
+
+export const basicExampleSource = `
+  <Button bsStyle="primary" bsSize="large" onClick={this.open}>
+  Launch basic modal
+  </Button>
+
+  <Modal show={this.state.showModal} onHide={this.close}>
+    <Modal.Header>
+      <button
+        className="close"
+        onClick={this.close}
+        aria-hidden="true"
+        aria-label="Close"
+      >
+        <Icon type="pf" name="close" />
+      </button>
+      <Modal.Title>Modal Overlay Title</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <form className="form-horizontal">
+        <div className="form-group">
+          <label className="col-sm-3 control-label" htmlFor="textInput">
+            Field One
+          </label>
+          <div className="col-sm-9">
+            <input type="text" id="textInput" className="form-control" />
+          </div>
+        </div>
+        <div className="form-group">
+          <label className="col-sm-3 control-label" htmlFor="textInput2">
+            Field Two
+          </label>
+          <div className="col-sm-9">
+            <input type="text" id="textInput2" className="form-control" />
+          </div>
+        </div>
+        <div className="form-group">
+          <label className="col-sm-3 control-label" htmlFor="textInput3">
+            Field Three
+          </label>
+          <div className="col-sm-9">
+            <input type="text" id="textInput3" className="form-control" />
+          </div>
+        </div>
+      </form>
+    </Modal.Body>
+    <Modal.Footer>
+      <Button
+        bsStyle="default"
+        className="btn-cancel"
+        onClick={this.close}
+      >
+        Cancel
+      </Button>
+      <Button bsStyle="primary" onClick={this.close}>
+        Save
+      </Button>
+    </Modal.Footer>
+  </Modal>
+`;

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,0 +1,1 @@
+export { default as Modal } from './Modal';

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export * from './components/Icon';
 export * from './components/ListGroup';
 export * from './components/ListView';
 export * from './components/MenuItem';
+export * from './components/Modal';
 export * from './components/OverlayTrigger';
 export * from './components/Popover';
 export * from './components/ToastNotification';


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
This PR adds the PatternFly modal patterns. To be used in #69 (Wizard) once done.

Would like to merge #74 (list-group PR) first, and then rebase this..

Storybook:
https://rawgit.com/priley86/patternfly-react/modal-storybook/index.html?knob-Label=Danger%20Will%20Robinson%21&selectedKind=Modal%20Overlay&selectedStory=Basic%20Example&full=0&down=1&left=1&panelRight=0&downPanel=storybooks%2Fstorybook-addon-knobs

<!-- How were these changes implemented? -->
**How**:
To add custom content classes to the `modal-content` div and support the [About Modal](https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/about-modal.html) pattern, a `CustomModalDialog` must be introduced. I've added an example of that here.

This seems to be a better alternative than [adding more custom css](https://github.com/react-bootstrap/react-bootstrap/issues/2772) and should give more fine grained control when needed.
<!-- feel free to add additional comments -->

Closes #68 