### PR TITLE
docs(addon-info): lock addon-info to 3.2.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@hypnosphi/fuse.js": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz",
-      "integrity": "sha1-6pn2EhtKjwZbTHH4VZXbJxRJiAc=",
-      "dev": true
-    },
     "@semantic-release/commit-analyzer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-2.0.0.tgz",
@@ -94,27 +88,27 @@
       }
     },
     "@storybook/addon-actions": {
-      "version": "3.2.18",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.2.18.tgz",
-      "integrity": "sha512-jIbNxYXm3MyPECcPWZ9Vxuq31/rwq/oPXhfPpf4xD9sdQcfwm/5on2d75UJOXKio60xWagP4RpECz7d3uc6nJA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.3.3.tgz",
+      "integrity": "sha512-5kpo3y3xpv2VePSOIh1g6aOaLcW+/nsmpLXG8QShIvdOi8zDk718t+IpO7b8XknHLdIIoIwiZsovegdJps33sA==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "3.2.18",
         "deep-equal": "1.0.1",
-        "json-stringify-safe": "5.0.1",
+        "global": "4.3.2",
+        "make-error": "1.3.2",
         "prop-types": "15.6.0",
         "react-inspector": "2.2.2",
         "uuid": "3.1.0"
       }
     },
     "@storybook/addon-info": {
-      "version": "3.2.18",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-3.2.18.tgz",
-      "integrity": "sha512-InEJmMUgWHpP4O0Q+Wq74p/K28cNf6qcW6LriOkYvFqES6p1LdMJUvbRoblpQh6T5gI88weGVS50+wRDLBKCdw==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-info/-/addon-info-3.2.12.tgz",
+      "integrity": "sha512-y26PbKy/8t162q3fRhe/NklziZN9wKbjxAta/OF3VSBnm97uDZZj7rRikVAqWoe+2oX+uwEvTpnTeIIcuUDWuw==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "3.2.18",
-        "@storybook/components": "3.2.18",
+        "@storybook/addons": "3.3.3",
+        "@storybook/components": "3.3.3",
         "babel-runtime": "6.26.0",
         "global": "4.3.2",
         "marksy": "2.0.1",
@@ -129,7 +123,7 @@
       "integrity": "sha512-Xnd54kx47boM5Xl0sVMqblcki3Z8Z9hS8CIWz5CCJCfxQKx7mhFtcOmHrIqUH2oUZhhFSj+aFrRx1zPcFcPaZQ==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "3.2.18",
+        "@storybook/addons": "3.3.3",
         "babel-runtime": "6.26.0",
         "deep-equal": "1.0.1",
         "global": "4.3.2",
@@ -144,45 +138,47 @@
       }
     },
     "@storybook/addon-links": {
-      "version": "3.2.18",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.2.18.tgz",
-      "integrity": "sha512-X96TNRA0x0rWWVweIQCDM84GJdQpAXQutxnARvskV0RD6bf8Bhq7nw3FVzElNilnFyfhtFzYVqCUlEOAJcKEgg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-3.3.3.tgz",
+      "integrity": "sha512-5Hq5GG9REIu6HXk+KerYui5pKenKd66QZaWpZ6dCiQ5I2rNw41t959boEMDRNy05mkckKYLbawBELRNzf9PEuQ==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "3.2.18"
+        "@storybook/components": "3.3.3",
+        "global": "4.3.2",
+        "prop-types": "15.6.0"
       }
     },
     "@storybook/addons": {
-      "version": "3.2.18",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.2.18.tgz",
-      "integrity": "sha512-I1oJhimBZiyrDa2UxorXhBBGapAIa+KxF8thtCUWmFgToeWhlHnRepQiRE+mCDM2yjSQpmTN+md/W8DPcLIHag==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-3.3.3.tgz",
+      "integrity": "sha512-IhOdLowoWGdaQ6E37WpMeD/xlQXq0fSNpvDUQYaaTCyFT5f1fvo8kqfcrD2gw3xvsRr6rFqFCMFlmn9+qAfp1A==",
       "dev": true
     },
     "@storybook/channel-postmessage": {
-      "version": "3.2.18",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.2.18.tgz",
-      "integrity": "sha512-a3SSLYlVf61BaAcM2pA/W4Rhdh/RCf1oise22TXfgC83ELUyRksKQX/Pm7FKn2NgffrZb5aRIUQRzfe3LH/www==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-3.3.3.tgz",
+      "integrity": "sha512-iNrHUhHhs81wfjdJJHMKshOFP66cGQG275N91OxcZwAQW+mByzvGhONQadLP3TPrkDQ/L8aoiXA9Tvu//oHiHw==",
       "dev": true,
       "requires": {
-        "@storybook/channels": "3.2.18",
+        "@storybook/channels": "3.3.3",
         "global": "4.3.2",
         "json-stringify-safe": "5.0.1"
       }
     },
     "@storybook/channels": {
-      "version": "3.2.18",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.2.18.tgz",
-      "integrity": "sha512-7+3Kic5FRWyojff/CA4wfhI24xxbXmQzdVLx0gUZm8r4+h/3JSt8hVfhJeXkS+GEvo852PRS/AOHnN4ENKw9uw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-3.3.3.tgz",
+      "integrity": "sha512-Z254W5TIvHvqJi7yxrlmKuaBwnWhuOBnNRkUidFzFjQtV80ATUZLLtTty0ppsQmLTB+Y9X2T14Pc1V4wZ4rJ7g==",
       "dev": true
     },
     "@storybook/components": {
-      "version": "3.2.18",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.2.18.tgz",
-      "integrity": "sha512-jvwUewMiwG+svDqLxu6YyHQdBdvDQ5etA5dUplpx7aPW4bZog+DHkZ0RLgwHadxbeff1qs/RXlz23D3El6BDxA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-3.3.3.tgz",
+      "integrity": "sha512-rRkKV2pmksUNoUy2fG1NL/VnjpfCDb198M0xs94dp8Uw3kUiT4UbrXFeCoOvywYw+ZmL1K79N4t2TsshQ6DtfA==",
       "dev": true,
       "requires": {
         "glamor": "2.20.40",
-        "glamorous": "4.11.0",
+        "glamorous": "4.11.2",
         "prop-types": "15.6.0"
       }
     },
