### PR TITLE
feat(Form): Add form related components

### DIFF
--- a/src/components/Form/Checkbox.js
+++ b/src/components/Form/Checkbox.js
@@ -1,0 +1,1 @@
+export { Checkbox as default } from 'react-bootstrap';

--- a/src/components/Form/ControlLabel.js
+++ b/src/components/Form/ControlLabel.js
@@ -1,0 +1,1 @@
+export { ControlLabel as default } from 'react-bootstrap';

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -1,0 +1,1 @@
+export { Form as default } from 'react-bootstrap';

--- a/src/components/Form/Form.stories.js
+++ b/src/components/Form/Form.stories.js
@@ -1,0 +1,254 @@
+/* eslint react/prop-types: 0 */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { defaultTemplate } from '../../../storybook/decorators/storyTemplates';
+import { Icon } from '../Icon';
+import { Col, Row, Grid } from '../Grid';
+import { Button } from '../Button';
+import { Modal } from '../Modal';
+import { Form } from './index';
+
+import {
+  InlineFormFields,
+  InlineFormButtons,
+  getInlineFormKnobs
+} from './Stories/InlineForm';
+import {
+  BasicFormFields,
+  BasicFormButtons,
+  BasicFormSpinner,
+  getBasicFormKnobs
+} from './Stories/BasicForm';
+import {
+  SupportedControlsFormFields,
+  getSupportedControlsFormKnobs
+} from './Stories/SupportedControlsForm';
+import {
+  InputGroupsFormFields,
+  getInputGroupsFormKnobs
+} from './Stories/InputGroupsForm';
+import { InlineFormField } from './Stories/InlineFormField';
+import { HorizontalFormField } from './Stories/HorizontalFormField';
+import { VerticalFormField } from './Stories/VerticalFormField';
+
+const stories = storiesOf('Forms', module);
+
+stories.addDecorator(withKnobs);
+
+const description = (
+  <p>
+    Those components are based on React Bootstrap Form components. See{' '}
+    <a href="https://react-bootstrap.github.io/components/forms/">
+      React Bootstrap Docs
+    </a>{' '}
+    for complete Form components documentation.
+  </p>
+);
+
+stories.addDecorator(
+  defaultTemplate({
+    title: 'Forms',
+    documentationLink:
+      'http://www.patternfly.org/pattern-library/widgets/#forms',
+    description: description
+  })
+);
+
+stories.addWithInfo('Inline Form', '', () => {
+  const formFieldsKnobs = getInlineFormKnobs();
+  const { bsSize, disabled } = formFieldsKnobs;
+  const buttonsProps = {};
+
+  if (bsSize) buttonsProps.bsSize = bsSize;
+  if (disabled) buttonsProps.disabled = disabled;
+
+  const formFields = InlineFormFields.map(formField =>
+    InlineFormField({ ...formField, ...formFieldsKnobs })
+  ).reduce((result = [], element) => {
+    return [...result, element, ' ']; // create spacing betwwen elements
+  }, []);
+
+  const formButtons = InlineFormButtons.map(({ text, ...props }) => (
+    <Button key={text} {...props} {...buttonsProps}>
+      {text}
+    </Button>
+  ));
+
+  return (
+    <Grid>
+      <Form inline>
+        {formFields} {formButtons}
+      </Form>
+    </Grid>
+  );
+});
+
+stories.addWithInfo('Horizontal Form', '', () => {
+  const formFieldsKnobs = getBasicFormKnobs();
+  const { bsSize, disabled } = formFieldsKnobs;
+  const buttonsProps = {};
+
+  if (bsSize) buttonsProps.bsSize = bsSize;
+  if (disabled) buttonsProps.disabled = disabled;
+
+  const showLoading = boolean('Show Loading', false);
+
+  const formFields = BasicFormFields.map(formField =>
+    HorizontalFormField({ ...formField, ...formFieldsKnobs })
+  );
+
+  const formButtons = BasicFormButtons.map(({ text, ...props }) => (
+    <span key={text}>
+      <Button {...props} {...buttonsProps}>
+        {text}
+      </Button>{' '}
+    </span>
+  ));
+
+  return (
+    <Grid>
+      <Form horizontal>
+        {formFields}
+        <Row style={{ paddingTop: '10px', paddingBottom: '10px' }}>
+          <Col smOffset={3} sm={9}>
+            {formButtons}
+          </Col>
+        </Row>
+        {showLoading && (
+          <Row style={{ paddingTop: '10px', paddingBottom: '10px' }}>
+            <Col smOffset={3} sm={9}>
+              {[...BasicFormSpinner]}
+            </Col>
+          </Row>
+        )}
+      </Form>
+    </Grid>
+  );
+});
+
+stories.addWithInfo('Vertical Form', '', () => {
+  const formFieldsKnobs = getBasicFormKnobs();
+  const { bsSize, disabled } = formFieldsKnobs;
+  const buttonsProps = {};
+
+  if (bsSize) buttonsProps.bsSize = bsSize;
+  if (disabled) buttonsProps.disabled = disabled;
+
+  const showLoading = boolean('Show Loading', false);
+
+  const formFields = BasicFormFields.map(formField =>
+    VerticalFormField({ ...formField, ...formFieldsKnobs })
+  );
+
+  const formButtons = BasicFormButtons.map(({ text, ...props }) => (
+    <span key={text}>
+      <Button {...props} {...buttonsProps}>
+        {text}
+      </Button>{' '}
+    </span>
+  ));
+
+  return (
+    <Grid>
+      <Form>
+        <Row>
+          <Col>{formFields}</Col>
+        </Row>
+        <Row style={{ paddingTop: '10px', paddingBottom: '10px' }}>
+          <Col>{formButtons}</Col>
+        </Row>
+        {showLoading && (
+          <Row style={{ paddingTop: '10px', paddingBottom: '10px' }}>
+            <Col>{BasicFormSpinner}</Col>
+          </Row>
+        )}
+      </Form>
+    </Grid>
+  );
+});
+
+stories.addWithInfo('Modal Form', '', () => {
+  const formFieldsKnobs = getBasicFormKnobs();
+  const { bsSize, disabled } = formFieldsKnobs;
+  const buttonsProps = {};
+
+  if (bsSize) buttonsProps.bsSize = bsSize;
+  if (disabled) buttonsProps.disabled = disabled;
+
+  const showModal = boolean('Show Modal', true);
+  const showLoading = boolean('Show Loading', false);
+
+  const formFields = BasicFormFields.map(formField =>
+    HorizontalFormField({ ...formField, ...formFieldsKnobs })
+  );
+
+  const formButtons = BasicFormButtons.map(({ text, ...props }) => (
+    <Button key={text} {...props} {...buttonsProps}>
+      {text}
+    </Button>
+  )).reverse();
+
+  const formSpinner = (
+    <div style={{ paddingTop: '20px', paddingBottom: '10px' }}>
+      {[...BasicFormSpinner].reverse()}
+    </div>
+  );
+
+  return (
+    <Modal show={showModal}>
+      <Modal.Header>
+        <button
+          className="close"
+          onClick={action('Close')}
+          aria-hidden="true"
+          aria-label="Close"
+        >
+          <Icon type="pf" name="close" />
+        </button>
+        <Modal.Title>Basic Settings</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form horizontal>{formFields}</Form>
+      </Modal.Body>
+      <Modal.Footer>
+        {formButtons}
+        {showLoading && formSpinner}
+      </Modal.Footer>
+    </Modal>
+  );
+});
+
+stories.addWithInfo('Supported Controls', '', () => {
+  const formFieldsKnobs = getSupportedControlsFormKnobs();
+
+  const formFields = SupportedControlsFormFields.map(formField =>
+    VerticalFormField({ ...formField, ...formFieldsKnobs })
+  );
+
+  return (
+    <Grid>
+      <Form>{formFields}</Form>
+    </Grid>
+  );
+});
+
+stories.addWithInfo('Input Groups', '', () => {
+  const formFieldsKnobs = getInputGroupsFormKnobs();
+
+  const formFields = InputGroupsFormFields.map(formField =>
+    VerticalFormField({ ...formField, ...formFieldsKnobs })
+  );
+
+  return (
+    <Grid>
+      <Form>
+        <Row>
+          <Col>{formFields}</Col>
+        </Row>
+      </Form>
+    </Grid>
+  );
+});

--- a/src/components/Form/FormControl.js
+++ b/src/components/Form/FormControl.js
@@ -1,0 +1,1 @@
+export { FormControl as default } from 'react-bootstrap';

--- a/src/components/Form/FormGroup.js
+++ b/src/components/Form/FormGroup.js
@@ -1,0 +1,1 @@
+export { FormGroup as default } from 'react-bootstrap';

--- a/src/components/Form/HelpBlock.js
+++ b/src/components/Form/HelpBlock.js
@@ -1,0 +1,1 @@
+export { HelpBlock as default } from 'react-bootstrap';

--- a/src/components/Form/InputGroup.js
+++ b/src/components/Form/InputGroup.js
@@ -1,0 +1,1 @@
+export { InputGroup as default } from 'react-bootstrap';

--- a/src/components/Form/Radio.js
+++ b/src/components/Form/Radio.js
@@ -1,0 +1,1 @@
+export { Radio as default } from 'react-bootstrap';

--- a/src/components/Form/Stories/BasicForm.js
+++ b/src/components/Form/Stories/BasicForm.js
@@ -1,0 +1,94 @@
+/* eslint react/prop-types: 0 */
+
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import { select, boolean } from '@storybook/addon-knobs';
+import { Spinner } from '../../Spinner';
+import { Button } from '../../Button';
+import { FormControl, InputGroup } from '../index';
+
+export const BasicFormFields = [
+  {
+    controlId: 'name',
+    label: 'Name',
+    help: 'Enter your name',
+    formControl: ({ validationState, ...props }) => (
+      <FormControl type="text" {...props} />
+    )
+  },
+  {
+    controlId: 'address',
+    label: 'Address',
+    help: 'Enter your address',
+    formControl: ({ validationState, ...props }) => (
+      <FormControl type="address" {...props} />
+    )
+  },
+  {
+    controlId: 'city',
+    label: 'City',
+    help: 'Enter your city',
+    formControl: ({ validationState, ...props }) => (
+      <FormControl type="text" {...props} />
+    )
+  },
+  {
+    controlId: 'email',
+    label: 'Email',
+    help: 'Enter a valid email address',
+    formControl: ({ validationState, ...props }) => (
+      <FormControl type="email" {...props} />
+    )
+  },
+  {
+    controlId: 'url',
+    label: 'My meeting URL',
+    help: 'Enter a valid URL',
+    formControl: ({ validationState, disabled, ...props }) => {
+      const controlProps = { disabled };
+      return (
+        <InputGroup {...props}>
+          <FormControl type="url" {...controlProps} />
+          <InputGroup.Button>
+            <Button onClick={action('CopyUrl')} {...controlProps}>
+              Copy URL
+            </Button>
+          </InputGroup.Button>
+        </InputGroup>
+      );
+    }
+  }
+];
+
+export const BasicFormButtons = [
+  {
+    text: 'Save',
+    bsStyle: 'primary',
+    onClick: action('Save')
+  },
+  {
+    text: 'Cancel',
+    bsStyle: 'default',
+    onClick: action('Cancel')
+  }
+];
+
+export const BasicFormSpinner = [
+  <Spinner key="spinner" size="xs" loading inline />,
+  ' ',
+  <span key="text">
+    Do not refresh this page. This request may take a minute...
+  </span>
+];
+
+export const getBasicFormKnobs = () => ({
+  validationState: select('Validation State', [
+    null,
+    'success',
+    'warning',
+    'error'
+  ]),
+  bsSize: select('Size', [null, 'small', 'large']),
+  showHelp: boolean('Show Help', true),
+  disabled: boolean('Disabled', false)
+});

