### PR TITLE
feat(ApplicationLauncher): Add Application Launcher Component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "react-bootstrap": "^0.32.1",
     "react-bootstrap-switch": "^15.5.3",
     "react-c3js": "^0.1.20",
+    "react-click-outside": "^3.0.1",
     "react-fontawesome": "^1.6.1",
     "reactabular-table": "^8.14.0",
     "recompose": "^0.26.0"

--- a/packages/core/src/components/ApplicationLauncher/ApplicationLauncher.js
+++ b/packages/core/src/components/ApplicationLauncher/ApplicationLauncher.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import ApplicationLauncherToggle from './ApplicationLauncherToggle';
+import { Dropdown } from '../Dropdown';
+import { noop } from '../../common/helpers';
+
+const ApplicationLauncher = ({
+  open,
+  grid,
+  tooltip,
+  tooltipPlacement,
+  children,
+  toggleLauncher,
+  className,
+  ...propTypes
+}) => {
+  const classes = classNames(
+    'applauncher-pf dropdown',
+    {
+      'applauncher-pf-block-list': grid
+    },
+    { open }
+  );
+  return (
+    <li className={classes}>
+      <ApplicationLauncherToggle
+        tooltip={tooltip}
+        tooltipPlacement={tooltipPlacement}
+        onClick={() => toggleLauncher()}
+        open={open}
+      />
+      <Dropdown.Menu className="dropdown-menu-right">{children}</Dropdown.Menu>
+    </li>
+  );
+};
+
+ApplicationLauncher.propTypes = {
+  /** Additional element css classes */
+  className: PropTypes.string,
+  /** Children Node */
+  children: PropTypes.node.isRequired,
+  /** Toggle Tooltip */
+  tooltip: PropTypes.string,
+  /** tooltipPlacement */
+  tooltipPlacement: PropTypes.string,
+  /** Application Launcher Type (Default List) */
+  grid: PropTypes.bool,
+  /** open bool */
+  open: PropTypes.bool,
+  /** Toggle launcher func */
+  toggleLauncher: PropTypes.func
+};
+ApplicationLauncher.defaultProps = {
+  className: '',
+  tooltip: '',
+  tooltipPlacement: 'left',
+  toggleLauncher: noop,
+  grid: false,
+  open: false
+};
+
+export default ApplicationLauncher;

--- a/packages/core/src/components/ApplicationLauncher/ApplicationLauncher.stories.js
+++ b/packages/core/src/components/ApplicationLauncher/ApplicationLauncher.stories.js
@@ -1,0 +1,22 @@
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+import {
+  storybookPackageName,
+  STORYBOOK_CATEGORY
+} from 'storybook/constants/siteConstants';
+import {
+  NavApplicationLauncherStory,
+  WrapperNavApplicationLauncherStory
+} from './Stories/index';
+import { name } from '../../../package.json';
+
+const stories = storiesOf(
+  `${storybookPackageName(name)}/${
+    STORYBOOK_CATEGORY.APPLICATION_FRAMEWORK
+  }/Launcher`,
+  module
+);
+stories.addDecorator(withKnobs);
+
+NavApplicationLauncherStory(stories);
+WrapperNavApplicationLauncherStory(stories);

