### PR TITLE
docs(list-group): list-group custom content and linked examples

### DIFF
--- a/src/components/ListGroup/ListGroup.stories.js
+++ b/src/components/ListGroup/ListGroup.stories.js
@@ -50,20 +50,11 @@ stories.addWithInfo('Badges', '', () => (
 ));
 
 stories.addWithInfo('Linked Items', '', () => {
-  const handleClick = e => {
-    e.preventDefault();
-  };
   return (
     <ListGroup>
-      <ListGroupItem href="#" onClick={handleClick}>
-        Cras justo odio
-      </ListGroupItem>
-      <ListGroupItem href="#" onClick={handleClick}>
-        Dapibus ac facilisis in
-      </ListGroupItem>
-      <ListGroupItem href="#" onClick={handleClick}>
-        Morbi leo risus
-      </ListGroupItem>
+      <ListGroupItem href="#">Cras justo odio</ListGroupItem>
+      <ListGroupItem href="#">Dapibus ac facilisis in</ListGroupItem>
+      <ListGroupItem href="#">Morbi leo risus</ListGroupItem>
     </ListGroup>
   );
 });
@@ -78,27 +69,25 @@ stories.addWithInfo('Contextual classes', '', () => (
 ));
 
 stories.addWithInfo('Custom content', '', () => {
-  const handleClick = e => {
-    e.preventDefault();
-  };
   return (
     <ListGroup>
-      <ListGroupItem href="#" onClick={handleClick} className="active">
-        <h4 className="list-group-item-heading">List group item heading</h4>
+      <ListGroupItem
+        href="#"
+        header="List group item heading"
+        className="active"
+      >
         <p className="list-group-item-text">
           Donec id elit non mi porta gravida at eget metus. Maecenas sed diam
           eget risus varius blandit.
         </p>
       </ListGroupItem>
-      <ListGroupItem href="#" onClick={handleClick}>
-        <h4 className="list-group-item-heading">List group item heading</h4>
+      <ListGroupItem href="#" header="List group item heading">
         <p className="list-group-item-text">
           Donec id elit non mi porta gravida at eget metus. Maecenas sed diam
           eget risus varius blandit.
         </p>
       </ListGroupItem>
-      <ListGroupItem href="#" onClick={handleClick}>
-        <h4 className="list-group-item-heading">List group item heading</h4>
+      <ListGroupItem href="#" header="List group item heading">
         <p className="list-group-item-text">
           Donec id elit non mi porta gravida at eget metus. Maecenas sed diam
           eget risus varius blandit.


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Adds storybook documentation tweaks to the list-group for custom content and linked examples.

Closes #85 (made some additional notes there)

<!-- feel free to add additional comments -->