### PR TITLE
feat(EmptyState): Add Empty State Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -223,7 +223,7 @@
         "common-tags": "1.6.0",
         "configstore": "3.1.1",
         "core-js": "2.5.3",
-        "css-loader": "0.28.7",
+        "css-loader": "0.28.8",
         "express": "4.16.2",
         "file-loader": "0.11.2",
         "find-cache-dir": "1.0.0",
@@ -3320,9 +3320,9 @@
       }
     },
     "css-loader": {
-      "version": "0.28.7",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.7.tgz",
-      "integrity": "sha512-GxMpax8a/VgcfRrVy0gXD6yLd5ePYbXX/5zGgTVYp4wXtJklS8Z2VaUArJgc//f6/Dzil7BaJObdSv8eKKCPgg==",
+      "version": "0.28.8",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.8.tgz",
+      "integrity": "sha512-4jGj7Ag6WUZ5lQyE4te9sJLn0lgkz6HI3WDE4aw98AkW1IAKXPP4blTpPeorlLDpNsYvojo0SYgRJOdz2KbuAw==",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -4278,9 +4278,9 @@
       }
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
-      "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -4337,7 +4337,7 @@
         "contains-path": "0.1.0",
         "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.1",
+        "eslint-import-resolver-node": "0.3.2",
         "eslint-module-utils": "2.1.1",
         "has": "1.0.1",
         "lodash.cond": "4.5.2",
@@ -9630,9 +9630,9 @@
       }
     },
     "patternfly": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.35.0.tgz",