--- a/packages/core/src/components/ApplicationLauncher/ApplicationLauncher.test.js
+++ b/packages/core/src/components/ApplicationLauncher/ApplicationLauncher.test.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import {
+  ApplicationLauncher,
+  ApplicationLauncherItem,
+  ApplicationLauncherToggle
+} from './index';
+
+const handleClick = e => {
+  e.preventDefault();
+};
+
+test('ApplicationLauncher is working properly', () => {
+  const component = mount(
+    <ApplicationLauncher type="grid" tooltipPlacement="left">
+      <ApplicationLauncherItem
+        icon="pficon pficon-storage-domain"
+        title="Recteque"
+        tooltip="Tooltip!"
+        onClick={handleClick}
+      />
+    </ApplicationLauncher>
+  );
+
+  expect(component.render()).toMatchSnapshot();
+});
+
+test('ApplicationLauncherItem with tooltip is working properly', () => {
+  const component = mount(
+    <ApplicationLauncherItem
+      icon="pficon pficon-storage-domain"
+      title="Recteque"
+      tooltip="Tooltip!"
+      onClick={handleClick}
+    />
+  );
+
+  expect(component.render()).toMatchSnapshot();
+});
+
+test('ApplicationLauncherItem without tooltip is working properly', () => {
+  const component = mount(
+    <ApplicationLauncherItem
+      icon="pficon pficon-storage-domain"
+      title="Recteque"
+      onClick={handleClick}
+    />
+  );
+
+  expect(component.render()).toMatchSnapshot();
+});
+
+test('ApplicationLauncherToggle is working properly', () => {
+  const component = mount(
+    <ApplicationLauncherToggle tooltipPlacement="left" onClick={handleClick} />
+  );
+
+  expect(component.render()).toMatchSnapshot();
+});

--- a/packages/core/src/components/ApplicationLauncher/ApplicationLauncherItem.js
+++ b/packages/core/src/components/ApplicationLauncher/ApplicationLauncherItem.js
@@ -1,0 +1,87 @@
+import classNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip } from '../Tooltip';
+import { OverlayTrigger } from '../OverlayTrigger';
+import { Icon } from '../Icon';
+
+const ApplicationLauncherItem = ({
+  onClick,
+  tooltip,
+  tooltipPlacement,
+  title,
+  icon,
+  noIcons,
+  className,
+  ...props
+}) => {
+  const classes = classNames('applauncher-pf-item', className);
+
+  if (tooltip !== null) {
+    return (
+      <OverlayTrigger
+        overlay={<Tooltip id={title}>{tooltip}</Tooltip>}
+        placement={tooltipPlacement}
+        trigger={['hover', 'focus']}
+        rootClose={false}
+      >
+        <li className={classes} role="presentation">
+          <a
+            className="applauncher-pf-link"
+            href="#"
+            onClick={e => onClick(e)}
+            role="menuitem"
+          >
+            {!noIcons && (
+              <Icon
+                type="pf"
+                name={icon}
+                className="applauncher-pf-link-icon"
+              />
+            )}
+            <span className="applauncher-pf-link-title">{title}</span>
+          </a>
+        </li>
+      </OverlayTrigger>
+    );
+  }
+  return (
+    <li className={classes} role="presentation">
+      <a
+        className="applauncher-pf-link"
+        href="#"
+        onClick={e => onClick(e)}
+        role="menuitem"
+      >
+        {!noIcons && (
+          <Icon type="pf" name={icon} className="applauncher-pf-link-icon" />
+        )}
+        <span className="applauncher-pf-link-title">{title}</span>
+      </a>
+    </li>
+  );
+};
+ApplicationLauncherItem.propTypes = {
+  /** Additional element css classes */
+  className: PropTypes.string,
+  /** onClick func */
+  onClick: PropTypes.func,
+  /** Title String */
+  title: PropTypes.string.isRequired,
+  /** Icon Type */
+  icon: PropTypes.string.isRequired,
+  /** App Tooltip */
+  tooltip: PropTypes.string,
+  /** Tooltip Placement */
+  tooltipPlacement: PropTypes.string,
+  /** No Icons Bool */
+  noIcons: PropTypes.bool
+};
+ApplicationLauncherItem.defaultProps = {
+  className: '',
+  onClick: null,
+  noIcons: false,
+  tooltipPlacement: 'left',
+  tooltip: null
+};
+export default ApplicationLauncherItem;

