### PR TITLE
Add `FieldLevelHelp` component

### DIFF
--- a/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -10,14 +10,7 @@ import { OverlayTrigger } from '../OverlayTrigger';
  */
 const FieldLevelHelp = ({ children, content, close, ...props }) => {
   const trigger = 'click';
-  const htmlContent = (
-    <div
-      dangerouslySetInnerHTML={{
-        __html: content
-      }}
-    />
-  );
-  const overlay = <Popover id="popover">{htmlContent}</Popover>;
+  const overlay = <Popover id="popover">{content}</Popover>;
   const rootClose = close === 'true';
 
   return (
@@ -36,7 +29,7 @@ const FieldLevelHelp = ({ children, content, close, ...props }) => {
 
 FieldLevelHelp.propTypes = {
   /** additional fieldlevelhelp classes */
-  content: PropTypes.string,
+  content: PropTypes.node,
   /** leave popover/tooltip open  */
   close: PropTypes.string,
   /** children nodes  */

--- a/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Icon } from '../Icon';
+import { Button } from '../Button';
 import { Popover } from '../Popover';
-import { Tooltip } from '../Tooltip';
 import { OverlayTrigger } from '../OverlayTrigger';
 
 /**
  * FieldLevelHelp Component for Patternfly React
  */
-const FieldLevelHelp = ({ children, mode, content, close, ...props }) => {
-  const trigger = mode === 'popover' ? 'click' : 'hover focus';
+const FieldLevelHelp = ({ children, content, close, ...props }) => {
+  const trigger = 'click';
   const htmlContent = (
     <div
       dangerouslySetInnerHTML={{
@@ -17,39 +17,28 @@ const FieldLevelHelp = ({ children, mode, content, close, ...props }) => {
       }}
     />
   );
-  const overlay =
-    mode === 'popover' ? (
-      <Popover id="{mode}">{htmlContent}</Popover>
-    ) : (
-      <Tooltip id="{mode}">{htmlContent}</Tooltip>
-    );
+  const overlay = <Popover id="popover">{htmlContent}</Popover>;
   const rootClose = close === 'true';
 
   return (
-    <div>
-      <label>{`${children} `}</label>
-      <OverlayTrigger
-        overlay={overlay}
-        placement={'top'}
-        trigger={trigger.split(' ')}
-        rootClose={rootClose}
+    <OverlayTrigger
+      overlay={overlay}
+      placement={'top'}
+      trigger={trigger.split(' ')}
+      rootClose={rootClose}
+    >
+      <Button
+        bsStyle="link"
+        style={{ textDecoration: 'none', outline: 'none' }}
       >
-        <Icon
-          className="fa-fw"
-          type="pf"
-          name={'info'}
-          style={{ color: '#0088ce' }}
-        />
-      </OverlayTrigger>
-    </div>
+        <Icon type="pf" name={'info'} />
+      </Button>
+    </OverlayTrigger>
   );
 };
 
 FieldLevelHelp.propTypes = {
   /** additional fieldlevelhelp classes */
-  /** Content type: popover or tooltip  */
-  mode: PropTypes.string,
-  /** Contents displayed with popover or tooltip  */
   content: PropTypes.string,
   /** leave popover/tooltip open  */
   close: PropTypes.string,
@@ -57,7 +46,6 @@ FieldLevelHelp.propTypes = {
   children: PropTypes.node
 };
 FieldLevelHelp.defaultProps = {
-  mode: 'popover',
   close: 'true'
 };
 

--- a/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -27,10 +27,7 @@ const FieldLevelHelp = ({ children, content, close, ...props }) => {
       trigger={trigger.split(' ')}
       rootClose={rootClose}
     >
-      <Button
-        bsStyle="link"
-        style={{ textDecoration: 'none', outline: 'none' }}
-      >
+      <Button bsStyle="link">
         <Icon type="pf" name={'info'} />
       </Button>
     </OverlayTrigger>

--- a/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -27,7 +27,7 @@ const FieldLevelHelp = ({ children, mode, content, ...props }) => {
 
   return (
     <div>
-      <label>{children + ' '}</label>
+      <label>{`${children} `}</label>
       <OverlayTrigger
         overlay={overlay}
         placement={'top'}

--- a/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -8,8 +8,8 @@ import { OverlayTrigger } from '../OverlayTrigger';
 /**
  * FieldLevelHelp Component for Patternfly React
  */
-const FieldLevelHelp = ({ children, contentType, content, ...props }) => {
-  const trigger = contentType === 'popover' ? 'click' : 'hover focus';
+const FieldLevelHelp = ({ children, mode, content, ...props }) => {
+  const trigger = mode === 'popover' ? 'click' : 'hover focus';
   const htmlContent = (
     <div
       dangerouslySetInnerHTML={{
@@ -18,10 +18,10 @@ const FieldLevelHelp = ({ children, contentType, content, ...props }) => {
     />
   );
   const overlay =
-    contentType === 'popover' ? (
-      <Popover id="{contentType}">{htmlContent}</Popover>
+    mode === 'popover' ? (
+      <Popover id="{mode}">{htmlContent}</Popover>
     ) : (
-      <Tooltip id="{contentType}">{htmlContent}</Tooltip>
+      <Tooltip id="{mode}">{htmlContent}</Tooltip>
     );
   const rootClose = true;
 
@@ -48,7 +48,7 @@ const FieldLevelHelp = ({ children, contentType, content, ...props }) => {
 FieldLevelHelp.propTypes = {
   /** additional fieldlevelhelp classes */
   /** Content type: popover or tooltip  */
-  contentType: PropTypes.string,
+  mode: PropTypes.string,
   /** Contents displayed with popover or tooltip  */
   content: PropTypes.string,
   /** children nodes  */

--- a/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -8,7 +8,7 @@ import { OverlayTrigger } from '../OverlayTrigger';
 /**
  * FieldLevelHelp Component for Patternfly React
  */
-const FieldLevelHelp = ({ children, mode, content, ...props }) => {
+const FieldLevelHelp = ({ children, mode, content, close, ...props }) => {
   const trigger = mode === 'popover' ? 'click' : 'hover focus';
   const htmlContent = (
     <div
@@ -23,7 +23,7 @@ const FieldLevelHelp = ({ children, mode, content, ...props }) => {
     ) : (
       <Tooltip id="{mode}">{htmlContent}</Tooltip>
     );
-  const rootClose = true;
+  const rootClose = close === 'true';
 
   return (
     <div>
@@ -51,8 +51,14 @@ FieldLevelHelp.propTypes = {
   mode: PropTypes.string,
   /** Contents displayed with popover or tooltip  */
   content: PropTypes.string,
+  /** leave popover/tooltip open  */
+  close: PropTypes.string,
   /** children nodes  */
   children: PropTypes.node
+};
+FieldLevelHelp.defaultProps = {
+  mode: 'popover',
+  close: 'true'
 };
 
 export default FieldLevelHelp;

--- a/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -26,17 +26,22 @@ const FieldLevelHelp = ({ children, contentType, content, ...props }) => {
   const rootClose = true;
 
   return (
-    <OverlayTrigger
-      overlay={overlay}
-      placement={'top'}
-      trigger={trigger.split(' ')}
-      rootClose={rootClose}
-    >
-      <label>
-        {children + ' '}
-        <Icon type="pf" name={'info'} style={{ color: '#0088ce' }} />
-      </label>
-    </OverlayTrigger>
+    <div>
+      <label>{children + ' '}</label>
+      <OverlayTrigger
+        overlay={overlay}
+        placement={'top'}
+        trigger={trigger.split(' ')}
+        rootClose={rootClose}
+      >
+        <Icon
+          className="fa-fw"
+          type="pf"
+          name={'info'}
+          style={{ color: '#0088ce' }}
+        />
+      </OverlayTrigger>
+    </div>
   );
 };
 

--- a/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -2,45 +2,74 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Icon } from '../Icon';
 import { Popover } from '../Popover';
+import { Tooltip } from '../Tooltip';
 import { OverlayTrigger } from '../OverlayTrigger';
 
 /**
  * FieldLevelHelp Component for Patternfly React
  */
-const FieldLevelHelp = ({ children, popoverContent, ...props }) => {
-  const htmlPopoverContent = (
+const FieldLevelHelp = ({ children, contentType, content, ...props }) => {
+  const placement = 'top';
+  const rootClose = true;
+  const htmlContent = (
     <div
       dangerouslySetInnerHTML={{
-        __html: popoverContent
+        __html: content
       }}
     />
   );
-  const popover = (
-    <Popover id="popover" >
-      {htmlPopoverContent}
-    </Popover>
-  );
-  const placement = 'top';
-  const trigger = 'click';
-  const rootClose = true;
-  return (
-    <OverlayTrigger
-      overlay={popover}
-      placement={placement}
-      trigger={trigger.split(' ')}
-      rootClose={rootClose}
-    >
-      <label>
-        {children + ' '}
-        <Icon type="pf" name={'info'} style={{ color: '#0088ce' }} />
-      </label>
-    </OverlayTrigger>
-  );
+
+  if (contentType === 'popover') {
+    const popover = (
+      <Popover id="popover" >
+        {htmlContent}
+      </Popover>
+    );
+    const trigger = 'click';
+
+    return (
+      <OverlayTrigger
+        overlay={popover}
+        placement={placement}
+        trigger={trigger.split(' ')}
+        rootClose={rootClose}
+      >
+        <label>
+          {children + ' '}
+          <Icon type="pf" name={'info'} style={{ color: '#0088ce' }} />
+        </label>
+      </OverlayTrigger>
+    );
+  } else if (contentType === 'tooltip') {
+    const tooltip = (
+      <Tooltip id="tooltip">
+        {htmlContent}
+      </Tooltip>
+    );
+    const trigger = 'hover focus';
+
+    return (
+      <OverlayTrigger
+        overlay={tooltip}
+        placement={placement}
+        trigger={trigger.split(' ')}
+        rootClose={rootClose}
+      >
+        <label>
+          {children + ' '}
+          <Icon type="pf" name={'info'} style={{ color: '#0088ce' }} />
+        </label>
+      </OverlayTrigger>
+    );
+  }
 };
+
 FieldLevelHelp.propTypes = {
   /** additional fieldlevelhelp classes */
-  /** Content displayed with popover  */
-  popoverContent: PropTypes.string,
+  /** Content type: popover or tooltip  */
+  contentType: PropTypes.string,
+  /** Contents displayed with popover or tooltip  */
+  content: PropTypes.string,
   /** children nodes  */
   children: PropTypes.node
 };

--- a/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Icon } from '../Icon';
+import { Popover } from '../Popover';
+import { OverlayTrigger } from '../OverlayTrigger';
+
+/**
+ * FieldLevelHelp Component for Patternfly React
+ */
+const FieldLevelHelp = ({ children, popoverContent, ...props }) => {
+  const htmlPopoverContent = (
+    <div
+      dangerouslySetInnerHTML={{
+        __html: popoverContent
+      }}
+    />
+  );
+  const popover = (
+    <Popover id="popover" >
+      {htmlPopoverContent}
+    </Popover>
+  );
+  const placement = 'top';
+  const trigger = 'click';
+  const rootClose = true;
+  return (
+    <OverlayTrigger
+      overlay={popover}
+      placement={placement}
+      trigger={trigger.split(' ')}
+      rootClose={rootClose}
+    >
+      <label>
+        {children + ' '}
+        <Icon type="pf" name={'info'} style={{ color: '#0088ce' }} />
+      </label>
+    </OverlayTrigger>
+  );
+};
+FieldLevelHelp.propTypes = {
+  /** additional fieldlevelhelp classes */
+  /** Content displayed with popover  */
+  popoverContent: PropTypes.string,
+  /** children nodes  */
+  children: PropTypes.node
+};
+
+export default FieldLevelHelp;

--- a/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -9,8 +9,7 @@ import { OverlayTrigger } from '../OverlayTrigger';
  * FieldLevelHelp Component for Patternfly React
  */
 const FieldLevelHelp = ({ children, contentType, content, ...props }) => {
-  const placement = 'top';
-  const rootClose = true;
+  const trigger = contentType === 'popover' ? 'click' : 'hover focus';
   const htmlContent = (
     <div
       dangerouslySetInnerHTML={{
@@ -18,50 +17,23 @@ const FieldLevelHelp = ({ children, contentType, content, ...props }) => {
       }}
     />
   );
+  const overlay = contentType === 'popover' ?
+    <Popover id={contentType}>{htmlContent}</Popover> : 
+    <Tooltip id={contentType}>{htmlContent}</Tooltip>;
 
-  if (contentType === 'popover') {
-    const popover = (
-      <Popover id="popover" >
-        {htmlContent}
-      </Popover>
-    );
-    const trigger = 'click';
-
-    return (
-      <OverlayTrigger
-        overlay={popover}
-        placement={placement}
-        trigger={trigger.split(' ')}
-        rootClose={rootClose}
-      >
-        <label>
-          {children + ' '}
-          <Icon type="pf" name={'info'} style={{ color: '#0088ce' }} />
-        </label>
-      </OverlayTrigger>
-    );
-  } else if (contentType === 'tooltip') {
-    const tooltip = (
-      <Tooltip id="tooltip">
-        {htmlContent}
-      </Tooltip>
-    );
-    const trigger = 'hover focus';
-
-    return (
-      <OverlayTrigger
-        overlay={tooltip}
-        placement={placement}
-        trigger={trigger.split(' ')}
-        rootClose={rootClose}
-      >
-        <label>
-          {children + ' '}
-          <Icon type="pf" name={'info'} style={{ color: '#0088ce' }} />
-        </label>
-      </OverlayTrigger>
-    );
-  }
+  return (
+    <OverlayTrigger
+      overlay={overlay}
+      placement={'top'}
+      trigger={trigger.split(' ')}
+      rootClose={true}
+    >
+      <label>
+        {children + ' '}
+        <Icon type="pf" name={'info'} style={{ color: '#0088ce' }} />
+      </label>
+    </OverlayTrigger>
+  );
 };
 
 FieldLevelHelp.propTypes = {

--- a/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -17,16 +17,20 @@ const FieldLevelHelp = ({ children, contentType, content, ...props }) => {
       }}
     />
   );
-  const overlay = contentType === 'popover' ?
-    <Popover id={contentType}>{htmlContent}</Popover> : 
-    <Tooltip id={contentType}>{htmlContent}</Tooltip>;
+  const overlay =
+    contentType === 'popover' ? (
+      <Popover id="{contentType}">{htmlContent}</Popover>
+    ) : (
+      <Tooltip id="{contentType}">{htmlContent}</Tooltip>
+    );
+  const rootClose = true;
 
   return (
     <OverlayTrigger
       overlay={overlay}
       placement={'top'}
       trigger={trigger.split(' ')}
-      rootClose={true}
+      rootClose={rootClose}
     >
       <label>
         {children + ' '}

--- a/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
@@ -23,10 +23,18 @@ stories.addWithInfo('FieldLevelHelp', 'FieldLevelHelp', () => {
   );
   const fieldLabel = text('Field Label', 'Hostname');
 
+  const htmlContent = (
+    <div
+      dangerouslySetInnerHTML={{
+        __html: content
+      }}
+    />
+  );
+
   return (
     <div style={{ textAlign: 'center' }}>
       {fieldLabel}
-      <FieldLevelHelp content={content} close={close} />
+      <FieldLevelHelp content={htmlContent} close={close} />
     </div>
   );
 });

--- a/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
-import { withKnobs, text } from '@storybook/addon-knobs';
+import { withKnobs } from '@storybook/addon-knobs';
 import { defaultTemplate } from '../../../storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from '../../../storybook/constants';
 import { FieldLevelHelp } from './index';
@@ -12,26 +11,26 @@ stories.addDecorator(
   defaultTemplate({
     title: 'FieldLevelHelp',
     documentationLink:
-    DOCUMENTATION_URL.PATTERNFLY_ORG_COMMUNICATION + 'inline-notifications/'
+      DOCUMENTATION_URL.PATTERNFLY_ORG_COMMUNICATION + 'inline-notifications/'
   })
 );
 
-stories.addWithInfo(
-  'with Popover',
-  'FieldLevelHelp',
-  () => (
-    <FieldLevelHelp contentType='popover' content={'Enter the hostname in a valid format <br>  <a href="http://www.test.example.com">Click here for examples of valid hostnames</a>'}>
-      Hostname
-    </FieldLevelHelp>
-  )
-);
+stories.addWithInfo('with Popover', 'FieldLevelHelp', () => (
+  <FieldLevelHelp
+    contentType="popover"
+    content={
+      'Enter the hostname in a valid format <br>  <a href="http://www.test.example.com">Click here for examples of valid hostnames</a>'
+    }
+  >
+    Hostname
+  </FieldLevelHelp>
+));
 
-stories.addWithInfo(
-  'with Tooltip',
-  'FieldLevelHelp',
-  () => (
-    <FieldLevelHelp contentType='tooltip' content={'Enter the hostname in a valid format'}>
-      Hostname
-    </FieldLevelHelp>
-  )
-);
+stories.addWithInfo('with Tooltip', 'FieldLevelHelp', () => (
+  <FieldLevelHelp
+    contentType="tooltip"
+    content={'Enter the hostname in a valid format'}
+  >
+    Hostname
+  </FieldLevelHelp>
+));

--- a/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs } from '@storybook/addon-knobs';
+import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { defaultTemplate } from '../../../storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from '../../../storybook/constants';
 import { FieldLevelHelp } from './index';
@@ -15,22 +15,33 @@ stories.addDecorator(
   })
 );
 
-stories.addWithInfo('with Popover', 'FieldLevelHelp', () => (
-  <FieldLevelHelp
-    contentType="popover"
-    content={
-      'Enter the hostname in a valid format <br>  <a href="http://www.test.example.com">Click here for examples of valid hostnames</a>'
-    }
-  >
-    Hostname
-  </FieldLevelHelp>
-));
+stories.addWithInfo('with Popover', 'FieldLevelHelp', () => {
+  const contentType = select('contentType', ['popover', 'tooltip'], 'popover');
+  const content = text(
+    'content',
+    'Enter the hostname in a valid format <br>  <a target="_blank" href="http://www.test.example.com">Click here for examples of valid hostnames</a>'
+  );
+  const fieldLabel = text('Field Label', 'Hostname');
 
-stories.addWithInfo('with Tooltip', 'FieldLevelHelp', () => (
-  <FieldLevelHelp
-    contentType="tooltip"
-    content={'Enter the hostname in a valid format'}
-  >
-    Hostname
-  </FieldLevelHelp>
-));
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <FieldLevelHelp contentType={contentType} content={content}>
+        {fieldLabel}
+      </FieldLevelHelp>
+    </div>
+  );
+});
+
+stories.addWithInfo('with Tooltip', 'FieldLevelHelp', () => {
+  const contentType = select('contentType', ['popover', 'tooltip'], 'tooltip');
+  const content = text('content', 'Enter the hostname in a valid format');
+  const fieldLabel = text('Field Label', 'Hostname');
+
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <FieldLevelHelp contentType={contentType} content={content}>
+        {fieldLabel}
+      </FieldLevelHelp>
+    </div>
+  );
+});

--- a/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
@@ -15,8 +15,7 @@ stories.addDecorator(
   })
 );
 
-stories.addWithInfo('with Popover', 'FieldLevelHelp', () => {
-  const mode = select('mode', ['popover', 'tooltip'], 'popover');
+stories.addWithInfo('FieldLevelHelp', 'FieldLevelHelp', () => {
   const close = select('Close Popover', ['true', 'false']);
   const content = text(
     'content',
@@ -26,23 +25,8 @@ stories.addWithInfo('with Popover', 'FieldLevelHelp', () => {
 
   return (
     <div style={{ textAlign: 'center' }}>
-      <FieldLevelHelp mode={mode} content={content} close={close}>
-        {fieldLabel}
-      </FieldLevelHelp>
-    </div>
-  );
-});
-
-stories.addWithInfo('with Tooltip', 'FieldLevelHelp', () => {
-  const mode = select('mode', ['popover', 'tooltip'], 'tooltip');
-  const content = text('content', 'Enter the hostname in a valid format');
-  const fieldLabel = text('Field Label', 'Hostname');
-
-  return (
-    <div style={{ textAlign: 'center' }}>
-      <FieldLevelHelp mode={mode} content={content}>
-        {fieldLabel}
-      </FieldLevelHelp>
+      {fieldLabel}
+      <FieldLevelHelp content={content} close={close} />
     </div>
   );
 });

--- a/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
@@ -16,7 +16,7 @@ stories.addDecorator(
 );
 
 stories.addWithInfo('with Popover', 'FieldLevelHelp', () => {
-  const contentType = select('contentType', ['popover', 'tooltip'], 'popover');
+  const mode = select('mode', ['popover', 'tooltip'], 'popover');
   const content = text(
     'content',
     'Enter the hostname in a valid format <br>  <a target="_blank" href="http://www.test.example.com">Click here for examples of valid hostnames</a>'
@@ -25,7 +25,7 @@ stories.addWithInfo('with Popover', 'FieldLevelHelp', () => {
 
   return (
     <div style={{ textAlign: 'center' }}>
-      <FieldLevelHelp contentType={contentType} content={content}>
+      <FieldLevelHelp mode={mode} content={content}>
         {fieldLabel}
       </FieldLevelHelp>
     </div>
@@ -33,13 +33,13 @@ stories.addWithInfo('with Popover', 'FieldLevelHelp', () => {
 });
 
 stories.addWithInfo('with Tooltip', 'FieldLevelHelp', () => {
-  const contentType = select('contentType', ['popover', 'tooltip'], 'tooltip');
+  const mode = select('mode', ['popover', 'tooltip'], 'tooltip');
   const content = text('content', 'Enter the hostname in a valid format');
   const fieldLabel = text('Field Label', 'Hostname');
 
   return (
     <div style={{ textAlign: 'center' }}>
-      <FieldLevelHelp contentType={contentType} content={content}>
+      <FieldLevelHelp mode={mode} content={content}>
         {fieldLabel}
       </FieldLevelHelp>
     </div>

--- a/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
@@ -20,7 +20,17 @@ stories.addWithInfo(
   'with Popover',
   'FieldLevelHelp',
   () => (
-    <FieldLevelHelp popoverContent={'Enter the hostname in a valid format <br>  <a href="http://www.test.example.com">Click here for examples of valid hostnames</a>'}>
+    <FieldLevelHelp contentType='popover' content={'Enter the hostname in a valid format <br>  <a href="http://www.test.example.com">Click here for examples of valid hostnames</a>'}>
+      Hostname
+    </FieldLevelHelp>
+  )
+);
+
+stories.addWithInfo(
+  'with Tooltip',
+  'FieldLevelHelp',
+  () => (
+    <FieldLevelHelp contentType='tooltip' content={'Enter the hostname in a valid format'}>
       Hostname
     </FieldLevelHelp>
   )

--- a/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
@@ -17,6 +17,7 @@ stories.addDecorator(
 
 stories.addWithInfo('with Popover', 'FieldLevelHelp', () => {
   const mode = select('mode', ['popover', 'tooltip'], 'popover');
+  const close = select('Close Popover', ['true', 'false']);
   const content = text(
     'content',
     'Enter the hostname in a valid format <br>  <a target="_blank" href="http://www.test.example.com">Click here for examples of valid hostnames</a>'
@@ -25,7 +26,7 @@ stories.addWithInfo('with Popover', 'FieldLevelHelp', () => {
 
   return (
     <div style={{ textAlign: 'center' }}>
-      <FieldLevelHelp mode={mode} content={content}>
+      <FieldLevelHelp mode={mode} content={content} close={close}>
         {fieldLabel}
       </FieldLevelHelp>
     </div>

--- a/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, text } from '@storybook/addon-knobs';
+import { defaultTemplate } from '../../../storybook/decorators/storyTemplates';
+import { DOCUMENTATION_URL } from '../../../storybook/constants';
+import { FieldLevelHelp } from './index';
+
+const stories = storiesOf('FieldLevelHelp', module);
+stories.addDecorator(withKnobs);
+stories.addDecorator(
+  defaultTemplate({
+    title: 'FieldLevelHelp',
+    documentationLink:
+    DOCUMENTATION_URL.PATTERNFLY_ORG_COMMUNICATION + 'inline-notifications/'
+  })
+);
+
+stories.addWithInfo(
+  'with Popover',
+  'FieldLevelHelp',
+  () => (
+    <FieldLevelHelp popoverContent={'Enter the hostname in a valid format <br>  <a href="http://www.test.example.com">Click here for examples of valid hostnames</a>'}>
+      Hostname
+    </FieldLevelHelp>
+  )
+);

--- a/src/components/FieldLevelHelp/FieldLevelHelp.test.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.test.js
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import FieldLevelHelp from './FieldLevelHelp';
+
+test('FieldLevelHelp renders properly', () => {
+  const component = renderer.create(
+    <FieldLevelHelp id="fieldlevelname1">Port Number</FieldLevelHelp>
+  );
+
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('FieldLevelHelp allows to specify contentType and content', () => {
+  const component = renderer.create(
+    <FieldLevelHelp
+      id="fieldlevelname1"
+      contentType="popover"
+      content="Enter Port number between the 4000-5000 range"
+    >
+      Port Number
+    </FieldLevelHelp>
+  );
+
+  let tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/FieldLevelHelp/FieldLevelHelp.test.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.test.js
@@ -25,6 +25,6 @@ test('FieldLevelHelp allows to specify mode and content', () => {
     </FieldLevelHelp>
   );
 
-  let tree = component.toJSON();
+  const tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/src/components/FieldLevelHelp/FieldLevelHelp.test.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.test.js
@@ -14,11 +14,11 @@ test('FieldLevelHelp renders properly', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('FieldLevelHelp allows to specify contentType and content', () => {
+test('FieldLevelHelp allows to specify mode and content', () => {
   const component = renderer.create(
     <FieldLevelHelp
       id="fieldlevelname1"
-      contentType="popover"
+      mode="popover"
       content="Enter Port number between the 4000-5000 range"
     >
       Port Number

--- a/src/components/FieldLevelHelp/FieldLevelHelp.test.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.test.js
@@ -14,12 +14,13 @@ test('FieldLevelHelp renders properly', () => {
   expect(tree).toMatchSnapshot();
 });
 
-test('FieldLevelHelp allows to specify mode and content', () => {
+test('FieldLevelHelp allows to specify mode content and close', () => {
   const component = renderer.create(
     <FieldLevelHelp
       id="fieldlevelname1"
       mode="popover"
       content="Enter Port number between the 4000-5000 range"
+      close="true"
     >
       Port Number
     </FieldLevelHelp>

--- a/src/components/FieldLevelHelp/FieldLevelHelp.test.js
+++ b/src/components/FieldLevelHelp/FieldLevelHelp.test.js
@@ -16,14 +16,15 @@ test('FieldLevelHelp renders properly', () => {
 
 test('FieldLevelHelp allows to specify mode content and close', () => {
   const component = renderer.create(
-    <FieldLevelHelp
-      id="fieldlevelname1"
-      mode="popover"
-      content="Enter Port number between the 4000-5000 range"
-      close="true"
-    >
-      Port Number
-    </FieldLevelHelp>
+    <div>
+      <label>Port Number</label>
+      <FieldLevelHelp
+        id="fieldlevelname1"
+        mode="popover"
+        content="Enter Port number between the 4000-5000 range"
+        close="true"
+      />
+    </div>
   );
 
   const tree = component.toJSON();

--- a/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
+++ b/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FieldLevelHelp allows to specify contentType and content 1`] = `
+exports[`FieldLevelHelp allows to specify mode and content 1`] = `
 <div>
   <label>
     Port Number 

--- a/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
+++ b/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FieldLevelHelp allows to specify mode and content 1`] = `
+exports[`FieldLevelHelp allows to specify mode content and close 1`] = `
 <div>
   <label>
     Port Number 
@@ -26,11 +26,7 @@ exports[`FieldLevelHelp renders properly 1`] = `
   <span
     aria-hidden="true"
     className="pficon pficon-info fa-fw"
-    onBlur={[Function]}
-    onClick={null}
-    onFocus={[Function]}
-    onMouseOut={[Function]}
-    onMouseOver={[Function]}
+    onClick={[Function]}
     style={
       Object {
         "color": "#0088ce",

--- a/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
+++ b/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FieldLevelHelp allows to specify contentType and content 1`] = `
+<div>
+  <label>
+    Port Number 
+  </label>
+  <span
+    aria-hidden="true"
+    className="pficon pficon-info fa-fw"
+    onClick={[Function]}
+    style={
+      Object {
+        "color": "#0088ce",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`FieldLevelHelp renders properly 1`] = `
+<div>
+  <label>
+    Port Number 
+  </label>
+  <span
+    aria-hidden="true"
+    className="pficon pficon-info fa-fw"
+    onBlur={[Function]}
+    onClick={null}
+    onFocus={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
+    style={
+      Object {
+        "color": "#0088ce",
+      }
+    }
+  />
+</div>
+`;

--- a/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
+++ b/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
@@ -9,12 +9,6 @@ exports[`FieldLevelHelp allows to specify mode content and close 1`] = `
     className="btn btn-link"
     disabled={false}
     onClick={[Function]}
-    style={
-      Object {
-        "outline": "none",
-        "textDecoration": "none",
-      }
-    }
     type="button"
   >
     <span
@@ -30,12 +24,6 @@ exports[`FieldLevelHelp renders properly 1`] = `
   className="btn btn-link"
   disabled={false}
   onClick={[Function]}
-  style={
-    Object {
-      "outline": "none",
-      "textDecoration": "none",
-    }
-  }
   type="button"
 >
   <span

--- a/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
+++ b/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
@@ -3,35 +3,44 @@
 exports[`FieldLevelHelp allows to specify mode content and close 1`] = `
 <div>
   <label>
-    Port Number 
+    Port Number
   </label>
-  <span
-    aria-hidden="true"
-    className="pficon pficon-info fa-fw"
+  <button
+    className="btn btn-link"
+    disabled={false}
     onClick={[Function]}
     style={
       Object {
-        "color": "#0088ce",
+        "outline": "none",
+        "textDecoration": "none",
       }
     }
-  />
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      className="pficon pficon-info"
+    />
+  </button>
 </div>
 `;
 
 exports[`FieldLevelHelp renders properly 1`] = `
-<div>
-  <label>
-    Port Number 
-  </label>
+<button
+  className="btn btn-link"
+  disabled={false}
+  onClick={[Function]}
+  style={
+    Object {
+      "outline": "none",
+      "textDecoration": "none",
+    }
+  }
+  type="button"
+>
   <span
     aria-hidden="true"
-    className="pficon pficon-info fa-fw"
-    onClick={[Function]}
-    style={
-      Object {
-        "color": "#0088ce",
-      }
-    }
+    className="pficon pficon-info"
   />
-</div>
+</button>
 `;

--- a/src/components/FieldLevelHelp/index.js
+++ b/src/components/FieldLevelHelp/index.js
@@ -1,0 +1,1 @@
+export { default as FieldLevelHelp } from './FieldLevelHelp';

--- a/src/components/Form/Stories/BasicForm.js
+++ b/src/components/Form/Stories/BasicForm.js
@@ -46,7 +46,6 @@ export const BasicFormFields = [
     useFieldLevelHelp: true,
     content:
       "Please specify Country code <br> <a target='_blank' href='https://countrycode.org/'>Click here for a list of Country codes</a>",
-    mode: 'popover',
     close: 'true',
     help: 'Enter a valid phone number',
     formControl: ({ validationState, ...props }) => (
@@ -104,9 +103,8 @@ export const getBasicFormKnobs = () => ({
   bsSize: select('Size', [null, 'small', 'large']),
   showHelp: boolean('Show Help', true),
   disabled: boolean('Disabled', false),
-  mode: select('Popover/Tooltip', ['popover', 'tooltip'], 'popover'),
   content: text(
-    'Popover/Tooltip Content',
+    'FieldLevelHelp Content',
     "Please specify Country code <br> <a target='_blank' href='https://countrycode.org/'>Click here for a list of Country codes</a>"
   ),
   close: select('Close Popover', ['true', 'false'], 'true')

--- a/src/components/Form/Stories/BasicForm.js
+++ b/src/components/Form/Stories/BasicForm.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { select, boolean } from '@storybook/addon-knobs';
+import { select, boolean, text } from '@storybook/addon-knobs';
 import { Spinner } from '../../Spinner';
 import { Button } from '../../Button';
 import { Form } from '../index';
@@ -38,6 +38,19 @@ export const BasicFormFields = [
     help: 'Enter a valid email address',
     formControl: ({ validationState, ...props }) => (
       <Form.FormControl type="email" {...props} />
+    )
+  },
+  {
+    controlId: 'phone',
+    label: 'Phone',
+    useFieldLevelHelp: true,
+    content:
+      "Please specify Country code <br> <a target='_blank' href='https://countrycode.org/'>Click here for a list of Country codes</a>",
+    mode: 'popover',
+    close: 'true',
+    help: 'Enter a valid phone number',
+    formControl: ({ validationState, ...props }) => (
+      <Form.FormControl type="phone" {...props} />
     )
   },
   {
@@ -90,5 +103,11 @@ export const getBasicFormKnobs = () => ({
   ]),
   bsSize: select('Size', [null, 'small', 'large']),
   showHelp: boolean('Show Help', true),
-  disabled: boolean('Disabled', false)
+  disabled: boolean('Disabled', false),
+  mode: select('Popover/Tooltip', ['popover', 'tooltip'], 'popover'),
+  content: text(
+    'Popover/Tooltip Content',
+    "Please specify Country code <br> <a target='_blank' href='https://countrycode.org/'>Click here for a list of Country codes</a>"
+  ),
+  close: select('Close Popover', ['true', 'false'], 'true')
 });

--- a/src/components/Form/Stories/BasicForm.js
+++ b/src/components/Form/Stories/BasicForm.js
@@ -104,7 +104,7 @@ export const getBasicFormKnobs = () => ({
   showHelp: boolean('Show Help', true),
   disabled: boolean('Disabled', false),
   content: text(
-    'FieldLevelHelp Content',
+    'Field Level Help Content',
     "Please specify Country code <br> <a target='_blank' href='https://countrycode.org/'>Click here for a list of Country codes</a>"
   ),
   close: select('Close Popover', ['true', 'false'], 'true')

--- a/src/components/Form/Stories/HorizontalFormField.js
+++ b/src/components/Form/Stories/HorizontalFormField.js
@@ -26,11 +26,18 @@ export const HorizontalFormField = ({
   const formGroupProps = { key: controlId, controlId, ...controlProps };
 
   if (useFieldLevelHelp) {
+    const htmlContent = (
+      <div
+        dangerouslySetInnerHTML={{
+          __html: content
+        }}
+      />
+    );
     return (
       <Form.FormGroup {...formGroupProps}>
         <Grid.Col componentClass={Form.ControlLabel} sm={3}>
           {label}
-          <FieldLevelHelp content={content} close={close} />
+          <FieldLevelHelp content={htmlContent} close={close} />
         </Grid.Col>
         <Grid.Col sm={9}>
           {formControl(controlProps)}

--- a/src/components/Form/Stories/HorizontalFormField.js
+++ b/src/components/Form/Stories/HorizontalFormField.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Grid } from '../../Grid';
 import { Form } from '../index';
+import { FieldLevelHelp } from '../../FieldLevelHelp/index';
 
 export const HorizontalFormField = ({
   controlId,
@@ -12,24 +13,51 @@ export const HorizontalFormField = ({
   validationState,
   bsSize,
   showHelp,
+  useFieldLevelHelp,
+  content,
+  mode,
+  close,
   ...props
 }) => {
   const controlProps = { ...props };
 
   if (bsSize) controlProps.bsSize = bsSize;
   if (validationState) controlProps.validationState = validationState;
+  if (mode) controlProps.mode = mode;
+  if (content) controlProps.content = content;
+  if (close) controlProps.close = close;
 
   const formGroupProps = { key: controlId, controlId, ...controlProps };
 
-  return (
-    <Form.FormGroup {...formGroupProps}>
-      <Grid.Col componentClass={Form.ControlLabel} sm={3}>
-        {label}
-      </Grid.Col>
-      <Grid.Col sm={9}>
-        {formControl(controlProps)}
-        {showHelp && help && <Form.HelpBlock>{help}</Form.HelpBlock>}
-      </Grid.Col>
-    </Form.FormGroup>
-  );
+  if (useFieldLevelHelp) {
+    return (
+      <Form.FormGroup {...formGroupProps}>
+        <Grid.Col componentClass={Form.ControlLabel} sm={3}>
+          <FieldLevelHelp
+            mode={controlProps.mode}
+            content={controlProps.content}
+            close={controlProps.close}
+          >
+            {label}
+          </FieldLevelHelp>
+        </Grid.Col>
+        <Grid.Col sm={9}>
+          {formControl(controlProps)}
+          {showHelp && help && <Form.HelpBlock>{help}</Form.HelpBlock>}
+        </Grid.Col>
+      </Form.FormGroup>
+    );
+  } else {
+    return (
+      <Form.FormGroup {...formGroupProps}>
+        <Grid.Col componentClass={Form.ControlLabel} sm={3}>
+          {label}
+        </Grid.Col>
+        <Grid.Col sm={9}>
+          {formControl(controlProps)}
+          {showHelp && help && <Form.HelpBlock>{help}</Form.HelpBlock>}
+        </Grid.Col>
+      </Form.FormGroup>
+    );
+  }
 };

--- a/src/components/Form/Stories/HorizontalFormField.js
+++ b/src/components/Form/Stories/HorizontalFormField.js
@@ -15,7 +15,6 @@ export const HorizontalFormField = ({
   showHelp,
   useFieldLevelHelp,
   content,
-  mode,
   close,
   ...props
 }) => {
@@ -23,9 +22,6 @@ export const HorizontalFormField = ({
 
   if (bsSize) controlProps.bsSize = bsSize;
   if (validationState) controlProps.validationState = validationState;
-  if (mode) controlProps.mode = mode;
-  if (content) controlProps.content = content;
-  if (close) controlProps.close = close;
 
   const formGroupProps = { key: controlId, controlId, ...controlProps };
 
@@ -33,13 +29,8 @@ export const HorizontalFormField = ({
     return (
       <Form.FormGroup {...formGroupProps}>
         <Grid.Col componentClass={Form.ControlLabel} sm={3}>
-          <FieldLevelHelp
-            mode={controlProps.mode}
-            content={controlProps.content}
-            close={controlProps.close}
-          >
-            {label}
-          </FieldLevelHelp>
+          {label}
+          <FieldLevelHelp content={content} close={close} />
         </Grid.Col>
         <Grid.Col sm={9}>
           {formControl(controlProps)}

--- a/src/components/Form/Stories/SupportedControlsForm.js
+++ b/src/components/Form/Stories/SupportedControlsForm.js
@@ -96,13 +96,12 @@ export const SupportedControlsFormFields = [
     help: 'Help text',
     formControl: ({ validationState, ...props }) => (
       <div>
+        Phone
         <FieldLevelHelp
           {...props}
           content="Please specify Country code <br> <a target='_blank' href='https://countrycode.org/'>Click here for a list of Country codes</a>"
           inline
-        >
-          Phone
-        </FieldLevelHelp>
+        />
       </div>
     )
   },

--- a/src/components/Form/Stories/SupportedControlsForm.js
+++ b/src/components/Form/Stories/SupportedControlsForm.js
@@ -92,7 +92,7 @@ export const SupportedControlsFormFields = [
   },
   {
     controlId: 'FieldLevelHelp',
-    label: 'FieldLevelHelp',
+    label: 'Field Level Help',
     help: 'Help text',
     formControl: ({ validationState, ...props }) => (
       <div>

--- a/src/components/Form/Stories/SupportedControlsForm.js
+++ b/src/components/Form/Stories/SupportedControlsForm.js
@@ -97,11 +97,7 @@ export const SupportedControlsFormFields = [
     formControl: ({ validationState, ...props }) => (
       <div>
         Phone
-        <FieldLevelHelp
-          {...props}
-          content="Please specify Country code <br> <a target='_blank' href='https://countrycode.org/'>Click here for a list of Country codes</a>"
-          inline
-        />
+        <FieldLevelHelp {...props} content="More info here" inline />
       </div>
     )
   },

--- a/src/components/Form/Stories/SupportedControlsForm.js
+++ b/src/components/Form/Stories/SupportedControlsForm.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import { select, boolean } from '@storybook/addon-knobs';
 import { Form } from '../index';
+import { FieldLevelHelp } from '../../FieldLevelHelp/index';
 
 export const SupportedControlsFormFields = [
   {
@@ -86,6 +87,22 @@ export const SupportedControlsFormFields = [
         <Form.Radio {...props} name="radioGroup" inline>
           3
         </Form.Radio>
+      </div>
+    )
+  },
+  {
+    controlId: 'FieldLevelHelp',
+    label: 'FieldLevelHelp',
+    help: 'Help text',
+    formControl: ({ validationState, ...props }) => (
+      <div>
+        <FieldLevelHelp
+          {...props}
+          content="Please specify Country code <br> <a target='_blank' href='https://countrycode.org/'>Click here for a list of Country codes</a>"
+          inline
+        >
+          Phone
+        </FieldLevelHelp>
       </div>
     )
   },

--- a/src/components/Form/Stories/VerticalFormField.js
+++ b/src/components/Form/Stories/VerticalFormField.js
@@ -25,11 +25,18 @@ export const VerticalFormField = ({
   const formGroupProps = { key: controlId, controlId, ...controlProps };
 
   if (useFieldLevelHelp) {
+    const htmlContent = (
+      <div
+        dangerouslySetInnerHTML={{
+          __html: content
+        }}
+      />
+    );
     return (
       <Form.FormGroup {...formGroupProps}>
         {label && <Form.ControlLabel>{label}</Form.ControlLabel>}
         <Form.ControlLabel>
-          <FieldLevelHelp content={content} close={close} />
+          <FieldLevelHelp content={htmlContent} close={close} />
         </Form.ControlLabel>
         {formControl(controlProps)}
         {showHelp && help && <Form.HelpBlock>{help}</Form.HelpBlock>}

--- a/src/components/Form/Stories/VerticalFormField.js
+++ b/src/components/Form/Stories/VerticalFormField.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Form } from '../index';
+import { FieldLevelHelp } from '../../FieldLevelHelp/index';
 
 export const VerticalFormField = ({
   controlId,
@@ -11,20 +12,47 @@ export const VerticalFormField = ({
   validationState,
   bsSize,
   showHelp,
+  useFieldLevelHelp,
+  content,
+  mode,
+  close,
   ...props
 }) => {
   const controlProps = { ...props };
 
   if (bsSize) controlProps.bsSize = bsSize;
   if (validationState) controlProps.validationState = validationState;
+  if (mode) controlProps.mode = mode;
+  if (content) controlProps.content = content;
+  if (close) controlProps.close = close;
 
   const formGroupProps = { key: controlId, controlId, ...controlProps };
 
-  return (
-    <Form.FormGroup {...formGroupProps}>
-      {label && <Form.ControlLabel>{label}</Form.ControlLabel>}
-      {formControl(controlProps)}
-      {showHelp && help && <Form.HelpBlock>{help}</Form.HelpBlock>}
-    </Form.FormGroup>
-  );
+  if (useFieldLevelHelp) {
+    return (
+      <Form.FormGroup {...formGroupProps}>
+        {label && (
+          <Form.ControlLabel>
+            <FieldLevelHelp
+              mode={controlProps.mode}
+              content={controlProps.content}
+              close={controlProps.close}
+            >
+              {label}
+            </FieldLevelHelp>
+          </Form.ControlLabel>
+        )}
+        {formControl(controlProps)}
+        {showHelp && help && <Form.HelpBlock>{help}</Form.HelpBlock>}
+      </Form.FormGroup>
+    );
+  } else {
+    return (
+      <Form.FormGroup {...formGroupProps}>
+        {label && <Form.ControlLabel>{label}</Form.ControlLabel>}
+        {formControl(controlProps)}
+        {showHelp && help && <Form.HelpBlock>{help}</Form.HelpBlock>}
+      </Form.FormGroup>
+    );
+  }
 };

--- a/src/components/Form/Stories/VerticalFormField.js
+++ b/src/components/Form/Stories/VerticalFormField.js
@@ -14,7 +14,6 @@ export const VerticalFormField = ({
   showHelp,
   useFieldLevelHelp,
   content,
-  mode,
   close,
   ...props
 }) => {
@@ -22,26 +21,16 @@ export const VerticalFormField = ({
 
   if (bsSize) controlProps.bsSize = bsSize;
   if (validationState) controlProps.validationState = validationState;
-  if (mode) controlProps.mode = mode;
-  if (content) controlProps.content = content;
-  if (close) controlProps.close = close;
 
   const formGroupProps = { key: controlId, controlId, ...controlProps };
 
   if (useFieldLevelHelp) {
     return (
       <Form.FormGroup {...formGroupProps}>
-        {label && (
-          <Form.ControlLabel>
-            <FieldLevelHelp
-              mode={controlProps.mode}
-              content={controlProps.content}
-              close={controlProps.close}
-            >
-              {label}
-            </FieldLevelHelp>
-          </Form.ControlLabel>
-        )}
+        {label && <Form.ControlLabel>{label}</Form.ControlLabel>}
+        <Form.ControlLabel>
+          <FieldLevelHelp content={content} close={close} />
+        </Form.ControlLabel>
         {formControl(controlProps)}
         {showHelp && help && <Form.HelpBlock>{help}</Form.HelpBlock>}
       </Form.FormGroup>

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ export * from './components/Button';
 export * from './components/Dropdown';
 export * from './components/DropdownKebab';
 export * from './components/EmptyState';
+export * from './components/FieldLevelHelp';
 export * from './components/Filter';
 export * from './components/Form';
 export * from './components/Grid';


### PR DESCRIPTION
Added a new component called `FieldLevelHelp` based on the design requirements in  http://www.patternfly.org/pattern-library/forms-and-controls/help-on-forms/

[FieldLevelHelp Storybook](https://rawgit.com/AparnaKarve/patternfly-react/add_fieldlevelhelp_component-storybook/index.html?knob-Show%20Modal=true&knob-content=Enter%20the%20hostname%20in%20a%20valid%20format%20%3Cbr%3E%20%20%3Ca%20target%3D%22_blank%22%20href%3D%22http%3A%2F%2Fwww.test.example.com%22%3EClick%20here%20for%20examples%20of%20valid%20hostnames%3C%2Fa%3E&knob-Close%20Popover=true&knob-Show%20Labels=false&knob-Show%20Help=true&knob-Show%20Loading=false&knob-Disabled=false&knob-Field%20Label=Hostname&knob-FieldLevelHelp%20Content=Please%20specify%20Country%20code%20%3Cbr%3E%20%3Ca%20target%3D%27_blank%27%20href%3D%27https%3A%2F%2Fcountrycode.org%2F%27%3EClick%20here%20for%20a%20list%20of%20Country%20codes%3C%2Fa%3E&selectedKind=Forms&selectedStory=Inline%20Form&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)

Fixes https://github.com/patternfly/patternfly-react/issues/115
