### PR TITLE
fix(InfoTip): Fix ref errors from react-bootstrap for InfoTip components.

### DIFF
--- a/src/common/Timer.test.js
+++ b/src/common/Timer.test.js
@@ -1,0 +1,71 @@
+import Timer from './Timer';
+
+jest.useFakeTimers();
+jest.spyOn(global, 'clearTimeout');
+jest.spyOn(global, 'setTimeout');
+
+beforeEach(() => {
+  global.clearTimeout.mockClear();
+  global.setTimeout.mockClear();
+});
+
+describe('clearTimer', () => {
+  test('checkes for timer before trying to clear it', () => {
+    const timer = new Timer(jest.fn(), 100);
+    timer.clearTimer();
+    expect(global.clearTimeout).not.toBeCalled();
+  });
+
+  test('clears the started timer', () => {
+    const timer = new Timer(jest.fn(), 100);
+    timer.startTimer();
+    timer.clearTimer();
+    expect(global.clearTimeout).toBeCalled();
+    expect(timer.timer).toBe(null);
+  });
+});
+
+describe('startTimer', () => {
+  test('uses function and delay from constructor', () => {
+    const fn = jest.fn();
+    const delay = 100;
+    const timer = new Timer(fn, delay);
+    timer.startTimer();
+    expect(global.setTimeout).toBeCalledWith(fn, delay);
+  });
+
+  test('uses the function passed to startTimer', () => {
+    const fn = jest.fn();
+    const delay = 100;
+    const timer = new Timer(jest.fn(), delay);
+    timer.startTimer(fn);
+    expect(global.setTimeout).toBeCalledWith(fn, delay);
+  });
+
+  test('uses the delay passed to startTimer', () => {
+    const fn = jest.fn();
+    const delay = 100;
+    const timer = new Timer(fn, 50);
+    timer.startTimer(undefined, delay);
+    expect(global.setTimeout).toBeCalledWith(fn, delay);
+  });
+});
+
+describe('skipTimer', () => {
+  test('executes the function and clears the timer', () => {
+    const fn = jest.fn();
+    const timer = new Timer(fn, 100);
+    timer.startTimer();
+    timer.skipTimer();
+    expect(fn).toBeCalledWith(true);
+    expect(global.clearTimeout).toBeCalled();
+  });
+
+  test('does not execute the function if the timer has not started', () => {
+    const fn = jest.fn();
+    const timer = new Timer(fn, 100);
+    timer.skipTimer();
+    expect(fn).not.toBeCalled();
+    expect(global.clearTimeout).not.toBeCalled();
+  });
+});

--- a/src/common/helpers.test.js
+++ b/src/common/helpers.test.js
@@ -1,0 +1,55 @@
+import * as helpers from './helpers';
+
+describe('bindMethods', () => {
+  test('binds specified methods and ignores unspecified', () => {
+    class Test {
+      constructor() {
+        helpers.bindMethods(this, ['bound']);
+      }
+
+      bound() {
+        expect(this).toBeInstanceOf(Test);
+      }
+
+      unbound() {
+        expect(this).toBeNull();
+      }
+    }
+    const instance = new Test();
+    instance.bound.call(null);
+    instance.unbound.call(null);
+  });
+});
+
+describe('selectKeys', () => {
+  test('defaults function to an identity function', () => {
+    const obj = {
+      key: 'value'
+    };
+    const newObj = helpers.selectKeys(obj, ['key']);
+    expect(newObj.key).toBe(obj.key);
+  });
+
+  test('allows a function to be passed', () => {
+    const obj = {
+      key: 'value'
+    };
+
+    const newValue = 'newValue';
+    const fn = jest.fn(() => newValue);
+    const newObj = helpers.selectKeys(obj, ['key'], fn);
+    expect(newObj.key).toBe(newValue);
+    expect(fn).toBeCalledWith(obj.key);
+  });
+
+  test('removes keys unspecified', () => {
+    const obj = {
+      key: 'value'
+    };
+
+    const newValue = 'newValue';
+    const fn = jest.fn(() => newValue);
+    const newObj = helpers.selectKeys(obj, [], fn);
+    expect(newObj.key).toBeUndefined();
+  });
+});

