### PR TITLE
fix(ToastNotificationList): ensures timeout on dismissal and not onhover

### DIFF
--- a/src/components/ToastNotification/ToastNotification.stories.js
+++ b/src/components/ToastNotification/ToastNotification.stories.js
@@ -114,6 +114,8 @@ class ToastNotificationStoryWrapper extends React.Component {
         <ToastNotificationList
           onMouseEnter={action('notification list: onMouseEnter fired')}
           onMouseLeave={action('notification list: onMouseLeave fired')}
+          onMouseOver={action('notification list: onMouseOver fired')}
+          onFocus={action('notification list: onFocus fired')}
         >
           {!this.state.infoNotificationDismissed && (
             <TimedToastNotification

--- a/src/components/ToastNotification/ToastNotification.test.js
+++ b/src/components/ToastNotification/ToastNotification.test.js
@@ -77,7 +77,7 @@ test('TimedToastNotification expectedly executes mouse enter/leave and dismiss f
   expect(eventCount).toBe(3);
 });
 
-test('ToastNotificationList expectedly executes mouse enter/leave functions', () => {
+test('ToastNotificationList expectedly executes mouse enter/leave/over functions', () => {
   let eventCount = 0;
   const component = ReactTestUtils.renderIntoDocument(
     testToastNotificationSnapshot(
@@ -85,7 +85,8 @@ test('ToastNotificationList expectedly executes mouse enter/leave functions', ()
       { type: 'warning' },
       {
         onMouseEnter: () => eventCount++,
-        onMouseLeave: () => eventCount++
+        onMouseLeave: () => eventCount++,
+        onMouseOver: () => eventCount++
       }
     )
   );
@@ -95,5 +96,6 @@ test('ToastNotificationList expectedly executes mouse enter/leave functions', ()
   );
   ReactTestUtils.Simulate.mouseEnter(notification);
   ReactTestUtils.Simulate.mouseLeave(notification);
-  expect(eventCount).toBe(2);
+  ReactTestUtils.Simulate.mouseOver(notification);
+  expect(eventCount).toBe(3);
 });

--- a/src/components/ToastNotification/ToastNotificationList.js
+++ b/src/components/ToastNotification/ToastNotificationList.js
@@ -11,18 +11,29 @@ class ToastNotificationList extends React.Component {
   constructor(props) {
     super(props);
     this.state = { paused: false };
-    bindMethods(this, ['onMouseEnter', 'onMouseLeave']);
+    bindMethods(this, ['onMouseEnter', 'onMouseLeave', 'onMouseOver']);
   }
+
+  componentWillReceiveProps() {
+    this.setState({ paused: false });
+  }
+
   onMouseEnter() {
     this.setState({ paused: true });
     const { onMouseEnter } = this.props;
-    onMouseEnter && onMouseEnter();
+    onMouseEnter();
   }
 
   onMouseLeave() {
     this.setState({ paused: false });
     const { onMouseLeave } = this.props;
-    onMouseLeave && onMouseLeave();
+    onMouseLeave();
+  }
+
+  onMouseOver() {
+    this.setState({ paused: true });
+    const { onMouseOver } = this.props;
+    onMouseOver();
   }
 
   renderChildren() {
@@ -48,6 +59,8 @@ class ToastNotificationList extends React.Component {
       <div
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
+        onMouseOver={this.onMouseOver}
+        onFocus={this.onMouseOver}
         className={classes}
       >
         {this.renderChildren()}
@@ -62,6 +75,8 @@ ToastNotificationList.propTypes = {
   onMouseEnter: PropTypes.func,
   /** onMouseLeave callback */
   onMouseLeave: PropTypes.func,
+  /** onMouseOver callback */
+  onMouseOver: PropTypes.func,
   /** children nodes  */
   children: PropTypes.node
 };
@@ -69,6 +84,7 @@ ToastNotificationList.defaultProps = {
   className: '',
   onMouseEnter: noop,
   onMouseLeave: noop,
+  onMouseOver: noop,
   children: null
 };
 export default ToastNotificationList;

--- a/src/components/ToastNotification/__snapshots__/ToastNotification.test.js.snap
+++ b/src/components/ToastNotification/__snapshots__/ToastNotification.test.js.snap
@@ -3,8 +3,10 @@
 exports[`TimedToastNotification persisted and paused renders properly 1`] = `
 <div
   className="toast-notifications-list-pf"
+  onFocus={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
+  onMouseOver={[Function]}
 >
   <div
     className="alert toast-pf alert-success alert-dismissable"
@@ -37,8 +39,10 @@ exports[`TimedToastNotification persisted and paused renders properly 1`] = `
 exports[`ToastNotification renders properly 1`] = `
 <div
   className="toast-notifications-list-pf"
+  onFocus={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
+  onMouseOver={[Function]}
 >
   <div
     className="alert toast-pf alert-danger alert-dismissable"


### PR DESCRIPTION
closes #172

https://AllenBW.github.io/patternfly-react/

So when you entered (before this pr) a notification list and dismiss the last notification, you exit the bounds of the list without doing a mouseLeave (which is a big deal, because without this, toast dismissal was never unpaused)  

The fix, is to unpause whenever the notificationlist changes (which it does when a toast is dismissed), BUT to not unpause while we are mouse(d)over notificationlist

🌮🥑💃