### PR TITLE
fix(TimedToastNotification): Stop passing down all props

### DIFF
--- a/src/components/ToastNotification/TimedToastNotification.js
+++ b/src/components/ToastNotification/TimedToastNotification.js
@@ -56,16 +56,18 @@ class TimedToastNotification extends React.Component {
     onMouseLeave && onMouseLeave();
   }
   render() {
-    const { children } = this.props;
-    return (
-      <ToastNotification
-        {...this.props}
-        onMouseEnter={this.onMouseEnter}
-        onMouseLeave={this.onMouseLeave}
-      >
-        {children}
-      </ToastNotification>
-    );
+    const { children, className, type, onDismiss } = this.props;
+    const { onMouseEnter, onMouseLeave } = this;
+
+    const toastProps = {
+      className,
+      type,
+      onDismiss,
+      onMouseEnter,
+      onMouseLeave
+    };
+
+    return <ToastNotification {...toastProps}>{children}</ToastNotification>;
   }
 }
 
@@ -77,7 +79,7 @@ TimedToastNotification.propTypes = {
   /** timer delay until dismiss */
   timerdelay: PropTypes.number,
   /** additional notification classes */
-  className: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
+  className: PropTypes.string,
   /** callback when alert is dismissed  */
   onDismiss: PropTypes.func,
   /** onMouseEnter callback */
@@ -85,7 +87,7 @@ TimedToastNotification.propTypes = {
   /** onMouseLeave callback */
   onMouseLeave: PropTypes.func,
   /** the type of alert  */
-  type: PropTypes.oneOf(TOAST_NOTIFICATION_TYPES).isRequired, // eslint-disable-line react/no-unused-prop-types
+  type: PropTypes.oneOf(TOAST_NOTIFICATION_TYPES).isRequired,
   /** children nodes  */
   children: PropTypes.node
 };

--- a/src/components/ToastNotification/__snapshots__/ToastNotification.test.js.snap
+++ b/src/components/ToastNotification/__snapshots__/ToastNotification.test.js.snap
@@ -5,8 +5,6 @@ exports[`TimedToastNotification renders properly 1`] = `
   className="alert toast-pf alert-danger alert-dismissable"
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
-  paused={false}
-  timerdelay={8000}
 >
   <button
     aria-hidden="true"


### PR DESCRIPTION
**What**:
Fix an issue when using the `TimedToastNotification`

[**Link to Storybook**](http://rawgit.com/sharvit/patternfly-react/storybook/fix-toast-props/?knob-Label=Danger%20Will%20Robinson%21&knob-Header=Great%20job%21&knob-Message=By%20default%2C%20a%20toast%20notification%27s%20timer%20expires%20after%20eight%20seconds.&knob-Type=success&knob-Dismiss=false&knob-Menu=true&knob-Action=true&selectedKind=ToastNotification&selectedStory=Toast%20Notification%20List&full=0&down=1&left=1&panelRight=0&downPanel=storybooks%2Fstorybook-addon-knobs)

When I tried to use the `TimedToastNotification` i received this error:
```
VM4358 preview.bundle.js:69198 Warning: Received `false` for a non-boolean attribute `paused`.

If you want to write it to the DOM, pass a string instead: paused="false" or paused={value.toString()}.

If you used to conditionally omit it with paused={condition && value}, pass paused={condition ? value : undefined} instead.
    in div (created by ToastNotification)
    in ToastNotification (created by TimedToastNotification)
    in TimedToastNotification (created by Toast)
    in Toast
```

It is happening because the prop `paused` is pass down into a `div`.