### PR TITLE
feat(helpers.js): Add getDisplayName helper from miq_v2v_ui_plugin

### DIFF
--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -36,3 +36,6 @@ export const propsChanged = (propNames, oldProps, newProps) =>
 export const nullValues = obj => selectKeys(obj, Object.keys(obj), () => null);
 
 export const noop = Function.prototype;
+
+export const getDisplayName = Component =>
+  Component.displayName || Component.name || 'Component';

--- a/src/common/helpers.test.js
+++ b/src/common/helpers.test.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import ShallowRenderer from 'react-test-renderer/shallow';
+import {
+  bindMethods,
+  selectKeys,
+  filterKeys,
+  childrenToArray,
+  filterChildren,
+  findChild,
+  propsChanged,
+  nullValues,
+  noop,
+  getDisplayName
+} from './helpers';
+
+describe('Helper functions', () => {
+  const renderer = new ShallowRenderer();
+
+  test('should bindMethods correctly', () => {
+    class UnboundTestComponent extends React.Component {
+      constructor() {
+        super();
+        this.state = { testValue: 'foo' };
+      }
+      testMethod() {
+        return this && this.state && this.state.testValue;
+      }
+      render() {
+        console.log(this.testMethod);
+        return this.testMethod();
+      }
+    }
+    class BoundTestComponent extends React.Component {
+      constructor() {
+        super();
+        this.state = { testValue: 'foo' };
+        bindMethods(this, ['testMethod']);
+      }
+      testMethod() {
+        return this && this.state && this.state.testValue;
+      }
+      render() {
+        return this.testMethod();
+      }
+    }
+    expect(renderer.render(<UnboundTestComponent />)).toBeUndefined();
+    expect(renderer.render(<BoundTestComponent />)).toBe('foo');
+  });
+  test('should selectKeys correctly', () => {
+    expect().toMatchSnapshot();
+  });
+  test('should filterKeys correctly', () => {
+    expect().toMatchSnapshot();
+  });
+  test('should convert childrenToArray correctly', () => {
+    expect().toMatchSnapshot();
+  });
+  test('should filterChildren correctly', () => {
+    expect().toMatchSnapshot();
+  });
+  test('should findChild correctly', () => {
+    expect().toMatchSnapshot();
+  });
+  test('should determine propsChanged correctly', () => {
+    expect().toMatchSnapshot();
+  });
+  test('should initialize nullValues correctly', () => {
+    expect().toMatchSnapshot();
+  });
+  test('should noop correctly', () => {
+    expect().toMatchSnapshot();
+  });
+  test('should getDisplayName correctly', () => {
+    expect().toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:

Adding the `getDisplayName` helper function that we had been using in the v2v plugin. It is generally useful for all pf-react.

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:

http://rawgit.com/mturley/patternfly-react/getDisplayName-sb/index.html

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

No. However we will want to delete the newly-empty `helpers.js` file in miq_v2v_ui_plugin once this helper is available in patternfly-react.

<!-- feel free to add additional comments -->