### PR TITLE
feat(Alert{type=danger}): Deprecate alert danger type

### DIFF
--- a/src/components/Alert/Alert.js
+++ b/src/components/Alert/Alert.js
@@ -3,13 +3,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
-import { getClassName, getIconName } from './helpers';
-import { ALERT_TYPES, ALERT_TYPE_ERROR } from './constants';
+import { getClassName, getIconName, warnIfDeprecatedType } from './helpers';
+import {
+  ALERT_TYPES,
+  DEPRECATED_ALERT_TYPES,
+  ALERT_TYPE_ERROR
+} from './constants';
 
 /**
  * Alert Component for Patternfly React
  */
 const Alert = ({ children, className, onDismiss, type, ...props }) => {
+  warnIfDeprecatedType(type);
+
   const alertClass = ClassNames('alert', className, getClassName(type), {
     'alert-dismissable': onDismiss
   });
@@ -34,7 +40,7 @@ Alert.propTypes = {
   /** callback when alert is dismissed  */
   onDismiss: PropTypes.func,
   /** the type of alert  */
-  type: PropTypes.oneOf(ALERT_TYPES).isRequired,
+  type: PropTypes.oneOf([...ALERT_TYPES, ...DEPRECATED_ALERT_TYPES]).isRequired,
   /** children nodes  */
   children: PropTypes.node
 };

--- a/src/components/Alert/Alert.stories.js
+++ b/src/components/Alert/Alert.stories.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { defaultTemplate } from '../../../storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from '../../../storybook/constants';
+import { ALERT_TYPES } from './constants';
 import { Alert } from './index';
 
 const stories = storiesOf('Alert', module);
@@ -16,62 +17,19 @@ stories.addDecorator(
   })
 );
 
