### PR TITLE
fix(index.js): Fix broken export of controlled helper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,5 +35,5 @@ export * from './components/TreeView';
 export * from './components/Wizard';
 export * from './components/VerticalNav';
 export { patternfly } from './common/patternfly';
-export { controlled } from './common/controlled';
+export { default as controlled } from './common/controlled';
 export * from './common/helpers';


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:

When I finished VerticalNav, I thought I would export the `controlled.js` state helper that I wrote for that, so we could use it in React components outside patternfly-react. I now want to use it in the ManageIQ V2V POC work, and found that it is not actually being exported due to a typo we didn't test for. This fixes that typo so we can actually use the exported helper.

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**: https://rawgit.com/mturley/patternfly-react/export-controlled-fix-sb/index.html

<!-- feel free to add additional comments -->