### PR TITLE
fix(chart): move char bar specific code to bar chart file

### DIFF
--- a/src/components/Chart/BarChart.js
+++ b/src/components/Chart/BarChart.js
@@ -1,8 +1,22 @@
 import React from 'react';
 import C3Chart from 'react-c3js';
 import { getComposer } from './constants';
+import { compose, mapProps } from 'recompose';
 
-const BarChart = getComposer('BAR_CHART')(
+import { c3ChartDefaults } from '../../common/patternfly';
+
+const mapBarChartProps = props => {
+  const newProps = Object.assign({}, props);
+
+  // Set Bar Chart tooltip
+  if (props.categories) {
+    newProps.tooltip = c3ChartDefaults.getDefaultBarTooltip(props.categories);
+  }
+
+  return newProps;
+};
+
+const BarChart = compose(getComposer('BAR_CHART'), mapProps(mapBarChartProps))(
   ({ className, type, data, ...props }) => (
     <C3Chart className={className} type={type} data={data} {...props} />
   ),

--- a/src/components/Chart/__snapshots__/BarChart.test.js.snap
+++ b/src/components/Chart/__snapshots__/BarChart.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BarChart renders properly 1`] = `
-<mapProps(Component)
+<mapProps(mapProps(Component))
   className="bar-chart-pf"
   color={
     Object {

--- a/src/components/Chart/constants.js
+++ b/src/components/Chart/constants.js
@@ -89,11 +89,6 @@ const mapChartProps = (name, props) => {
     newProps.data.type = props.type;
   }
 
-  // Set Bar Chart tooltip
-  if (name === 'BAR_CHART' && props.categories) {
-    newProps.tooltip = c3ChartDefaults.getDefaultBarTooltip(props.categories);
-  }
-
   return newProps;
 };
 


### PR DESCRIPTION
Currently we update `BarChart` props on the global  `getComposer` method in `constatants.js`. This can be done only for the `BarChart` component, in `BarChart.js`, like we do it for the `DonutChart`.