### PR TITLE
fix(jest-config): fix roots path for jest module imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     ],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
-    ]
+    ],
+    "roots": ["<rootDir>/packages", "<rootDir>/scripts"]
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
this fixes an issue on master branch builds w/ jest importing duplicate modules from unexpected
paths in travis CI

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- feel free to add additional comments -->