### PR TITLE
fix(Wizard): Allow numbers as step identifiers

### DIFF
--- a/src/components/Wizard/WizardSidebarGroup.js
+++ b/src/components/Wizard/WizardSidebarGroup.js
@@ -13,7 +13,7 @@ const WizardSidebarGroup = ({
   activeStep,
   ...rest
 }) => {
-  const classes = cx({ hidden: step !== activeStep }, className);
+  const classes = cx({ hidden: `${step}` !== `${activeStep}` }, className);
   return (
     <ListGroup componentClass="ul" className={classes} {...rest}>
       {children}
@@ -26,9 +26,9 @@ WizardSidebarGroup.propTypes = {
   /** Additional css classes */
   className: PropTypes.string,
   /** The wizard step number for this step */
-  step: PropTypes.string,
+  step: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** The active step */
-  activeStep: PropTypes.string
+  activeStep: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 WizardSidebarGroup.defaultProps = {
   children: null,

--- a/src/components/Wizard/WizardSidebarGroupItem.js
+++ b/src/components/Wizard/WizardSidebarGroupItem.js
@@ -18,7 +18,10 @@ const WizardSidebarGroupItem = ({
   onClick,
   ...rest
 }) => {
-  const classes = cx({ active: subStep === activeSubStep }, className);
+  const classes = cx(
+    { active: `${subStep}` === `${activeSubStep}` },
+    className
+  );
   return (
     <ListGroupItem className={classes} listItem {...rest}>
       <a
@@ -42,13 +45,13 @@ WizardSidebarGroupItem.propTypes = {
   /** Additional css classes */
   className: PropTypes.string,
   /** This wizard sub step name */
-  subStep: PropTypes.string,
+  subStep: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** This wizard sub step label */
   label: PropTypes.string,
   /** This wizard sub step title */
   title: PropTypes.string,
   /** The currently active wizard substep */
-  activeSubStep: PropTypes.string,
+  activeSubStep: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Sidebar group item click handler */
   onClick: PropTypes.func
 };

--- a/src/components/Wizard/WizardStep.js
+++ b/src/components/Wizard/WizardStep.js
@@ -19,7 +19,7 @@ const WizardStep = ({
 }) => {
   const classes = cx(
     'wizard-pf-step',
-    { active: step === activeStep },
+    { active: `${step}` === `${activeStep}` },
     className
   );
   return (
@@ -46,13 +46,13 @@ WizardStep.propTypes = {
   /** The wizard step index */
   stepIndex: PropTypes.number.isRequired,
   /** The wizard step for this step */
-  step: PropTypes.string,
+  step: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** The wizard step number label */
   label: PropTypes.string,
   /** The wizard step title */
   title: PropTypes.string,
   /** The active step */
-  activeStep: PropTypes.string,
+  activeStep: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** Step click handler */
   onClick: PropTypes.func
 };

--- a/src/components/Wizard/WizardSubStep.js
+++ b/src/components/Wizard/WizardSubStep.js
@@ -14,7 +14,7 @@ const WizardSubStep = ({
 }) => {
   const classes = cx(
     'wizard-pf-step-title-substep',
-    { active: subStep === activeSubStep },
+    { active: `${subStep}` === `${activeSubStep}` },
     className
   );
   return (
@@ -27,11 +27,11 @@ WizardSubStep.propTypes = {
   /** Additional css classes */
   className: PropTypes.string,
   /** The wizard sub step for this step */
-  subStep: PropTypes.string,
+  subStep: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /** The wizard sub step title */
   title: PropTypes.string,
   /** The active step */
-  activeSubStep: PropTypes.string
+  activeSubStep: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 };
 WizardSubStep.defaultProps = {
   className: '',

--- a/src/components/Wizard/__mocks__/mockWizardItems.js
+++ b/src/components/Wizard/__mocks__/mockWizardItems.js
@@ -13,7 +13,7 @@ export const mockLoadingContents = () => (
 
 export const mockWizardItems = [
   {
-    step: '1',
+    step: 1,
     label: '1',
     title: 'First Step',
     subSteps: [
@@ -63,7 +63,7 @@ export const mockWizardItems = [
     ]
   },
   {
-    step: '3',
+    step: 3,
     label: '3',
     title: 'Review',
     subSteps: [
@@ -73,8 +73,8 @@ export const mockWizardItems = [
         title: 'Summary'
       },
       {
-        subStep: '3.2',
-        label: '3B.',
+        subStep: 4,
+        label: '4A.',
         title: 'Progress'
       }
     ]

--- a/src/components/Wizard/__snapshots__/Wizard.test.js.snap
+++ b/src/components/Wizard/__snapshots__/Wizard.test.js.snap
@@ -229,7 +229,7 @@ exports[`Wizard embedded renders properly 1`] = `
               <span
                 className="wizard-pf-substep-number"
               >
-                3B.
+                4A.
               </span>
               <span
                 className="wizard-pf-substep-title"


### PR DESCRIPTION
**What**:
Wizard updates to allow numbers, in addition to strings, as step identifiers. Convenience more or less since it ends up converting them to strings anyway. The advantage is in the implementation, instead of having to use string numbers for steps, they can be actual numbers.

closes #244 

**Link to Storybook**:
[Storybook](https://rawgit.com/cdcabrera/patternfly-react/issues/244-storybook/index.html?selectedKind=Wizard&selectedStory=Modal%20wizard&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)