@@ -203,13 +199,13 @@
       "integrity": "sha512-/TWoVYHfoUnEAjcEj463zRIA7SJjB6RIzShFzI2HtJw+P2EdT8mFN2EYGdsuGHQqkbGSC3owHSy1Jxuy1GVuqQ==",
       "dev": true,
       "requires": {
-        "@storybook/addon-actions": "3.2.18",
-        "@storybook/addon-links": "3.2.18",
-        "@storybook/addons": "3.2.18",
-        "@storybook/channel-postmessage": "3.2.18",
-        "@storybook/ui": "3.2.18",
+        "@storybook/addon-actions": "3.3.3",
+        "@storybook/addon-links": "3.3.3",
+        "@storybook/addons": "3.3.3",
+        "@storybook/channel-postmessage": "3.3.3",
+        "@storybook/ui": "3.3.3",
         "airbnb-js-shims": "1.4.0",
-        "autoprefixer": "7.2.3",
+        "autoprefixer": "7.2.4",
         "babel-core": "6.26.0",
         "babel-loader": "7.1.2",
         "babel-plugin-react-docgen": "1.8.1",
@@ -224,7 +220,7 @@
         "case-sensitive-paths-webpack-plugin": "2.1.1",
         "chalk": "2.3.0",
         "commander": "2.12.2",
-        "common-tags": "1.5.1",
+        "common-tags": "1.6.0",
         "configstore": "3.1.1",
         "core-js": "2.5.3",
         "css-loader": "0.28.7",
@@ -232,7 +228,7 @@
         "file-loader": "0.11.2",
         "find-cache-dir": "1.0.0",
         "glamor": "2.20.40",
-        "glamorous": "4.11.0",
+        "glamorous": "4.11.2",
         "global": "4.3.2",
         "json-loader": "0.5.7",
         "json-stringify-safe": "5.0.1",
@@ -240,7 +236,7 @@
         "lodash.flattendeep": "4.4.0",
         "lodash.pick": "4.4.0",
         "postcss-flexbugs-fixes": "3.2.0",
-        "postcss-loader": "2.0.9",
+        "postcss-loader": "2.0.10",
         "prop-types": "15.6.0",
         "qs": "6.5.1",
         "react-modal": "2.4.1",
@@ -267,18 +263,6 @@
             "schema-utils": "0.3.0"
           }
         }
