### PR TITLE
feat(tootip): add the pf tooltip

### DIFF
--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -1,0 +1,2 @@
+import { Tooltip } from 'react-bootstrap'
+export default Tooltip

--- a/src/Tooltip/Tooltip.stories.js
+++ b/src/Tooltip/Tooltip.stories.js
@@ -1,0 +1,64 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { withKnobs, text, select, boolean } from '@storybook/addon-knobs'
+import { defaultTemplate } from '../../storybook/decorators/storyTemplates'
+import { Button, OverlayTrigger, Tooltip } from '../index.js'
+
+const stories = storiesOf('Tooltip', module)
+const description = (
+  <p>
+    This component is based on React Bootstrap Tooltip component. See{' '}
+    <a href="https://react-bootstrap.github.io/components.html#tooltips">
+      React Bootstrap Docs
+    </a>{' '}
+    for complete Tooltip component documentation.
+  </p>
+)
+stories.addDecorator(withKnobs)
+stories.addDecorator(
+  defaultTemplate({
+    title: 'Tooltip',
+    documentationLink:
+      'http://www.patternfly.org/pattern-library/widgets/#tooltip',
+    description: description
+  })
+)
+
+stories.addWithInfo('Tooltip', () => {
+  const tooltip = (
+    <Tooltip id="tooltip">
+      <div
+        dangerouslySetInnerHTML={{
+          __html: text(
+            'Tooltip',
+            '<strong>Holy guacamole!</strong> Check this info.'
+          )
+        }}
+      />
+    </Tooltip>
+  )
+  const placement = select(
+    'Placement',
+    ['top', 'bottom', 'left', 'right'],
+    'right'
+  )
+  const trigger = select(
+    'Trigger',
+    ['hover', 'focus', 'hover focus', 'click'],
+    'hover focus'
+  )
+  const rootClose = boolean('Root Close', false)
+
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <OverlayTrigger
+        overlay={tooltip}
+        placement={placement}
+        trigger={trigger.split(' ')}
+        rootClose={rootClose}
+      >
+        <Button bsStyle="default">Holy guacamole!</Button>
+      </OverlayTrigger>
+    </div>
+  )
+})

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ export { default as Icon } from './Icon/Icon'
 export { default as MenuItem } from './MenuItem/MenuItem'
 export { default as OverlayTrigger } from './OverlayTrigger/OverlayTrigger'
 export { default as Popover } from './Popover/Popover'
+export { default as Tooltip } from './Tooltip/Tooltip'
 export {
   default as ToastNotification
 } from './ToastNotification/ToastNotification'


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
This PR adds the PatternFly tooltip patterns. To be used to close #19 (Tooltip) once done.

Storybook: https://rawgit.com/dabeng/patternfly-react/tooltip-storybook/.out/index.html?knob-Label=Danger%20Will%20Robinson%21&knob-Tooltip=%3Cstrong%3EHoly%20guacamole%21%3C%2Fstrong%3E%20Check%20this%20info.&knob-Placement=right&knob-Trigger=hover%20focus&knob-Root%20Close=false&selectedKind=Tooltip&selectedStory=Tooltip&full=0&down=1&left=1&panelRight=0&downPanel=storybooks%2Fstorybook-addon-knobs

**How**:
Encapsulating react-bootstrap tooltip as a story of patternfly-react storybook.

@priley86 , please review.