### PR TITLE
feat(popover): add the pf popover

### DIFF
--- a/src/OverlayTrigger/OverlayTrigger.js
+++ b/src/OverlayTrigger/OverlayTrigger.js
@@ -1,0 +1,2 @@
+import { OverlayTrigger } from 'react-bootstrap'
+export default OverlayTrigger

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -1,0 +1,2 @@
+import { Popover } from 'react-bootstrap'
+export default Popover

--- a/src/Popover/Popover.stories.js
+++ b/src/Popover/Popover.stories.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { withKnobs, text, select, boolean } from '@storybook/addon-knobs'
+import { defaultTemplate } from '../../storybook/decorators/storyTemplates'
+import { Button, OverlayTrigger, Popover } from '../index.js'
+
+const stories = storiesOf('Popover', module)
+const description = (
+  <p>
+    This component is based on React Bootstrap Popover component. See{' '}
+    <a href="https://react-bootstrap.github.io/components.html#popovers">
+      React Bootstrap Docs
+    </a>{' '}
+    for complete Popover component documentation.
+  </p>
+)
+stories.addDecorator(withKnobs)
+stories.addDecorator(
+  defaultTemplate({
+    title: 'Popover',
+    documentationLink:
+      'http://www.patternfly.org/pattern-library/widgets/#popover',
+    description: description
+  })
+)
+
+stories.addWithInfo('Popover', () => {
+  const title = (
+    <div
+      dangerouslySetInnerHTML={{ __html: text('Popover Title', 'Popover') }}
+    />
+  )
+  const content = (
+    <div
+      dangerouslySetInnerHTML={{
+        __html: text(
+          'Popover Content',
+          '<strong>Holy guacamole!</strong> Check this info.'
+        )
+      }}
+    />
+  )
+  const popover = (
+    <Popover id="popover" title={title}>
+      {content}
+    </Popover>
+  )
+  const placement = select(
+    'Placement',
+    ['top', 'bottom', 'left', 'right'],
+    'right'
+  )
+  const trigger = select(
+    'Trigger',
+    ['hover', 'focus', 'hover focus', 'click'],
+    'click'
+  )
+  const rootClose = boolean('Root Close', true)
+
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <OverlayTrigger
+        overlay={popover}
+        placement={placement}
+        trigger={trigger.split(' ')}
+        rootClose={rootClose}
+      >
+        <Button bsStyle="default">Holy guacamole!</Button>
+      </OverlayTrigger>
+    </div>
+  )
+})

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ export { default as ListGroupItem } from './ListGroup/ListGroupItem'
 export { default as ListView } from './ListView/ListView'
 export { default as Icon } from './Icon/Icon'
 export { default as MenuItem } from './MenuItem/MenuItem'
+export { default as OverlayTrigger } from './OverlayTrigger/OverlayTrigger'
+export { default as Popover } from './Popover/Popover'
 export {
   default as ToastNotification
 } from './ToastNotification/ToastNotification'


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
This PR adds the PatternFly popover patterns. To be used to close #20 (Popover) once done.

Storybook: https://rawgit.com/dabeng/patternfly-react/popover-storybook/.out/index.html?knob-Label=Danger%20Will%20Robinson%21&knob-Popover%20Title=Popover&knob-Popover%20Content=%3Cstrong%3EHoly%20guacamole%21%3C%2Fstrong%3E%20Check%20this%20info.&knob-Placement=right&knob-Trigger=click&knob-Root%20Close=true&selectedKind=Popover&selectedStory=Popover&full=0&down=1&left=1&panelRight=0&downPanel=storybooks%2Fstorybook-addon-knobs

**How**:
Encapsulating react-bootstrap popover as a story of patternfly-react storybook.

@priley86 , please review.