### PR TITLE
fix(toolbar): Allow single option for filter and sort selectors

### DIFF
--- a/less/patternfly-react.less
+++ b/less/patternfly-react.less
@@ -4,3 +4,4 @@
 
 @import 'utilization-bar';
 @import 'breadcrumb';
+@import 'toolbar';

--- a/less/toolbar.less
+++ b/less/toolbar.less
@@ -1,0 +1,9 @@
+.single-filter-select-pf, .single-sort-select-pf {
+  background: @btn-default-bg;
+  padding: 2px 6px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid @btn-default-border;
+  position: relative;
+  float: left;
+}

--- a/sass/patternfly-react.scss
+++ b/sass/patternfly-react.scss
@@ -5,12 +5,14 @@ $font-path: '~patternfly/dist/fonts/';
 $img-path: '~patternfly/dist/img/';
 $icon-font-path: '~patternfly/dist/fonts/';
 
+// Must include patternfly variables first
+@import 'patternfly/variables';
+
 // Bootstrap Core variables and mixins
 @import 'bootstrap/variables';
 @import 'bootstrap/mixins';
 
 // Patternfly Core variables and mixins
-@import 'patternfly/variables';
 @import 'patternfly/fonts';
 @import 'patternfly/bootstrap-mixin-overrides';
 @import 'patternfly/mixins';

--- a/sass/patternfly-react/_patternfly-react.scss
+++ b/sass/patternfly-react/_patternfly-react.scss
@@ -4,3 +4,4 @@
 
 @import 'utilization-bar';
 @import 'breadcrumb';
+@import 'toolbar';

--- a/sass/patternfly-react/_toolbar.scss
+++ b/sass/patternfly-react/_toolbar.scss
@@ -1,0 +1,9 @@
+.single-filter-select-pf, .single-sort-select-pf {
+  background: $btn-default-bg;
+  padding: 2px 6px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid $btn-default-border;
+  position: relative;
+  float: left;
+}

--- a/src/components/Filter/FilterTypeSelector.js
+++ b/src/components/Filter/FilterTypeSelector.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { DropdownButton } from '../Button';
+import { ButtonGroup, DropdownButton } from '../Button';
 import { MenuItem } from '../MenuItem';
 import { noop } from '../../common/helpers';
 