--- a/packages/core/src/components/ApplicationLauncher/ApplicationLauncherToggle.js
+++ b/packages/core/src/components/ApplicationLauncher/ApplicationLauncherToggle.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { OverlayTrigger } from '../OverlayTrigger';
+import { Tooltip } from '../Tooltip';
+import { Icon } from '../Icon';
+import { Button } from '../Button';
+
+const ApplicationLauncherToggle = ({
+  open,
+  tooltip,
+  onClick,
+  tooltipPlacement
+}) => {
+  if (tooltip)
+    return (
+      <OverlayTrigger
+        placement={tooltipPlacement}
+        id="applauncher-pf-block-list"
+        overlay={<Tooltip id={tooltip}>{tooltip}</Tooltip>}
+      >
+        <Button
+          onClick={onClick}
+          bsStyle="link"
+          className="nav-item-iconic dropdown-toggle"
+          aria-expanded={open}
+        >
+          <Icon name="th applauncher-pf-icon" />
+        </Button>
+      </OverlayTrigger>
+    );
+  return (
+    <Button
+      onClick={onClick}
+      bsStyle="link"
+      className="nav-item-iconic dropdown-toggle"
+      aria-expanded={open}
+    >
+      <Icon name="th applauncher-pf-icon" />
+      <span className="dropdown-title">
+        <span className="applauncher-pf-title">
+          Application Launcher
+          <span className="caret" aria-hidden="true" />
+        </span>
+      </span>
+    </Button>
+  );
+};
+ApplicationLauncherToggle.propTypes = {
+  /** onClick func */
+  onClick: PropTypes.func,
+  /** tooltipPlacement */
+  tooltipPlacement: PropTypes.string,
+  /** Toggle Tooltip */
+  tooltip: PropTypes.string,
+  /** is Open bool */
+  open: PropTypes.bool.isRequired
+};
+ApplicationLauncherToggle.defaultProps = {
+  onClick: null,
+  tooltipPlacement: 'bottom',
+  tooltip: ''
+};
+
+export default ApplicationLauncherToggle;

--- a/packages/core/src/components/ApplicationLauncher/Stories/NavApplicationLauncherStory.js
+++ b/packages/core/src/components/ApplicationLauncher/Stories/NavApplicationLauncherStory.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import { boolean, select } from '@storybook/addon-knobs';
+import { inlineTemplate } from 'storybook/decorators/storyTemplates';
+import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
+import ApplicationLauncher from '../ApplicationLauncher';
+import ApplicationLauncherItem from '../ApplicationLauncherItem';
+
+const handleClick = e => {
+  e.preventDefault();
+  action('app clicked!')();
+};
+
+const NavApplicationLauncherStory = stories => {
+  stories.addWithInfo('Launcher', '', () => {
+    const type = select(
+      'Launcher Type',
+      { true: 'Grid', false: 'List' },
+      'true'
+    );
+    const iconBool = boolean('Icons', true);
+
+    const story = (
+      <nav className="navbar navbar-pf-vertical">
+        <nav className="collapse navbar-collapse">
+          <ul className="nav navbar-nav navbar-right navbar-iconic">
+            <ApplicationLauncher
+              grid={type === 'true'}
+              tooltipPlacement="left"
+              open
+            >
+              <ApplicationLauncherItem
+                key="app1"
+                icon="storage-domain"
+                title="Recteque"
+                tooltip="Tooltip!"
+                tooltipPlacement="left"
+                onClick={handleClick}
+                noIcons={!iconBool}
+              />
+              <ApplicationLauncherItem
+                key="app2"
+                icon="virtual-machine"
+                title="No Tooltip"
+                onClick={handleClick}
+                noIcons={!iconBool}
+              />
+              <ApplicationLauncherItem
+                key="app3"
+                icon="domain"
+                title="Lorem"
+                tooltip="Tooltip!"
+                tooltipPlacement="left"
+                onClick={handleClick}
+                noIcons={!iconBool}
+              />
+              <ApplicationLauncherItem
+                key="app4"
+                icon="home"
+                title="Home"
+                tooltip="Tooltip!"
+                tooltipPlacement="left"
+                onClick={handleClick}
+                noIcons={!iconBool}
+              />
+            </ApplicationLauncher>
+          </ul>
+        </nav>
+      </nav>
+    );
+    return inlineTemplate({
+      title: 'ApplicationLauncher',
+      documentationLink: `${
+        DOCUMENTATION_URL.PATTERNFLY_ORG_APPLICATION_FRAMEWORK
+      }launcher/`,
+      story
+    });
+  });
+};
+
+export default NavApplicationLauncherStory;

--- a/packages/core/src/components/ApplicationLauncher/Stories/WrapperNavApplicationLauncherStory.js
+++ b/packages/core/src/components/ApplicationLauncher/Stories/WrapperNavApplicationLauncherStory.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import { boolean, select } from '@storybook/addon-knobs';
+import { inlineTemplate } from 'storybook/decorators/storyTemplates';
+import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
+import StatefulApplicationLauncherWrapper from '../Wrappers/StatefulApplicationLauncherWrapper';
+
+const handleClick = e => {
+  e.preventDefault();
+  action('app clicked!')();
+};
+
+const Apps = [
+  {
+    title: 'No Tooltip',
+    icon: 'home',
+    onClick: e => {
+      handleClick(e);
+    }
+  },
+  {
+    title: 'Royal',
+    icon: 'virtual-machine',
+    tooltip: 'Tooltip!',
+    onClick: e => {
+      handleClick(e);
+    }
+  },
+  {
+    title: 'Lemon',
+    icon: 'storage-domain',
+    tooltip: 'Tooltip!',
+    onClick: e => {
+      handleClick(e);
+    }
+  },
+  {
+    title: 'Domain',
+    icon: 'domain',
+    tooltip: 'Tooltip!',
+    onClick: e => {
+      handleClick(e);
+    }
+  }
+];
+
+const WrapperNavApplicationLauncherStory = stories => {
+  stories.addWithInfo('Stateful Launcher', '', () => {
+    const type = select(
+      'Launcher Type',
+      { true: 'Grid', false: 'List' },
+      'true'
+    );
+    const iconBool = boolean('Icons', true);
+
+    const story = (
+      <nav className="navbar navbar-pf-vertical">
+        <nav className="collapse navbar-collapse">
+          <ul className="nav navbar-nav navbar-right navbar-iconic">
+            <StatefulApplicationLauncherWrapper
+              apps={Apps}
+              noIcons={!iconBool}
+              grid={type === 'true'}
+              tooltipPlacement="left"
+            />
+          </ul>
+        </nav>
+      </nav>
+    );
+    return inlineTemplate({
+      title: 'WrapperApplicationLauncher',
+      documentationLink: `${
+        DOCUMENTATION_URL.PATTERNFLY_ORG_APPLICATION_FRAMEWORK
+      }launcher/`,
+      story
+    });
+  });
+};
+
+export default WrapperNavApplicationLauncherStory;

--- a/packages/core/src/components/ApplicationLauncher/Stories/index.js
+++ b/packages/core/src/components/ApplicationLauncher/Stories/index.js
@@ -1,0 +1,6 @@
+export {
+  default as NavApplicationLauncherStory
+} from './NavApplicationLauncherStory';
+export {
+  default as WrapperNavApplicationLauncherStory
+} from './WrapperNavApplicationLauncherStory';

