### PR TITLE
style(default-name): Added import-default-name eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,13 @@
     "jsx-a11y/click-events-have-key-events": "off",
     "jsx-a11y/no-static-element-interactions": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
+    "import-default-name": [
+      "error",
+      {
+        "classnames": "classNames",
+        "prop-types": "PropTypes"
+      }
+    ],
     "import/no-extraneous-dependencies": [
       "error",
       {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
   "editor.formatOnSave": true,
   "prettier.eslintIntegration": true,
   "prettier.singleQuote": true,
-  "prettier.trailingComma": "none"
+  "prettier.trailingComma": "none",
+  "eslint.options": {
+    "rulePaths": ["./lint-rules"]
+  }
 }

--- a/lint-rules/import-default-name.js
+++ b/lint-rules/import-default-name.js
@@ -1,0 +1,52 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Force default import names to match specified values',
+      category: 'Possible Errors',
+      recommended: true
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {},
+        additionalProperties: true
+      }
+    ]
+  },
+  create(context) {
+    const [importMap = {}] = context.options;
+    return {
+      ImportDeclaration(node) {
+        const defaultImport = node.specifiers.find(
+          spec => spec.type === 'ImportDefaultSpecifier'
+        );
+        if (!defaultImport) {
+          return;
+        }
+        const expectedName = importMap[node.source.value];
+        const receivedName = defaultImport.local.name;
+        if (expectedName && expectedName !== receivedName) {
+          context.report({
+            node,
+            message:
+              'Expected default import to be named "{{ expected }}" but received "{{ received }}"',
+            data: {
+              expected: expectedName,
+              received: receivedName
+            },
+            fix(fixer) {
+              const [varDecl] = context.getDeclaredVariables(node);
+              return [
+                ...varDecl.references.map(ref =>
+                  fixer.replaceText(ref.identifier, expectedName)
+                ),
+                fixer.replaceText(defaultImport, expectedName)
+              ];
+            }
+          });
+        }
+      }
+    };
+  }
+};

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "build:scripts": "babel src --out-dir dist/js --ignore .test.js,__mocks__",
     "build:less": "mkdir -p dist/less && cp -r less/* dist/less",
     "build:sass": "mkdir -p dist/sass && cp -r sass/patternfly-react/* dist/sass && node-sass --output-style compressed --include-path sass $npm_package_sassIncludes_patternfly $npm_package_sassIncludes_bootstrap $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react.scss",
-    "lint": "eslint --fix --max-warnings 0 src storybook && npm run stylelint",
+    "lint": "eslint --rulesdir lint-rules/ --fix --max-warnings 0 src storybook && npm run stylelint",
     "prettier": "prettier --write --single-quote --trailing-comma=none '{src,storybook}/**/*.js'",
     "prepare": "npm run build",
     "test": "npm run lint && jest",

--- a/sass/patternfly-react/_patternfly-react.scss
+++ b/sass/patternfly-react/_patternfly-react.scss
@@ -2,7 +2,6 @@
   Patternfly React Partials
 */
 @import 'card';
-
 @import 'utilization-bar';
 @import 'breadcrumb';
 @import 'label-remove';

--- a/src/components/Cards/AggregateStatusCard/AggregateStatusCard.test.js
+++ b/src/components/Cards/AggregateStatusCard/AggregateStatusCard.test.js
@@ -8,9 +8,7 @@ import {
 } from './index';
 
 test('Aggregate Status Card Count is working properly', () => {
-  const component = mount(
-    <AggregateStatusCount> 9 </AggregateStatusCount>
-  );
+  const component = mount(<AggregateStatusCount> 9 </AggregateStatusCount>);
 
   expect(component.render()).toMatchSnapshot();
 });

