### PR TITLE
fix(pagination): Allow drop down for page size selector

### DIFF
--- a/src/components/Pagination/Paginate.test.js
+++ b/src/components/Pagination/Paginate.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { Paginator, PaginationRow, PAGINATION_VIEW_TYPES } from './index';
 
-const testPaginationRowSnapshot = viewType => {
+const testPaginationRowSnapshot = (viewType, pageSizeDropUp = true) => {
   const component = renderer.create(
     <PaginationRow
       viewType={viewType}
@@ -13,6 +13,7 @@ const testPaginationRowSnapshot = viewType => {
         perPageOptions: [6, 10, 15, 25, 50]
       }}
       amountOfPages={5}
+      pageSizeDropUp={pageSizeDropUp}
       itemCount={75}
       itemsStart={1}
       itemsEnd={15}
@@ -54,6 +55,10 @@ test('PaginationRow.Items renders', () => {
   );
   let tree = component.toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+test('PaginationRow renders with dropdown page size selector', () => {
+  testPaginationRowSnapshot(PAGINATION_VIEW_TYPES.List, false);
 });
 
 test('PaginationRow.Back renders', () => {

--- a/src/components/Pagination/Pagination.stories.js
+++ b/src/components/Pagination/Pagination.stories.js
@@ -2,7 +2,13 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
-import { withKnobs, text, number, select } from '@storybook/addon-knobs';
+import {
+  withKnobs,
+  text,
+  number,
+  select,
+  boolean
+} from '@storybook/addon-knobs';
 import { inlineTemplate } from '../../../storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from '../../../storybook/constants';
 
@@ -43,6 +49,7 @@ stories.add(
           PAGINATION_VIEW_TYPES[0]
         )}
         amountOfPages={number('Number of Pages', 5)}
+        pageSizeDropUp={boolean('Page Size Drop Up', true)}
         itemCount={number('Item Count:', 75)}
         itemsStart={number('Items Start:', 1)}
         itemsEnd={number('Items End', 15)}

--- a/src/components/Pagination/PaginationRow.js
+++ b/src/components/Pagination/PaginationRow.js
@@ -20,6 +20,7 @@ const PaginationRow = ({
   className,
   viewType,
   pagination,
+  pageSizeDropUp,
   pageInputValue,
   amountOfPages,
   itemCount,
@@ -54,7 +55,7 @@ const PaginationRow = ({
       <FormGroup>
         <DropdownButton
           title={perPage}
-          dropup
+          dropup={pageSizeDropUp}
           componentClass={PaginationRowButtonGroup}
           onSelect={onPerPageSelect}
           id={dropdownButtonId}
@@ -126,6 +127,8 @@ PaginationRow.propTypes = {
     /** per page options */
     perPageOptions: PropTypes.array
   }),
+  /** Page size button drops up */
+  pageSizeDropUp: PropTypes.bool,
   /** page input (optional override for page input) */
   pageInputValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** calculated amount of pages */
@@ -173,6 +176,7 @@ PaginationRow.defaultProps = {
     perPage: 'per page',
     of: 'of'
   },
+  pageSizeDropUp: true,
   onSubmit: noop,
   onPerPageSelect: noop,
   onFirstPage: noop,

--- a/src/components/Pagination/__mocks__/mockPaginationRow.js
+++ b/src/components/Pagination/__mocks__/mockPaginationRow.js
@@ -29,6 +29,7 @@ export class MockPaginationRow extends React.Component {
     const {
       viewType,
       amountOfPages,
+      pageSizeDropUp,
       itemCount,
       itemsStart,
       itemsEnd,
@@ -43,6 +44,7 @@ export class MockPaginationRow extends React.Component {
         viewType={viewType}
         pagination={this.state.pagination}
         amountOfPages={amountOfPages}
+        pageSizeDropUp={pageSizeDropUp}
         itemCount={itemCount}
         itemsStart={itemsStart}
         itemsEnd={itemsEnd}
@@ -59,6 +61,7 @@ export class MockPaginationRow extends React.Component {
 MockPaginationRow.propTypes = {
   viewType: PropTypes.oneOf(PAGINATION_VIEW_TYPES),
   amountOfPages: PropTypes.number,
+  pageSizeDropUp: PropTypes.bool,
   itemCount: PropTypes.number,
   itemsStart: PropTypes.number,
   itemsEnd: PropTypes.number,

--- a/src/components/Pagination/__snapshots__/Paginate.test.js.snap
+++ b/src/components/Pagination/__snapshots__/Paginate.test.js.snap
@@ -446,6 +446,229 @@ exports[`PaginationRow list renders properly 1`] = `
 </form>
 `;
 
+exports[`PaginationRow renders with dropdown page size selector 1`] = `
+<form
+  className="content-view-pf-pagination paginator clearfix "
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group"
+  >
+    <div
+      className="dropdown pagination-pf-pagesize btn-group"
+    >
+      <button
+        aria-expanded={false}
+        aria-haspopup={true}
+        className="dropdown-toggle btn btn-default"
+        disabled={false}
+        id="pagination-row-dropdown"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="button"
+        type="button"
+      >
+        6
+         
+        <span
+          className="caret"
+        />
+      </button>
+      <ul
+        aria-labelledby="pagination-row-dropdown"
+        className="dropdown-menu"
+        role="menu"
+      >
+        <li
+          className="active"
+          role="presentation"
+          style={undefined}
+        >
+          <a
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="menuitem"
+            tabIndex="-1"
+          >
+            6
+          </a>
+        </li>
+        <li
+          className=""
+          role="presentation"
+          style={undefined}
+        >
+          <a
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="menuitem"
+            tabIndex="-1"
+          >
+            10
+          </a>
+        </li>
+        <li
+          className=""
+          role="presentation"
+          style={undefined}
+        >
+          <a
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="menuitem"
+            tabIndex="-1"
+          >
+            15
+          </a>
+        </li>
+        <li
+          className=""
+          role="presentation"
+          style={undefined}
+        >
+          <a
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="menuitem"
+            tabIndex="-1"
+          >
+            25
+          </a>
+        </li>
+        <li
+          className=""
+          role="presentation"
+          style={undefined}
+        >
+          <a
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="menuitem"
+            tabIndex="-1"
+          >
+            50
+          </a>
+        </li>
+      </ul>
+    </div>
+    <span>
+      לדף
+    </span>
+  </div>
+  <div
+    className="form-group"
+  >
+    <span>
+      <span
+        className="pagination-pf-items-current"
+      >
+        1
+        -
+        15
+      </span>
+       
+      שֶׁל
+       
+      <span
+        className="pagination-pf-items-total"
+      >
+        75
+      </span>
+    </span>
+    <ul
+      className="pagination pagination-pf-back"
+    >
+      <li
+        className="disabled"
+      >
+        <a
+          href="#"
+          onClick={[Function]}
+          title="עמוד ראשון"
+        >
+          <span
+            aria-hidden={true}
+            className="fa fa-angle-double-left i"
+          />
+        </a>
+      </li>
+      <li
+        className="disabled"
+      >
+        <a
+          href="#"
+          onClick={[Function]}
+          title="עמוד קודם"
+        >
+          <span
+            aria-hidden={true}
+            className="fa fa-angle-left i"
+          />
+        </a>
+      </li>
+    </ul>
+    <label
+      className="sr-only control-label"
+      htmlFor={undefined}
+    />
+    <input
+      className="pagination-pf-page form-control"
+      id={undefined}
+      onChange={[MockFunction]}
+      type="text"
+      value={1}
+    />
+    <span>
+       
+      שֶׁל
+       
+      <span
+        className="pagination-pf-pages"
+      >
+        5
+      </span>
+    </span>
+    <ul
+      className="pagination pagination-pf-forward"
+    >
+      <li
+        className=""
+      >
+        <a
+          href="#"
+          onClick={[Function]}
+          title="עמוד הבא"
+        >
+          <span
+            aria-hidden={true}
+            className="fa fa-angle-right i"
+          />
+        </a>
+      </li>
+      <li
+        className=""
+      >
+        <a
+          href="#"
+          onClick={[Function]}
+          title="עמוד אחרון"
+        >
+          <span
+            aria-hidden={true}
+            className="fa fa-angle-double-right i"
+          />
+        </a>
+      </li>
+    </ul>
+  </div>
+</form>
+`;
+
 exports[`PaginationRow table renders properly 1`] = `
 <form
   className="content-view-pf-pagination paginator table-view-pf-pagination clearfix "


### PR DESCRIPTION
**What**:
The PaginationRow component cannot be used at the top of the page because the page size selector is set to be dropup only and selections are not visible. This PR adds the property `pageSizeDropUp` which defaults to true but can be set to false so that the selections drop down instead.

**Link to Storybook**:
https://jeff-phillips-18.github.io/patternfly-react/