-      }
-    },
-    "@storybook/react-fuzzy": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@storybook/react-fuzzy/-/react-fuzzy-0.4.3.tgz",
-      "integrity": "sha512-TaFbDiEc/34eiAFyOjyvrh5tOqoKscyVH2BHJB15cQ8RepccX3LKIBqSNr7IUi1jmMB5aWjeefvJywPQf13ByQ==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "classnames": "2.2.5",
-        "fuse.js": "3.2.0",
-        "prop-types": "15.6.0"
       }
     },
     "@storybook/react-komposer": {
@@ -343,19 +327,18 @@
       }
     },
     "@storybook/ui": {
-      "version": "3.2.18",
-      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.2.18.tgz",
-      "integrity": "sha512-n3j//YF5gbTRZHrdIREGK8C+weaCF/pu4iWKu4Pty8rbMjrghkgrhENga2XaFvEOfTsBUc2ldXCCjNw0tJOGWg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.3.3.tgz",
+      "integrity": "sha512-EwuMeIAh/R88ZGCIwCVBS2MYYCCyPxhjJ8FJo29YtaXhFXosnXsyG0Ws8cR8RJ6IbNDFO4OjKtrmWKWoUa/BYQ==",
       "dev": true,
       "requires": {
-        "@hypnosphi/fuse.js": "3.0.9",
-        "@storybook/components": "3.2.18",
+        "@storybook/components": "3.3.3",
         "@storybook/mantra-core": "1.7.2",
-        "@storybook/react-fuzzy": "0.4.3",
         "@storybook/react-komposer": "2.0.3",
         "babel-runtime": "6.26.0",
         "deep-equal": "1.0.1",
         "events": "1.1.1",
+        "fuse.js": "3.2.0",
         "global": "4.3.2",
         "json-stringify-safe": "5.0.1",
         "keycode": "2.1.9",
@@ -365,10 +348,11 @@
         "podda": "1.2.2",
         "prop-types": "15.6.0",
         "qs": "6.5.1",
+        "react-fuzzy": "0.5.1",
         "react-icons": "2.2.7",
         "react-inspector": "2.2.2",
         "react-modal": "3.1.10",
-        "react-split-pane": "0.1.72",
+        "react-split-pane": "0.1.74",
         "react-treebeard": "2.1.0",
         "redux": "3.7.2"
       },
@@ -393,9 +377,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.0.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.31.tgz",
-      "integrity": "sha512-ft7OuDGUo39e+9LGwUewf2RyEaNBOjWbHUmD5bzjNuSuDabccE/1IuO7iR0dkzLjVUKxTMq69E+FmKfbgBcfbQ==",
+      "version": "16.0.34",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.34.tgz",
+      "integrity": "sha512-Ee66fX2qMsDnDq7sPnDtq1bGoo479j6Fo1BlSnne+L5rp6ndzBUgz72+MRNuN56zg9uuteRCkJAMdDJEX2Uqig==",
       "dev": true
     },
     "abab": {
@@ -421,9 +405,9 @@
       }
     },
     "acorn": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -506,7 +490,7 @@
         "array.prototype.flatten": "1.1.1",
         "es5-shim": "4.5.10",
         "es6-shim": "0.35.3",
-        "function.prototype.name": "1.0.3",
+        "function.prototype.name": "1.1.0",
         "object.entries": "1.0.4",
         "object.getownpropertydescriptors": "2.0.3",
         "object.values": "1.0.4",
