### PR TITLE
feat(ModalPattern): Add ModalPattern and StatefulModalPattern components

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Modal/Modal.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/Modal.js
@@ -2,6 +2,9 @@ import { Modal as BsModal } from 'react-bootstrap';
 import CustomModalDialog from './InnerComponents/CustomModalDialog';
 import ModalCloseButton from './ModalCloseButton';
 
+import ModalPattern from './Patterns/ModalPattern';
+import StatefulModalPattern from './Patterns/StatefulModalPattern';
+
 /**
  * Modal Component for Patternfly React
  */
@@ -11,11 +14,18 @@ class Modal extends BsModal {
   }
 }
 
+Modal.propTypes = {
+  ...BsModal.propTypes
+};
+
 Modal.defaultProps = {
   ...BsModal.defaultProps,
   dialogComponentClass: CustomModalDialog
 };
 
 Modal.CloseButton = ModalCloseButton;
+
+Modal.Pattern = ModalPattern;
+Modal.Pattern.Stateful = StatefulModalPattern;
 
 export default Modal;

--- a/packages/patternfly-3/patternfly-react/src/components/Modal/Modal.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/Modal.stories.js
@@ -1,48 +1,23 @@
-import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withInfo } from '@storybook/addon-info';
-import { inlineTemplate } from 'storybook/decorators/storyTemplates';
-import { storybookPackageName, DOCUMENTATION_URL, STORYBOOK_CATEGORY } from 'storybook/constants/siteConstants';
+import { storybookPackageName, STORYBOOK_CATEGORY } from 'storybook/constants/siteConstants';
 
-import { MockModalManager, basicExampleSource } from './__mocks__/mockModalManager';
-import { Modal } from '../../index';
 import { name } from '../../../package.json';
-import { boolean, withKnobs } from '@storybook/addon-knobs';
+import { modalExampleWithInfo, modalPatternExampleAddWithInfo } from './Stories';
 
