### PR TITLE
fix(cards): match height container can be null if not rendered

### DIFF
--- a/src/components/Cards/CardHeightMatching.js
+++ b/src/components/Cards/CardHeightMatching.js
@@ -45,20 +45,22 @@ class CardHeightMatching extends React.Component {
   }
 
   _matchHeights(selectors = this._selectors) {
-    const arrayMap = elements =>
-      Array.prototype.map
-        .call(elements, el => el.scrollHeight)
-        .reduce((pre, cur) => Math.max(pre, cur), -Infinity);
-    selectors.forEach(selector => {
-      const elements = this._container.querySelectorAll(selector);
-      elements.forEach(el => {
-        el.style.height = null;
+    if (this._container) {
+      const arrayMap = elements =>
+        Array.prototype.map
+          .call(elements, el => el.scrollHeight)
+          .reduce((pre, cur) => Math.max(pre, cur), -Infinity);
+      selectors.forEach(selector => {
+        const elements = this._container.querySelectorAll(selector);
+        elements.forEach(el => {
+          el.style.height = null;
+        });
+        const maxHeight = arrayMap(elements);
+        elements.forEach(el => {
+          el.style.height = `${maxHeight}px`;
+        });
       });
-      const maxHeight = arrayMap(elements);
-      elements.forEach(el => {
-        el.style.height = `${maxHeight}px`;
-      });
-    });
+    }
   }
 
   render() {


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
I noticed that when a modal overlay pops up in our downstream app that the card match container element can become null. It seems that we are rendering/re-rendering the card content. This seems to be an edge case but a sanity check does not hurt. Otherwise this will just give a reference error in the console when the modal opens.

Still testing this downstream...

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- feel free to add additional comments -->