-      "integrity": "sha1-L1pbEtuIqW/TUh36z1VS5v2YMwg=",
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.35.1.tgz",
+      "integrity": "sha1-dT0dW/S2okp+akxxRVxLlp8xNTk=",
       "requires": {
         "bootstrap": "3.3.7",
         "bootstrap-datepicker": "1.6.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "dependencies": {
     "classnames": "^2.2.5",
-    "patternfly": "^3.35.0",
+    "patternfly": "^3.35.1",
     "react-bootstrap": "^0.31.5",
     "react-c3js": "^0.1.20",
     "react-fontawesome": "^1.6.1",

--- a/src/components/EmptyState/EmptyState.js
+++ b/src/components/EmptyState/EmptyState.js
@@ -1,0 +1,23 @@
+import ClassNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Empty State Component for Patternfly React
+ */
+const EmptyState = ({ children, className, ...props }) => {
+  const classes = ClassNames('blank-slate-pf', className);
+
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
+};
+EmptyState.propTypes = {
+  /** Child nodes */
+  children: PropTypes.node.isRequired,
+  /** Additional element css classes */
+  className: PropTypes.string
+};
+export default EmptyState;

--- a/src/components/EmptyState/EmptyState.stories.js
+++ b/src/components/EmptyState/EmptyState.stories.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { defaultTemplate } from '../../../storybook/decorators/storyTemplates';
+import { Button } from '../Button';
+import { EmptyState } from './index';
+
+const stories = storiesOf('EmptyState', module);
+
+stories.addDecorator(
+  defaultTemplate({
+    title: 'Empty State',
+    documentationLink:
+      'http://www.patternfly.org/pattern-library/communication/empty-state/'
+  })
+);
+
+stories.addWithInfo('EmptyState', () => {
+  return (
+    <EmptyState>
+      <EmptyState.Icon />
+      <EmptyState.Title>Empty State Title</EmptyState.Title>
+      <EmptyState.Info>
+        This is the Empty State component. The goal of a empty state pattern is
+        to provide a good first impression that helps users to achieve their
+        goals. It should be used when a view is empty because no objects exists
+        and you want to guide the user to perform specific actions.
+      </EmptyState.Info>
+      <EmptyState.Help onClick={action('help action')}>
+        For more information please see{' '}
+        <a
+          href="#"
+          onClick={event => {
+            event.preventDefault();
+          }}
+        >
+          pfExample
+        </a>
+      </EmptyState.Help>
+      <EmptyState.Action>
+        <Button
+          bsStyle="primary"
+          bsSize="large"
+          onClick={action('main action')}
+        >
+          Main Action
+        </Button>
+      </EmptyState.Action>
+      <EmptyState.Action secondary>
+        <Button
+          onClick={action('secondary action 1')}
+          title="Perform an action"
+        >
+          Secondary Action 1
+        </Button>
+        <Button
+          onClick={action('secondary action 2')}
+          title="Perform an action"
+        >
+          Secondary Action 2
+        </Button>
+        <Button
+          onClick={action('secondary action 3')}
+          title="Perform an action"
+        >
+          Secondary Action 3
+        </Button>
+      </EmptyState.Action>
+    </EmptyState>
+  );
+});

--- a/src/components/EmptyState/EmptyState.test.js
+++ b/src/components/EmptyState/EmptyState.test.js
@@ -1,0 +1,80 @@
+/* eslint-env jest */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Button } from '../Button';
+import { EmptyState } from './index';
+
+test('Empty state icon renders properly', () => {
+  const component = renderer.create(
+    <EmptyState>
+      <EmptyState.Icon />
+    </EmptyState>
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Empty state title renders properly', () => {
+  const component = renderer.create(
+    <EmptyState>
+      <EmptyState.Title>Empty State Title</EmptyState.Title>
+    </EmptyState>
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Empty state info renders properly', () => {
+  const component = renderer.create(
+    <EmptyState>
+      <EmptyState.Info>This is the Empty State component.</EmptyState.Info>
+    </EmptyState>
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Empty state help renders properly', () => {
+  const component = renderer.create(
+    <EmptyState>
+      <EmptyState.Help>
+        For more information please see <a href="#">pfExample</a>
+      </EmptyState.Help>
+    </EmptyState>
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Empty state main action renders properly', () => {
+  const component = renderer.create(
+    <EmptyState>
+      <EmptyState.Action>
+        <Button className={'btn-primary btn-lg'}>Main Action</Button>
+      </EmptyState.Action>
+    </EmptyState>
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Empty state secondary action renders properly', () => {
+  const component = renderer.create(
+    <EmptyState>
+      <EmptyState.Action secondary>
+        <Button title="Perform an action">Secondary Action 1</Button>
+        <Button title="Perform an action">Secondary Action 2</Button>
+        <Button title="Perform an action">Secondary Action 3</Button>
+      </EmptyState.Action>
+    </EmptyState>
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/EmptyState/EmptyStateAction.js
+++ b/src/components/EmptyState/EmptyStateAction.js
@@ -1,0 +1,31 @@
+import ClassNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * EmptyStateAction renders contents of the element
+ */
+const EmptyStateAction = ({ children, className, secondary, ...props }) => {
+  const classes = ClassNames(
+    {
+      'blank-slate-pf-main-action': !secondary,
+      'blank-slate-pf-secondary-action': secondary
+    },
+    className
+  );
+
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
+};
+EmptyStateAction.propTypes = {
+  /** Child node - contents of the element */
+  children: PropTypes.node.isRequired,
+  /** Additional element css classes */
+  className: PropTypes.string,
+  /** Turn on secondary container styling */
+  secondary: PropTypes.bool
+};
+export default EmptyStateAction;

--- a/src/components/EmptyState/EmptyStateHelp.js
+++ b/src/components/EmptyState/EmptyStateHelp.js
@@ -1,0 +1,23 @@
+import ClassNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * EmptyStateHelp renders contents of the element
+ */
+const EmptyStateHelp = ({ children, className, ...props }) => {
+  const classes = ClassNames('blank-slate-pf-helpLink', className);
+
+  return (
+    <p className={classes} {...props}>
+      {children}
+    </p>
+  );
+};
+EmptyStateHelp.propTypes = {
+  /** Child node - contents of the element */
+  children: PropTypes.node.isRequired,
+  /** Additional element css classes */
+  className: PropTypes.string
+};
+export default EmptyStateHelp;

--- a/src/components/EmptyState/EmptyStateIcon.js
+++ b/src/components/EmptyState/EmptyStateIcon.js
@@ -1,0 +1,30 @@
+import ClassNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Icon } from '../Icon';
+
+/**
+ * EmptyStateIcon renders element
+ */
+const EmptyStateIcon = ({ className, type, name, ...props }) => {
+  const classes = ClassNames('blank-slate-pf-icon', className);
+
+  return (
+    <div className={classes}>
+      <Icon type={type} name={name} {...props} />
+    </div>
+  );
+};
+EmptyStateIcon.propTypes = {
+  /** Additional element css classes */
+  className: PropTypes.string,
+  /** Icon type (pf or fa) */
+  type: PropTypes.string,
+  /** Name of the icon font */
+  name: PropTypes.string
+};
+EmptyStateIcon.defaultProps = {
+  type: 'pf',
+  name: 'add-circle-o'
+};
+export default EmptyStateIcon;

--- a/src/components/EmptyState/EmptyStateInfo.js
+++ b/src/components/EmptyState/EmptyStateInfo.js
@@ -1,0 +1,23 @@
+import ClassNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * EmptyStateInfo renders contents of the element
+ */
+const EmptyStateInfo = ({ children, className, ...props }) => {
+  const classes = ClassNames('blank-slate-pf-info', className);
+
+  return (
+    <p className={classes} {...props}>
+      {children}
+    </p>
+  );
+};
+EmptyStateInfo.propTypes = {
+  /** Child node - contents of the element */
+  children: PropTypes.node.isRequired,
+  /** Additional element css classes */
+  className: PropTypes.string
+};
+export default EmptyStateInfo;

--- a/src/components/EmptyState/EmptyStateTitle.js
+++ b/src/components/EmptyState/EmptyStateTitle.js
@@ -1,0 +1,22 @@
+import ClassNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * EmptyStateTitle renders contents of the element
+ */
+const EmptyStateTitle = ({ children, className, ...props }) => {
+  const classes = ClassNames('h1', 'blank-slate-pf-title', className);
+  return (
+    <h4 className={classes} {...props}>
+      {children}
+    </h4>
+  );
+};
+EmptyStateTitle.propTypes = {
+  /** Child node - contents of the element */
+  children: PropTypes.node.isRequired,
+  /** Additional element css classes */
+  className: PropTypes.string
+};
+export default EmptyStateTitle;

--- a/src/components/EmptyState/__snapshots__/EmptyState.test.js.snap
+++ b/src/components/EmptyState/__snapshots__/EmptyState.test.js.snap
@@ -1,0 +1,110 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Empty state help renders properly 1`] = `
+<div
+  className="blank-slate-pf"
+>
+  <p
+    className="blank-slate-pf-helpLink"
+  >
+    For more information please see 
+    <a
+      href="#"
+    >
+      pfExample
+    </a>
+  </p>
+</div>
+`;
+
+exports[`Empty state icon renders properly 1`] = `
+<div
+  className="blank-slate-pf"
+>
+  <div
+    className="blank-slate-pf-icon"
+  >
+    <span
+      aria-hidden="true"
+      className="pficon pficon-add-circle-o"
+    />
+  </div>
+</div>
+`;
+
+exports[`Empty state info renders properly 1`] = `
+<div
+  className="blank-slate-pf"
+>
+  <p
+    className="blank-slate-pf-info"
+  >
+    This is the Empty State component.
+  </p>
+</div>
+`;
+
+exports[`Empty state main action renders properly 1`] = `
+<div
+  className="blank-slate-pf"
+>
+  <div
+    className="blank-slate-pf-main-action"
+  >
+    <button
+      className="btn-primary btn-lg btn btn-default"
+      disabled={false}
+      type="button"
+    >
+      Main Action
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Empty state secondary action renders properly 1`] = `
+<div
+  className="blank-slate-pf"
+>
+  <div
+    className="blank-slate-pf-secondary-action"
+  >
+    <button
+      className="btn btn-default"
+      disabled={false}
+      title="Perform an action"
+      type="button"
+    >
+      Secondary Action 1
+    </button>
+    <button
+      className="btn btn-default"
+      disabled={false}
+      title="Perform an action"
+      type="button"
+    >
+      Secondary Action 2
+    </button>
+    <button
+      className="btn btn-default"
+      disabled={false}
+      title="Perform an action"
+      type="button"
+    >
+      Secondary Action 3
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Empty state title renders properly 1`] = `
+<div
+  className="blank-slate-pf"
+>
+  <h4
+    className="h1 blank-slate-pf-title"
+  >
+    Empty State Title
+  </h4>
+</div>
+`;

--- a/src/components/EmptyState/index.js
+++ b/src/components/EmptyState/index.js
@@ -1,0 +1,21 @@
+import EmptyState from './EmptyState';
+import EmptyStateIcon from './EmptyStateIcon';
+import EmptyStateTitle from './EmptyStateTitle';
+import EmptyStateInfo from './EmptyStateInfo';
+import EmptyStateHelp from './EmptyStateHelp';
+import EmptyStateAction from './EmptyStateAction';
+
+EmptyState.Title = EmptyStateTitle;
+EmptyState.Icon = EmptyStateIcon;
+EmptyState.Info = EmptyStateInfo;
+EmptyState.Help = EmptyStateHelp;
+EmptyState.Action = EmptyStateAction;
+
+export {
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateTitle,
+  EmptyStateInfo,
+  EmptyStateHelp,
+  EmptyStateAction
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ export * from './components/Breadcrumb';
 export * from './components/Button';
 export * from './components/Dropdown';
 export * from './components/DropdownKebab';
+export * from './components/EmptyState';
 export * from './components/Filter';
 export * from './components/Grid';
 export * from './components/Icon';


### PR DESCRIPTION
What:
Adding Empty State component

[Link to Storybook](https://cdcabrera.github.io/patternfly-react/?knob-Label=Danger%20Will%20Robinson%21&selectedKind=EmptyState&selectedStory=EmptyState&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)

closes #82 related to [Patternfly PR 900](https://github.com/patternfly/patternfly/pull/900)

@serenamarie125 

#### Remaining pieces
- [x] Dependency around a slight CSS/styling modification to Patternfly. Research & implement style that appears to only be in Angular PF, currently. [See PR 900](https://github.com/patternfly/patternfly/pull/900)
  - May need some input around adding this Patternfly
- [x] Snapshot checkin, once the styling/CSS and DOM has been tweaked
- [ ] ~~Heading tag, uses an H4 with ```class="h1...```, per the AngularPF template, perhaps a H1, [like the Foreman implementation](https://github.com/theforeman/foreman/pull/5024)~~
- [x] ~~[Input on handling the ```className``` and ```...props``` not being placed on the root element for the icon component](https://github.com/patternfly/patternfly-react/pull/141/files#diff-033de1e06b346ba6550374d7294f8d5eR14)~~
- [x] Addon-actions
- [x] Rebase
  
  