### PR TITLE
fix(wizard): expose onExited callback

### DIFF
--- a/src/components/Wizard/Wizard.js
+++ b/src/components/Wizard/Wizard.js
@@ -11,11 +11,13 @@ const Wizard = ({
   dialogClassName,
   show,
   onClose,
+  onExited,
   ...rest
 }) => (
   <Modal
     show={show}
     onHide={onClose}
+    onExited={onExited}
     dialogClassName={dialogClassName || 'modal-lg wizard-pf'}
     {...rest}
   >
@@ -32,13 +34,16 @@ Wizard.propTypes = {
   /** show modal */
   show: PropTypes.bool,
   /** on close callback */
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+  /** on exited callback */
+  onExited: PropTypes.func
 };
 Wizard.defaultProps = {
   children: null,
   className: '',
   dialogClassName: '',
   show: false,
-  onClose: noop
+  onClose: noop,
+  onExited: noop
 };
 export default Wizard;


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
expose `onExited` callback via `Wizard` now that it consumes `Modal`. This is needed for smooth exit animation.


<!-- feel free to add additional comments -->
completes v2v upgrade to `2.0` downstream:
https://github.com/priley86/miq_v2v_ui_plugin/pull/237