### PR TITLE
fix(storybook): add CSS styling to react-console storybook

### DIFF
--- a/storybook/sass/base.scss
+++ b/storybook/sass/base.scss
@@ -16,3 +16,9 @@ $icon-font-path: '~patternfly/dist/fonts/';
   Patternfly React Specific Extensions
 */
 @import 'patternfly-react';
+
+/**
+  @patternfly/react-console
+ */
+@import "~xterm/dist/xterm.css";
+@import 'console';


### PR DESCRIPTION
After splitting the project to monorepo, styling of subpackages is handled independently and must be
explicitly added to storybook.

ISSUES CLOSED: #340

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->


<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**: https://mareklibra.github.io/patternfly-react/

<!-- Are there any upstream issues or separate issues you need to reference? -->



<!-- feel free to add additional comments -->