--- a/packages/core/src/components/ApplicationLauncher/Wrappers/ApplicationLauncherWrapper.js
+++ b/packages/core/src/components/ApplicationLauncher/Wrappers/ApplicationLauncherWrapper.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ApplicationLauncher from '../ApplicationLauncher';
+import ApplicationLauncherItem from '../ApplicationLauncherItem';
+import { noop } from '../../../common/helpers';
+
+const ApplicationLauncherWrapper = ({
+  apps,
+  noIcons,
+  grid,
+  tooltip,
+  tooltipPlacement,
+  toggleLauncher,
+  open
+}) => {
+  const renderApps = apps.map((app, i) => (
+    <ApplicationLauncherItem
+      key={i}
+      icon={app.icon}
+      title={app.title}
+      tooltip={app.tooltip}
+      tooltipPlacement={tooltipPlacement}
+      onClick={app.onClick}
+      noIcons={noIcons}
+    />
+  ));
+
+  return (
+    <ApplicationLauncher
+      grid={grid}
+      tooltip={tooltip}
+      tooltipPlacement={tooltipPlacement}
+      open={open}
+      toggleLauncher={toggleLauncher}
+    >
+      {renderApps}
+    </ApplicationLauncher>
+  );
+};
+ApplicationLauncherWrapper.propTypes = {
+  /** Array of App Objects */
+  apps: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      icon: PropTypes.string,
+      tooltip: PropTypes.string,
+      onClick: PropTypes.func
+    })
+  ),
+  /** No Icons Bool */
+  noIcons: PropTypes.bool,
+  /** Grid instead of List (List is Default) */
+  grid: PropTypes.bool,
+  /** Toggle Tooltip */
+  tooltip: PropTypes.string,
+  /** Tooltip Placement */
+  tooltipPlacement: PropTypes.string,
+  /** Launcher open bool */
+  open: PropTypes.bool.isRequired,
+  /** Toggle launcher func */
+  toggleLauncher: PropTypes.func
+};
+ApplicationLauncherWrapper.defaultProps = {
+  noIcons: false,
+  tooltip: '',
+  tooltipPlacement: 'left',
+  grid: false,
+  toggleLauncher: noop,
+  apps: [
+    {
+      title: 'Royal',
+      icon: 'virtual-machine',
+      tooltip: 'Tooltip!',
+      onClick: e => {
+        e.preventDefault();
+      }
+    }
+  ]
+};
+
+export default ApplicationLauncherWrapper;

--- a/packages/core/src/components/ApplicationLauncher/Wrappers/StatefulApplicationLauncherWrapper.js
+++ b/packages/core/src/components/ApplicationLauncher/Wrappers/StatefulApplicationLauncherWrapper.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ApplicationLauncherWrapper from './ApplicationLauncherWrapper';
+import enhanceWithClickOutside from 'react-click-outside';
+
+class StatefulApplicationLauncherWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      open: false
+    };
+  }
+
+  toggleLauncher = () => {
+    this.setState({ open: !this.state.open });
+  };
+
+  handleClickOutside = () => {
+    if (this.state.open === true) this.toggleLauncher();
+  };
+
+  render() {
+    return (
+      <ApplicationLauncherWrapper
+        apps={this.props.apps}
+        noIcons={this.props.noIcons}
+        grid={this.props.grid}
+        tooltip={this.props.tooltip}
+        tooltipPlacement={this.props.tooltipPlacement}
+        open={this.state.open}
+        toggleLauncher={this.toggleLauncher}
+      />
+    );
+  }
+}
+StatefulApplicationLauncherWrapper.propTypes = {
+  /** Array of App Objects */
+  apps: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      icon: PropTypes.string,
+      tooltip: PropTypes.string,
+      onClick: PropTypes.func
+    })
+  ),
+  /** No Icons Bool */
+  noIcons: PropTypes.bool,
+  /** Grid instead of List (List is Default) */
+  grid: PropTypes.bool,
+  /** Toggle Tooltip */
+  tooltip: PropTypes.string,
+  /** Tooltip Placement */
+  tooltipPlacement: PropTypes.string
+};
+StatefulApplicationLauncherWrapper.defaultProps = {
+  noIcons: false,
+  tooltip: '',
+  tooltipPlacement: 'left',
+  grid: false,
+  apps: [
+    {
+      title: 'Royal',
+      icon: 'virtual-machine',
+      tooltip: 'Tooltip!',
+      onClick: e => {
+        e.preventDefault();
+      }
+    }
+  ]
+};
+export default enhanceWithClickOutside(StatefulApplicationLauncherWrapper);