@@ -812,16 +796,16 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.3.tgz",
-      "integrity": "sha512-dqzVGiz3v934+s3YZA6nk7tAs9xuTz5wMJbX1M+L4cY/MTNkOUqP61c1GWkEVlUL/PEy1pKRSCFuoRZrXYx9qA==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.4.tgz",
+      "integrity": "sha512-am8jJ7Rbh1sy7FvLvNxxQScWvhv2FwLAS3bIhvrZpx9HbX5PEcc/7v6ecgpWuiu0Dwlj+p/z/1boHd8x60JFwA==",
       "dev": true,
       "requires": {
-        "browserslist": "2.10.0",
-        "caniuse-lite": "1.0.30000784",
+        "browserslist": "2.11.0",
+        "caniuse-lite": "1.0.30000787",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
-        "postcss": "6.0.14",
+        "postcss": "6.0.15",
         "postcss-value-parser": "3.3.0"
       }
     },
@@ -2002,7 +1986,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.10.0",
+        "browserslist": "2.11.0",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -2361,9 +2345,9 @@
       }
     },
     "bowser": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.8.1.tgz",
-      "integrity": "sha512-NMPaR8ILtdLSWzxQtEs16XbxMcY8ohWGQ5V+TZSJS3fNUt/PBAGkF6YWO9B/4qWE23bK3o0moQKq8UyFEosYkA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.1.tgz",
+      "integrity": "sha512-UXti1JB6oK8hO983AImunnV6j/fqAEeDlPXh99zhsP5g32oLbxJJ6qcOaUesR+tqqhnUVQHlRJyD0dfiV0Hxaw==",
       "dev": true
     },
     "brace-expansion": {
@@ -2487,13 +2471,13 @@
       }
     },
     "browserslist": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.10.0.tgz",
-      "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.0.tgz",
+      "integrity": "sha512-mNYp0RNeu1xueGuJFSXkU+K0nH+dBE/gcjtyhtNKfU8hwdrVIfoA7i5iFSjOmzkGdL2QaO7YX9ExiVPE7AY9JA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000784",
-        "electron-to-chromium": "1.3.29"
+        "caniuse-lite": "1.0.30000787",
+        "electron-to-chromium": "1.3.30"
       }
     },
     "bser": {
@@ -2603,7 +2587,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000784",
+        "caniuse-db": "1.0.30000787",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -2614,22 +2598,22 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000784",
-            "electron-to-chromium": "1.3.29"
+            "caniuse-db": "1.0.30000787",
+            "electron-to-chromium": "1.3.30"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000784",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000784.tgz",
-      "integrity": "sha1-G+lQEtlInHcZB0+BruV9vf/mNhs=",
+      "version": "1.0.30000787",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000787.tgz",
+      "integrity": "sha1-ygeigb5Taoi9f6yWuolfPPU/gRs=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000784",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000784.tgz",
-      "integrity": "sha1-EpztdOmhKApEGIC2zSvOMO9Z5sA=",
+      "version": "1.0.30000787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000787.tgz",
+      "integrity": "sha1-p2xPodasAGQER+yDwefGsz3WFcU=",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {
@@ -2669,6 +2653,17 @@
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
         "supports-color": "4.5.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "change-emitter": {
@@ -3010,9 +3005,9 @@
       }
     },
     "common-tags": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.5.1.tgz",
