### PR TITLE
feat(About): add ability to use product title image

### DIFF
--- a/src/components/AboutModal/AboutModal.js
+++ b/src/components/AboutModal/AboutModal.js
@@ -51,8 +51,8 @@ AboutModal.propTypes = {
   show: PropTypes.bool.isRequired,
   /** Function to call when modal is closed */
   onHide: PropTypes.func.isRequired,
-  /** Text to show for the product title */
-  productTitle: PropTypes.string,
+  /** Text or Element to show for the product title */
+  productTitle: PropTypes.node,
   /** Image Source for the Product logo */
   logo: PropTypes.string,
   /** Alternate text if invalid logo */

--- a/src/components/AboutModal/__mocks__/mockAboutModal.js
+++ b/src/components/AboutModal/__mocks__/mockAboutModal.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button } from '../../Button';
 import { AboutModal } from '../index';
 import logo from 'patternfly/dist/img/logo-alt.svg';
+import productTitle from 'patternfly/dist/img/brand-alt.svg';
 
 export class MockAboutModal extends React.Component {
   constructor() {
@@ -26,7 +27,7 @@ export class MockAboutModal extends React.Component {
         <AboutModal
           show={this.state.showModal}
           onHide={this.close}
-          productTitle="Product Title"
+          productTitle={<img src={productTitle} alt="Product Title" />}
           logo={logo}
           altLogo="Patternfly Logo"
           trademarkText="Trademark and Copyright Information"


### PR DESCRIPTION
**What**:
Adds the ability to pass an image (or other node) for the product title in the about modal.

**Link to Storybook**:
https://jeff-phillips-18.github.io/patternfly-react/

**Additional issues**:
Fixes #197 
