### PR TITLE
test(Label): Refactor Label tests to use shallow rendering

### DIFF
--- a/src/components/Label/DisposableLabel.js
+++ b/src/components/Label/DisposableLabel.js
@@ -1,32 +1,19 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Label from './Label';
-import RemoveButton from './RemoveButton';
 import { noop } from '../../common/helpers';
 
 /**
  * Country page Component
  */
-const DisposableLabel = ({ children, type, onRemoveClick, ...rest }) => (
-  <Label bsStyle={type} {...rest}>
-    {children}
-    <RemoveButton onRemoveClick={onRemoveClick} title="Remove" />
-  </Label>
-);
+const DisposableLabel = props => <Label {...props} />;
 
 DisposableLabel.propTypes = {
-  /** Children nodes */
-  children: PropTypes.node,
-  /** Label type */
-  type: PropTypes.string,
-  /** callback when Label is removed  */
-  onRemoveClick: PropTypes.func
+  ...Label.propTypes
 };
 
 DisposableLabel.defaultProps = {
-  children: null,
-  type: 'default',
+  ...Label.defaultProps,
   onRemoveClick: noop
 };
-/** sdd */
+
 export default DisposableLabel;

--- a/src/components/Label/DisposableLabel.test.js
+++ b/src/components/Label/DisposableLabel.test.js
@@ -1,18 +1,17 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import { DisposableLabel } from './index';
-import { MockLabelRemove } from './__mocks__/mockLabelExamples';
+import { shallow } from 'enzyme';
+import DisposableLabel from './DisposableLabel';
+import Label from './Label';
+import { noop } from '../../common/helpers';
 