--- a/src/components/Form/Stories/HorizontalFormField.js
+++ b/src/components/Form/Stories/HorizontalFormField.js
@@ -1,0 +1,35 @@
+/* eslint react/prop-types: 0 */
+
+import React from 'react';
+import { Col } from '../../Grid';
+import { FormGroup, ControlLabel, HelpBlock } from '../index';
+
+export const HorizontalFormField = ({
+  controlId,
+  label,
+  help,
+  formControl,
+  validationState,
+  bsSize,
+  showHelp,
+  ...props
+}) => {
+  const controlProps = { ...props };
+
+  if (bsSize) controlProps.bsSize = bsSize;
+  if (validationState) controlProps.validationState = validationState;
+
+  const formGroupProps = { key: controlId, controlId, ...controlProps };
+
+  return (
+    <FormGroup {...formGroupProps}>
+      <Col componentClass={ControlLabel} sm={3}>
+        {label}
+      </Col>
+      <Col sm={9}>
+        {formControl(controlProps)}
+        {showHelp && help && <HelpBlock>{help}</HelpBlock>}
+      </Col>
+    </FormGroup>
+  );
+};

--- a/src/components/Form/Stories/InlineForm.js
+++ b/src/components/Form/Stories/InlineForm.js
@@ -1,0 +1,35 @@
+/* eslint react/prop-types: 0 */
+
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import { select, boolean } from '@storybook/addon-knobs';
+import { FormControl } from '../index';
+
+export const InlineFormFields = [
+  {
+    controlId: 'email',
+    label: 'Email',
+    placeholder: 'Email',
+    formControl: props => <FormControl type="email" {...props} />
+  },
+  {
+    controlId: 'password',
+    label: 'Password',
+    placeholder: 'Password',
+    formControl: props => <FormControl type="password" {...props} />
+  }
+];
+
+export const InlineFormButtons = [
+  {
+    text: 'Log In',
+    bsStyle: 'primary',
+    onClick: action('Login')
+  }
+];
+
+export const getInlineFormKnobs = () => ({
+  bsSize: select('Size', [null, 'small', 'large']),
+  disabled: boolean('Disabled', false),
+  showLabel: boolean('Show Labels', false)
+});

