### PR TITLE
chore(.githooks/post-merge): Add git-hooks and a post-merge yarn install

### DIFF
--- a/.githooks/post-merge/check_package_json
+++ b/.githooks/post-merge/check_package_json
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# MIT © Sindre Sorhus - sindresorhus.com
+# https://gist.github.com/sindresorhus/7996717
+
+# git hook to run a command after `git pull` if a specified file was changed
+
+changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+
+check_run() {
+	echo "$changed_files" | grep --quiet "$1" && eval "$2"
+}
+
+check_run package.json "yarn install"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "breakjs": "^1.0.0",
     "classnames": "^2.2.5",
     "css-element-queries": "^1.0.1",
+    "git-hooks": "^1.1.10",
     "patternfly": "^3.42.0",
     "react-bootstrap": "^0.32.1",
     "react-bootstrap-switch": "^15.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2024,6 +2024,10 @@ bootstrap-select@^1.12.2:
   dependencies:
     jquery ">=1.8"
 
+bootstrap-slider-without-jquery@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-slider-without-jquery/-/bootstrap-slider-without-jquery-10.0.0.tgz#5c304461b3b915037c7c118806c8ca08102f5de3"
+
 bootstrap-slider@^9.9.0:
   version "9.10.0"
   resolved "https://registry.npmjs.org/bootstrap-slider/-/bootstrap-slider-9.10.0.tgz#1103d6bc00cfbfa8cfc9a2599ab518c55643da3f"
@@ -4660,6 +4664,10 @@ getpass@^0.1.1:
   resolved "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
   dependencies:
     assert-plus "^1.0.0"
+
+git-hooks@^1.1.10:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/git-hooks/-/git-hooks-1.1.10.tgz#c3113a8506593ac703bffc3bc77badbe8c9e1536"
 
 git-log-parser@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:

After pulling down this change, developers will have to `yarn install` one last time to set up `git-hooks`, but thereafter anytime the `package.json` file changes in a `git merge` (and therefore in a `git pull`), this hook will automatically run `yarn install`.

No more wondering why your code doesn't work and remembering you forgot to `yarn install`.
<!-- feel free to add additional comments -->