### PR TITLE
Prepare vs prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "build:sass": "mkdir -p dist/sass && cp -r sass/patternfly-react/* dist/sass && node-sass --output-style compressed --include-path sass $npm_package_sassIncludes_patternfly $npm_package_sassIncludes_bootstrap $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react.scss",
     "lint": "eslint --max-warnings 0 src storybook",
     "prettier": "prettier --write --single-quote --trailing-comma=none '{src,storybook}/**/*.js'",
-    "prepare": "npm run build",
+    "prepublish": "npm run build",
     "test": "npm run lint && jest",
     "test:watch": "jest --watchAll",
     "test:current": "jest --watch",


### PR DESCRIPTION
One of the latest changes around the NPM publish failing. This correlates (but isn't necessarily the cause) with Node 8 vs Node 6 testing. Reverted NPM script prepare back to prepublish.

Created as a "chore" but can alter to a "build" commit.