### PR TITLE
fix(babel): fix regex to exclude only .test.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "start": "concurrently \"npm run storybook:run\" \"npm run storybook:openurl\"",
     "commit": "git-cz",
     "build": "npm run build:scripts && npm run build:sass && npm run build:less",
-    "build:scripts": "babel src --out-dir dist/js --ignore test.js,__mocks__",
+    "build:scripts": "babel src --out-dir dist/js --ignore .test.js,__mocks__",
     "build:less": "mkdir -p dist/less && cp -r less/* dist/less",
     "build:sass": "mkdir -p dist/sass && cp -r sass/patternfly-react/* dist/sass && node-sass --output-style compressed --include-path sass $npm_package_sassIncludes_patternfly $npm_package_sassIncludes_bootstrap $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react.scss",
     "lint": "eslint --fix --max-warnings 0 src storybook && npm run stylelint",


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Babel preset should ignore `*.test.js` and `__mocks__`

See #284 

I did a filemerge diff locally...but you can check me ;)