### PR TITLE
chore(vscode): remove eslint rule path options override

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,5 @@
   "editor.formatOnSave": true,
   "prettier.eslintIntegration": true,
   "prettier.singleQuote": true,
-  "prettier.trailingComma": "none",
-  "eslint.options": {
-    "rulePaths": ["./lint-rules"]
-  }
+  "prettier.trailingComma": "none"
 }


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
the `eslint.options` rule path override is no longer needed now that all eslint rules have been moved into `eslint-plugin-patternfly-react`. Custom rules can be added into that package instead and we should get automatic eslint integration in the IDE. Prettier will also auto-fix our custom eslint rules ;)

<!-- feel free to add additional comments -->


![vscode](https://user-images.githubusercontent.com/4237045/40005784-d4783774-5766-11e8-9247-9f2160531fd6.gif)