--- a/src/components/Form/Stories/InlineFormField.js
+++ b/src/components/Form/Stories/InlineFormField.js
@@ -1,0 +1,28 @@
+/* eslint react/prop-types: 0 */
+
+import React from 'react';
+import { FormGroup, ControlLabel } from '../index';
+
+export const InlineFormField = ({
+  controlId,
+  label,
+  formControl,
+  validationState,
+  bsSize,
+  showLabel,
+  ...props
+}) => {
+  const controlProps = { ...props };
+
+  if (bsSize) controlProps.bsSize = bsSize;
+  if (validationState) controlProps.validationState = validationState;
+
+  const formGroupProps = { key: controlId, controlId, ...controlProps };
+
+  return (
+    <FormGroup {...formGroupProps}>
+      {showLabel && label && <ControlLabel>{label}</ControlLabel>}{' '}
+      {formControl(controlProps)}
+    </FormGroup>
+  );
+};

--- a/src/components/Form/Stories/InputGroupsForm.js
+++ b/src/components/Form/Stories/InputGroupsForm.js
@@ -1,0 +1,142 @@
+/* eslint react/prop-types: 0 */
+
+import React from 'react';
+import { select, boolean } from '@storybook/addon-knobs';
+import { Button, DropdownButton } from '../../Button';
+import { Icon } from '../../Icon';
+import { MenuItem } from '../../MenuItem';
+import { FormControl, InputGroup } from '../index';
+
+export const InputGroupsFormFields = [
+  {
+    controlId: 'control-1',
+    formControl: ({
+      validationState = 'default',
+      disabled = false,
+      ...props
+    }) => (
+      <InputGroup {...props}>
+        <InputGroup.Addon>@</InputGroup.Addon>
+        <FormControl type="text" disabled={disabled} />
+      </InputGroup>
+    )
+  },
+  {
+    controlId: 'control-2',
+    formControl: ({
+      validationState = 'default',
+      disabled = false,
+      ...props
+    }) => (
+      <InputGroup {...props}>
+        <FormControl type="text" disabled={disabled} />
+        <InputGroup.Addon>.00</InputGroup.Addon>
+      </InputGroup>
+    )
+  },
+  {
+    controlId: 'control-3',
+    formControl: ({
+      validationState = 'default',
+      disabled = false,
+      ...props
+    }) => (
+      <InputGroup {...props}>
+        <InputGroup.Addon>$</InputGroup.Addon>
+        <FormControl type="text" disabled={disabled} />
+        <InputGroup.Addon>.00</InputGroup.Addon>
+      </InputGroup>
+    )
+  },
+  {
+    controlId: 'control-4',
+    formControl: ({
+      validationState = 'default',
+      disabled = false,
+      ...props
+    }) => (
+      <InputGroup {...props}>
+        <FormControl type="text" disabled={disabled} />
+        <InputGroup.Addon>
+          <Icon name="music" />
+        </InputGroup.Addon>
+      </InputGroup>
+    )
+  },
+  {
+    controlId: 'control-5',
+    formControl: ({
+      validationState = 'default',
+      disabled = false,
+      ...props
+    }) => (
+      <InputGroup {...props}>
+        <InputGroup.Button>
+          <Button disabled={disabled}>Before</Button>
+        </InputGroup.Button>
+        <FormControl type="text" disabled={disabled} />
+      </InputGroup>
+    )
+  },
+  {
+    controlId: 'control-6',
+    formControl: ({
+      validationState = 'default',
+      disabled = false,
+      ...props
+    }) => (
+      <InputGroup {...props}>
+        <FormControl type="text" disabled={disabled} />
+        <DropdownButton
+          componentClass={InputGroup.Button}
+          id="input-dropdown-addon"
+          title="Action"
+          disabled={disabled}
+        >
+          <MenuItem key="1">Item</MenuItem>
+        </DropdownButton>
+      </InputGroup>
+    )
+  },
+  {
+    controlId: 'control-7',
+    formControl: ({
+      validationState = 'default',
+      disabled = false,
+      ...props
+    }) => (
+      <InputGroup {...props}>
+        <InputGroup.Addon>
+          <input type="radio" disabled={disabled} />
+        </InputGroup.Addon>
+        <FormControl type="text" disabled={disabled} />
+      </InputGroup>
+    )
+  },
+  {
+    controlId: 'control-8',
+    formControl: ({
+      validationState = 'default',
+      disabled = false,
+      ...props
+    }) => (
+      <InputGroup {...props}>
+        <InputGroup.Addon>
+          <input type="checkbox" disabled={disabled} />
+        </InputGroup.Addon>
+        <FormControl type="text" disabled={disabled} />
+      </InputGroup>
+    )
+  }
+];
+
+export const getInputGroupsFormKnobs = () => ({
+  validationState: select('Validation State', [
+    null,
+    'success',
+    'warning',
+    'error'
+  ]),
+  bsSize: select('Size', [null, 'small', 'large']),
+  disabled: boolean('Disabled', false)
+});

