### PR TITLE
fix(NotificationDrawer): add Translation capability

### DIFF
--- a/packages/core/src/components/Notification/NotificationDrawer/NotificationDrawerEmptyState.js
+++ b/packages/core/src/components/Notification/NotificationDrawer/NotificationDrawerEmptyState.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { EmptyState, EmptyStateIcon, EmptyStateTitle } from '../../EmptyState';
+
+const NotificationDrawerEmptyState = ({ title, className, ...props }) => (
+  <EmptyState>
+    <EmptyStateIcon name="info" />
+    <EmptyStateTitle>{title}</EmptyStateTitle>
+  </EmptyState>
+);
+NotificationDrawerEmptyState.propTypes = {
+  /** Additional element css classes */
+  className: PropTypes.string,
+  /** Title */
+  title: PropTypes.string
+};
+NotificationDrawerEmptyState.defaultProps = {
+  className: '',
+  title: 'No Notifications Available'
+};
+
+export default NotificationDrawerEmptyState;

--- a/packages/core/src/components/Notification/NotificationDrawer/index.js
+++ b/packages/core/src/components/Notification/NotificationDrawer/index.js
@@ -11,6 +11,7 @@ import NotificationDrawerPanelHeading from './NotificationDrawerAccordion/Notifi
 import NotificationDrawerPanelTitle from './NotificationDrawerAccordion/NotificationDrawerPanelTitle';
 import NotificationDrawerDropDown from './NotificationDrawerAccordion/NotificationDrawerDropDown';
 import NotificationDrawerToggle from './NotificationDrawerToggle';
+import NotificationDrawerEmptyState from './NotificationDrawerEmptyState';
 
 import NotificationDrawerWrapper from '../Wrappers/NotificationDrawerWrapper';
 import NotificationDrawerPanelWrapper from '../Wrappers/NotificationDrawerPanelWrapper';
@@ -29,6 +30,7 @@ NotificationDrawer.PanelTitle = NotificationDrawerPanelTitle;
 NotificationDrawer.Title = NotificationDrawerTitle;
 NotificationDrawer.Dropdown = NotificationDrawerDropDown;
 NotificationDrawer.Toggle = NotificationDrawerToggle;