-test('Label renders properly', () => {
-  const component = mount(
-    <DisposableLabel type="default">Some text</DisposableLabel>
-  );
-  expect(component.render()).toMatchSnapshot();
+test('defaults props', () => {
+  const view = shallow(<DisposableLabel />);
+  expect(view).toMatchSnapshot();
+  expect(view.find(Label).props().onRemoveClick).toBe(noop);
 });
 
-test('Label is removed via function', () => {
-  const component = mount(<MockLabelRemove />);
-  expect(component.instance().state.types).toHaveLength(5);
-  component.instance().removeMe(1);
-  expect(component.instance().state.types).toHaveLength(4);
+test('onRemoveClick is passed to the Label', () => {
+  const onRemoveClick = jest.fn();
+  const component = shallow(<DisposableLabel onRemoveClick={onRemoveClick} />);
+  expect(component.find(Label).props().onRemoveClick).toBe(onRemoveClick);
 });

--- a/src/components/Label/Label.js
+++ b/src/components/Label/Label.js
@@ -1,17 +1,31 @@
 import React from 'react';
 import { Label as BsLabel } from 'react-bootstrap';
-import DisposableLabel from './DisposableLabel';
+import PropTypes from 'prop-types';
+import RemoveButton from './RemoveButton';
 
-const Label = props => {
-  if (props.onRemoveClick) {
-    return <DisposableLabel {...props} />;
-  }
-  return <BsLabel {...props} />;
-};
+const Label = ({ children, onRemoveClick, type, ...rest }) => (
+  <BsLabel bsStyle={type} {...rest}>
+    {children}
+    {!!onRemoveClick && (
+      <RemoveButton onRemoveClick={onRemoveClick} title="Remove" />
+    )}
+  </BsLabel>
+);
 
 Label.propTypes = {
   ...BsLabel.propTypes,
-  ...DisposableLabel.propTypes
+  /** Children nodes */
+  children: PropTypes.node,
+  /** Label type */
+  type: PropTypes.string,
+  /** callback when Label is removed  */
+  onRemoveClick: PropTypes.func
+};
+
+Label.defaultProps = {
+  children: null,
+  type: 'default',
+  onRemoveClick: undefined
 };
 
 export default Label;

--- a/src/components/Label/Label.test.js
+++ b/src/components/Label/Label.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Label as BsLabel } from 'react-bootstrap';
+import Label from './Label';
+import RemoveButton from './RemoveButton';
+
+it('sets bsStyle to type', () => {
+  const type = 'primary';
+  const view = shallow(<Label type={type} />);
+  expect(view.find(BsLabel).props().bsStyle).toBe(type);
+});
+
+it('spreads additional props to Bootstrap Label', () => {
+  const view = shallow(<Label id="id" another="another" />);
+  expect(view.find(BsLabel).props()).toMatchSnapshot(
+    'Bootstrap label has correct props.'
+  );
+});
+
+it('does not render RemoveButton if onRemoveClick is not present', () => {
+  const view = shallow(<Label />);
+  expect(view.find(RemoveButton).exists()).toBe(false);
+});
+
+it('renders RemoveButton if onRemoveClick is present', () => {
+  const view = shallow(<Label onRemoveClick={jest.fn()} />);
+  expect(view.find(RemoveButton).exists()).toBe(true);
+});

--- a/src/components/Label/RemoveButton.test.js
+++ b/src/components/Label/RemoveButton.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import RemoveButton from './RemoveButton';
+
+it('calls preventDefault on click', () => {
+  const preventDefault = jest.fn();
+  const view = shallow(<RemoveButton />);
+  view.find('a').simulate('click', { preventDefault });
+  expect(preventDefault).toBeCalled();
+});
+
+it('handles onRemoveClick having a falsy value', () => {
+  const preventDefault = jest.fn();
+  const view = shallow(<RemoveButton onRemoveClick={null} />);
+  expect(() => {
+    view.find('a').simulate('click', { preventDefault });
+    expect(preventDefault).toBeCalled();
+  }).not.toThrow();
+});
+
+it('spreads additional props and className to icon', () => {
+  const view = shallow(
+    <RemoveButton id="id" another="another" className="additional classes" />
+  );
+  expect(view).toMatchSnapshot('Icon has correct props.');
+});

--- a/src/components/Label/__snapshots__/DisposableLabel.test.js.snap
+++ b/src/components/Label/__snapshots__/DisposableLabel.test.js.snap
@@ -1,23 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Label renders properly 1`] = `
-<span
-  class="label label-default"
->
-  Some text
-  <a
-    class="pf-remove-button"
-    href="#"
-  >
-    <span
-      aria-hidden="true"
-      class="pficon pficon-close"
-    />
-    <span
-      class="sr-only"
-    >
-      Remove
-    </span>
-  </a>
-</span>
+exports[`defaults props 1`] = `
+<Label
+  onRemoveClick={[Function]}
+  type="default"
+/>
 `;

--- a/src/components/Label/__snapshots__/Label.test.js.snap
+++ b/src/components/Label/__snapshots__/Label.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`spreads additional props to Bootstrap Label: Bootstrap label has correct props. 1`] = `
+Object {
+  "another": "another",
+  "bsClass": "label",
+  "bsStyle": "default",
+  "children": Array [
+    null,
+    false,
+  ],
+  "id": "id",
+}
+`;

--- a/src/components/Label/__snapshots__/RemoveButton.test.js.snap
+++ b/src/components/Label/__snapshots__/RemoveButton.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`spreads additional props and className to icon: Icon has correct props. 1`] = `
+<a
+  className="pf-remove-button"
+  href="#"
+  onClick={[Function]}
+>
+  <span
+    another="another"
+    aria-hidden="true"
+    className="pficon pficon-close additional classes"
+    id="id"
+  />
+  <span
+    className="sr-only"
+  >
+    Remove
+  </span>
+</a>
+`;


### PR DESCRIPTION

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
* Modified tests under Label to use shallow rendering and targeted snapshots
* Removed circular dependncy for Label and DisposableLabel.  This fixes importing DisposableLabel directly.
* Added tests for Label and RemoveButton

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
N/A

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
N/A

<!-- feel free to add additional comments -->