-const stories = storiesOf(
-  `${storybookPackageName(name)}/${STORYBOOK_CATEGORY.FORMS_AND_CONTROLS}/Modal Overlay`,
+/**
+ * Modal Component stories
+ */
+const componentStories = storiesOf(
+  `${storybookPackageName(name)}/${STORYBOOK_CATEGORY.FORMS_AND_CONTROLS}/Modal Overlay/Components`,
   module
 );
+modalExampleWithInfo(componentStories);
 
-stories.addDecorator(withKnobs);
-
-const description = (
-  <div>
-    Adding the class <b>right-side-modal-pf</b> will show the modal on the right side of the window.
-  </div>
+/**
+ * Modal Pattern stories
+ */
+const patternStories = storiesOf(
+  `${storybookPackageName(name)}/${STORYBOOK_CATEGORY.FORMS_AND_CONTROLS}/Modal Overlay/Patterns`,
+  module
 );
-
-stories.add(
-  'Modal',
-  withInfo({
-    source: false,
-    propTables: [Modal, Modal.CloseButton, Modal.Header, Modal.Body, Modal.Footer],
-    propTablesExclude: [MockModalManager],
-    text: (
-      <div>
-        <h1>Story Source</h1>
-        <pre>{basicExampleSource}</pre>
-      </div>
-    )
-  })(() => {
-    const rightSide = boolean('Right Side', false);
-    const story = <MockModalManager rightSide={rightSide} />;
-    return inlineTemplate({
-      title: 'Modal Example',
-      documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_FORMS}modal-overlay/`,
-      reactBootstrapDocumentationLink: `${DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT}modal/`,
-      description,
-      story
-    });
-  })
-);
+modalPatternExampleAddWithInfo(patternStories);

--- a/packages/patternfly-3/patternfly-react/src/components/Modal/Patterns/ModalPattern.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/Patterns/ModalPattern.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { noop } from '../../../index';
+import Modal from '../Modal';
+import CustomModalDialog from '../InnerComponents/CustomModalDialog';
+import { Modal as BsModal } from 'react-bootstrap';
+
+/**
+ * Modal Pattern component.
+ */
+const ModalPattern = ({ show, title, onClose, footer, children, ...rest }) => (
+  <Modal show={show} {...rest}>
+    <Modal.Header>
+      <Modal.CloseButton onClick={onClose} />
+      <Modal.Title>{title}</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>{children}</Modal.Body>
+    <Modal.Footer>{footer}</Modal.Footer>
+  </Modal>
+);
+
+ModalPattern.propTypes = {
+  ...BsModal.propTypes,
+  show: PropTypes.bool,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  onClose: PropTypes.func,
+  footer: PropTypes.node,
+  children: PropTypes.node
+};
+
+ModalPattern.defaultProps = {
+  ...BsModal.defaultProps,
+  dialogComponentClass: CustomModalDialog,
+  show: false,
+  title: '',
+  onClose: noop,
+  footer: null,
+  children: null
+};
+
+ModalPattern.displayName = 'ModalPattern';
+
+export default ModalPattern;

--- a/packages/patternfly-3/patternfly-react/src/components/Modal/Patterns/StatefulModalPattern.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/Patterns/StatefulModalPattern.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import ModalPattern from './ModalPattern';
+import { propOrState, excludeKeys } from '../../../index';
+
+/**
+ * Stateful Modal Pattern component.
+ */
+class StatefulModalPattern extends React.Component {
+  static getDerivedStateFromProps(nextProps, prevState) {
+    return {
+      show: propOrState(nextProps, prevState, 'show')
+    };
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = { show: false };
+  }
+
+  open = () => {
+    this.setState({ show: true });
+  };
+
+  close = () => {
+    this.setState({ show: false });
+  };
+
+  getModalPatternProps = () => this.props;
+
+  render() {
+    return <ModalPattern {...this.getModalPatternProps()} show={this.state.show} onClose={this.close} />;
+  }
+}
+
+StatefulModalPattern.propTypes = {
+  ...excludeKeys(ModalPattern.propTypes, ['onClose'])
+};
+
+StatefulModalPattern.defaultProps = {
+  ...excludeKeys(ModalPattern.defaultProps, ['onClose', 'show'])
+};
+
+StatefulModalPattern.displayName = 'StatefulModalPattern';
+
+export default StatefulModalPattern;

--- a/packages/patternfly-3/patternfly-react/src/components/Modal/Stories/ModalExampleStory.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/Stories/ModalExampleStory.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { withInfo } from '@storybook/addon-info';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+import { inlineTemplate } from 'storybook/decorators/storyTemplates';
+import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
+
+import { MockModalManager, basicExampleSource } from '../__mocks__/mockModalManager';
+import { Modal } from '../../../index';
+
+const modalExampleWithInfo = stories => {
+  stories.addDecorator(withKnobs);
+
+  const description = (
+    <div>
+      Adding the class <b>right-side-modal-pf</b> will show the modal on the right side of the window.
+    </div>
+  );
+
+  stories.add(
+    'Modal',
+    withInfo({
+      source: false,
+      propTables: [Modal, Modal.CloseButton, Modal.Header, Modal.Body, Modal.Footer],
+      propTablesExclude: [MockModalManager],
+      text: (
+        <div>
+          <h1>Story Source</h1>
+          <pre>{basicExampleSource}</pre>
+        </div>
+      )
+    })(() => {
+      const rightSide = boolean('Right Side', false);
+      const story = <MockModalManager rightSide={rightSide} />;
+      return inlineTemplate({
+        title: 'Modal Example',
+        documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_FORMS}modal-overlay/`,
+        reactBootstrapDocumentationLink: `${DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT}modal/`,
+        description,
+        story
+      });
+    })
+  );
+};
+
+export default modalExampleWithInfo;

