### PR TITLE
refactor(ToastNotification): Reuse Alert inside ToastNotification

### DIFF
--- a/src/components/Alert/Alert.js
+++ b/src/components/Alert/Alert.js
@@ -1,6 +1,7 @@
 import ClassNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { getClassName, getIconName } from './helpers';
 import { ALERT_TYPES, ALERT_TYPE_ERROR } from './constants';
@@ -9,7 +10,7 @@ import { ALERT_TYPES, ALERT_TYPE_ERROR } from './constants';
  * Alert Component for Patternfly React
  */
 const Alert = ({ children, className, onDismiss, type, ...props }) => {
-  const alertClass = ClassNames(className, 'alert', getClassName(type), {
+  const alertClass = ClassNames('alert', className, getClassName(type), {
     'alert-dismissable': onDismiss
   });
 
@@ -18,14 +19,9 @@ const Alert = ({ children, className, onDismiss, type, ...props }) => {
   return (
     <div className={alertClass} {...props}>
       {onDismiss && (
-        <button
-          type="button"
-          className="close"
-          aria-hidden="true"
-          onClick={onDismiss}
-        >
+        <Button bsClass="close" aria-hidden="true" onClick={onDismiss}>
           <Icon type="pf" name="close" />
-        </button>
+        </Button>
       )}
       <Icon type="pf" name={iconName} />
       {children}

--- a/src/components/Alert/Alert.test.js
+++ b/src/components/Alert/Alert.test.js
@@ -4,14 +4,23 @@ import React from 'react';
 import Alert from './Alert';
 import renderer from 'react-test-renderer';
 
-test('Alert renders properly', () => {
-  const handleAlertClose = jest.fn();
+const testAlertSnapshot = (type, onDismiss) => {
   const component = renderer.create(
-    <Alert type="danger" onDismiss={handleAlertClose}>
-      <span>Danger Will Robinson!</span>
+    <Alert type={type} onDismiss={onDismiss}>
+      <span>Alert Message!</span>
     </Alert>
   );
 
-  let tree = component.toJSON();
+  const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
+};
+
+Alert.ALERT_TYPES.forEach(type => {
+  test(`Alert ${type} renders properly`, () => {
+    testAlertSnapshot(type);
+  });
+
+  test(`Alert ${type} renders properly with dismiss button`, () => {
+    testAlertSnapshot(type, jest.fn());
+  });
 });

--- a/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -1,12 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Alert renders properly 1`] = `
+exports[`Alert danger renders properly 1`] = `
+<div
+  className="alert alert-danger"
+>
+  <span
+    aria-hidden="true"
+    className="pficon pficon-error-circle-o"
+  />
+  <span>
+    Alert Message!
+  </span>
+</div>
+`;
+
+exports[`Alert danger renders properly with dismiss button 1`] = `
 <div
   className="alert alert-danger alert-dismissable"
 >
   <button
     aria-hidden="true"
-    className="close"
+    className="close close-default"
+    disabled={false}
     onClick={[Function]}
     type="button"
   >
@@ -20,7 +35,167 @@ exports[`Alert renders properly 1`] = `
     className="pficon pficon-error-circle-o"
   />
   <span>
-    Danger Will Robinson!
+    Alert Message!
+  </span>
+</div>
+`;
+
+exports[`Alert error renders properly 1`] = `
+<div
+  className="alert alert-danger"
+>
+  <span
+    aria-hidden="true"
+    className="pficon pficon-error-circle-o"
+  />
+  <span>
+    Alert Message!
+  </span>
+</div>
+`;
+
+exports[`Alert error renders properly with dismiss button 1`] = `
+<div
+  className="alert alert-danger alert-dismissable"
+>
+  <button
+    aria-hidden="true"
+    className="close close-default"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      className="pficon pficon-close"
+    />
+  </button>
+  <span
+    aria-hidden="true"
+    className="pficon pficon-error-circle-o"
+  />
+  <span>
+    Alert Message!
+  </span>
+</div>
+`;
+
+exports[`Alert info renders properly 1`] = `
+<div
+  className="alert alert-info"
+>
+  <span
+    aria-hidden="true"
+    className="pficon pficon-info"
+  />
+  <span>
+    Alert Message!
+  </span>
+</div>
+`;
+
+exports[`Alert info renders properly with dismiss button 1`] = `
+<div
+  className="alert alert-info alert-dismissable"
+>
+  <button
+    aria-hidden="true"
+    className="close close-default"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      className="pficon pficon-close"
+    />
+  </button>
+  <span
+    aria-hidden="true"
+    className="pficon pficon-info"
+  />
+  <span>
+    Alert Message!
+  </span>
+</div>
+`;
+
+exports[`Alert success renders properly 1`] = `
+<div
+  className="alert alert-success"
+>
+  <span
+    aria-hidden="true"
+    className="pficon pficon-ok"
+  />
+  <span>
+    Alert Message!
+  </span>
+</div>
+`;
+
+exports[`Alert success renders properly with dismiss button 1`] = `
+<div
+  className="alert alert-success alert-dismissable"
+>
+  <button
+    aria-hidden="true"
+    className="close close-default"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      className="pficon pficon-close"
+    />
+  </button>
+  <span
+    aria-hidden="true"
+    className="pficon pficon-ok"
+  />
+  <span>
+    Alert Message!
+  </span>
+</div>
+`;
+
+exports[`Alert warning renders properly 1`] = `
+<div
+  className="alert alert-warning"
+>
+  <span
+    aria-hidden="true"
+    className="pficon pficon-warning-triangle-o"
+  />
+  <span>
+    Alert Message!
+  </span>
+</div>
+`;
+
+exports[`Alert warning renders properly with dismiss button 1`] = `
+<div
+  className="alert alert-warning alert-dismissable"
+>
+  <button
+    aria-hidden="true"
+    className="close close-default"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      className="pficon pficon-close"
+    />
+  </button>
+  <span
+    aria-hidden="true"
+    className="pficon pficon-warning-triangle-o"
+  />
+  <span>
+    Alert Message!
   </span>
 </div>
 `;

--- a/src/components/ToastNotification/TimedToastNotification.js
+++ b/src/components/ToastNotification/TimedToastNotification.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { bindMethods } from '../../common/helpers';
 import Timer from '../../common/Timer';
 import ToastNotification from './ToastNotification';
-import { TOAST_NOTIFICATION_TYPES } from './constants';
 
 /**
  * TimedToastNotification Component for Patternfly React
@@ -72,31 +71,26 @@ class TimedToastNotification extends React.Component {
 }
 
 TimedToastNotification.propTypes = {
+  ...ToastNotification.propTypes,
   /** pauses notification from dismissing */
   paused: PropTypes.bool,
   /** persistent keeps the notification up endlessly until closed */
   persistent: PropTypes.bool,
   /** timer delay until dismiss */
   timerdelay: PropTypes.number,
-  /** additional notification classes */
-  className: PropTypes.string,
-  /** callback when alert is dismissed  */
-  onDismiss: PropTypes.func,
   /** onMouseEnter callback */
   onMouseEnter: PropTypes.func,
   /** onMouseLeave callback */
-  onMouseLeave: PropTypes.func,
-  /** the type of alert  */
-  type: PropTypes.oneOf(TOAST_NOTIFICATION_TYPES).isRequired,
-  /** children nodes  */
-  children: PropTypes.node
+  onMouseLeave: PropTypes.func
 };
 TimedToastNotification.defaultProps = {
+  ...ToastNotification.defaultProps,
   paused: false,
-  type: 'error',
   timerdelay: 8000
 };
 
-TimedToastNotification.TOAST_NOTIFICATION_TYPES = TOAST_NOTIFICATION_TYPES;
+TimedToastNotification.TOAST_NOTIFICATION_TYPES = [
+  ...ToastNotification.TOAST_NOTIFICATION_TYPES
+];
 
 export default TimedToastNotification;

--- a/src/components/ToastNotification/ToastNotification.js
+++ b/src/components/ToastNotification/ToastNotification.js
@@ -1,65 +1,23 @@
 import ClassNames from 'classnames';
 import React from 'react';
-import PropTypes from 'prop-types';
-import { Button } from '../Button';
-import { TOAST_NOTIFICATION_TYPES } from './constants';
+import { Alert } from '../Alert';
 
 /**
  * ToastNotification Component for Patternfly React
  */
-const ToastNotification = ({
-  className,
-  onDismiss,
-  type,
-  children,
-  ...props
-}) => {
-  const notificationClasses = ClassNames(
-    {
-      alert: true,
-      'toast-pf': true,
-      'alert-danger': type === 'danger' || type === 'error',
-      'alert-warning': type === 'warning',
-      'alert-success': type === 'success',
-      'alert-info': type === 'info',
-      'alert-dismissable': onDismiss
-    },
-    className
-  );
-  const iconClass = ClassNames({
-    pficon: true,
-    'pficon-error-circle-o': type === 'danger' || type === 'error',
-    'pficon-warning-triangle-o': type === 'warning',
-    'pficon-ok': type === 'success',
-    'pficon-info': type === 'info'
-  });
+const ToastNotification = ({ children, className, ...props }) => {
+  const notificationClasses = ClassNames('toast-pf', className);
 
   return (
-    <div className={notificationClasses} {...props}>
-      {onDismiss && (
-        <Button bsClass="close" aria-hidden="true" onClick={onDismiss}>
-          <span className="pficon pficon-close" />
-        </Button>
-      )}
-      <span className={iconClass} />
+    <Alert className={notificationClasses} {...props}>
       {children}
-    </div>
+    </Alert>
   );
 };
-ToastNotification.propTypes = {
-  /** additional notification classes */
-  className: PropTypes.string,
-  /** callback when alert is dismissed  */
-  onDismiss: PropTypes.func,
-  /** the type of alert  */
-  type: PropTypes.oneOf(TOAST_NOTIFICATION_TYPES).isRequired,
-  /** children nodes  */
-  children: PropTypes.node
-};
-ToastNotification.defaultProps = {
-  type: 'error'
-};
 
-ToastNotification.TOAST_NOTIFICATION_TYPES = TOAST_NOTIFICATION_TYPES;
+ToastNotification.propTypes = { ...Alert.propTypes };
+ToastNotification.defaultProps = { ...Alert.defaultProps };
+
+ToastNotification.TOAST_NOTIFICATION_TYPES = [...Alert.ALERT_TYPES];
 
 export default ToastNotification;

--- a/src/components/ToastNotification/ToastNotification.test.js
+++ b/src/components/ToastNotification/ToastNotification.test.js
@@ -6,39 +6,28 @@ import renderer from 'react-test-renderer';
 import ToastNotification from './ToastNotification';
 import TimedToastNotification from './TimedToastNotification';
 
-test('ToastNotification renders properly', () => {
+const testToastNotificationSnapshot = Component => {
   const handleNotificationClose = jest.fn();
   const handleOnMouseEnter = jest.fn();
   const handleOnMouseLeave = jest.fn();
   const component = renderer.create(
-    <ToastNotification
+    <Component
       type="danger"
       onDismiss={handleNotificationClose}
       onMouseEnter={handleOnMouseEnter}
       onMouseLeave={handleOnMouseLeave}
     >
       <span>Danger Will Robinson!</span>
-    </ToastNotification>
+    </Component>
   );
   let tree = component.toJSON();
   expect(tree).toMatchSnapshot();
+};
+
+test('ToastNotification renders properly', () => {
+  testToastNotificationSnapshot(ToastNotification);
 });
 
 test('TimedToastNotification renders properly', () => {
-  const handleNotificationClose = jest.fn();
-  const handleOnMouseEnter = jest.fn();
-  const handleOnMouseLeave = jest.fn();
-  const component = renderer.create(
-    <TimedToastNotification
-      type="danger"
-      onDismiss={handleNotificationClose}
-      onMouseEnter={handleOnMouseEnter}
-      onMouseLeave={handleOnMouseLeave}
-      paused={false}
-    >
-      <span>Danger Will Robinson!</span>
-    </TimedToastNotification>
-  );
-  let tree = component.toJSON();
-  expect(tree).toMatchSnapshot();
+  testToastNotificationSnapshot(TimedToastNotification);
 });

--- a/src/components/ToastNotification/__snapshots__/ToastNotification.test.js.snap
+++ b/src/components/ToastNotification/__snapshots__/ToastNotification.test.js.snap
@@ -14,10 +14,12 @@ exports[`TimedToastNotification renders properly 1`] = `
     type="button"
   >
     <span
+      aria-hidden="true"
       className="pficon pficon-close"
     />
   </button>
   <span
+    aria-hidden="true"
     className="pficon pficon-error-circle-o"
   />
   <span>
@@ -40,10 +42,12 @@ exports[`ToastNotification renders properly 1`] = `
     type="button"
   >
     <span
+      aria-hidden="true"
       className="pficon pficon-close"
     />
   </button>
   <span
+    aria-hidden="true"
     className="pficon pficon-error-circle-o"
   />
   <span>

--- a/src/components/ToastNotification/constants.js
+++ b/src/components/ToastNotification/constants.js
@@ -1,7 +1,0 @@
-export const TOAST_NOTIFICATION_TYPES = [
-  'danger',
-  'error',
-  'warning',
-  'success',
-  'info'
-];


### PR DESCRIPTION
**What**:
Refactor Alert and ToastNotification:
* Reuse the `Alert` component inside the `ToastNotification` component.
* Replace `Alert` `<button />` with `<Button />`
* Add tests to `Alert.test`

[**Link to Storybook**](http://rawgit.com/sharvit/patternfly-react/storybook/refactor/reuse-alert-in-toast/?knob-Label=Danger%20Will%20Robinson%21&knob-Header=Great%20job%21&knob-Message=This%20is%20really%20working%20out.&knob-Type=success&knob-Dismiss=false&knob-Menu=true&knob-Action=true&selectedKind=ToastNotification&selectedStory=Toast%20Notification&full=0&down=1&left=1&panelRight=0&downPanel=storybooks%2Fstorybook-addon-knobs)