### PR TITLE
fix(wizard): fix wizard contents default props

### DIFF
--- a/src/components/Wizard/WizardContents.js
+++ b/src/components/Wizard/WizardContents.js
@@ -39,14 +39,16 @@ WizardContents.propTypes = {
   /** The wizard step index for these contents */
   stepIndex: PropTypes.number.isRequired,
   /** The wizard sub step index for these contents */
-  subStepIndex: PropTypes.number.isRequired,
+  subStepIndex: PropTypes.number,
   /** The active wizard step index */
   activeStepIndex: PropTypes.number.isRequired,
   /** The active wizard sub step index */
-  activeSubStepIndex: PropTypes.number.isRequired
+  activeSubStepIndex: PropTypes.number
 };
 WizardContents.defaultProps = {
   children: null,
-  className: ''
+  className: '',
+  subStepIndex: null,
+  activeSubStepIndex: null
 };
 export default WizardContents;


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
`WizardContents` should not require activeSubstepIndex/subStepIndex (as some wizards do not have sub steps). This was a miss introduced in #216 

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
none

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- feel free to add additional comments -->