--- a/packages/patternfly-3/patternfly-react/src/components/Modal/Stories/ModalPatternExample.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/Stories/ModalPatternExample.js
@@ -1,0 +1,154 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { boolean } from '@storybook/addon-knobs';
+import { Button, Spinner, Modal } from '../../../index';
+
+export class ModalPatternExample extends React.Component {
+  state = {
+    showModal: false,
+    loading: false
+  };
+
+  open = () => {
+    this.setState({ showModal: true, loading: true });
+    setTimeout(() => {
+      this.setState({ loading: false });
+    }, 1000);
+  };
+
+  close = () => {
+    this.setState({ showModal: false, loading: false });
+  };
+
+  renderStateless = () => {
+    // We need knobs on the stateless example, because we must drive its state ourselves.
+    const { loading } = this.state;
+
+    return (
+      <div>
+        <Button bsStyle="primary" bsSize="large" onClick={this.open}>
+          Launch Stateless Modal
+        </Button>
+
+        <Modal.Pattern
+          show={this.state.showModal}
+          title="Stateless Modal Pattern Example"
+          onClose={this.close}
+          footer={
+            <Button bsStyle="primary" onClick={this.close}>
+              Close
+            </Button>
+          }
+        >
+          <Spinner loading={boolean('Loading', loading)}>(Modal Contents Here)</Spinner>
+        </Modal.Pattern>
+      </div>
+    );
+  };
+
+  renderStateful = () => (
+    // No knobs for the stateful example, we want to let it control its own state.
+    <div>
+      <Button bsStyle="primary" bsSize="large" onClick={this.open}>
+        Launch Stateful Modal
+      </Button>
+
+      <Modal.Pattern.Stateful
+        show={this.state.showModal}
+        title="Stateful Modal Pattern Example"
+        onClose={this.close}
+        footer={
+          <Button bsStyle="primary" onClick={this.close}>
+            Close
+          </Button>
+        }
+      >
+        <Spinner loading={this.state.loading}>(Modal Contents Here)</Spinner>
+      </Modal.Pattern.Stateful>
+    </div>
+  );
+
+  render() {
+    return this.props.stateful ? this.renderStateful() : this.renderStateless();
+  }
+}
+
+ModalPatternExample.propTypes = {
+  stateful: PropTypes.bool
+};
+
+ModalPatternExample.defaultProps = {
+  stateful: false
+};
+
+export const modalPatternExampleSource = `
+export class ModalPatternExample extends React.Component {
+  state = {
+    showModal: false,
+    loading: false
+  };
+
+  open = () => {
+    this.setState({ showModal: true, loading: true });
+    setTimeout(() => {
+      this.setState({ loading: false });
+    }, 1000);
+  };
+
+  close = () => {
+    this.setState({ showModal: false, loading: false });
+  };
+
+  renderStateless = () => {
+    // We need knobs on the stateless example, because we must drive its state ourselves.
+    const { loading } = this.state;
+
+    return (
+      <div>
+        <Button bsStyle="primary" bsSize="large" onClick={this.open}>
+          Launch Stateless Modal
+        </Button>
+
+        <Modal.Pattern
+          show={this.state.showModal}
+          title="Stateless Modal Pattern Example"
+          onClose={this.close}
+          footer={
+            <Button bsStyle="primary" onClick={this.close}>
+              Close
+            </Button>
+          }
+        >
+          <Spinner loading={boolean('Loading', loading)}>(Modal Contents Here)</Spinner>
+        </Modal.Pattern>
+      </div>
+    );
+  };
+
+  renderStateful = () => (
+    // No knobs for the stateful example, we want to let it control its own state.
+    <div>
+      <Button bsStyle="primary" bsSize="large" onClick={this.open}>
+        Launch Stateful Modal
+      </Button>
+
+      <Modal.Pattern.Stateful
+        show={this.state.showModal}
+        title="Stateful Modal Pattern Example"
+        onClose={this.close}
+        footer={
+          <Button bsStyle="primary" onClick={this.close}>
+            Close
+          </Button>
+        }
+      >
+        <Spinner loading={this.state.loading}>(Modal Contents Here)</Spinner>
+      </Modal.Pattern.Stateful>
+    </div>
+  );
+
+  render() {
+    return this.props.stateful ? this.renderStateful() : this.renderStateless();
+  }
+}
+`;

