### PR TITLE
feat(VerticalNav): Add a prop to allow disabling persistence

### DIFF
--- a/src/components/VerticalNav/VerticalNav.js
+++ b/src/components/VerticalNav/VerticalNav.js
@@ -488,8 +488,7 @@ const controlledState = {
     hoverPath: null,
     mobilePath: null,
     pinnedPath: null
-  },
-  persist: ['navCollapsed', 'pinnedPath']
+  }
 };
 
 BaseVerticalNav.propTypes = {
@@ -569,12 +568,28 @@ BaseVerticalNav.defaultProps = {
   children: null
 };
 
-const VerticalNav = controlled(controlledState)(BaseVerticalNav);
+const NoPersist = controlled(controlledState)(BaseVerticalNav);
+const WithPersist = controlled({
+  ...controlledState,
+  persist: ['navCollapsed', 'pinnedPath']
+})(BaseVerticalNav);
+
+const VerticalNav = ({ persist, ...props }) =>
+  persist ? <WithPersist {...props} /> : <NoPersist {...props} />;
 
 VerticalNav.propTypes = {
-  ...BaseVerticalNav.propTypes
+  ...BaseVerticalNav.propTypes,
+  persist: PropTypes.bool
+};
+
+VerticalNav.defaultProps = {
+  ...BaseVerticalNav.defaultProps,
+  persist: true
 };
 
 VerticalNav.displayName = 'VerticalNav';
+
+VerticalNav.NoPersist = NoPersist;
+VerticalNav.WithPersist = WithPersist;
 
 export default VerticalNav;

--- a/src/components/VerticalNav/VerticalNav.stories.js
+++ b/src/components/VerticalNav/VerticalNav.stories.js
@@ -201,6 +201,23 @@ stories.add(
 );
 
 stories.add(
+  'Persistence Disabled',
+  withInfo({
+    propTablesExclude: [MockFixedLayout],
+    text: `Example using the **persist** prop. (items from 'Items as JSX')\n\n${propTypesAreBroke}`
+  })(() => (
+    <MockFixedLayout>
+      <div className="layout-pf layout-pf-fixed faux-layout">
+        {basicExample({
+          persist: false
+        })}
+        {mockBodyContainer('nav-pf-vertical-with-badges')}
+      </div>
+    </MockFixedLayout>
+  ))
+);
+
+stories.add(
   'Custom Masthead',
   withInfo({
     propTablesExclude: [

--- a/src/components/VerticalNav/VerticalNav.test.js
+++ b/src/components/VerticalNav/VerticalNav.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import { VerticalNav } from './index';
 
@@ -21,6 +21,16 @@ test('VerticalNav renders properly in mobile mode', () => {
   const component = mount(basicExample({ isMobile: true }));
 
   expect(component.render()).toMatchSnapshot();
+});
+
+test('VerticalNav renders without errors with persistence on', () => {
+  const component = shallow(<VerticalNav persist />);
+  expect(component.find(VerticalNav.WithPersist).exists()).toBe(true);
+});
+
+test('VerticalNav renders without errors with persistence off', () => {
+  const component = shallow(<VerticalNav persist={false} />);
+  expect(component.find(VerticalNav.NoPersist).exists()).toBe(true);
 });
 
 test('VerticalNav renders properly with a custom className on a nav item', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2024,6 +2024,10 @@ bootstrap-select@^1.12.2:
   dependencies:
     jquery ">=1.8"
 
+bootstrap-slider-without-jquery@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-slider-without-jquery/-/bootstrap-slider-without-jquery-10.0.0.tgz#5c304461b3b915037c7c118806c8ca08102f5de3"
+
 bootstrap-slider@^9.9.0:
   version "9.10.0"
   resolved "https://registry.npmjs.org/bootstrap-slider/-/bootstrap-slider-9.10.0.tgz#1103d6bc00cfbfa8cfc9a2599ab518c55643da3f"


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:

You can now pass persist={false} to VerticalNav to turn off the persistence behavior.

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:

http://rawgit.com/mturley/patternfly-react/vert-nav-persist-sb/index.html

<!-- feel free to add additional comments -->