--- a/packages/core/src/components/ApplicationLauncher/Wrappers/Wrappers.test.js
+++ b/packages/core/src/components/ApplicationLauncher/Wrappers/Wrappers.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import ApplicationLauncherWrapper from './ApplicationLauncherWrapper';
+import StatefulApplicationLauncherWrapper from './StatefulApplicationLauncherWrapper';
+
+const handleClick = e => {
+  e.preventDefault();
+};
+
+const Apps = [
+  {
+    title: 'Ipsum',
+    icon: 'pficon pficon-home',
+    tooltip: 'Tooltip!',
+    onClick: e => {
+      handleClick(e);
+    }
+  },
+  {
+    title: 'Royal',
+    icon: 'pficon pficon-virtual-machine',
+    tooltip: 'Tooltip!',
+    onClick: e => {
+      handleClick(e);
+    }
+  },
+  {
+    title: 'Lemon',
+    icon: 'pficon pficon-storage-domain',
+    tooltip: 'Tooltip!',
+    onClick: e => {
+      handleClick(e);
+    }
+  },
+  {
+    title: 'Domain',
+    icon: 'pficon pficon-domain',
+    tooltip: 'Tooltip!',
+    onClick: e => {
+      handleClick(e);
+    }
+  }
+];
+
+test('ApplicationLauncherWrapper is working properly as Grid', () => {
+  const component = mount(<ApplicationLauncherWrapper apps={Apps} grid />);
+
+  expect(component.render()).toMatchSnapshot();
+});
+
+test('ApplicationLauncherWrapper is working properly as List with no Icons', () => {
+  const component = mount(<ApplicationLauncherWrapper apps={Apps} noIcons />);
+
+  expect(component.render()).toMatchSnapshot();
+});
+
+test('StatefulApplicationLauncherWrapper is working properly as Grid', () => {
+  const component = mount(
+    <StatefulApplicationLauncherWrapper grid apps={Apps} />
+  );
+
+  expect(component.render()).toMatchSnapshot();
+});

