### PR TITLE
fix(NotificationDrawer) - Dividing onNotificationClick to two functions

### DIFF
--- a/packages/core/src/components/Notification/Wrappers/NotificationDrawerPanelWrapper.js
+++ b/packages/core/src/components/Notification/Wrappers/NotificationDrawerPanelWrapper.js
@@ -7,6 +7,7 @@ import { Icon } from '../../Icon';
 import { Button } from '../../Button';
 import { MenuItem } from '../../MenuItem';
 import { EmptyState, EmptyStateTitle, EmptyStateIcon } from '../../../index';
+import { noop } from '../../../common/helpers';
 import getIconClass from './Icon.consts';
 
 const NotificationDrawerPanelWrapper = ({
@@ -17,6 +18,7 @@ const NotificationDrawerPanelWrapper = ({
   isExpanded,
   togglePanel,
   onNotificationClick,
+  onNotificationAsRead,
   onNotificationHide,
   onMarkPanelAsRead,
   onClickedLink,
@@ -31,11 +33,21 @@ const NotificationDrawerPanelWrapper = ({
     return '1 Unread Event';
   };
 
+  const notificationClickHandler = (panel, notification, seen) => {
+    onNotificationClick(panel, notification);
+
+    if (!seen) {
+      onNotificationAsRead(panel, notification);
+    }
+  };
+
   const notificationsMap = notifications.map((notification, i) => (
     <Notification
       key={i}
       seen={notification.seen}
-      onClick={() => onNotificationClick(panelkey, notification.id)}
+      onClick={() =>
+        notificationClickHandler(panelkey, notification.id, notification.seen)
+      }
     >
       {Object.keys(notification.actions).length > 0 && (
         <NotificationDrawer.Dropdown pullRight id={i}>
@@ -140,12 +152,15 @@ NotificationDrawerPanelWrapper.propTypes = {
   isExpanded: PropTypes.bool,
   /** function(panelkey, notificationkey) on Notification Click */
   onNotificationClick: PropTypes.func,
+  /** function(panelkey, notificationkey) on Notification Mark as Read Click */
+  onNotificationAsRead: PropTypes.func,
   /** on function(panelkey) Panel Read All Click */
   onMarkPanelAsRead: PropTypes.func,
   /** function(url) on Dropdown Link Click */
   onClickedLink: PropTypes.func,
   /** function(panelkey, notificationkey) on Notification Hide Click */
   onNotificationHide: PropTypes.func,
+
   /** function(panelkey) Panel Clear All Click */
   onMarkPanelAsClear: PropTypes.func,
   /** function() togglePanel Click */
@@ -159,12 +174,13 @@ NotificationDrawerPanelWrapper.defaultProps = {
   isExpanded: false,
   className: null,
   panelName: null,
-  onNotificationClick: null,
-  onMarkPanelAsRead: null,
-  onClickedLink: null,
-  onNotificationHide: null,
-  onMarkPanelAsClear: null,
-  togglePanel: null,
+  onNotificationClick: noop,
+  onNotificationAsRead: noop,
+  onMarkPanelAsRead: noop,
+  onClickedLink: noop,
+  onNotificationHide: noop,
+  onMarkPanelAsClear: noop,
+  togglePanel: noop,
   showLoading: false
 };
 

--- a/packages/core/src/components/Notification/Wrappers/NotificationDrawerWrapper.js
+++ b/packages/core/src/components/Notification/Wrappers/NotificationDrawerWrapper.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { NotificationDrawer } from '../NotificationDrawer/index';
 import { NotificationDrawerPanelWrapper } from './index';
 import { EmptyState, EmptyStateIcon, EmptyStateTitle } from '../../EmptyState';
+import { noop } from '../../../common/helpers';
 
 const NotificationDrawerWrapper = ({
   panels,
@@ -13,6 +14,7 @@ const NotificationDrawerWrapper = ({
   expandedPanel,
   togglePanel,
   onNotificationClick,
+  onNotificationAsRead,
   onNotificationHide,
   onMarkPanelAsRead,
   onMarkPanelAsClear,
@@ -28,6 +30,7 @@ const NotificationDrawerWrapper = ({
       togglePanel={togglePanel}
       isExpanded={expandedPanel === panel.panelkey}
       onNotificationClick={onNotificationClick}
+      onNotificationAsRead={onNotificationAsRead}
       onNotificationHide={onNotificationHide}
       onMarkPanelAsRead={onMarkPanelAsRead}
       onMarkPanelAsClear={onMarkPanelAsClear}
@@ -68,6 +71,8 @@ NotificationDrawerWrapper.propTypes = {
   isExpanded: PropTypes.bool,
   /** function(panelkey, notificationkey) on Notification Click */
   onNotificationClick: PropTypes.func,
+  /** function(panelkey, notificationkey) on Notification Mark as Read Click */
+  onNotificationAsRead: PropTypes.func,
   /** on function(panelkey) Panel Read All Click */
   onMarkPanelAsRead: PropTypes.func,
   /** function(url) on Dropdown Link Click */
@@ -86,15 +91,16 @@ NotificationDrawerWrapper.propTypes = {
 
 NotificationDrawerWrapper.defaultProps = {
   panels: null,
-  toggleDrawerHide: null,
-  toggleDrawerExpand: null,
+  toggleDrawerHide: noop,
+  toggleDrawerExpand: noop,
   togglePanel: null,
   isExpanded: false,
-  onNotificationClick: null,
-  onMarkPanelAsRead: null,
-  onClickedLink: null,
-  onNotificationHide: null,
-  onMarkPanelAsClear: null,
+  onNotificationClick: noop,
+  onNotificationAsRead: noop,
+  onMarkPanelAsRead: noop,
+  onClickedLink: noop,
+  onNotificationHide: noop,
+  onMarkPanelAsClear: noop,
   isExpandable: true,
   expandedPanel: null
 };

--- a/packages/core/src/components/Notification/Wrappers/StatefulNotificationDrawerWrapper.js
+++ b/packages/core/src/components/Notification/Wrappers/StatefulNotificationDrawerWrapper.js
@@ -40,7 +40,7 @@ class StatefulNotificationDrawerWrapper extends React.Component {
     this.updateUnreadCount();
   };
 
-  onNotificationClick = (panelkey, nkey) => {
+  onNotificationAsRead = (panelkey, nkey) => {
     const panels = this.state.panels.map(panel => {
       if (panel.panelkey === panelkey) {
         panel.notifications.map(notification => {
@@ -52,6 +52,10 @@ class StatefulNotificationDrawerWrapper extends React.Component {
     });
     this.setState({ panels });
     this.updateUnreadCount();
+  };
+
+  onNotificationClick = () => {
+    // On Click
   };
 
   onNotificationHide = (panelkey, nkey) => {
@@ -104,6 +108,7 @@ class StatefulNotificationDrawerWrapper extends React.Component {
         expandedPanel={this.state.expandedPanel}
         toggleDrawerHide={this.props.toggleDrawer}
         onNotificationClick={this.onNotificationClick}
+        onNotificationAsRead={this.onNotificationAsRead}
         onNotificationHide={this.onNotificationHide}
         onMarkPanelAsClear={this.onMarkPanelAsClear}
         onMarkPanelAsRead={this.onMarkPanelAsRead}

--- a/packages/core/src/components/Notification/Wrappers/Wrappers.test.js
+++ b/packages/core/src/components/Notification/Wrappers/Wrappers.test.js
@@ -97,6 +97,7 @@ test('NotificationDrawerPanelWraper is working properly', () => {
       isExpanded
       togglePanel={jest.fn()}
       onNotificationClick={jest.fn()}
+      onNotificationAsRead={jest.fn()}
       onNotificationHide={jest.fn()}
       onMarkPanelAsRead={jest.fn()}
       onClickedLink={jest.fn()}
@@ -118,6 +119,7 @@ test('DrawerWraper is working properly', () => {
       isExpandable
       isExpanded
       onNotificationClick={jest.fn()}
+      onNotificationAsRead={jest.fn()}
       onNotificationHide={jest.fn()}
       onMarkPanelAsRead={jest.fn()}
       onMarkPanelAsClear={jest.fn()}


### PR DESCRIPTION
affects: patternfly-react

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Dividing `onNotificationClick` to two Functions:

- `onNotificationAsRead`
- `onNotificationClick`

Fixing an issue where unwanted `onNotificationClick` actions are called when clicking on notifications that are already seen for consumers who don't want additional functionality , while keeping the drawer generic for consumers who want to trigger an action whether the notification is seen or not.

`onNotificationAsRead` is only called if the notification is unread
`onNotificationClick` is always called (if its not null).


<!-- feel free to add additional comments -->