-stories.addWithInfo(
-  'with danger',
-  `This is the Alert with danger type.`,
-  () => (
-    <Alert type="danger" onDismiss={action('onDismiss')}>
-      <span>{text('Label', 'Danger Will Robinson!')}</span>
+stories.addWithInfo('Alert types', 'Those are the available alert types', () =>
+  ALERT_TYPES.map(type => (
+    <Alert type={type} onDismiss={action(`${type}Dismissed`)}>
+      I am an Alert with type="{type}"
     </Alert>
-  )
+  ))
 );
 
 stories.addWithInfo(
-  'with warning',
-  `This is the Alert with warning type.`,
-  () => (
-    <Alert type="warning" onDismiss={action('onDismiss')}>
-      <span>
-        {text(
-          'Label',
-          'Warning! Better check yourself, you are not looking too good.'
-        )}
-      </span>
-    </Alert>
-  )
-);
-
-stories.addWithInfo('with info', `This is the Alert with info type.`, () => (
-  <Alert type="info" onDismiss={action('onDismiss')}>
-    <span>
-      {text(
-        'Label',
-        'Heads up! This alert needs your attention, but it is not super important.'
-      )}
-    </span>
-  </Alert>
-));
-
-stories.addWithInfo(
-  'with success',
-  `This is the Alert with success type.`,
-  () => (
-    <Alert type="success" onDismiss={action('onDismiss')}>
-      <span>
-        {text(
-          'Label',
-          'Well done! You successfully read this important alert message.'
-        )}
-      </span>
-    </Alert>
-  )
-);
-
-stories.addWithInfo(
-  'without dismiss',
+  'Alert without dismiss',
   `This is the Alert without a dismiss icon.`,
   () => (
-    <Alert type="success">
+    <Alert type={select('Type', ALERT_TYPES)}>
       <span>
         {text(
           'Label',

--- a/src/components/Alert/Alert.test.js
+++ b/src/components/Alert/Alert.test.js
@@ -1,8 +1,11 @@
 /* eslint-env jest */
 
 import React from 'react';
-import Alert from './Alert';
 import renderer from 'react-test-renderer';
+import Alert from './Alert';
+import { ALERT_TYPES, DEPRECATED_ALERT_TYPES } from './constants';
+
+const ALL_ALERT_TYPES = [...ALERT_TYPES, ...DEPRECATED_ALERT_TYPES];
 
 const testAlertSnapshot = (type, onDismiss) => {
   const component = renderer.create(
@@ -15,7 +18,10 @@ const testAlertSnapshot = (type, onDismiss) => {
   expect(tree).toMatchSnapshot();
 };
 
-Alert.ALERT_TYPES.forEach(type => {
+ALL_ALERT_TYPES.forEach(type => {
+  beforeAll(() => jest.spyOn(console, 'warn').mockImplementation(() => {}));
+  afterAll(() => console.warn.mockRestore());
+
   test(`Alert ${type} renders properly`, () => {
     testAlertSnapshot(type);
   });

--- a/src/components/Alert/__snapshots__/helpers.test.js.snap
+++ b/src/components/Alert/__snapshots__/helpers.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Alert helpers should get class name for type danger 1`] = `"alert-danger"`;
+
+exports[`Alert helpers should get class name for type error 1`] = `"alert-danger"`;
+
+exports[`Alert helpers should get class name for type info 1`] = `"alert-info"`;
+
+exports[`Alert helpers should get class name for type success 1`] = `"alert-success"`;
+
+exports[`Alert helpers should get class name for type warning 1`] = `"alert-warning"`;
+
+exports[`Alert helpers should get icon name for type danger 1`] = `"error-circle-o"`;
+
+exports[`Alert helpers should get icon name for type error 1`] = `"error-circle-o"`;
+
+exports[`Alert helpers should get icon name for type info 1`] = `"info"`;
+
+exports[`Alert helpers should get icon name for type success 1`] = `"ok"`;
+
+exports[`Alert helpers should get icon name for type warning 1`] = `"warning-triangle-o"`;
+
+exports[`Alert helpers should warn about deprecated types 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "
+      Warning: Deprecated Alert.type='danger'.
+      Please migrate to Alert.type='error'
+    ",
+    ],
+  ],
+}
+`;

--- a/src/components/Alert/constants.js
+++ b/src/components/Alert/constants.js
@@ -1,13 +1,14 @@
-export const ALERT_TYPE_DANGER = 'danger';
 export const ALERT_TYPE_ERROR = 'error';
 export const ALERT_TYPE_WARNING = 'warning';
 export const ALERT_TYPE_SUCCESS = 'success';
 export const ALERT_TYPE_INFO = 'info';
+export const ALERT_TYPE_DANGER = 'danger'; // deprecated!!!
 
 export const ALERT_TYPES = [
-  ALERT_TYPE_DANGER,
   ALERT_TYPE_ERROR,
   ALERT_TYPE_WARNING,
   ALERT_TYPE_SUCCESS,
   ALERT_TYPE_INFO
 ];
+
+export const DEPRECATED_ALERT_TYPES = [ALERT_TYPE_DANGER];

--- a/src/components/Alert/helpers.js
+++ b/src/components/Alert/helpers.js
@@ -6,6 +6,15 @@ import {
   ALERT_TYPE_INFO
 } from './constants';
 
+export const warnIfDeprecatedType = type => {
+  if (type === ALERT_TYPE_DANGER) {
+    console.warn(`
+      Warning: Deprecated Alert.type='${ALERT_TYPE_DANGER}'.
+      Please migrate to Alert.type='${ALERT_TYPE_ERROR}'
+    `);
+  }
+};
+
 export const getIconName = type => {
   switch (type) {
     case ALERT_TYPE_DANGER:

--- a/src/components/Alert/helpers.test.js
+++ b/src/components/Alert/helpers.test.js
@@ -1,0 +1,27 @@
+import { warnIfDeprecatedType, getIconName, getClassName } from './helpers';
+import { ALERT_TYPES, DEPRECATED_ALERT_TYPES } from './constants';
+
+const ALL_ALERT_TYPES = [...ALERT_TYPES, ...DEPRECATED_ALERT_TYPES];
+
+describe('Alert helpers', () => {
+  beforeAll(() => jest.spyOn(console, 'warn').mockImplementation(() => {}));
+  afterAll(() => console.warn.mockRestore());
+
+  test('should warn about deprecated types', () => {
+    ALL_ALERT_TYPES.forEach(type => warnIfDeprecatedType(type));
+
+    expect(console.warn).toMatchSnapshot();
+  });
+
+  ALL_ALERT_TYPES.forEach(type => {
+    test(`should get icon name for type ${type}`, () => {
+      expect(getIconName(type)).toMatchSnapshot();
+    });
+  });
+
+  ALL_ALERT_TYPES.forEach(type => {
+    test(`should get class name for type ${type}`, () => {
+      expect(getClassName(type)).toMatchSnapshot();
+    });
+  });
+});

--- a/src/components/ToastNotification/ToastNotification.stories.js
+++ b/src/components/ToastNotification/ToastNotification.stories.js
@@ -24,7 +24,7 @@ stories.addWithInfo(
     const message = text('Message', 'This is really working out.');
     const type = select(
       'Type',
-      ['success', 'danger', 'warning', 'info'],
+      ToastNotification.TOAST_NOTIFICATION_TYPES,
       'success'
     );
     const dismissEnabled = boolean('Dismiss', false);

--- a/src/components/ToastNotification/ToastNotification.test.js
+++ b/src/components/ToastNotification/ToastNotification.test.js
@@ -12,7 +12,7 @@ const testToastNotificationSnapshot = Component => {
   const handleOnMouseLeave = jest.fn();
   const component = renderer.create(
     <Component
-      type="danger"
+      type="error"
       onDismiss={handleNotificationClose}
       onMouseEnter={handleOnMouseEnter}
       onMouseLeave={handleOnMouseLeave}


### PR DESCRIPTION
BREAKING CHANGE: Alert{type=danger} is deprecated, migrate to Alert{type=error}

fix #144

**What**:
Deprecating `<Alert type="danger" />`
The component will continue to function normally, you should only get a warning message in your console.

**Additional issues**:
In what version we should drop the support of the `danger` type?
I think we should update this pr so the warning message will contain the version it will get dropped.

[storybook](https://rawgit.com/sharvit/patternfly-react/storybook/feature/deprecate-alert-danger-type/index.html?selectedKind=Alert&selectedStory=Alert%20types&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)

