### PR TITLE
feat(VerticalNav): Add Divider as a Secondary Item

### DIFF
--- a/packages/patternfly-react/less/patternfly-react.less
+++ b/packages/patternfly-react/less/patternfly-react.less
@@ -9,3 +9,4 @@
 @import 'inline-edit';
 @import 'field-level-help';
 @import 'type-ahead-select';
+@import 'verticalnavdivider';

--- a/packages/patternfly-react/less/verticalnavdivider.less
+++ b/packages/patternfly-react/less/verticalnavdivider.less
@@ -1,0 +1,13 @@
+.vertical-sub-header-pf {
+  line-height: 25px;
+  font-size: @font-size-base;
+  margin-left: 20px;
+  padding: 20px 0 2px 5px;
+  font-weight: bold;
+  color: @nav-pf-vertical-secondary-color;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: ~'calc(@{nav-pf-vertical-width} - 20px)';
+}

--- a/packages/patternfly-react/sass/patternfly-react/_patternfly-react.scss
+++ b/packages/patternfly-react/sass/patternfly-react/_patternfly-react.scss
@@ -9,3 +9,4 @@
 @import 'inline-edit';
 @import 'field-level-help';
 @import 'type-ahead-select';
+@import 'verticalnavdivider';

--- a/packages/patternfly-react/sass/patternfly-react/_verticalnavdivider.scss
+++ b/packages/patternfly-react/sass/patternfly-react/_verticalnavdivider.scss
@@ -1,0 +1,13 @@
+.vertical-sub-header-pf {
+  line-height: 25px;
+  font-size: $font-size-base;
+  margin-left: 20px;
+  padding: 20px 0 2px 5px;
+  font-weight: bold;
+  color: $nav-pf-vertical-secondary-color;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: calc(#{$nav-pf-vertical-width} - 20px);
+}

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNav.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNav.js
@@ -318,6 +318,7 @@ class BaseVerticalNav extends React.Component {
           {primaryItem.subItems &&
             primaryItem.subItems.map(secondaryItem => (
               <VerticalNavSecondaryItem
+                isDivider={secondaryItem.isDivider}
                 item={secondaryItem}
                 key={`secondary_${secondaryItem.title}`}
               >

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNavDividerItem.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNavDividerItem.js
@@ -1,0 +1,24 @@
+import classNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const VerticalNavDividerItem = ({ title, className, ...props }) => {
+  const classes = classNames('vertical-sub-header-pf', className);
+
+  return (
+    <span className={classes} {...props}>
+      {title}
+    </span>
+  );
+};
+VerticalNavDividerItem.propTypes = {
+  /** Additional element css classes */
+  className: PropTypes.string,
+  /** Title of divider */
+  title: PropTypes.string
+};
+VerticalNavDividerItem.defaultProps = {
+  className: '',
+  title: ''
+};
+export default VerticalNavDividerItem;

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
@@ -7,6 +7,7 @@ import { OverlayTrigger } from '../OverlayTrigger';
 import { Tooltip } from '../Tooltip';
 import VerticalNavBadge from './VerticalNavBadge';
 import { filterChildren } from '../../common/helpers';
+import VerticalNavDividerItem from './VerticalNavDividerItem';
 import {
   NavContextProvider,
   getNextDepth,
@@ -201,6 +202,7 @@ class BaseVerticalNavItemHelper extends React.Component {
     const {
       pinnableMenus,
       hiddenIcons,
+      isDivider,
       navCollapsed,
       showMobileSecondary,
       showMobileTertiary,
@@ -266,7 +268,7 @@ class BaseVerticalNavItemHelper extends React.Component {
       />
     );
 
-    return (
+    const item = (
       <ListGroupItem
         listItem // Renders as <li>. Other props can change this, see logic in react-bootstrap's ListGroupItem.
         className={classNames(
@@ -340,6 +342,14 @@ class BaseVerticalNavItemHelper extends React.Component {
           )}
       </ListGroupItem>
     );
+
+    const divider = (
+      <ListGroupItem listItem>
+        <VerticalNavDividerItem title={title} />
+      </ListGroupItem>
+    );
+
+    return isDivider ? divider : item;
   }
 }
 
@@ -353,13 +363,16 @@ BaseVerticalNavItemHelper.propTypes = {
    * Can alternatively pass subItems array as part of item or as its own prop.
    */
   children: PropTypes.node,
-  title: PropTypes.string
+  title: PropTypes.string,
+  /** Divider bool */
+  isDivider: PropTypes.bool
 };
 
 BaseVerticalNavItemHelper.defaultProps = {
   item: {},
   children: null,
-  title: ''
+  title: '',
+  isDivider: false
 };
 
 const VerticalNavItemHelper = getContext(navContextTypes)(

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNavSecondaryItem.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNavSecondaryItem.js
@@ -14,6 +14,7 @@ import VerticalNavItemHelper from './VerticalNavItemHelper';
  */
 const BaseVerticalNavSecondaryItem = props => {
   if (wrongDepth(props, 'secondary')) return correctDepth(props);
+
   return <VerticalNavItemHelper {...props} />;
 };
 

--- a/packages/patternfly-react/src/components/VerticalNav/__mocks__/basicExample.js
+++ b/packages/patternfly-react/src/components/VerticalNav/__mocks__/basicExample.js
@@ -24,10 +24,12 @@ export const basicExample = (props, firstItemClass) => (
         title="Item 2-B (external link)"
         href="http://www.patternfly.org"
       />
+      <VerticalNav.SecondaryItem title="Divider" isDivider />
       <VerticalNav.SecondaryItem title="Item 2-C" />
     </VerticalNav.Item>
     <VerticalNav.Item title="Item 3" iconClass="fa fa-info-circle">
       <VerticalNav.SecondaryItem title="Item 3-A" />
+      <VerticalNav.SecondaryItem title="Divider" isDivider />
       <VerticalNav.SecondaryItem title="Item 3-B">
         <VerticalNav.TertiaryItem title="Item 3-B-i" />
         <VerticalNav.TertiaryItem title="Item 3-B-ii" />

--- a/packages/patternfly-react/src/components/VerticalNav/__mocks__/mockNavItems.js
+++ b/packages/patternfly-react/src/components/VerticalNav/__mocks__/mockNavItems.js
@@ -24,6 +24,10 @@ export const mockNavItems = [
         ]
       },
       {
+        title: 'Divider 1',
+        isDivider: true
+      },
+      {
         title: 'Item 1-B',
         iconClass: 'fa fa-bell',
         subItems: [
@@ -39,7 +43,38 @@ export const mockNavItems = [
         ]
       },
       {
-        title: 'Item 1-C'
+        title: 'Item 1-B-2',
+        iconClass: 'fa fa-bell',
+        subItems: [
+          {
+            title: 'Item 1-B-i'
+          },
+          {
+            title: 'Item 1-B-ii'
+          },
+          {
+            title: 'Item 1-B-iii'
+          }
+        ]
+      },
+      {
+        title: 'Divider 2',
+        isDivider: true
+      },
+      {
+        title: 'Item 1-D',
+        iconClass: 'fa fa-bell',
+        subItems: [
+          {
+            title: 'Item 1-D-i'
+          },
+          {
+            title: 'Item 1-D-ii'
+          },
+          {
+            title: 'Item 1-D-iii'
+          }
+        ]
       }
     ]
   },

--- a/packages/patternfly-react/src/components/VerticalNav/index.js
+++ b/packages/patternfly-react/src/components/VerticalNav/index.js
@@ -6,6 +6,7 @@ import VerticalNavTertiaryItem from './VerticalNavTertiaryItem';
 import VerticalNavBrand from './VerticalNavBrand';
 import VerticalNavIconBar from './VerticalNavIconBar';
 import VerticalNavBadge from './VerticalNavBadge';
+import VerticalNavDividerItem from './VerticalNavDividerItem';
 
 VerticalNav.Masthead = VerticalNavMasthead;
 VerticalNav.Item = VerticalNavItem;
@@ -14,6 +15,7 @@ VerticalNav.TertiaryItem = VerticalNavTertiaryItem;
 VerticalNav.Brand = VerticalNavBrand;
 VerticalNav.IconBar = VerticalNavIconBar;
 VerticalNav.Badge = VerticalNavBadge;
+VerticalNav.Divider = VerticalNavDividerItem;
 
 export {
   VerticalNav,
@@ -23,5 +25,6 @@ export {
   VerticalNavTertiaryItem,
   VerticalNavBrand,
   VerticalNavIconBar,
-  VerticalNavBadge
+  VerticalNavBadge,
+  VerticalNavDividerItem
 };


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Added the ability to show a divider between secondary items instead of the Tertiary approach.
This functionality is needed in Foreman's VerticalNav. I tried to keep the pattern of the code, but suggestions are welcome.

Result:
<img width="299" alt="screen shot 2018-05-08 at 15 30 39" src="https://user-images.githubusercontent.com/24938324/39758014-507c5920-52d7-11e8-83fd-99bc62452a5a.png">

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
[Storybook](https://rawgit.com/gilad215/patternfly-react/storybook/feature/verticalnavdivider/index.html?selectedKind=Vertical%20Navigation&selectedStory=Items%20as%20Objects&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)
<!-- Are there any upstream issues or separate issues you need to reference? -->



<!-- feel free to add additional comments -->