--- a/packages/core/src/components/ApplicationLauncher/Wrappers/__snapshots__/Wrappers.test.js.snap
+++ b/packages/core/src/components/ApplicationLauncher/Wrappers/__snapshots__/Wrappers.test.js.snap
@@ -1,0 +1,330 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ApplicationLauncherWrapper is working properly as Grid 1`] = `
+<li
+  class="applauncher-pf dropdown applauncher-pf-block-list"
+>
+  <button
+    aria-expanded="false"
+    class="nav-item-iconic dropdown-toggle btn btn-link"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="fa fa-th applauncher-pf-icon"
+    />
+    <span
+      class="dropdown-title"
+    >
+      <span
+        class="applauncher-pf-title"
+      >
+        Application Launcher
+        <span
+          aria-hidden="true"
+          class="caret"
+        />
+      </span>
+    </span>
+  </button>
+  <ul
+    class="dropdown-menu-right dropdown-menu"
+    role="menu"
+  >
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          aria-hidden="true"
+          class="pficon pficon-pficon pficon-home applauncher-pf-link-icon"
+        />
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Ipsum
+        </span>
+      </a>
+    </li>
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          aria-hidden="true"
+          class="pficon pficon-pficon pficon-virtual-machine applauncher-pf-link-icon"
+        />
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Royal
+        </span>
+      </a>
+    </li>
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          aria-hidden="true"
+          class="pficon pficon-pficon pficon-storage-domain applauncher-pf-link-icon"
+        />
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Lemon
+        </span>
+      </a>
+    </li>
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          aria-hidden="true"
+          class="pficon pficon-pficon pficon-domain applauncher-pf-link-icon"
+        />
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Domain
+        </span>
+      </a>
+    </li>
+  </ul>
+</li>
+`;
+
+exports[`ApplicationLauncherWrapper is working properly as List with no Icons 1`] = `
+<li
+  class="applauncher-pf dropdown"
+>
+  <button
+    aria-expanded="false"
+    class="nav-item-iconic dropdown-toggle btn btn-link"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="fa fa-th applauncher-pf-icon"
+    />
+    <span
+      class="dropdown-title"
+    >
+      <span
+        class="applauncher-pf-title"
+      >
+        Application Launcher
+        <span
+          aria-hidden="true"
+          class="caret"
+        />
+      </span>
+    </span>
+  </button>
+  <ul
+    class="dropdown-menu-right dropdown-menu"
+    role="menu"
+  >
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Ipsum
+        </span>
+      </a>
+    </li>
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Royal
+        </span>
+      </a>
+    </li>
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Lemon
+        </span>
+      </a>
+    </li>
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Domain
+        </span>
+      </a>
+    </li>
+  </ul>
+</li>
+`;
+
+exports[`StatefulApplicationLauncherWrapper is working properly as Grid 1`] = `
+<li
+  class="applauncher-pf dropdown applauncher-pf-block-list"
+>
+  <button
+    aria-expanded="false"
+    class="nav-item-iconic dropdown-toggle btn btn-link"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="fa fa-th applauncher-pf-icon"
+    />
+    <span
+      class="dropdown-title"
+    >
+      <span
+        class="applauncher-pf-title"
+      >
+        Application Launcher
+        <span
+          aria-hidden="true"
+          class="caret"
+        />
+      </span>
+    </span>
+  </button>
+  <ul
+    class="dropdown-menu-right dropdown-menu"
+    role="menu"
+  >
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          aria-hidden="true"
+          class="pficon pficon-pficon pficon-home applauncher-pf-link-icon"
+        />
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Ipsum
+        </span>
+      </a>
+    </li>
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          aria-hidden="true"
+          class="pficon pficon-pficon pficon-virtual-machine applauncher-pf-link-icon"
+        />
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Royal
+        </span>
+      </a>
+    </li>
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          aria-hidden="true"
+          class="pficon pficon-pficon pficon-storage-domain applauncher-pf-link-icon"
+        />
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Lemon
+        </span>
+      </a>
+    </li>
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          aria-hidden="true"
+          class="pficon pficon-pficon pficon-domain applauncher-pf-link-icon"
+        />
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Domain
+        </span>
+      </a>
+    </li>
+  </ul>
+</li>
+`;

--- a/packages/core/src/components/ApplicationLauncher/__snapshots__/ApplicationLauncher.test.js.snap
+++ b/packages/core/src/components/ApplicationLauncher/__snapshots__/ApplicationLauncher.test.js.snap
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ApplicationLauncher is working properly 1`] = `
+<li
+  class="applauncher-pf dropdown"
+>
+  <button
+    aria-expanded="false"
+    class="nav-item-iconic dropdown-toggle btn btn-link"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="fa fa-th applauncher-pf-icon"
+    />
+    <span
+      class="dropdown-title"
+    >
+      <span
+        class="applauncher-pf-title"
+      >
+        Application Launcher
+        <span
+          aria-hidden="true"
+          class="caret"
+        />
+      </span>
+    </span>
+  </button>
+  <ul
+    class="dropdown-menu-right dropdown-menu"
+    role="menu"
+  >
+    <li
+      class="applauncher-pf-item"
+      role="presentation"
+    >
+      <a
+        class="applauncher-pf-link"
+        href="#"
+        role="menuitem"
+      >
+        <span
+          aria-hidden="true"
+          class="pficon pficon-pficon pficon-storage-domain applauncher-pf-link-icon"
+        />
+        <span
+          class="applauncher-pf-link-title"
+        >
+          Recteque
+        </span>
+      </a>
+    </li>
+  </ul>
+</li>
+`;
+
+exports[`ApplicationLauncherItem with tooltip is working properly 1`] = `
+<li
+  class="applauncher-pf-item"
+  role="presentation"
+>
+  <a
+    class="applauncher-pf-link"
+    href="#"
+    role="menuitem"
+  >
+    <span
+      aria-hidden="true"
+      class="pficon pficon-pficon pficon-storage-domain applauncher-pf-link-icon"
+    />
+    <span
+      class="applauncher-pf-link-title"
+    >
+      Recteque
+    </span>
+  </a>
+</li>
+`;
+
+exports[`ApplicationLauncherItem without tooltip is working properly 1`] = `
+<li
+  class="applauncher-pf-item"
+  role="presentation"
+>
+  <a
+    class="applauncher-pf-link"
+    href="#"
+    role="menuitem"
+  >
+    <span
+      aria-hidden="true"
+      class="pficon pficon-pficon pficon-storage-domain applauncher-pf-link-icon"
+    />
+    <span
+      class="applauncher-pf-link-title"
+    >
+      Recteque
+    </span>
+  </a>
+</li>
+`;
+
+exports[`ApplicationLauncherToggle is working properly 1`] = `
+<button
+  class="nav-item-iconic dropdown-toggle btn btn-link"
+  type="button"
+>
+  <span
+    aria-hidden="true"
+    class="fa fa-th applauncher-pf-icon"
+  />
+  <span
+    class="dropdown-title"
+  >
+    <span
+      class="applauncher-pf-title"
+    >
+      Application Launcher
+      <span
+        aria-hidden="true"
+        class="caret"
+      />
+    </span>
+  </span>
+</button>
+`;