-      "integrity": "sha512-NrUYGY5TApAk9KB+IZXkR3GR4tA3g26HDsoiGt4kCMHZ727gOGkC+UNfq0Z22jE15bLkc/6RV5Jw1RBW6Usg6A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.6.0.tgz",
+      "integrity": "sha512-sgmgEodNLbxnSSoR5a2xH23CoDJ9J5MKsJS/tqplfmJLpikG0oWMpAb+tM8ERQCMpp9I+ERf6SYl158G6GwX0w==",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
@@ -3491,7 +3486,7 @@
           "dev": true,
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000784",
+            "caniuse-db": "1.0.30000787",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -3504,8 +3499,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000784",
-            "electron-to-chromium": "1.3.29"
+            "caniuse-db": "1.0.30000787",
+            "electron-to-chromium": "1.3.30"
           }
         },
         "chalk": {
@@ -3894,11 +3889,20 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
-    "electron-to-chromium": {
-      "version": "1.3.29",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.29.tgz",
-      "integrity": "sha1-elgja5VGjD52YAkTSFItZddzazY=",
+    "electron-releases": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/electron-releases/-/electron-releases-2.1.0.tgz",
+      "integrity": "sha512-cyKFD1bTE/UgULXfaueIN1k5EPFzs+FRc/rvCY5tIynefAPqopQEgjr0EzY+U3Dqrk/G4m9tXSPuZ77v6dL/Rw==",
       "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.30",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz",
+      "integrity": "sha512-zx1Prv7kYLfc4OA60FhxGbSo4qrEjgSzpo1/37i7l9ltXPYOoQBtjQxY9KmsgfHnBxHlBGXwLlsbt/gub1w5lw==",
+      "dev": true,
+      "requires": {
+        "electron-releases": "2.1.0"
+      }
     },
     "elliptic": {
       "version": "6.4.0",
@@ -4400,7 +4404,7 @@
         "doctrine": "1.5.0",
         "has": "1.0.1",
         "jsx-ast-utils": "1.4.1",
-        "object.assign": "4.0.4"
+        "object.assign": "4.1.0"
       },
       "dependencies": {
         "doctrine": {
@@ -4427,7 +4431,7 @@
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -5888,9 +5892,9 @@
       "dev": true
     },
     "function.prototype.name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
-      "integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
+      "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
@@ -6005,9 +6009,9 @@
       }
     },
     "git-up": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-2.0.9.tgz",
-      "integrity": "sha1-IZv9J8gtrurYSVvrOG3Bjq5jY20=",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-2.0.10.tgz",
+      "integrity": "sha512-2v4UN3qV2RGypD9QpmUjpk+4+RlYpW8GFuiZqQnKmvei08HsFPd0RfbDvEhnE4wBvnYs8ORVtYpOFuuCEmBVBw==",
       "dev": true,
       "requires": {
         "is-ssh": "1.3.0",
@@ -6020,7 +6024,7 @@
       "integrity": "sha1-vkkCThS4SHVTQ2tFcri0OVMvqHE=",
       "dev": true,
       "requires": {
-        "git-up": "2.0.9"
+        "git-up": "2.0.10"
       }
     },
     "github": {
@@ -6061,9 +6065,9 @@
       }
     },
     "glamorous": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.11.0.tgz",
-      "integrity": "sha512-qWRmq5HZ6kGnp09/z3I0L5ZWZF8PX9W90ED8Ndm3ccfaamWRcEURYilk3zA1M1VW1xJlV28+aD2XlwbQF5YlSw==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/glamorous/-/glamorous-4.11.2.tgz",
+      "integrity": "sha512-fqeRIlPR/+92i7u+cEPjLVtoy1l9i8aRsTZGnhf0X65UAQAi8f8yHQnz5IkYd8UgIa5hAIII+GE5czz7MhOwqw==",
       "dev": true,
       "requires": {
         "brcast": "3.0.1",
@@ -6260,6 +6264,12 @@
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -6454,7 +6464,7 @@
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       }
     },
     "ieee754": {
@@ -6536,7 +6546,7 @@
       "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
       "dev": true,
       "requires": {
-        "bowser": "1.8.1",
+        "bowser": "1.9.1",
         "css-in-js-utils": "2.0.0"
       }
     },
@@ -6675,9 +6685,9 @@
       "dev": true
     },
     "is-ci": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
         "ci-info": "1.1.2"
@@ -7134,7 +7144,7 @@
             "callsites": "2.0.0",
             "chalk": "1.1.3",
             "graceful-fs": "4.1.11",
-            "is-ci": "1.0.10",
+            "is-ci": "1.1.0",
             "istanbul-api": "1.2.1",
             "istanbul-lib-coverage": "1.1.1",
             "istanbul-lib-instrument": "1.9.1",
@@ -8384,6 +8394,12 @@
         "pify": "3.0.0"
       }
     },