--- a/packages/patternfly-3/patternfly-react/src/components/Modal/Stories/ModalPatternExampleStory.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/Stories/ModalPatternExampleStory.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { withInfo } from '@storybook/addon-info';
+import { withKnobs } from '@storybook/addon-knobs';
+import { inlineTemplate } from 'storybook/decorators/storyTemplates';
+import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
+import { Row, Col } from '../../../index';
+
+import { ModalPatternExample, modalPatternExampleSource } from './ModalPatternExample';
+
+/**
+ * Modal Pattern stories
+ */
+
+const description = (
+  <div>
+    The modal pattern example contains <i>ModalPattern</i> and <i>StatefulModalPattern</i>
+    pattern components.
+    <br />
+    <br />
+    The <i>ModalPattern</i> is a <b>stateless</b> modal pattern which brings the smaller modal related components
+    together into a logical higher level component. Modal content is provided via <i>children</i> prop and footer
+    content (typically modal buttons) via <i>footer</i> prop.
+    <br />
+    <br />
+    The <i>StatefulModalPattern</i> is a <b>stateful</b> modal pattern which will automatically manage the <i>show</i>
+    parameter through component state. This can be overridden by passing <i>show</i> as a prop. It also defines
+    <i>open</i> and <i>close</i> methods on the component instance.
+  </div>
+);
+const documentationLink = `${DOCUMENTATION_URL.PATTERNFLY_ORG_WIDGETS}#modal`;
+
+const modalPatternExampleAddWithInfo = stories => {
+  stories.addDecorator(withKnobs);
+
+  stories.add(
+    'Stateless ModalPattern Example',
+    withInfo({
+      source: false,
+      propTablesExclude: [Row, Col, ModalPatternExample],
+      text: (
+        <div>
+          <h1>Story Source</h1>
+          <pre>{modalPatternExampleSource}</pre>
+        </div>
+      )
+    })(() => {
+      const story = (
+        <Row>
+          <Col sm={12}>
+            <ModalPatternExample />
+          </Col>
+        </Row>
+      );
+      return inlineTemplate({
+        title: 'Stateless ModalPattern Example',
+        description,
+        documentationLink,
+        story
+      });
+    })
+  );
+
+  stories.add(
+    'Stateful ModalPattern Example',
+    withInfo({
+      source: false,
+      propTablesExclude: [Row, Col, ModalPatternExample],
+      text: (
+        <div>
+          <h1>Story Source</h1>
+          <pre>{modalPatternExampleSource}</pre>
+        </div>
+      )
+    })(() => {
+      const story = (
+        <Row>
+          <Col sm={12}>
+            <ModalPatternExample stateful />
+          </Col>
+        </Row>
+      );
+      return inlineTemplate({
+        title: 'Stateful ModalPattern Example',
+        description,
+        documentationLink,
+        story
+      });
+    })
+  );
+};
+
+export default modalPatternExampleAddWithInfo;

--- a/packages/patternfly-3/patternfly-react/src/components/Modal/Stories/index.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/Stories/index.js
@@ -1,0 +1,3 @@
+export { default as modalExampleWithInfo } from './ModalExampleStory';
+
+export { default as modalPatternExampleAddWithInfo } from './ModalPatternExampleStory';

--- a/packages/patternfly-3/patternfly-react/src/components/Modal/index.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/index.js
@@ -1,4 +1,7 @@
 import Modal from './Modal';
 import ModalCloseButton from './ModalCloseButton';
 
-export { Modal, ModalCloseButton };
+import ModalPattern from './Patterns/ModalPattern';
+import StatefulModalPattern from './Patterns/StatefulModalPattern';
+
+export { Modal, ModalCloseButton, ModalPattern, StatefulModalPattern };


### PR DESCRIPTION
**What**: this PR adds new pattern components, `ModalPattern` and `StatefulModalPattern`.

`Modal` vs. `ModalPattern` is just like `Wizard` vs. `WizardPattern`.

`StatefulModalPattern` adds the ability to manage the `show` flag via component state, similar to how `StatefulWizardPattern` manages `activeStepIndex`. `StatefulModalPattern` also adds `open` and `close` methods to support component instance interaction (e.g. when using React refs).

There are no breaking changes. :smiley: 

This PR also contains small wizard pattern component improvements - most notably, remove exclusion of `activeStepIndex` in `StatefulWizardPattern.propTypes` since this prop is still used via `propOrState` and therefore should be part of `StatefulWizardPattern.propTypes`.

**Stories and tests are missing.** I'll add those after initial feedback. I think that `Modal` stories should be refactored to match `Wizard` stories for easier maintenance in the future.

@priley86 let me know what you think.