### PR TITLE
fix(infotip): adds some eslint fixes for infotip

### DIFF
--- a/src/components/InfoTip/InfoTip.js
+++ b/src/components/InfoTip/InfoTip.js
@@ -42,6 +42,7 @@ class InfoTip extends React.Component {
       case KEY_CODES.ESCAPE_KEY:
         return this.setState({ open: false });
       default:
+        return null;
     }
   }
 

--- a/src/components/InfoTip/InfoTip.stories.js
+++ b/src/components/InfoTip/InfoTip.stories.js
@@ -11,12 +11,12 @@ const stories = storiesOf('InfoTip', module);
 stories.addDecorator(
   defaultTemplate({
     title: 'InfoTip',
-    documentationLink: DOCUMENTATION_URL.PATTERNFLY_ORG_WIDGETS + '#info-tip'
+    documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_WIDGETS}#info-tip`
   })
 );
 
 stories.addWithInfo('InfoTip', '', () => (
-  <nav className="navbar navbar-default navbar-pf" role="navigation">
+  <nav className="navbar navbar-default navbar-pf">
     <div className="navbar-header">
       <button
         type="button"

--- a/src/components/InfoTip/InfoTip.test.js
+++ b/src/components/InfoTip/InfoTip.test.js
@@ -103,13 +103,13 @@ const component = renderer.create(
 );
 
 test('InfoTip is a instance', () => {
-  var instance = component.getInstance();
+  const instance = component.getInstance();
   expect(instance).toBeTruthy();
 });
 
 test('InfoTip handleEnterKeyDown', () => {
-  var instance = component.getInstance();
-  var event = {
+  const instance = component.getInstance();
+  const event = {
     preventDefault() {},
     key: 'Enter',
     keyCode: 13,
@@ -124,8 +124,8 @@ test('InfoTip handleEnterKeyDown', () => {
 });
 
 test('InfoTip handleTabKeyDown', () => {
-  var instance = component.getInstance();
-  var event = {
+  const instance = component.getInstance();
+  const event = {
     stopPropagation() {},
     nativeEvent: {
       stopImmediatePropagation() {}
@@ -146,8 +146,8 @@ test('InfoTip handleTabKeyDown', () => {
 });
 
 test('InfoTip handleClick', () => {
-  var instance = component.getInstance();
-  var event = {
+  const instance = component.getInstance();
+  const event = {
     preventDefault() {}
   };
   instance.state.open = false;
@@ -162,7 +162,7 @@ test('InfoTip handleClick', () => {
 });
 
 test('InfoTip handleBackFocus', () => {
-  var instance = component.getInstance();
+  const instance = component.getInstance();
   instance.state.open = true;
 
   // Should close the menu
@@ -175,8 +175,8 @@ test('InfoTip handleBackFocus', () => {
 });
 
 test('InfoTip handleKeyDown', () => {
-  var instance = component.getInstance();
-  var eventEnterKey = {
+  const instance = component.getInstance();
+  const eventEnterKey = {
     preventDefault() {},
     key: 'Enter',
     keyCode: 13,
@@ -186,7 +186,7 @@ test('InfoTip handleKeyDown', () => {
   instance.handleKeyDown(eventEnterKey);
   expect(instance.state.open).toBeFalsy();
 
-  var eventTabKey = {
+  const eventTabKey = {
     stopPropagation() {},
     nativeEvent: {
       stopImmediatePropagation() {}
@@ -202,7 +202,7 @@ test('InfoTip handleKeyDown', () => {
   expect(instance.state.open).toBeFalsy();
   expect(instance.state.footerFocused).toBeFalsy();
 
-  var eventEscKey = {
+  const eventEscKey = {
     stopPropagation() {},
     nativeEvent: {
       stopImmediatePropagation() {}

--- a/src/components/InfoTip/InfoTipMenu.js
+++ b/src/components/InfoTip/InfoTipMenu.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ClassNames from 'classnames';
 import PropTypes from 'prop-types';
 
+// eslint-disable-next-line react/prefer-stateless-function
 class InfoTipMenu extends React.Component {
   render() {
     const {
@@ -9,9 +10,9 @@ class InfoTipMenu extends React.Component {
       className,
       bsRole,
       rootCloseEvent,
-      labelledBy,
-      pullRight,
-      bsClass,
+      labelledBy, // eslint-disable-line react/prop-types
+      pullRight, // eslint-disable-line react/prop-types
+      bsClass, // eslint-disable-line react/prop-types
       ...props
     } = this.props;
 
@@ -24,7 +25,6 @@ class InfoTipMenu extends React.Component {
     return (
       <div className={infoTipMenuClass} style={{ padding: '' }} {...props}>
         <div className="arrow" />
-
         {children}
       </div>
     );
@@ -35,12 +35,11 @@ InfoTipMenu.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node.isRequired,
   bsRole: PropTypes.string,
-  rootCloseEvent: PropTypes.oneOf(['click', 'mousedown']),
-  labelledBy: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  pullRight: PropTypes.bool,
-  bsClass: PropTypes.string
+  rootCloseEvent: PropTypes.oneOf(['click', 'mousedown'])
 };
 InfoTipMenu.defaultProps = {
-  bsRole: 'menu'
+  bsRole: 'menu',
+  className: '',
+  rootCloseEvent: 'click'
 };
 export default InfoTipMenu;

--- a/src/components/InfoTip/InfoTipMenuFooter.js
+++ b/src/components/InfoTip/InfoTipMenuFooter.js
@@ -1,24 +1,22 @@
 import React from 'react';
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-class InfoTipMenuFooter extends React.Component {
-  render() {
-    const { children, className, ...props } = this.props;
+const InfoTipMenuFooter = ({ children, className, ...props }) => {
+  const infoTipMenuFooterClass = classNames('footer', className);
 
-    const infoTipMenuFooterClass = ClassNames('footer', className);
-
-    return (
-      <div ref="InfotipFooter" className={infoTipMenuFooterClass} {...props}>
-        {children}
-      </div>
-    );
-  }
-}
+  return (
+    <div className={infoTipMenuFooterClass} {...props}>
+      {children}
+    </div>
+  );
+};
 
 InfoTipMenuFooter.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string
 };
-
+InfoTipMenuFooter.defaultProps = {
+  className: ''
+};
 export default InfoTipMenuFooter;

--- a/src/components/InfoTip/InfoTipMenuItemIcon.js
+++ b/src/components/InfoTip/InfoTipMenuItemIcon.js
@@ -1,34 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import { Icon } from '../Icon';
 
-class InfoTipMenuItemIcon extends React.Component {
-  render() {
-    const { type, name, className, ...props } = this.props;
+const InfoTipMenuItemIcon = ({ type, name, className, ...props }) => {
+  const infoTipMenuItemIconClass = classNames('i', className);
 
-    const infoTipMenuItemIconClass = ClassNames('i', className);
-
-    return (
-      <Icon
-        type={type}
-        name={name}
-        className={infoTipMenuItemIconClass}
-        {...props}
-      />
-    );
-  }
-}
+  return (
+    <Icon
+      type={type}
+      name={name}
+      className={infoTipMenuItemIconClass}
+      {...props}
+    />
+  );
+};
 
 InfoTipMenuItemIcon.propTypes = {
   type: PropTypes.oneOf(['fa', 'pf']),
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   className: PropTypes.string
 };
 
 InfoTipMenuItemIcon.defaultProps = {
   type: 'pf',
-  name: 'info'
+  name: 'info',
+  className: ''
 };
 
 export default InfoTipMenuItemIcon;

--- a/src/components/InfoTip/InfoTipToggle.js
+++ b/src/components/InfoTip/InfoTipToggle.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Dropdown } from '../Dropdown';
 import { Icon } from '../Icon';
 
+// eslint-disable-next-line react/prefer-stateless-function
 class InfoTipToggle extends React.Component {
   render() {
     const { children, className, bsRole, bsClass, open, ...props } = this.props;
@@ -23,7 +24,10 @@ InfoTipToggle.propTypes = {
 };
 
 InfoTipToggle.defaultProps = {
-  bsRole: 'toggle'
+  bsRole: 'toggle', // eslint-disable-line react/default-props-match-prop-types
+  children: null,
+  open: false,
+  className: ''
 };
 
 export default InfoTipToggle;

--- a/src/components/InfoTip/__snapshots__/InfoTip.test.js.snap
+++ b/src/components/InfoTip/__snapshots__/InfoTip.test.js.snap
@@ -9,7 +9,7 @@ exports[`InfoTip renders properly with a default MenuItemIcon 1`] = `
 >
   <a
     aria-expanded={false}
-    className={undefined}
+    className=""
     disabled={undefined}
     href="#"
     id="infotip-widget"
@@ -82,7 +82,7 @@ exports[`InfoTip renders properly with another MenuItemIcon 1`] = `
 >
   <a
     aria-expanded={false}
-    className={undefined}
+    className=""
     disabled={undefined}
     href="#"
     id="infotip-widget"
@@ -155,7 +155,7 @@ exports[`InfoTip renders properly with item children 1`] = `
 >
   <a
     aria-expanded={false}
-    className={undefined}
+    className=""
     disabled={undefined}
     href="#"
     id="infotip-widget"


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Temporarily fixes build/info tip eslint rules broken to fix pf-react build.

Was not able to convert all components to stateless b/c it breaks some tests. Also removing some props would break other tests introduced. 

This is just to fix our rolling build...

Filed [247](https://github.com/patternfly/patternfly-react/issues/247) for future.

Also fixed by removing redundant role:
  19:3  error  The element nav has an implicit role of navigation. Defining this explicitly is redundant and should beavoided  jsx-a11y/no-redundant-roles

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
https://rawgit.com/priley86/patternfly-react/infotip-lint-fixes/index.html

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- feel free to add additional comments -->