--- a/src/components/InfoTip/InfoTipMenu.js
+++ b/src/components/InfoTip/InfoTipMenu.js
@@ -2,39 +2,47 @@ import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-const InfoTipMenu = ({
-  children,
-  className,
-  bsRole,
-  rootCloseEvent,
-  labelledBy, // eslint-disable-line react/prop-types
-  pullRight, // eslint-disable-line react/prop-types
-  bsClass, // eslint-disable-line react/prop-types
-  ...props
-}) => {
-  const infoTipMenuClass = classNames(
-    'dropdown-menu',
-    'infotip',
-    'bottom-right',
-    className
-  );
-  return (
-    <div className={infoTipMenuClass} style={{ padding: '' }} {...props}>
-      <div className="arrow" />
-      {children}
-    </div>
-  );
-};
-InfoTipMenu.propTypes = {
-  className: PropTypes.string,
-  children: PropTypes.node.isRequired,
-  bsRole: PropTypes.string,
-  rootCloseEvent: PropTypes.oneOf(['click', 'mousedown'])
-};
-InfoTipMenu.defaultProps = {
-  bsRole: 'menu',
-  className: '',
-  rootCloseEvent: 'click'
-};
+// This must be a class component react-bootstrap passes a ref to it.
+// eslint-disable-next-line react/prefer-stateless-function
+class InfoTipMenu extends React.Component {
+  static propTypes = {
+    className: PropTypes.string,
+    children: PropTypes.node.isRequired,
+    bsRole: PropTypes.string,
+    rootCloseEvent: PropTypes.oneOf(['click', 'mousedown'])
+  };
+
+  static defaultProps = {
+    bsRole: 'menu',
+    className: '',
+    rootCloseEvent: 'click'
+  };
+
+  render() {
+    const {
+      children,
+      className,
+      bsRole,
+      rootCloseEvent,
+      labelledBy, // eslint-disable-line react/prop-types
+      pullRight, // eslint-disable-line react/prop-types
+      bsClass, // eslint-disable-line react/prop-types
+      ...props
+    } = this.props;
+    const infoTipMenuClass = classNames(
+      'dropdown-menu',
+      'infotip',
+      'bottom-right',
+      className
+    );
+
+    return (
+      <div className={infoTipMenuClass} style={{ padding: '' }} {...props}>
+        <div className="arrow" />
+        {children}
+      </div>
+    );
+  }
+}
 
 export default InfoTipMenu;

--- a/src/components/InfoTip/InfoTipToggle.js
+++ b/src/components/InfoTip/InfoTipToggle.js
@@ -3,22 +3,32 @@ import PropTypes from 'prop-types';
 import { Dropdown } from '../Dropdown';
 import { Icon } from '../Icon';
 
-const InfoTipToggle = ({ bsClass, bsRole, children, open, ...props }) => (
-  <a href="#" aria-expanded={open} {...props}>
-    <Icon type="pf" name="info" /> {children}
-  </a>
-);
-InfoTipToggle.propTypes = {
-  ...Dropdown.propTypes,
-  children: PropTypes.node,
-  open: PropTypes.bool,
-  className: PropTypes.string
-};
-InfoTipToggle.defaultProps = {
-  bsRole: 'toggle', // eslint-disable-line react/default-props-match-prop-types
-  children: null,
-  open: false,
-  className: ''
-};
+// Must be a class component react-bootstrap passes a ref to this.
+// eslint-disable-next-line react/prefer-stateless-function
+class InfoTipToggle extends React.Component {
+  static propTypes = {
+    ...Dropdown.propTypes,
+    children: PropTypes.node,
+    open: PropTypes.bool,
+    className: PropTypes.string
+  };
+
+  static defaultProps = {
+    bsRole: 'toggle', // eslint-disable-line react/default-props-match-prop-types
+    children: null,
+    open: false,
+    className: ''
+  };
+
+  render() {
+    const { bsClass, bsRole, children, open, ...props } = this.props;
+
+    return (
+      <a href="#" aria-expanded={open} {...props}>
+        <Icon type="pf" name="info" /> {children}
+      </a>
+    );
+  }
+}
 
 export default InfoTipToggle;


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
react-bootstrap's Dropdown component passes, and tries to use, a ref passed to InfoTipMenu and
InfoTipToggle. Since SFC's cannot have refs passed to them, I converted these two components back to class components.

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
https://rawgit.com/dmiller9911/patternfly-react/info-tip-fix-storybook/index.html

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
fix #297


<!-- feel free to add additional comments -->