+NotificationDrawer.EmptyState = NotificationDrawerEmptyState;
 
 export {
   NotificationDrawer,

--- a/packages/core/src/components/Notification/Wrappers/NotificationDrawerPanelWrapper.js
+++ b/packages/core/src/components/Notification/Wrappers/NotificationDrawerPanelWrapper.js
@@ -6,7 +6,6 @@ import { NotificationDrawer } from '../NotificationDrawer/index';
 import { Icon } from '../../Icon';
 import { Button } from '../../Button';
 import { MenuItem } from '../../MenuItem';
-import { EmptyState, EmptyStateTitle, EmptyStateIcon } from '../../../index';
 import { noop } from '../../../common/helpers';
 import getIconClass from './Icon.consts';
 
@@ -23,14 +22,15 @@ const NotificationDrawerPanelWrapper = ({
   onMarkPanelAsRead,
   onClickedLink,
   onMarkPanelAsClear,
-  showLoading
+  showLoading,
+  translations
 }) => {
   const unreadCount = notifications.filter(notification => !notification.seen)
     .length;
 
   const getUnread = () => {
-    if (unreadCount !== 1) return `${unreadCount} Unread Events`;
-    return '1 Unread Event';
+    if (unreadCount !== 1) return `${unreadCount} ${translations.unreadEvents}`;
+    return `1 ${translations.unreadEvent}`;
   };
 
   const notificationClickHandler = (panel, notification, seen) => {
@@ -65,7 +65,7 @@ const NotificationDrawerPanelWrapper = ({
             id="notification-kebab-hide"
             onClick={() => onNotificationHide(panelkey, notification.id)}
           >
-            Hide this notification
+            {translations.deleteNotification}
           </MenuItem>
         </NotificationDrawer.Dropdown>
       )}
@@ -100,26 +100,21 @@ const NotificationDrawerPanelWrapper = ({
           data-toggle="mark-all-read"
         >
           <Button bsStyle="link" onClick={() => onMarkPanelAsRead(panelkey)}>
-            Mark All Read
+            {translations.readAll}
           </Button>
         </NotificationDrawer.PanelActionLink>
       )}
       <NotificationDrawer.PanelActionLink data-toggle="clear-all">
         <Button bsStyle="link" onClick={() => onMarkPanelAsClear(panelkey)}>
           <Icon type="pf" name="close" />
-          Clear All
+          {translations.clearAll}
         </Button>
       </NotificationDrawer.PanelActionLink>
     </NotificationDrawer.PanelAction>
   );
 
   const noNotificationsMessage = (
-    <NotificationDrawer.PanelBody key="noNotifications">
-      <EmptyState>
-        <EmptyStateIcon name="info" />
-        <EmptyStateTitle>No Notifications Available</EmptyStateTitle>
-      </EmptyState>
-    </NotificationDrawer.PanelBody>
+    <NotificationDrawer.EmptyState title={translations.emptyState} />
   );
 
   return (
@@ -166,7 +161,17 @@ NotificationDrawerPanelWrapper.propTypes = {
   /** function() togglePanel Click */
   togglePanel: PropTypes.func,
   /** show Loading notification Bool */
-  showLoading: PropTypes.bool
+  showLoading: PropTypes.bool,
+  /** translations for Title, EmptyState, Read/Clear */
+  translations: PropTypes.shape({
+    title: PropTypes.string,
+    unreadEvent: PropTypes.string,
+    unreadEvents: PropTypes.string,
+    emptyState: PropTypes.string,
+    readAll: PropTypes.string,
+    clearAll: PropTypes.string,
+    deleteNotification: PropTypes.string
+  })
 };
 NotificationDrawerPanelWrapper.defaultProps = {
   panelkey: '1',
@@ -181,7 +186,16 @@ NotificationDrawerPanelWrapper.defaultProps = {
   onNotificationHide: noop,
   onMarkPanelAsClear: noop,
   togglePanel: noop,
-  showLoading: false
+  showLoading: false,
+  translations: {
+    title: 'Notifications',
+    unreadEvent: 'Unread Event',
+    unreadEvents: 'Unread Events',
+    emptyState: 'No Notifications Available',
+    readAll: 'Mark All Read',
+    clearAll: 'Clear All',
+    deleteNotification: 'Hide this notification'
+  }
 };
 
 export default NotificationDrawerPanelWrapper;

--- a/packages/core/src/components/Notification/Wrappers/NotificationDrawerWrapper.js
+++ b/packages/core/src/components/Notification/Wrappers/NotificationDrawerWrapper.js
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { NotificationDrawer } from '../NotificationDrawer/index';
 import { NotificationDrawerPanelWrapper } from './index';
-import { EmptyState, EmptyStateIcon, EmptyStateTitle } from '../../EmptyState';
 import { noop } from '../../../common/helpers';
 
 const NotificationDrawerWrapper = ({
   panels,
+  translations,
   toggleDrawerHide,
   toggleDrawerExpand,
   isExpandable,
@@ -20,6 +20,11 @@ const NotificationDrawerWrapper = ({
   onMarkPanelAsClear,
   onClickedLink
 }) => {
+  const translationsWrapper = {
+    ...NotificationDrawerPanelWrapper.defaultProps.translations,
+    ...translations
+  };
+
   const notificationPanels = panels.map((panel, i) => (
     <NotificationDrawerPanelWrapper
       key={i}
@@ -35,19 +40,17 @@ const NotificationDrawerWrapper = ({
       onMarkPanelAsRead={onMarkPanelAsRead}
       onMarkPanelAsClear={onMarkPanelAsClear}
       showLoading={panel.showLoading}
+      translations={translationsWrapper}
     />
   ));
   const noNotificationsMessage = (
-    <EmptyState>
-      <EmptyStateIcon name="info" />
-      <EmptyStateTitle>No Notifications Available</EmptyStateTitle>
-    </EmptyState>
+    <NotificationDrawer.EmptyState title={translations.emptyState} />
   );
 
   return (
     <NotificationDrawer expanded={isExpanded}>
       <NotificationDrawer.Title
-        title="Notifications"
+        title={translations.title}
         onCloseClick={() => toggleDrawerHide()}
         expandable={isExpandable}
         onExpandClick={toggleDrawerExpand}
@@ -86,7 +89,17 @@ NotificationDrawerWrapper.propTypes = {
   /** show Loading notification Bool */
   isExpandable: PropTypes.bool,
   /** expanded Panel */
-  expandedPanel: PropTypes.string
+  expandedPanel: PropTypes.string,
+  /** translations for Title, EmptyState, Read/Clear */
+  translations: PropTypes.shape({
+    title: PropTypes.string,
+    unreadEvent: PropTypes.string,
+    unreadEvents: PropTypes.string,
+    emptyState: PropTypes.string,
+    readAll: PropTypes.string,
+    clearAll: PropTypes.string,
+    deleteNotification: PropTypes.string
+  })
 };
 
 NotificationDrawerWrapper.defaultProps = {
@@ -102,7 +115,8 @@ NotificationDrawerWrapper.defaultProps = {
   onNotificationHide: noop,
   onMarkPanelAsClear: noop,
   isExpandable: true,
-  expandedPanel: null
+  expandedPanel: null,
+  translations: {}
 };
 
 export default NotificationDrawerWrapper;

--- a/packages/core/src/components/Notification/Wrappers/Wrappers.test.js
+++ b/packages/core/src/components/Notification/Wrappers/Wrappers.test.js
@@ -9,6 +9,8 @@ import {
 import { Icon } from '../../Icon';
 import getIconClass from './Icon.consts';
 
+jest.unmock('./NotificationDrawerPanelWrapper');
+
 const p1Notifications = [
   {
     id: 12,

--- a/packages/core/src/components/Notification/Wrappers/__snapshots__/Wrappers.test.js.snap
+++ b/packages/core/src/components/Notification/Wrappers/__snapshots__/Wrappers.test.js.snap
@@ -891,25 +891,21 @@ exports[`StatefulNotificationDrawerWrapper is working properly 1`] = `
         id="1"
       >
         <div
-          class="panel-body"
+          class="blank-slate-pf"
         >
           <div
-            class="blank-slate-pf"
+            class="blank-slate-pf-icon"
           >
-            <div
-              class="blank-slate-pf-icon"
-            >
-              <span
-                aria-hidden="true"
-                class="pficon pficon-info"
-              />
-            </div>
-            <h4
-              class="h1 blank-slate-pf-title"
-            >
-              No Notifications Available
-            </h4>
+            <span
+              aria-hidden="true"
+              class="pficon pficon-info"
+            />
           </div>
+          <h4
+            class="h1 blank-slate-pf-title"
+          >
+            No Notifications Available
+          </h4>
         </div>
       </div>
     </div>
@@ -984,25 +980,21 @@ exports[`StatefulToggleNotificationDrawerWrapper is working properly 1`] = `
           id="1"
         >
           <div
-            class="panel-body"
+            class="blank-slate-pf"
           >
             <div
-              class="blank-slate-pf"
+              class="blank-slate-pf-icon"
             >
-              <div
-                class="blank-slate-pf-icon"
-              >
-                <span
-                  aria-hidden="true"
-                  class="pficon pficon-info"
-                />
-              </div>
-              <h4
-                class="h1 blank-slate-pf-title"
-              >
-                No Notifications Available
-              </h4>
+              <span
+                aria-hidden="true"
+                class="pficon pficon-info"
+              />
             </div>
+            <h4
+              class="h1 blank-slate-pf-title"
+            >
+              No Notifications Available
+            </h4>
           </div>
         </div>
       </div>


### PR DESCRIPTION
affects: patternfly-react

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Added ability to add Translations to the Drawer. Components that can be translated:
```
  translations: {
    title: 'Notifications',
    emptyState: 'No Notifications Available',
    readAll: 'Mark All Read',
    clearAll: 'Clear All'
  }
```
Panels and Notifications were already translatable.



<!-- feel free to add additional comments -->