### PR TITLE
refactor(Storybook reorder): move all stories to their folders based on package name

### DIFF
--- a/packages/console/src/SerialConsole/SerialConsole.stories.js
+++ b/packages/console/src/SerialConsole/SerialConsole.stories.js
@@ -6,7 +6,9 @@ import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { SerialConsole } from './index';
 import { CONNECTED, DISCONNECTED, LOADING } from './constants';
 
-const stories = storiesOf('SerialConsole', module);
+import { name } from '../../package.json';
+
+const stories = storiesOf(`${name}/SerialConsole`, module);
 stories.addDecorator(
   defaultTemplate({
     title: 'SerialConsole',

--- a/packages/console/src/VncConsole/VncConsole.stories.js
+++ b/packages/console/src/VncConsole/VncConsole.stories.js
@@ -3,10 +3,11 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { inlineTemplate } from 'storybook/decorators/storyTemplates';
+import { name } from '../../package.json';
 
 import VncConsole from './VncConsole';
 
-const stories = storiesOf('@patternfly-react/console', module);
+const stories = storiesOf(`${name}/vncConsole`, module);
 
 stories.add(
   'VncConsole',

--- a/packages/core/src/components/AboutModal/AboutModal.stories.js
+++ b/packages/core/src/components/AboutModal/AboutModal.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
+import { name } from '../../../package.json';
 
 import {
   AboutModal,
@@ -14,7 +15,7 @@ import {
   MockAboutModalSource
 } from './__mocks__/mockAboutModal';
 
-const stories = storiesOf('About Modal', module);
+const stories = storiesOf(`${name}/AboutModal`, module);
 
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/Alert/Alert.stories.js
+++ b/packages/core/src/components/Alert/Alert.stories.js
@@ -7,8 +7,9 @@ import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { ALERT_TYPES } from './AlertConstants';
 import { Alert } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Alert', module);
+const stories = storiesOf(`${name}/Alert`, module);
 stories.addDecorator(withKnobs);
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/Badge/Badge.stories.js
+++ b/packages/core/src/components/Badge/Badge.stories.js
@@ -5,8 +5,9 @@ import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Badge } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Badges', module);
+const stories = storiesOf(`${name}/Badges`, module);
 
 const description = (
   <p>

--- a/packages/core/src/components/Breadcrumb/Breadcrumb.stories.js
+++ b/packages/core/src/components/Breadcrumb/Breadcrumb.stories.js
@@ -4,8 +4,9 @@ import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Breadcrumb } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Breadcrumb', module);
+const stories = storiesOf(`${name}/Breadcrumb`, module);
 
 const description = (
   <p>

--- a/packages/core/src/components/Button/Button.stories.js
+++ b/packages/core/src/components/Button/Button.stories.js
@@ -8,8 +8,9 @@ import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Grid, Row, Col, MenuItem } from '../../index';
 import { Button, ButtonGroup, DropdownButton, SplitButton } from './index';
 import { BUTTON_BS_STYLES } from './ButtonConstants';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Button', module);
+const stories = storiesOf(`${name}/Button`, module);
 
 stories.addDecorator(withKnobs);
 

--- a/packages/core/src/components/Cards/Cards.stories.js
+++ b/packages/core/src/components/Cards/Cards.stories.js
@@ -10,7 +10,9 @@ import {
   utilizationBarCardStory
 } from './Stories/index';
 
-const stories = storiesOf('Cards', module);
+import { name } from '../../../package.json';
+
+const stories = storiesOf(`${name}/Cards`, module);
 stories.addDecorator(withKnobs);
 
 baseCardAddWithInfo(stories);

--- a/packages/core/src/components/Chart/Chart.stories.js
+++ b/packages/core/src/components/Chart/Chart.stories.js
@@ -7,7 +7,9 @@ import {
   pieChart
 } from './Stories';
 
-const stories = storiesOf('Chart', module);
+import { name } from '../../../package.json';
+
+const stories = storiesOf(`${name}/Chart`, module);
 
 /**
  * Chart stories

--- a/packages/core/src/components/DropdownKebab/DropdownKebab.stories.js
+++ b/packages/core/src/components/DropdownKebab/DropdownKebab.stories.js
@@ -7,8 +7,9 @@ import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Button } from '../Button';
 import { MenuItem } from '../MenuItem';
 import { DropdownKebab } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('DropdownKebab', module);
+const stories = storiesOf(`${name}/DropdownKebab`, module);
 stories.addDecorator(withKnobs);
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/EmptyState/EmptyState.stories.js
+++ b/packages/core/src/components/EmptyState/EmptyState.stories.js
@@ -6,8 +6,9 @@ import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Button } from '../Button';
 import { EmptyState } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('EmptyState', module);
+const stories = storiesOf(`${name}/EmptyState`, module);
 
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
+++ b/packages/core/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
@@ -5,8 +5,9 @@ import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { FieldLevelHelp } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('FieldLevelHelp', module);
+const stories = storiesOf(`${name}/FieldLevelHelp`, module);
 stories.addDecorator(withKnobs);
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/Filter/Filter.stories.js
+++ b/packages/core/src/components/Filter/Filter.stories.js
@@ -18,8 +18,9 @@ import {
   MockFilterExample,
   mockFilterExampleSource
 } from './__mocks__/mockFilterExample';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Filter', module);
+const stories = storiesOf(`${name}/Filter`, module);
 
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/Form/Form.stories.js
+++ b/packages/core/src/components/Form/Form.stories.js
@@ -35,8 +35,9 @@ import {
 import { InlineFormField } from './Stories/InlineFormField';
 import { HorizontalFormField } from './Stories/HorizontalFormField';
 import { VerticalFormField } from './Stories/VerticalFormField';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Forms', module);
+const stories = storiesOf(`${name}/Forms`, module);
 
 stories.addDecorator(withKnobs);
 

--- a/packages/core/src/components/Grid/Grid.stories.js
+++ b/packages/core/src/components/Grid/Grid.stories.js
@@ -5,8 +5,9 @@ import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Grid } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Grid', module);
+const stories = storiesOf(`${name}/Grid`, module);
 stories.addDecorator(withKnobs);
 
 const description = (

--- a/packages/core/src/components/Icon/Icon.stories.js
+++ b/packages/core/src/components/Icon/Icon.stories.js
@@ -5,8 +5,9 @@ import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Icon } from './index';
+import { name } from '../../../package.json';
 
-const IconStories = storiesOf('Icon', module);
+const IconStories = storiesOf(`${name}/Icon`, module);
 
 IconStories.addDecorator(withKnobs);
 IconStories.addDecorator(

--- a/packages/core/src/components/InfoTip/InfoTip.stories.js
+++ b/packages/core/src/components/InfoTip/InfoTip.stories.js
@@ -4,10 +4,10 @@ import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { ListGroup, ListGroupItem } from '../ListGroup';
-
+import { name } from '../../../package.json';
 import { InfoTip } from './index';
 
-const stories = storiesOf('InfoTip', module);
+const stories = storiesOf(`${name}/InfoTip`, module);
 
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/Label/Label.stories.js
+++ b/packages/core/src/components/Label/Label.stories.js
@@ -8,8 +8,9 @@ import {
   MockLabelRemove,
   mockLabelRemoveSource
 } from './__mocks__/mockLabelExamples';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Label', module);
+const stories = storiesOf(`${name}/Label`, module);
 
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/ListGroup/ListGroup.stories.js
+++ b/packages/core/src/components/ListGroup/ListGroup.stories.js
@@ -5,8 +5,9 @@ import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Badge } from '../Badge';
 import { ListGroup, ListGroupItem } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('ListGroup', module);
+const stories = storiesOf(`${name}/ListGroup`, module);
 
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/ListView/ListView.stories.js
+++ b/packages/core/src/components/ListView/ListView.stories.js
@@ -16,8 +16,9 @@ import {
   MockCompoundExpansionSource
 } from './__mocks__/mockCompoundExpansionExample';
 import { mockListItems } from './__mocks__/mockListItems';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('ListView', module);
+const stories = storiesOf(`${name}/ListView`, module);
 stories.addDecorator(withKnobs);
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/MenuItem/MenuItem.stories.js
+++ b/packages/core/src/components/MenuItem/MenuItem.stories.js
@@ -6,7 +6,9 @@ import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { MenuItem } from './index';
 
-const stories = storiesOf('MenuItem', module);
+import { name } from '../../../package.json';
+
+const stories = storiesOf(`${name}/MenuItem`, module);
 
 const description = (
   <p>

--- a/packages/core/src/components/Modal/Modal.stories.js
+++ b/packages/core/src/components/Modal/Modal.stories.js
@@ -9,8 +9,9 @@ import {
   basicExampleSource
 } from './__mocks__/mockModalManager';
 import { Modal } from '../../index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Modal Overlay', module);
+const stories = storiesOf(`${name}/Modal Overlay`, module);
 
 stories.add(
   'Modal',

--- a/packages/core/src/components/Notification/NotificationDrawerStory.stories.js
+++ b/packages/core/src/components/Notification/NotificationDrawerStory.stories.js
@@ -5,8 +5,9 @@ import {
   WrapperNotificationDrawerStory,
   StatefulNotificationDrawerStory
 } from './Stories/index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('NotificationDrawer', module);
+const stories = storiesOf(`${name}/NotificationDrawer`, module);
 stories.addDecorator(withKnobs);
 
 basicNotificationDrawerStory(stories);

--- a/packages/core/src/components/Pagination/Pagination.stories.js
+++ b/packages/core/src/components/Pagination/Pagination.stories.js
@@ -22,8 +22,9 @@ import {
   MockPaginationRow,
   mockPaginationSource
 } from './__mocks__/mockPaginationRow';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Pagination', module);
+const stories = storiesOf(`${name}/Pagination`, module);
 stories.addDecorator(withKnobs);
 
 stories.add(

--- a/packages/core/src/components/Popover/Popover.stories.js
+++ b/packages/core/src/components/Popover/Popover.stories.js
@@ -5,8 +5,9 @@ import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Button, OverlayTrigger, Popover } from '../../index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Popover', module);
+const stories = storiesOf(`${name}/Popover`, module);
 stories.addDecorator(withKnobs);
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/ProgressBar/ProgressBar.stories.js
+++ b/packages/core/src/components/ProgressBar/ProgressBar.stories.js
@@ -4,8 +4,9 @@ import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { ProgressBar } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('ProgressBar', module);
+const stories = storiesOf(`${name}/ProgressBar`, module);
 stories.addDecorator(
   defaultTemplate({
     title: 'Progress Bar',

--- a/packages/core/src/components/Slider/Slider.stories.js
+++ b/packages/core/src/components/Slider/Slider.stories.js
@@ -5,8 +5,9 @@ import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Slider } from './index';
 import { Form, FormControl, ControlLabel, FormGroup, Col } from '../../index';
+import { name } from '../../../package.json';
 
-const SliderStories = storiesOf('Slider', module);
+const SliderStories = storiesOf(`${name}/Slider`, module);
 
 SliderStories.addDecorator(withKnobs);
 SliderStories.addDecorator(

--- a/packages/core/src/components/Sort/Sort.stories.js
+++ b/packages/core/src/components/Sort/Sort.stories.js
@@ -7,8 +7,9 @@ import {
   MockSortExample,
   mockSortExampleSource
 } from './__mocks__/mockSortExample';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Sort', module);
+const stories = storiesOf(`${name}/Sort`, module);
 
 export const mockSortFields = [
   {

--- a/packages/core/src/components/Spinner/Spinner.stories.js
+++ b/packages/core/src/components/Spinner/Spinner.stories.js
@@ -5,8 +5,9 @@ import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Spinner } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Widgets', module);
+const stories = storiesOf(`${name}/Widgets`, module);
 
 stories.addDecorator(withKnobs);
 stories.addDecorator(

--- a/packages/core/src/components/Switch/Switch.stories.js
+++ b/packages/core/src/components/Switch/Switch.stories.js
@@ -6,8 +6,9 @@ import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 import { inlineTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Switch } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Widgets', module);
+const stories = storiesOf(`${name}/Widgets`, module);
 stories.addDecorator(withKnobs);
 
 stories.add(

--- a/packages/core/src/components/Table/Table.stories.js
+++ b/packages/core/src/components/Table/Table.stories.js
@@ -10,8 +10,9 @@ import {
   inlineEditColumnTable,
   inlineEditCellTable
 } from './Stories';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Table', module);
+const stories = storiesOf(`${name}/Table`, module);
 stories.addDecorator(withKnobs);
 
 /**

--- a/packages/core/src/components/Tabs/Tabs.stories.js
+++ b/packages/core/src/components/Tabs/Tabs.stories.js
@@ -14,8 +14,9 @@ import {
   TabPane,
   TabContent
 } from '../../index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Tabs', module);
+const stories = storiesOf(`${name}/Tabs`, module);
 const description = (
   <p>
     This component is based on React Bootstrap Tabs component. See{' '}

--- a/packages/core/src/components/ToastNotification/ToastNotification.stories.js
+++ b/packages/core/src/components/ToastNotification/ToastNotification.stories.js
@@ -13,8 +13,9 @@ import {
   TimedToastNotification,
   ToastNotificationList
 } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('ToastNotification', module);
+const stories = storiesOf(`${name}/ToastNotification`, module);
 stories.addDecorator(withKnobs);
 
 stories.add(

--- a/packages/core/src/components/Toolbar/Toolbar.stories.js
+++ b/packages/core/src/components/Toolbar/Toolbar.stories.js
@@ -17,7 +17,9 @@ import {
   mockToolbarExampleSource
 } from './__mocks__/mockToolbarExample';
 
-const stories = storiesOf('Toolbar', module);
+import { name } from '../../../package.json';
+
+const stories = storiesOf(`${name}/Toolbar`, module);
 
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/Tooltip/Tooltip.stories.js
+++ b/packages/core/src/components/Tooltip/Tooltip.stories.js
@@ -5,8 +5,9 @@ import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { Button, OverlayTrigger, Tooltip } from '../../index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('Tooltip', module);
+const stories = storiesOf(`${name}/Tooltip`, module);
 stories.addDecorator(withKnobs);
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/TreeView/TreeView.stories.js
+++ b/packages/core/src/components/TreeView/TreeView.stories.js
@@ -9,7 +9,9 @@ import { MockTreeView, MockTreeViewSource } from './__mocks__/MockTreeView';
 import TreeViewNodeSpecification from './__mocks__/TreeViewNodeSpecification';
 import TreeView from './TreeView';
 
-const stories = storiesOf('TreeView', module);
+import { name } from '../../../package.json';
+
+const stories = storiesOf(`${name}/TreeView`, module);
 stories.addDecorator(withKnobs);
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/UtilizationBar/UtilizationBar.stories.js
+++ b/packages/core/src/components/UtilizationBar/UtilizationBar.stories.js
@@ -4,8 +4,9 @@ import { withKnobs, number, boolean, text } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { UtilizationBar } from './index';
+import { name } from '../../../package.json';
 
-const stories = storiesOf('UtilizationBar', module);
+const stories = storiesOf(`${name}/UtilizationBar`, module);
 stories.addDecorator(withKnobs);
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/VerticalNav/VerticalNav.stories.js
+++ b/packages/core/src/components/VerticalNav/VerticalNav.stories.js
@@ -17,6 +17,8 @@ import { VerticalNav, Icon, MenuItem, Dropdown } from '../../index';
 
 const { Masthead, Brand, IconBar, Item } = VerticalNav;
 
+import { name } from '../../../package.json';
+
 // Vertical Nav CSS uses position: fixed, but storybook doesn't render components at the top of the page body.
 // We need this little bit of magic to force position: fixed children to render relative to the storybook body.
 // translateZ trick found at https://stackoverflow.com/a/38796408.
@@ -51,7 +53,7 @@ const mockBodyContainer = className => (
 const propTypesAreBroke = `***Note: Prop Type descriptions are missing on this page
 due to a Storybook bug. Please see the source code for propType description comments.***`;
 
-const stories = storiesOf('Vertical Navigation', module);
+const stories = storiesOf(`${name}/Vertical Navigation`, module);
 stories.addDecorator(withKnobs);
 stories.addDecorator(
   defaultTemplate({

--- a/packages/core/src/components/Wizard/Wizard.stories.js
+++ b/packages/core/src/components/Wizard/Wizard.stories.js
@@ -5,15 +5,17 @@ import {
   wizardPatternExampleAddWithInfo
 } from './Stories';
 
+import { name } from '../../../package.json';
+
 /**
  * Wizard Component stories
  */
-const componentStories = storiesOf('Wizard/Components', module);
+const componentStories = storiesOf(`${name}/Wizard/Components`, module);
 loadingWizardExampleWithInfo(componentStories);
 wizardExampleWithInfo(componentStories);
 
 /**
  * Wizard Pattern stories
  */
-const patternStories = storiesOf('Wizard/Patterns', module);
+const patternStories = storiesOf(`${name}/Wizard/Patterns`, module);
 wizardPatternExampleAddWithInfo(patternStories);


### PR DESCRIPTION
**Affects**
* @patternfly/react-console
* patternfly-react

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
When PF-react moved from single repo to monorepo all stories were dquished together on top level. This is hard to understand from which package to use which component. So this PR adopts to this change by adding `package.json`'s name before each stories so they are aligned in folders. No changes in code, just in stories.

**Link to Storybook**:
https://zen-swanson-2d3350.netlify.com/