### PR TITLE
chore(ToastNotification) update storybook, increase test coverage

### DIFF
--- a/src/components/ToastNotification/ToastNotification.stories.js
+++ b/src/components/ToastNotification/ToastNotification.stories.js
@@ -32,7 +32,7 @@ stories.addWithInfo(
     const actionEnabled = boolean('Action', true);
 
     const story = (
-      <div>
+      <ToastNotificationList>
         <ToastNotification
           type={type}
           onDismiss={
@@ -59,7 +59,7 @@ stories.addWithInfo(
             {message}
           </span>
         </ToastNotification>
-      </div>
+      </ToastNotificationList>
     );
 
     return inlineTemplate({

--- a/src/components/ToastNotification/__snapshots__/ToastNotification.test.js.snap
+++ b/src/components/ToastNotification/__snapshots__/ToastNotification.test.js.snap
@@ -1,57 +1,69 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TimedToastNotification renders properly 1`] = `
+exports[`TimedToastNotification persisted and paused renders properly 1`] = `
 <div
-  className="alert toast-pf alert-danger alert-dismissable"
+  className="toast-notifications-list-pf"
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
 >
-  <button
-    aria-hidden="true"
-    className="close close-default"
-    disabled={false}
-    onClick={[MockFunction]}
-    type="button"
+  <div
+    className="alert toast-pf alert-success alert-dismissable"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
+    <button
+      aria-hidden="true"
+      className="close close-default"
+      disabled={false}
+      onClick={[MockFunction]}
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        className="pficon pficon-close"
+      />
+    </button>
     <span
       aria-hidden="true"
-      className="pficon pficon-close"
+      className="pficon pficon-ok"
     />
-  </button>
-  <span
-    aria-hidden="true"
-    className="pficon pficon-error-circle-o"
-  />
-  <span>
-    Danger Will Robinson!
-  </span>
+    <span>
+      Success Will Robinson!
+    </span>
+  </div>
 </div>
 `;
 
 exports[`ToastNotification renders properly 1`] = `
 <div
-  className="alert toast-pf alert-danger alert-dismissable"
-  onMouseEnter={[MockFunction]}
-  onMouseLeave={[MockFunction]}
+  className="toast-notifications-list-pf"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
-  <button
-    aria-hidden="true"
-    className="close close-default"
-    disabled={false}
-    onClick={[MockFunction]}
-    type="button"
+  <div
+    className="alert toast-pf alert-danger alert-dismissable"
+    onMouseEnter={[MockFunction]}
+    onMouseLeave={[MockFunction]}
   >
+    <button
+      aria-hidden="true"
+      className="close close-default"
+      disabled={false}
+      onClick={[MockFunction]}
+      type="button"
+    >
+      <span
+        aria-hidden="true"
+        className="pficon pficon-close"
+      />
+    </button>
     <span
       aria-hidden="true"
-      className="pficon pficon-close"
+      className="pficon pficon-error-circle-o"
     />
-  </button>
-  <span
-    aria-hidden="true"
-    className="pficon pficon-error-circle-o"
-  />
-  <span>
-    Danger Will Robinson!
-  </span>
+    <span>
+      Success Will Robinson!
+    </span>
+  </div>
 </div>
 `;


### PR DESCRIPTION
fixes #220

yeah so here's that storybook thing, [look **LOOK** toast is no longer full view port 😏 ](https://allenbw.github.io/patternfly-react/?knob-Header=Great%20job%21&knob-Message=This%20is%20really%20working%20out.&knob-Type=success&knob-Dismiss=false&knob-Menu=true&knob-Action=true&selectedKind=ToastNotification&selectedStory=Toast%20Notification&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)


~~close your eyes, don't look, list of things I KNOW gotta happen before this can be un-wipped (really we're just walking through the motions of throwing up a wip pr, gettin' da 👣 💧, secretly stealing travis runtime to get a sense of coverage increase )~~

* ~~need storybook~~
* ~~squash all da commits~~
* ~~even mo coverage~~
* ~~clean it all up~~
* ~~add some reviewers~~