### PR TITLE
fix(NotificationDrawer) - Dropdown not overlapping Clear/Read Section

### DIFF
--- a/packages/core/less/notificationdrawer.less
+++ b/packages/core/less/notificationdrawer.less
@@ -23,19 +23,27 @@
     }
 
     .panel-collapse.in {
-      display: flex;
-      flex-direction: column;
-      flex: 1 1 auto;
       min-height: 0;
+      overflow-y: auto;
 
       .panel-body {
-        flex: 1 1 auto;
-        overflow-y: auto;
+        display: block;
+        .dropdown-menu-right {
+          position: absolute;
+        }
       }
     }
   }
 
   .drawer-pf-action {
-    flex: none;
+    position: relative;
+    position: sticky;
+    position: -webkit-sticky;
+    position: -moz-sticky;
+    position: -ms-sticky;
+    position: -o-sticky;
+    bottom: 0px;
+    background-color: @color-pf-white;
+    border-top: 1px solid @card-pf-border-color;
   }
 }

--- a/packages/core/sass/patternfly-react/_notificationdrawer.scss
+++ b/packages/core/sass/patternfly-react/_notificationdrawer.scss
@@ -23,19 +23,27 @@
     }
 
     .panel-collapse.in {
-      display: flex;
-      flex-direction: column;
-      flex: 1 1 auto;
       min-height: 0;
+      overflow-y: auto;
 
       .panel-body {
-        flex: 1 1 auto;
-        overflow-y: auto;
+        display: block;
+        .dropdown-menu-right {
+          position: absolute;
+        }
       }
     }
   }
 
   .drawer-pf-action {
-    flex: none;
+    position: relative;
+    position: sticky;
+    position: -webkit-sticky;
+    position: -moz-sticky;
+    position: -ms-sticky;
+    position: -o-sticky;
+    bottom: 0px;
+    background-color: $color-pf-white;
+    border-top: 1px solid $card-pf-border-color;
   }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Fixing Dropdown not overlapping Clear/Read Section.
More Info: patternfly/patternfly#1039

After wrestling with the CSS finally found a solution for this issue while keeping flex for the outer part of the drawer 🎉 

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
[Storybook](https://rawgit.com/gilad215/patternfly-react/storybook/fix/notificationdrawer/index.html?knob-is%20Drawer%20Expandable=true&selectedKind=NotificationDrawer&selectedStory=Stateful%20Drawer%20Wrapper&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)
<!-- Are there any upstream issues or separate issues you need to reference? -->



<!-- feel free to add additional comments -->