@@ -15,7 +15,7 @@ const FilterTypeSelector = ({
   ...rest
 }) => {
   const classes = cx('input-group-btn', className);
-  if (placeholder || (filterTypes && filterTypes.length > 1)) {
+  if (placeholder || (filterTypes && filterTypes.length > 0)) {
     let title;
     if (currentFilterType) {
       title = currentFilterType.title || currentFilterType;
@@ -25,6 +25,16 @@ const FilterTypeSelector = ({
 
     let menuId = 'filterFieldTypeMenu';
     menuId += id ? `_${id}` : '';
+
+    if (filterTypes.length === 1) {
+      return (
+        <div className={classes} {...rest}>
+          <ButtonGroup>
+            <span className="single-filter-select-pf">{title}</span>
+          </ButtonGroup>
+        </div>
+      );
+    }
 
     return (
       <div className={classes} {...rest}>

--- a/src/components/Sort/SortTypeSelector.js
+++ b/src/components/Sort/SortTypeSelector.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { DropdownButton } from '../Button';
+import { ButtonGroup, DropdownButton } from '../Button';
 import { MenuItem } from '../MenuItem';
 import { noop } from '../../common/helpers';
 
@@ -14,12 +14,20 @@ const SortTypeSelector = ({
 }) => {
   let menuId = 'sortTypeMenu';
   menuId += id ? `_${id}` : '';
-  if (sortTypes && sortTypes.length > 1) {
+  if (sortTypes && sortTypes.length > 0) {
     let title;
     if (currentSortType) {
       title = currentSortType.title || currentSortType;
     } else {
       title = currentSortType[0].title || currentSortType[0];
+    }
+
+    if (sortTypes.length === 1) {
+      return (
+        <ButtonGroup className={className} {...rest}>
+          <span className="single-sort-select-pf">{title}</span>
+        </ButtonGroup>
+      );
     }
 
     return (

--- a/src/components/Toolbar/Toolbar.stories.js
+++ b/src/components/Toolbar/Toolbar.stories.js
@@ -2,6 +2,10 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { decorateAction } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info/dist/index';
+import {
+  withKnobs,
+  boolean
+} from '@storybook/addon-knobs';
 import { defaultTemplate } from '../../../storybook/decorators/storyTemplates';
 import {
   Toolbar,
@@ -17,6 +21,7 @@ import {
 } from './__mocks__/mockToolbarExample';
 
 const stories = storiesOf('Toolbar', module);
+stories.addDecorator(withKnobs);
 
 stories.addDecorator(
   defaultTemplate({
@@ -53,6 +58,8 @@ stories.add(
         onViewChanged={logAction('viewChanged')}
         onActionPerformed={logAction('actionPerformed')}
         onFindAction={logAction('findAction')}
+        singleFilter={boolean('Single Filter:', false)}
+        singleSort={boolean('Single Sort:', false)}
       />
     );
   })

--- a/src/components/Toolbar/__mocks__/mockToolbarExample.js
+++ b/src/components/Toolbar/__mocks__/mockToolbarExample.js
@@ -228,13 +228,23 @@ export class MockToolbarExample extends React.Component {
       currentViewType
     } = this.state;
 
-    const { onActionPerformed, onFindAction } = this.props;
+    const {
+      onActionPerformed,
+      onFindAction,
+      singleFilter,
+      singleSort
+    } = this.props;
+
+    const filterTypes = singleFilter
+      ? [mockFilterExampleFields[0]]
+      : [...mockFilterExampleFields];
+    const sortTypes = singleSort ? [mockSortFields[0]] : mockSortFields;
 
     return (
       <Toolbar>
         <Filter>
           <Filter.TypeSelector
-            filterTypes={mockFilterExampleFields}
+            filterTypes={filterTypes}
             currentFilterType={currentFilterType}
             onFilterTypeSelected={this.selectFilterType}
           />
@@ -242,7 +252,7 @@ export class MockToolbarExample extends React.Component {
         </Filter>
         <Sort>
           <Sort.TypeSelector
-            sortTypes={mockSortFields}
+            sortTypes={sortTypes}
             currentSortType={currentSortType}
             onSortTypeSelected={this.updateCurrentSortType}
           />
@@ -394,7 +404,9 @@ MockToolbarExample.propTypes = {
   onSortChanged: PropTypes.func,
   onViewChanged: PropTypes.func,
   onActionPerformed: PropTypes.func,
-  onFindAction: PropTypes.func
+  onFindAction: PropTypes.func,
+  singleFilter: PropTypes.bool,
+  singleSort: PropTypes.bool
 };
 
 MockToolbarExample.defaultProps = {
@@ -402,7 +414,9 @@ MockToolbarExample.defaultProps = {
   onSortChanged: noop,
   onViewChanged: noop,
   onActionPerformed: noop,
-  onFindAction: noop
+  onFindAction: noop,
+  singleFilter: false,
+  singleSort: false
 };
 
 export const mockToolbarExampleSource = `


### PR DESCRIPTION
**What**:
Allows filter and sort to have a single category selection

**Link to Storybook**:
[Storybook](https://jeff-phillips-18.github.io/patternfly-react/?knob-Single%20Filter%3A=false&knob-Single%20Sort%3A=false&selectedKind=Toolbar&selectedStory=Toolbar&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)

**Note**:
 This also fixes an issue with using patternfly variables in sass. For sass, we must include patternfly variables before bootstrap variables due to the use of the !default flag in sass.

@serenamarie125 