### PR TITLE
feat(Breadcrumb): breadcrumbs combined with page title

### DIFF
--- a/less/breadcrumb.less
+++ b/less/breadcrumb.less
@@ -1,0 +1,4 @@
+.breadcrumbs-pf-title .active span {
+  font-size: 16px;
+  vertical-align: -2px;
+}

--- a/less/patternfly-react.less
+++ b/less/patternfly-react.less
@@ -1,4 +1,6 @@
 /**
   Patternfly React Specific Extensions
 */
-@import "utilization-bar";
+
+@import 'utilization-bar';
+@import 'breadcrumb';

--- a/sass/patternfly-react/_breadcrumb.scss
+++ b/sass/patternfly-react/_breadcrumb.scss
@@ -1,0 +1,4 @@
+.breadcrumbs-pf-title .active span {
+  font-size: 16px;
+  vertical-align: -2px;
+}

--- a/sass/patternfly-react/_patternfly-react.scss
+++ b/sass/patternfly-react/_patternfly-react.scss
@@ -1,4 +1,6 @@
 /**
   Patternfly React Partials
 */
-@import "utilization-bar";
+
+@import 'utilization-bar';
+@import 'breadcrumb';

--- a/src/components/Breadcrumb/Breadcrumb.js
+++ b/src/components/Breadcrumb/Breadcrumb.js
@@ -1,1 +1,24 @@
-export { Breadcrumb as default } from 'react-bootstrap';
+import React from 'react';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import { Breadcrumb as BsBreadcrumb } from 'react-bootstrap';
+
+const Breadcrumb = ({ title, ...props }) => {
+  const breadcrumbClass = cx({
+    'breadcrumbs-pf-title': title
+  });
+  return <BsBreadcrumb className={breadcrumbClass} {...props} />;
+};
+
+Breadcrumb.propTypes = {
+  ...BsBreadcrumb.propTypes,
+  title: PropTypes.bool
+};
+
+Breadcrumb.defaultProps = {
+  title: false
+};
+
+Breadcrumb.Item = BsBreadcrumb.Item;
+
+export default Breadcrumb;

--- a/src/components/Breadcrumb/Breadcrumb.stories.js
+++ b/src/components/Breadcrumb/Breadcrumb.stories.js
@@ -36,3 +36,13 @@ stories.addWithInfo('Breadcrumb', '', () => (
     <Breadcrumb.Item active>Data</Breadcrumb.Item>
   </Breadcrumb>
 ));
+
+stories.addWithInfo('Breadcrumb combined with page title', '', () => (
+  <Breadcrumb title>
+    <Breadcrumb.Item href="#">Home</Breadcrumb.Item>
+    <Breadcrumb.Item href="http://getbootstrap.com/components/#breadcrumbs">
+      Library
+    </Breadcrumb.Item>
+    <Breadcrumb.Item active>Data</Breadcrumb.Item>
+  </Breadcrumb>
+));

--- a/src/components/Breadcrumb/Breadcrumb.test.js
+++ b/src/components/Breadcrumb/Breadcrumb.test.js
@@ -1,0 +1,35 @@
+/* eslint-env jest */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { Breadcrumb } from './index';
+
+test('Breadcrumb icon renders properly', () => {
+  const component = renderer.create(
+    <Breadcrumb>
+      <Breadcrumb.Item href="#">Home</Breadcrumb.Item>
+      <Breadcrumb.Item href="http://getbootstrap.com/components/#breadcrumbs">
+        Library
+      </Breadcrumb.Item>
+      <Breadcrumb.Item active>Data</Breadcrumb.Item>
+    </Breadcrumb>
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+test('Breadcrum combined with page title', () => {
+  const component = renderer.create(
+    <Breadcrumb title>
+      <Breadcrumb.Item href="#">Home</Breadcrumb.Item>
+      <Breadcrumb.Item href="http://getbootstrap.com/components/#breadcrumbs">
+        Library
+      </Breadcrumb.Item>
+      <Breadcrumb.Item active>Data</Breadcrumb.Item>
+    </Breadcrumb>
+  );
+
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.js.snap
+++ b/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.js.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Breadcrum combined with page title 1`] = `
+<ol
+  aria-label="breadcrumbs"
+  className="breadcrumbs-pf-title breadcrumb"
+  role="navigation"
+>
+  <li
+    className=""
+  >
+    <a
+      href="#"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      target={undefined}
+      title={undefined}
+    >
+      Home
+    </a>
+  </li>
+  <li
+    className=""
+  >
+    <a
+      href="http://getbootstrap.com/components/#breadcrumbs"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      target={undefined}
+      title={undefined}
+    >
+      Library
+    </a>
+  </li>
+  <li
+    className="active"
+  >
+    <span>
+      Data
+    </span>
+  </li>
+</ol>
+`;
+
+exports[`Breadcrumb icon renders properly 1`] = `
+<ol
+  aria-label="breadcrumbs"
+  className="breadcrumb"
+  role="navigation"
+>
+  <li
+    className=""
+  >
+    <a
+      href="#"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+      target={undefined}
+      title={undefined}
+    >
+      Home
+    </a>
+  </li>
+  <li
+    className=""
+  >
+    <a
+      href="http://getbootstrap.com/components/#breadcrumbs"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      target={undefined}
+      title={undefined}
+    >
+      Library
+    </a>
+  </li>
+  <li
+    className="active"
+  >
+    <span>
+      Data
+    </span>
+  </li>
+</ol>
+`;


### PR DESCRIPTION
Adds breadcrumbs combined with page title as it described in the patternfly design page. 
Storybook:
https://rawgit.com/amirfefer/patternfly-react/storybook/feature/breadcrumbs-combined-with-title/index.html?selectedKind=About%20Modal&selectedStory=AboutModal&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs
