### PR TITLE
build(babelrc): Export ES modules in addition to commonJS

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,3 @@
 {
-  "presets": ["env", "react"],
-  "plugins": [
-    "transform-class-properties",
-    "transform-export-extensions",
-    "transform-object-rest-spread",
-    "transform-object-assign"
-  ],
-  "ignore": ["src/**/__snapshots__", "src/**/*.stories.js", "src/**/Stories"]
+  "presets": ["./.babelrc.js"]
 }

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,23 @@
+const babelENV = process.env.BABEL_ENV || 'development';
+const modules = babelENV !== 'production:esm' ? 'commonjs' : false;
+
+module.exports = {
+  presets: [['env', { modules: modules }], 'react'],
+  plugins: [
+    'transform-class-properties',
+    'transform-export-extensions',
+    'transform-object-rest-spread',
+    'transform-object-assign'
+  ],
+  ignore: (() => {
+    const ignore = [
+      'src/**/__snapshots__',
+      'src/**/*.stories.js',
+      'src/**/Stories'
+    ];
+    if (babelENV.includes('production')) {
+      ignore.push('test.js', '__mocks__');
+    }
+    return ignore;
+  })()
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4120,6 +4120,24 @@
         "object-assign": "4.1.1"
       }
     },
+    "cross-env": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.4.tgz",
+      "integrity": "sha512-Mx8mw6JWhfpYoEk7PGvHxJMLQwQHORAs8+2bX+C1lGQ4h3GkDb1zbzC2Nw85YH9ZQMlO0BHZxMacgrfPmMFxbg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "is-windows": "1.0.2"
+      },
+      "dependencies": {
+        "is-windows": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+          "dev": true
+        }
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.0-semantically-released",
   "description": "This library provides a set of common React components for use with the PatternFly reference implementation.",
   "main": "dist/js/index.js",
+  "module": "dist/esm/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/patternfly/patternfly-react.git"
@@ -55,6 +57,7 @@
     "commitizen": "^2.9.6",
     "concurrently": "^3.5.1",
     "coveralls": "^3.0.0",
+    "cross-env": "^5.1.4",
     "css-loader": "^0.28.8",
     "cz-conventional-changelog": "^2.1.0",
     "enzyme": "^3.3.0",
@@ -107,7 +110,9 @@
     "start": "concurrently \"npm run storybook:run\" \"npm run storybook:openurl\"",
     "commit": "git-cz",
     "build": "npm run build:scripts && npm run build:sass && npm run build:less",
-    "build:scripts": "babel src --out-dir dist/js --ignore .test.js,__mocks__",
+    "build:scripts": "concurrently \"npm run build:cjs\" \"npm run build:esm\"",
+    "build:cjs": "cross-env BABEL_ENV=production:cjs babel src --out-dir dist/js",
+    "build:esm": "cross-env BABEL_ENV=production:esm babel src --out-dir dist/esm",
     "build:less": "mkdir -p dist/less && cp -r less/* dist/less",
     "build:sass": "mkdir -p dist/sass && cp -r sass/patternfly-react/* dist/sass && node-sass --output-style compressed --include-path sass $npm_package_sassIncludes_patternfly $npm_package_sassIncludes_bootstrap $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react.scss",
     "lint": "eslint --fix --max-warnings 0 src storybook && npm run stylelint",


### PR DESCRIPTION
* Added .babelrcjs to be used by .babelrc. 
* Added script to build components with ES modules and output to dist/esm.  
* Added modules property in package.json to point to new esm directory.

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Now exporting ES Modules in addition to the CommonJS modules we currently export. This does not currently fix treeshaking for webpack 3, but it puts us on the right track.  Since we use `export *` syntax at the base webpack cannot treeshake this project, I added sideEffects fals to the project.json.  This will allow any consumer that is using webpack 4 to treeshake patternfly-react.

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
N/A

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
N/A

<!-- feel free to add additional comments -->