--- a/src/components/Form/Stories/SupportedControlsForm.js
+++ b/src/components/Form/Stories/SupportedControlsForm.js
@@ -1,0 +1,120 @@
+/* eslint react/prop-types: 0 */
+
+import React from 'react';
+import { select, boolean } from '@storybook/addon-knobs';
+import { FormControl, Checkbox, Radio } from '../index';
+
+export const SupportedControlsFormFields = [
+  {
+    controlId: 'text',
+    label: 'Text',
+    help: 'Help text',
+    formControl: ({ validationState, ...props }) => (
+      <FormControl type="text" {...props} />
+    )
+  },
+  {
+    controlId: 'email',
+    label: 'Email',
+    help: 'Help text',
+    formControl: ({ validationState, ...props }) => (
+      <FormControl type="email" {...props} />
+    )
+  },
+  {
+    controlId: 'password',
+    label: 'Password',
+    help: 'Help text',
+    formControl: ({ validationState, ...props }) => (
+      <FormControl type="password" {...props} />
+    )
+  },
+  {
+    controlId: 'file',
+    label: 'File',
+    help: 'Help text',
+    formControl: ({ validationState, bsSize, ...props }) => (
+      <FormControl type="file" {...props} />
+    )
+  },
+  {
+    controlId: 'checkbox',
+    label: 'Checkbox',
+    help: 'Help text',
+    formControl: ({ validationState, ...props }) => (
+      <Checkbox {...props}>Checkbox</Checkbox>
+    )
+  },
+  {
+    controlId: 'radio',
+    label: 'Radio',
+    help: 'Help text',
+    formControl: ({ validationState, ...props }) => (
+      <Radio {...props}>Radio</Radio>
+    )
+  },
+  {
+    controlId: 'checkboxGroup',
+    label: 'Checkbox Group',
+    help: 'Help text',
+    formControl: ({ validationState, ...props }) => (
+      <div>
+        <Checkbox {...props} inline>
+          1
+        </Checkbox>
+        <Checkbox {...props} inline>
+          2
+        </Checkbox>
+        <Checkbox {...props} inline>
+          3
+        </Checkbox>
+      </div>
+    )
+  },
+  {
+    controlId: 'radioGroup',
+    label: 'Radio Group',
+    help: 'Help text',
+    formControl: ({ validationState, ...props }) => (
+      <div>
+        <Radio {...props} name="radioGroup" inline>
+          1
+        </Radio>
+        <Radio {...props} name="radioGroup" inline>
+          2
+        </Radio>
+        <Radio {...props} name="radioGroup" inline>
+          3
+        </Radio>
+      </div>
+    )
+  },
+  {
+    controlId: 'textarea',
+    label: 'Textarea',
+    help: 'Help text',
+    formControl: ({ validationState, ...props }) => (
+      <FormControl componentClass="textarea" {...props} />
+    )
+  },
+  {
+    controlId: 'static',
+    label: 'Static',
+    help: 'Help text',
+    formControl: ({ validationState, ...props }) => (
+      <FormControl.Static {...props}>email@example.com</FormControl.Static>
+    )
+  }
+];
+
+export const getSupportedControlsFormKnobs = () => ({
+  validationState: select('Validation State', [
+    null,
+    'success',
+    'warning',
+    'error'
+  ]),
+  bsSize: select('Size', [null, 'small', 'large']),
+  showHelp: boolean('Show Help', true),
+  disabled: boolean('Disabled', false)
+});