--- a/src/components/Cards/AggregateStatusCard/AggregateStatusCount.js
+++ b/src/components/Cards/AggregateStatusCard/AggregateStatusCount.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const AggregateStatusCount = ({ children, className, ...props }) => {
-  const classes = ClassNames('card-pf-aggregate-status-count', className);
+  const classes = classNames('card-pf-aggregate-status-count', className);
 
   return (
     <span className={classes} {...props}>

--- a/src/components/Cards/AggregateStatusCard/AggregateStatusNotification.js
+++ b/src/components/Cards/AggregateStatusCard/AggregateStatusNotification.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const AggregateStatusNotification = ({ children, className, ...props }) => {
-  const classes = ClassNames(
+  const classes = classNames(
     'card-pf-aggregate-status-notification',
     className
   );

--- a/src/components/Cards/AggregateStatusCard/AggregateStatusNotifications.js
+++ b/src/components/Cards/AggregateStatusCard/AggregateStatusNotifications.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const AggregateStatusNotifications = ({ children, className, ...props }) => {
-  const classes = ClassNames(
+  const classes = classNames(
     'card-pf-aggregate-status-notifications',
     className
   );

--- a/src/components/Cards/Card.js
+++ b/src/components/Cards/Card.js
@@ -1,4 +1,4 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -12,7 +12,7 @@ const Card = ({
   cardRef,
   ...props
 }) => {
-  const classes = ClassNames(
+  const classes = classNames(
     'card-pf',
     { 'card-pf-accented': accented },
     { 'card-pf-aggregate-status': aggregated },

--- a/src/components/Cards/CardBody.js
+++ b/src/components/Cards/CardBody.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const CardBody = ({ children, className, ...props }) => {
-  const classes = ClassNames('card-pf-body', className);
+  const classes = classNames('card-pf-body', className);
 
   return (
     <div className={classes} {...props}>

--- a/src/components/Cards/CardDropdownButton.js
+++ b/src/components/Cards/CardDropdownButton.js
@@ -1,4 +1,4 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown } from '../Dropdown';
@@ -12,7 +12,7 @@ const CardDropdownButton = ({
   pullRight,
   ...props
 }) => {
-  const classes = ClassNames('card-pf-time-frame-filter', className);
+  const classes = classNames('card-pf-time-frame-filter', className);
   const CustomButtonGroup = customGroup => (
     <ButtonGroup {...customGroup} bsClass=" " />
   );

--- a/src/components/Cards/CardFooter.js
+++ b/src/components/Cards/CardFooter.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const CardFooter = ({ children, className, ...props }) => {
-  const classes = ClassNames('card-pf-footer', className);
+  const classes = classNames('card-pf-footer', className);
 
   return (
     <div className={classes} {...props}>

--- a/src/components/Cards/CardGrid.js
+++ b/src/components/Cards/CardGrid.js
@@ -1,11 +1,11 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import CardHeightMatching from './CardHeightMatching';
 import { Grid } from '../Grid/index';
 
 const CardGrid = ({ matchHeight, children, className, ...props }) => {
-  const classes = ClassNames('container-cards-pf', className);
+  const classes = classNames('container-cards-pf', className);
   const cardSelector = ['.card-pf-match-height'];
 
   if (matchHeight) {

--- a/src/components/Cards/CardHeading.js
+++ b/src/components/Cards/CardHeading.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const CardHeading = ({ children, className, ...props }) => {
-  const classes = ClassNames('card-pf-heading', className);
+  const classes = classNames('card-pf-heading', className);
 
   return (
     <div className={classes} {...props}>

--- a/src/components/Cards/CardLink.js
+++ b/src/components/Cards/CardLink.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const CardLink = ({ disabled, children, className, icon, ...props }) => {
-  const classes = ClassNames(
+  const classes = classNames(
     {
       'card-pf-link-with-icon': icon,
       disabled

--- a/src/components/Cards/CardTitle.js
+++ b/src/components/Cards/CardTitle.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const CardTitle = ({ children, className, ...props }) => {
-  const classes = ClassNames('card-pf-title', className);
+  const classes = classNames('card-pf-title', className);
 
   return (
     <h2 className={classes} {...props}>

--- a/src/components/Cards/Cards.test.js
+++ b/src/components/Cards/Cards.test.js
@@ -29,9 +29,7 @@ test('Card Title is working properly', () => {
 });
 
 test('Card Footer is working properly', () => {
-  const component = mount(
-    <CardFooter>This is a Card Footer</CardFooter>
-  );
+  const component = mount(<CardFooter>This is a Card Footer</CardFooter>);
 
   expect(component.render()).toMatchSnapshot();
 });

--- a/src/components/Cards/UtilizationTrendCard/UtilizationCard.js
+++ b/src/components/Cards/UtilizationTrendCard/UtilizationCard.js
@@ -1,10 +1,10 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Card } from '../index';
 
 const UtilizationCard = ({ children, className, ...props }) => {
-  const classes = ClassNames('card-pf-utilization', className);
+  const classes = classNames('card-pf-utilization', className);
 
   return (
     <Card className={classes} {...props}>

--- a/src/components/Cards/UtilizationTrendCard/UtilizationCardDetails.js
+++ b/src/components/Cards/UtilizationTrendCard/UtilizationCardDetails.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const UtilizationCardDetails = ({ children, className, ...props }) => {
-  const classes = ClassNames('card-pf-utilization-details', className);
+  const classes = classNames('card-pf-utilization-details', className);
 
   return (
     <p className={classes} {...props}>

--- a/src/components/Cards/UtilizationTrendCard/UtilizationCardDetailsCount.js
+++ b/src/components/Cards/UtilizationTrendCard/UtilizationCardDetailsCount.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const UtilizationCardDetailsCount = ({ children, className, ...props }) => {
-  const classes = ClassNames(
+  const classes = classNames(
     'card-pf-utilization-card-details-count',
     className
   );

--- a/src/components/Cards/UtilizationTrendCard/UtilizationCardDetailsDesc.js
+++ b/src/components/Cards/UtilizationTrendCard/UtilizationCardDetailsDesc.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const UtilizationCardDetailsDesc = ({ children, className, ...props }) => {
-  const classes = ClassNames(
+  const classes = classNames(
     'card-pf-utilization-card-details-description',
     className
   );

--- a/src/components/Cards/UtilizationTrendCard/UtilizationCardDetailsLine1.js
+++ b/src/components/Cards/UtilizationTrendCard/UtilizationCardDetailsLine1.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const UtilizationCardDetailsLine1 = ({ children, className, ...props }) => {
-  const classes = ClassNames(
+  const classes = classNames(
     'card-pf-utilization-card-details-line-1',
     className
   );

--- a/src/components/Cards/UtilizationTrendCard/UtilizationCardDetailsLine2.js
+++ b/src/components/Cards/UtilizationTrendCard/UtilizationCardDetailsLine2.js
@@ -1,9 +1,9 @@
-import ClassNames from 'classnames';
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
 const UtilizationCardDetailsLine2 = ({ children, className, ...props }) => {
-  const classes = ClassNames(
+  const classes = classNames(
     'card-pf-utilization-card-details-line-2',
     className
   );


### PR DESCRIPTION
Added a rule to force the naming of the default import specified packages. This will fix
inconsistencies with variable names.

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Eslint rule for default imports

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
N/A

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
Piggybacks off of PR: https://github.com/patternfly/patternfly-react/pull/274


<!-- feel free to add additional comments -->