--- a/packages/core/src/components/ApplicationLauncher/index.js
+++ b/packages/core/src/components/ApplicationLauncher/index.js
@@ -1,0 +1,12 @@
+import ApplicationLauncherToggle from './ApplicationLauncherToggle';
+import ApplicationLauncher from './ApplicationLauncher';
+import ApplicationLauncherItem from './ApplicationLauncherItem';
+
+ApplicationLauncher.Toggle = ApplicationLauncherToggle;
+ApplicationLauncher.Item = ApplicationLauncherItem;
+
+export {
+  ApplicationLauncher,
+  ApplicationLauncherItem,
+  ApplicationLauncherToggle
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5985,7 +5985,7 @@ hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
-hoist-non-react-statics@^2.3.1:
+hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
@@ -10071,6 +10071,12 @@ react-c3js@^0.1.20:
   resolved "https://registry.yarnpkg.com/react-c3js/-/react-c3js-0.1.20.tgz#561bb211bd691be42af39726d11bab42d09f3e7b"
   dependencies:
     c3 "^0.4.11"
+
+react-click-outside@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-click-outside/-/react-click-outside-3.0.1.tgz#6e77e84d2f17afaaac26dbad743cbbf909f5e24c"
+  dependencies:
+    hoist-non-react-statics "^2.1.1"
 
 react-color@^2.14.0:
   version "2.14.1"


### PR DESCRIPTION
fix #184

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Add an Application Launcher Component.

Managed to show all the launcher types in one storybook: `Grid/List Icons/No Icons` with the help of the knobs
<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
[Storybook](https://rawgit.com/gilad215/patternfly-react/storybook/feature/applauncher/index.html?knob-Launcher%20Type=true&knob-Icons=true&knob-Label=Well%20done%21%20You%20successfully%20read%20this%20important%20alert%20message.&selectedKind=patternfly-react%2FApplication%20Framework%2FLauncher&selectedStory=Stateful%20Launcher&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)
<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
- Figuring out the Icons names are a real pain, any easy way to do it?
e.g. - `applauncher-pf-link-icon pficon pficon-domain` - What is the name prop that i need to give to `<Icon />` in order to render this icon?

<!-- feel free to add additional comments -->

**TODO:**
- [x] Create Tests