+    "make-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.2.tgz",
+      "integrity": "sha512-l9ra35l5VWLF24y75Tg8XgfGLX0ueRhph118WKM6H5denx4bB5QF59+4UAm9oJ2qsPQZas/CQUDdtDdfvYHBdQ==",
+      "dev": true
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -8406,9 +8422,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
-      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw==",
       "dev": true
     },
     "marksy": {
@@ -8419,7 +8435,7 @@
       "requires": {
         "babel-standalone": "6.26.0",
         "he": "1.1.1",
-        "marked": "0.3.7"
+        "marked": "0.3.9"
       }
     },
     "material-colors": {
@@ -9251,13 +9267,14 @@
       "dev": true
     },
     "object.assign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
         "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
         "object-keys": "1.0.11"
       }
     },
@@ -9424,10 +9441,13 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -9435,8 +9455,14 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
     },
     "pad-right": {
       "version": "0.2.2",
@@ -9604,9 +9630,9 @@
       }
     },
     "patternfly": {
-      "version": "3.32.1",
-      "resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.32.1.tgz",
-      "integrity": "sha1-M3JdZSrJprf00/GKQYnbwxntWTo=",
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/patternfly/-/patternfly-3.35.0.tgz",
+      "integrity": "sha1-L1pbEtuIqW/TUh36z1VS5v2YMwg=",
       "requires": {
         "bootstrap": "3.3.7",
         "bootstrap-datepicker": "1.6.4",
@@ -9901,14 +9927,14 @@
       }
     },
     "postcss": {
-      "version": "6.0.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-      "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.15.tgz",
+      "integrity": "sha512-v/SpyMzLbtkmh45zUdaqLAaqXqzPdSrw8p4cQVO0/w6YiYfpj4k+Wkzhn68qk9br+H+0qfddhdPEVnbmBPfXVQ==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "source-map": "0.6.1",
-        "supports-color": "4.5.0"
+        "supports-color": "5.1.0"
       }
     },
     "postcss-calc": {
@@ -10563,7 +10589,7 @@
       "integrity": "sha512-0AuD9HG1Ey3/3nqPWu9yqf7rL0KCPu5VgjDsjf5mzEcuo9H/z8nco/fljKgjsOUrZypa95MI0kS4xBZeBzz2lw==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       }
     },
     "postcss-load-config": {
@@ -10599,13 +10625,13 @@
       }
     },
     "postcss-loader": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.9.tgz",
-      "integrity": "sha512-sgoXPtmgVT3aBAhU47Kig8oPF+mbXl8Unjvtz1Qj1q2D2EvSVJW2mKJNzxv5y/LvA9xWwuvdysvhc7Zn80UWWw==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.10.tgz",
+      "integrity": "sha512-xQaDcEgJ/2JqFY18zpFkik8vyYs7oS5ZRbrjvDqkP97k2wYWfPT4+qA0m4o3pTSCsz0u26PNqs8ZO9FRUWAqrA==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
-        "postcss": "6.0.14",
+        "postcss": "6.0.15",
         "postcss-load-config": "1.2.0",
         "schema-utils": "0.3.0"
       }
@@ -10779,8 +10805,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000784",
-            "electron-to-chromium": "1.3.29"
+            "caniuse-db": "1.0.30000787",
+            "electron-to-chromium": "1.3.30"
           }
         },
         "chalk": {
@@ -11144,7 +11170,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       }
     },
     "postcss-modules-local-by-default": {
@@ -11154,7 +11180,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       }
     },
     "postcss-modules-scope": {
@@ -11164,7 +11190,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       }
     },
     "postcss-modules-values": {
@@ -11174,7 +11200,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.15"
       }
     },
     "postcss-normalize-charset": {
@@ -12046,7 +12072,7 @@
           "integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
           "dev": true,
           "requires": {
-            "bowser": "1.8.1",
+            "bowser": "1.9.1",
             "hyphenate-style-name": "1.0.2"
           }
         }
@@ -12263,6 +12289,18 @@
         "prop-types": "15.6.0"
       }
     },