--- a/src/components/Form/Stories/VerticalFormField.js
+++ b/src/components/Form/Stories/VerticalFormField.js
@@ -1,0 +1,30 @@
+/* eslint react/prop-types: 0 */
+
+import React from 'react';
+import { FormGroup, ControlLabel, HelpBlock } from '../index';
+
+export const VerticalFormField = ({
+  controlId,
+  label,
+  help,
+  formControl,
+  validationState,
+  bsSize,
+  showHelp,
+  ...props
+}) => {
+  const controlProps = { ...props };
+
+  if (bsSize) controlProps.bsSize = bsSize;
+  if (validationState) controlProps.validationState = validationState;
+
+  const formGroupProps = { key: controlId, controlId, ...controlProps };
+
+  return (
+    <FormGroup {...formGroupProps}>
+      {label && <ControlLabel>{label}</ControlLabel>}
+      {formControl(controlProps)}
+      {showHelp && help && <HelpBlock>{help}</HelpBlock>}
+    </FormGroup>
+  );
+};

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -1,0 +1,8 @@
+export { default as Checkbox } from './Checkbox';
+export { default as ControlLabel } from './ControlLabel';
+export { default as Form } from './Form';
+export { default as FormControl } from './FormControl';
+export { default as FormGroup } from './FormGroup';
+export { default as HelpBlock } from './HelpBlock';
+export { default as InputGroup } from './InputGroup';
+export { default as Radio } from './Radio';

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export * from './components/Button';
 export * from './components/Dropdown';
 export * from './components/DropdownKebab';
 export * from './components/Filter';
+export * from './components/Form';
 export * from './components/Grid';
 export * from './components/Icon';
 export * from './components/Chart';


### PR DESCRIPTION
**What**:
Add form related components
closes #118, closes #117, closes #116

[**Link to Storybook**](http://rawgit.com/sharvit/patternfly-react/storybook/forms/index.html?knob-Label=Danger%20Will%20Robinson%21&knob-Disabled=false&knob-Show%20Labels=false&selectedKind=Forms&selectedStory=Inline%20Form&full=0&down=1&left=1&panelRight=0&downPanel=storybooks%2Fstorybook-addon-knobs)

**Discussion:**
1. I created some `Field` level components (e.g. `Stories/HorizontalFormField.js`), do you think those components should get exported to consumers?
2. Do you think I should get rid of some [InputGroups](http://rawgit.com/sharvit/patternfly-react/storybook/forms/index.html?knob-Label=Danger%20Will%20Robinson%21&knob-Disabled=false&knob-Show%20Labels=false&selectedKind=Forms&selectedStory=Input%20Groups&full=0&down=1&left=1&panelRight=0&downPanel=storybooks%2Fstorybook-addon-knobs) because they do not feel like patternfly?

**Additional issues**:
* This pr is based on #130, please merge #130 before

