### PR TITLE
test(polyfill): Fix the requestAnimationFrame warning when running tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10959,6 +10959,15 @@
         }
       }
     },
+    "raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+      "dev": true,
+      "requires": {
+        "performance-now": "2.1.0"
+      }
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "less-loader": "^4.0.5",
     "patternfly": "^3.27.4",
     "prettier": "^1.7.4",
+    "raf": "^3.4.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",
@@ -84,6 +85,11 @@
     "storybook:deploy": "storybook-to-ghpages",
     "build-storybook": "build-storybook -c storybook -o .out",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+  },
+  "jest": {
+    "setupFiles": [
+      "./src/test.env.js"
+    ]
   },
   "czConfig": {
     "path": "node_modules/cz-conventional-changelog"

--- a/src/test.env.js
+++ b/src/test.env.js
@@ -1,0 +1,1 @@
+import 'raf/polyfill';


### PR DESCRIPTION
**What**:
Fix the requestAnimationFrame warning when running tests

**Why**:
Because we are getting warnings when running tests:
```bash
    console.error node_modules/fbjs/lib/warning.js:33
      Warning: React depends on requestAnimationFrame. Make sure that you load a polyfill in older browsers. http://fb.me/react-polyfills
```

**How**:
Import `raf/polyfill` before running tests as suggested by
https://reactjs.org/docs/javascript-environment-requirements.html