+    "react-fuzzy": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/react-fuzzy/-/react-fuzzy-0.5.1.tgz",
+      "integrity": "sha512-m2QClpw+Z51m6oEpfznVr7CQ9zdUGQ7vvidv05+drt0c3UMkpOWqmB0fQhYJYP/5QNh7ojyMCgu99cxvFaya6Q==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "classnames": "2.2.5",
+        "fuse.js": "3.2.0",
+        "prop-types": "15.6.0"
+      }
+    },
     "react-html-attributes": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/react-html-attributes/-/react-html-attributes-1.4.1.tgz",
@@ -12326,14 +12364,13 @@
       }
     },
     "react-split-pane": {
-      "version": "0.1.72",
-      "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.72.tgz",
-      "integrity": "sha512-9dFQsCLNsz9SYBr61kcHUoMsyNtaB2sHNIMtaMX4RJjUWlRGnDqoGYeCnH+C+y6VbWSC7lBKpwibF83e5pdQNg==",
+      "version": "0.1.74",
+      "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.74.tgz",
+      "integrity": "sha512-2g5GD9fzKWwYLAhpL6uoGdYa8uxQs7Yyt3dE8pj991wmEKrUbpb2qxctp/kRv45W0KeIxicMIUEt1VVpHWV5gg==",
       "dev": true,
       "requires": {
         "@types/inline-style-prefixer": "3.0.1",
-        "@types/react": "16.0.31",
-        "fast-deep-equal": "1.0.0",
+        "@types/react": "16.0.34",
         "inline-style-prefixer": "3.0.8",
         "prop-types": "15.6.0",
         "react-style-proptype": "3.1.0"
@@ -13637,9 +13674,9 @@
       }
     },
     "supports-color": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+      "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
       "dev": true,
       "requires": {
         "has-flag": "2.0.0"
@@ -14544,7 +14581,7 @@
       "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
@@ -14573,6 +14610,15 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.12",
-    "@storybook/addon-info": "^3.2.12",
+    "@storybook/addon-info": "3.2.12",
     "@storybook/addon-knobs": "3.2.12",
     "@storybook/addon-links": "^3.2.12",
     "@storybook/react": "3.2.12",
@@ -56,6 +56,7 @@
     "jest": "^19.0.2",
     "node-sass": "^4.7.2",
     "patternfly": "^3.31.0",
+    "prop-types": "^15.6.0",
     "prettier": "^1.7.4",
     "raf": "^3.4.0",
     "react": "^16.2.0",
@@ -66,9 +67,9 @@
     "style-loader": "^0.19.0"
   },
   "peerDependencies": {
-    "prop-types": "^15.5.10",
-    "react": "^15.6.2 || ^16.0.0",
-    "react-dom": "^15.6.2 || ^16.0.0"
+    "prop-types": "^15.6.0",
+    "react": "^15.6.2 || ^16.2.0",
+    "react-dom": "^15.6.2 || ^16.2.0"
   },
   "sassIncludes": {
     "patternfly": "--include-path node_modules/patternfly/dist/sass",


### PR DESCRIPTION
lock addon-info to 3.2.12 to temporarily address 3.2.18 issues

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
There is currently a bug when resizing the addon panel:
![knobs-panel-broke](https://user-images.githubusercontent.com/4237045/34462347-1c4b3850-ee10-11e7-99c1-ed2570b736f0.gif)

This appears to be due to some conflicts with `3.2.18` and some of the newer `3.3` packages now being pulled in semantically. 

I first attempted to update all `@storybook` packages to `3.3.3`, however it seems there a few issues which need to be resolved first. I commented on those [here](https://github.com/storybooks/storybook/pull/2345#issuecomment-354581381) and [here](https://github.com/storybooks/storybook/issues/790#issuecomment-354582743).

Locking addon-info temporarily seems to resolve the resize issue noted in the giphy above and avoids the new 3.3.3 issues presented upstream. 

Once 3.3.3 issues are resolved, we should be able to update all `@storybook` packages along with removing our [currently deprecated usage](https://github.com/storybooks/storybook/tree/master/addons/info#deprecated-usage) of the addon-info component.

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
Working storybook built by these updates is here:
https://rawgit.com/priley86/patternfly-react/fix-storybook-sb/index.html

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
nope

<!-- feel free to add additional comments -->