### PR TITLE
feat(ListView): Adding hideCloseIcon prop

### DIFF
--- a/src/components/ListView/ListView.stories.js
+++ b/src/components/ListView/ListView.stories.js
@@ -54,22 +54,35 @@ stories.addWithInfo(
   () => {
     return (
       <ListView>
-        {mockListItems.map((item, index) => (
-          <ListView.Item
-            key={index}
-            actions={renderActions(item.actions)}
-            checkboxInput={<input type="checkbox" />}
-            leftContent={<ListView.Icon name="plane" />}
-            additionalInfo={renderAdditionalInfoItems(item.properties)}
-            heading={item.title}
-            description={item.description}
-            stacked={boolean('Stacked', false)}
-          >
-            <Row>
-              <Col sm={11}>{item.expandedContentText}</Col>
-            </Row>
-          </ListView.Item>
-        ))}
+        {mockListItems.map(
+          (
+            {
+              actions,
+              properties,
+              title,
+              description,
+              expandedContentText,
+              ...rest
+            },
+            index
+          ) => (
+            <ListView.Item
+              key={index}
+              actions={renderActions(actions)}
+              checkboxInput={<input type="checkbox" />}
+              leftContent={<ListView.Icon name="plane" />}
+              additionalInfo={renderAdditionalInfoItems(properties)}
+              heading={title}
+              description={description}
+              stacked={boolean('Stacked', false)}
+              {...rest}
+            >
+              <Row>
+                <Col sm={11}>{expandedContentText}</Col>
+              </Row>
+            </ListView.Item>
+          )
+        )}
       </ListView>
     );
   }

--- a/src/components/ListView/ListViewItem.js
+++ b/src/components/ListView/ListViewItem.js
@@ -38,6 +38,7 @@ class ListViewItem extends React.Component {
       heading,
       leftContent,
       checkboxInput,
+      hideCloseIcon,
       ...other
     } = this.props;
     const { expanded } = this.state;
@@ -61,7 +62,7 @@ class ListViewItem extends React.Component {
           </ListViewGroupItemHeader>
           <ListViewGroupItemContainer
             expanded={expanded}
-            onClose={() => this.toggleExpanded()}
+            onClose={hideCloseIcon ? undefined : () => this.toggleExpanded()}
           >
             {children}
           </ListViewGroupItemContainer>
@@ -103,9 +104,12 @@ ListViewItem.propTypes = {
   /** Contents for left section of ListViewItem (usually ListViewIcon) */
   leftContent: PropTypes.node,
   /** Checkbox form input component */
-  checkboxInput: PropTypes.node
+  checkboxInput: PropTypes.node,
+  /** Optionally hide the close icon in expanded content */
+  hideCloseIcon: PropTypes.bool
 };
 ListViewItem.defaultProps = {
-  stacked: false
+  stacked: false,
+  hideCloseIcon: false
 };
 export default ListViewItem;

--- a/src/components/ListView/__mocks__/mockListItems.js
+++ b/src/components/ListView/__mocks__/mockListItems.js
@@ -37,9 +37,9 @@ export const mockListItems = [
       'Lorem Ipsum is simply dummy text of the printing and typesetting industry'
   },
   {
-    title: 'Item without description',
-    expandedContentText:
-      'Lorem Ipsum is simply dummy text of the printing and typesetting industry'
+    title: 'Item without description or close icon',
+    expandedContentText: 'There is no close `x` on the right of this box.',
+    hideCloseIcon: true
   }
 ];
 

--- a/src/components/ListView/__snapshots__/ListView.test.js.snap
+++ b/src/components/ListView/__snapshots__/ListView.test.js.snap
@@ -659,7 +659,7 @@ exports[`ListView renders properly 1`] = `
             <div
               className="list-group-item-heading"
             >
-              Item without description
+              Item without description or close icon
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**: `hideCloseIcon` prop will optionally remove the closing x icon on expanded content

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**: https://rawgit.com/danseethaler/patternfly-react/hide-close-icon-153-storybook/index.html

<!-- Are there any upstream issues or separate issues you need to reference? -->
fix #153

<!-- feel free to add additional comments -->