### PR TITLE
feat(EmptyState): Create an EmptyStatePattern

### DIFF
--- a/src/components/EmptyState/EmptyState.stories.js
+++ b/src/components/EmptyState/EmptyState.stories.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
+import { withKnobs, text } from '@storybook/addon-knobs';
 import { defaultTemplate } from '../../../storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from '../../../storybook/constants';
-import { Button } from '../Button';
-import { EmptyState } from './index';
+import { EmptyStatePattern } from './index';
 
 const stories = storiesOf('EmptyState', module);
 
+stories.addDecorator(withKnobs);
 stories.addDecorator(
   defaultTemplate({
     title: 'Empty State',
@@ -17,17 +18,23 @@ stories.addDecorator(
   })
 );
 
-stories.addWithInfo('EmptyState', () => (
-  <EmptyState>
-    <EmptyState.Icon />
-    <EmptyState.Title>Empty State Title</EmptyState.Title>
-    <EmptyState.Info>
-      This is the Empty State component. The goal of a empty state pattern is to
-      provide a good first impression that helps users to achieve their goals.
-      It should be used when a view is empty because no objects exists and you
-      want to guide the user to perform specific actions.
-    </EmptyState.Info>
-    <EmptyState.Help onClick={action('help action')}>
+const createAction = name => ({
+  onClick: action(name),
+  title: text(`${name} Title`, 'Perform an action'),
+  children: text(`${name} Children`, name)
+});
+
+const getPatternData = () => ({
+  title: text('Title', 'Empty State Title'),
+  info: text(
+    'Info',
+    `This is the Empty State component. The goal of a empty state pattern is to
+  provide a good first impression that helps users to achieve their goals.
+  It should be used when a view is empty because no objects exists and you
+  want to guide the user to perform specific actions.`
+  ),
+  help: (
+    <span onClick={action('help action')}>
       For more information please see{' '}
       <a
         href="#"
@@ -37,22 +44,18 @@ stories.addWithInfo('EmptyState', () => (
       >
         pfExample
       </a>
-    </EmptyState.Help>
-    <EmptyState.Action>
-      <Button bsStyle="primary" bsSize="large" onClick={action('main action')}>
-        Main Action
-      </Button>
-    </EmptyState.Action>
-    <EmptyState.Action secondary>
-      <Button onClick={action('secondary action 1')} title="Perform an action">
-        Secondary Action 1
-      </Button>
-      <Button onClick={action('secondary action 2')} title="Perform an action">
-        Secondary Action 2
-      </Button>
-      <Button onClick={action('secondary action 3')} title="Perform an action">
-        Secondary Action 3
-      </Button>
-    </EmptyState.Action>
-  </EmptyState>
+    </span>
+  ),
+  mainAction: createAction('Main Action'),
+  actions: [
+    'Secondary Action 1',
+    'Secondary Action 2',
+    'Secondary Action 3'
+  ].map(actionName => createAction(actionName))
+});
+
+stories.addWithInfo('EmptyState', () => EmptyStatePattern(getPatternData()));
+
+stories.addWithInfo('EmptyState Pattern', () => (
+  <EmptyStatePattern {...getPatternData()} />
 ));

--- a/src/components/EmptyState/EmptyStatePattern.js
+++ b/src/components/EmptyState/EmptyStatePattern.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Button } from '../Button';
+
+import EmptyState from './EmptyState';
+import EmptyStateIcon from './EmptyStateIcon';
+import EmptyStateTitle from './EmptyStateTitle';
+import EmptyStateInfo from './EmptyStateInfo';
+import EmptyStateHelp from './EmptyStateHelp';
+import EmptyStateAction from './EmptyStateAction';
+
+const EmptyStatePattern = ({
+  className,
+  title,
+  info,
+  help,
+  mainAction,
+  actions,
+  ...props
+}) => (
+  <EmptyState className={className} {...props}>
+    <EmptyStateIcon />
+    {title && <EmptyStateTitle>{title}</EmptyStateTitle>}
+    {info && <EmptyStateInfo>{info}</EmptyStateInfo>}
+    {help && <EmptyStateHelp>{help}</EmptyStateHelp>}
+    {mainAction && (
+      <EmptyStateAction>
+        <Button
+          bsStyle="primary"
+          bsSize="large"
+          onClick={mainAction.onClick}
+          title={mainAction.title}
+        >
+          {mainAction.children}
+        </Button>
+      </EmptyStateAction>
+    )}
+    {actions &&
+      actions.length > 0 && (
+        <EmptyStateAction secondary>
+          {actions.map((action, index) => (
+            <Button onClick={action.onClick} title={action.title} key={index}>
+              {action.children}
+            </Button>
+          ))}
+        </EmptyStateAction>
+      )}
+  </EmptyState>
+);
+const actionShape = PropTypes.shape({
+  /** onClick callback */
+  onClick: PropTypes.func,
+  /** button title (title attribute) */
+  title: PropTypes.string,
+  /** button content */
+  children: PropTypes.node
+});
+
+EmptyStatePattern.propTypes = {
+  /** Additional element css classes */
+  className: PropTypes.string,
+  /** story title */
+  title: PropTypes.node,
+  /** story info */
+  info: PropTypes.node,
+  /** story help */
+  help: PropTypes.node,
+  /** story main-action */
+  mainAction: actionShape,
+  /** story secondary-actions */
+  actions: PropTypes.arrayOf(actionShape)
+};
+EmptyStatePattern.defaultProps = {
+  className: '',
+  title: null,
+  info: null,
+  help: null,
+  mainAction: null,
+  actions: null
+};
+export default EmptyStatePattern;

--- a/src/components/EmptyState/EmptyStatePattern.test.js
+++ b/src/components/EmptyState/EmptyStatePattern.test.js
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+
+import React from 'react';
+import ShallowRenderer from 'react-test-renderer/shallow';
+import EmptyStatePattern from './EmptyStatePattern';
+
+const renderer = new ShallowRenderer();
+
+test('should renderer a minimal EmptyStatePattern', () => {
+  const tree = renderer.render(<EmptyStatePattern />);
+
+  expect(tree).toMatchSnapshot();
+});
+
+test('should renderer a full EmptyStatePattern', () => {
+  const props = {
+    title: 'some title',
+    info: 'some info',
+    help: 'some help',
+    mainAction: {
+      onClick: jest.fn(),
+      title: 'Main Action Title',
+      children: 'Main Action Children'
+    },
+    actions: [
+      {
+        onClick: jest.fn(),
+        title: 'Secondary Action 1 Title',
+        children: 'Secondary Action 1 Children'
+      },
+      {
+        onClick: jest.fn(),
+        title: 'Secondary Action 2 Title',
+        children: 'Secondary Action 2 Children'
+      },
+      {
+        onClick: jest.fn(),
+        title: 'Secondary Action 3 Title',
+        children: 'Secondary Action 3 Children'
+      }
+    ]
+  };
+
+  const tree = renderer.render(<EmptyStatePattern {...props} />);
+
+  expect(tree).toMatchSnapshot();
+});

--- a/src/components/EmptyState/__snapshots__/EmptyStatePattern.test.js.snap
+++ b/src/components/EmptyState/__snapshots__/EmptyStatePattern.test.js.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should renderer a full EmptyStatePattern 1`] = `
+<EmptyState
+  className=""
+>
+  <EmptyStateIcon
+    className=""
+    name="add-circle-o"
+    type="pf"
+  />
+  <EmptyStateTitle
+    className=""
+  >
+    some title
+  </EmptyStateTitle>
+  <EmptyStateInfo
+    className=""
+  >
+    some info
+  </EmptyStateInfo>
+  <EmptyStateHelp
+    className=""
+  >
+    some help
+  </EmptyStateHelp>
+  <EmptyStateAction
+    className=""
+    secondary={false}
+  >
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsSize="large"
+      bsStyle="primary"
+      disabled={false}
+      onClick={[MockFunction]}
+      title="Main Action Title"
+    >
+      Main Action Children
+    </Button>
+  </EmptyStateAction>
+  <EmptyStateAction
+    className=""
+    secondary={true}
+  >
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      disabled={false}
+      onClick={[MockFunction]}
+      title="Secondary Action 1 Title"
+    >
+      Secondary Action 1 Children
+    </Button>
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      disabled={false}
+      onClick={[MockFunction]}
+      title="Secondary Action 2 Title"
+    >
+      Secondary Action 2 Children
+    </Button>
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="default"
+      disabled={false}
+      onClick={[MockFunction]}
+      title="Secondary Action 3 Title"
+    >
+      Secondary Action 3 Children
+    </Button>
+  </EmptyStateAction>
+</EmptyState>
+`;
+
+exports[`should renderer a minimal EmptyStatePattern 1`] = `
+<EmptyState
+  className=""
+>
+  <EmptyStateIcon
+    className=""
+    name="add-circle-o"
+    type="pf"
+  />
+</EmptyState>
+`;

--- a/src/components/EmptyState/index.js
+++ b/src/components/EmptyState/index.js
@@ -4,6 +4,7 @@ import EmptyStateTitle from './EmptyStateTitle';
 import EmptyStateInfo from './EmptyStateInfo';
 import EmptyStateHelp from './EmptyStateHelp';
 import EmptyStateAction from './EmptyStateAction';
+import EmptyStatePattern from './EmptyStatePattern';
 
 EmptyState.Title = EmptyStateTitle;
 EmptyState.Icon = EmptyStateIcon;
@@ -17,5 +18,6 @@ export {
   EmptyStateTitle,
   EmptyStateInfo,
   EmptyStateHelp,
-  EmptyStateAction
+  EmptyStateAction,
+  EmptyStatePattern
 };


### PR DESCRIPTION
I thought about the discussion of abusing the mocks folder #250

Basically, since patternfly is **opinionated** and its a library of **patterns** I think it makes sense to export those mocks/stories/**patterns** so
* It will be easier to use patternfly patterns as patternfly believe they should be
* Consumers can use them with a data-driven approach, it will make it easier to connect a store
* At the end, consumers are going to copy-paste from the storybook anyway, let's give them patterns that getting updated and maintained.

**Time for a new level of abstraction?**

Notice: both of the stories are consuming the same pattern component.
[Storybook](https://rawgit.com/sharvit/patternfly-react/storybook/feature/empty-state-pattern/index.html?knob-Title=Empty%20State%20Title&knob-Secondary%20Action%201%20Title=Perform%20an%20action&knob-Secondary%20Action%202%20Title=Perform%20an%20action&knob-Secondary%20Action%203%20Title=Perform%20an%20action&knob-Info=This%20is%20the%20Empty%20State%20component.%20The%20goal%20of%20a%20empty%20state%20pattern%20is%20to%0A%20%20provide%20a%20good%20first%20impression%20that%20helps%20users%20to%20achieve%20their%20goals.%0A%20%20It%20should%20be%20used%20when%20a%20view%20is%20empty%20because%20no%20objects%20exists%20and%20you%0A%20%20want%20to%20guide%20the%20user%20to%20perform%20specific%20actions.&knob-Secondary%20Action%203%20Children=Secondary%20Action%203&knob-Secondary%20Action%202%20Children=Secondary%20Action%202&knob-Secondary%20Action%201%20Children=Secondary%20Action%201&knob-Main%20Action%20Children=Main%20Action&knob-Main%20Action%20Title=Perform%20an%20action&selectedKind=EmptyState&selectedStory=EmptyState%20Pattern&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)