### PR TITLE
fix(VerticalNav): Add mastHeadOnly display prop

### DIFF
--- a/packages/core/src/components/VerticalNav/VerticalNav.js
+++ b/packages/core/src/components/VerticalNav/VerticalNav.js
@@ -158,12 +158,14 @@ class BaseVerticalNav extends React.Component {
       dynamicBodyClasses,
       navCollapsed,
       pinnedPath,
-      isMobile
+      isMobile,
+      mastHeadOnly
     } = this.props;
     const collapsed = navCollapsed && pinnedPath === null;
+
     if (dynamicBodyClasses) {
       setBodyClassIf(!isMobile && collapsed, 'collapsed-nav');
-      setBodyClassIf(isMobile, 'hidden-nav');
+      setBodyClassIf(isMobile || mastHeadOnly, 'hidden-nav');
     }
   };
 
@@ -354,7 +356,8 @@ class BaseVerticalNav extends React.Component {
       activePath,
       hoverPath,
       mobilePath,
-      pinnedPath
+      pinnedPath,
+      mastHeadOnly
     } = this.props;
 
     const getPathDepth = path =>
@@ -400,33 +403,37 @@ class BaseVerticalNav extends React.Component {
         forceHideSecondaryMenu={this.forceHideSecondaryMenu}
         hoverDelay={hoverDelay}
         blurDelay={blurDelay}
+        mastHeadOnly={mastHeadOnly}
       >
         <nav className={classNames('navbar navbar-pf-vertical')}>
           {!hideMasthead && masthead}
         </nav>
-        <div
-          className={classNames(
-            'nav-pf-vertical nav-pf-vertical-with-sub-menus',
-            {
-              'nav-pf-vertical-collapsible-menus': pinnableMenus,
-              'hidden-icons-pf': hiddenIcons,
-              'nav-pf-vertical-with-badges': showBadges,
-              'nav-pf-persistent-secondary': persistentSecondary,
-              'show-mobile-secondary': showMobileSecondary,
-              'show-mobile-tertiary': showMobileTertiary,
-              'hover-secondary-nav-pf': hoverSecondaryNav,
-              'hover-tertiary-nav-pf': hoverTertiaryNav,
-              'collapsed-secondary-nav-pf': pinnableMenus && pinnedSecondaryNav,
-              'collapsed-tertiary-nav-pf': pinnableMenus && pinnedTertiaryNav,
-              hidden: isMobile,
-              collapsed: !isMobile && navCollapsed,
-              'force-hide-secondary-nav-pf': forceHidden,
-              'show-mobile-nav': showMobileNav
-            }
-          )}
-        >
-          <ListGroup componentClass="ul">{itemComponents}</ListGroup>
-        </div>
+        {!mastHeadOnly && (
+          <div
+            className={classNames(
+              'nav-pf-vertical nav-pf-vertical-with-sub-menus',
+              {
+                'nav-pf-vertical-collapsible-menus': pinnableMenus,
+                'hidden-icons-pf': hiddenIcons,
+                'nav-pf-vertical-with-badges': showBadges,
+                'nav-pf-persistent-secondary': persistentSecondary,
+                'show-mobile-secondary': showMobileSecondary,
+                'show-mobile-tertiary': showMobileTertiary,
+                'hover-secondary-nav-pf': hoverSecondaryNav,
+                'hover-tertiary-nav-pf': hoverTertiaryNav,
+                'collapsed-secondary-nav-pf':
+                  pinnableMenus && pinnedSecondaryNav,
+                'collapsed-tertiary-nav-pf': pinnableMenus && pinnedTertiaryNav,
+                hidden: isMobile,
+                collapsed: !isMobile && navCollapsed,
+                'force-hide-secondary-nav-pf': forceHidden,
+                'show-mobile-nav': showMobileNav
+              }
+            )}
+          >
+            <ListGroup componentClass="ul">{itemComponents}</ListGroup>
+          </div>
+        )}
       </NavContextProvider>
     );
   }
@@ -511,7 +518,9 @@ BaseVerticalNav.propTypes = {
   /** Navigation items, passed as Item, SecondaryItem and TertiaryItem children. */
   children: PropTypes.node,
   /** Helper injected by `controlled()` to manage controlledStateTypes values */
-  setControlledState: PropTypes.func // eslint-disable-line react/require-default-props
+  setControlledState: PropTypes.func, // eslint-disable-line react/require-default-props
+  /** Only display navigation masthead */
+  mastHeadOnly: PropTypes.bool
 };
 
 BaseVerticalNav.defaultProps = {
@@ -536,7 +545,8 @@ BaseVerticalNav.defaultProps = {
   onItemPin: null,
   onMobileSelection: null,
   onNavigate: noop,
-  children: null
+  children: null,
+  mastHeadOnly: false
 };
 
 const NoPersist = controlled(controlledState)(BaseVerticalNav);

--- a/packages/core/src/components/VerticalNav/VerticalNav.stories.js
+++ b/packages/core/src/components/VerticalNav/VerticalNav.stories.js
@@ -220,6 +220,41 @@ stories.add(
 );
 
 stories.add(
+  'Custom Masthead Only',
+  withInfo({
+    propTablesExclude: [
+      MockFixedLayout,
+      MockIconBarChildren,
+      Icon,
+      MenuItem,
+      Dropdown,
+      Dropdown.Menu,
+      Dropdown.Toggle
+    ],
+    text: `Example display the **Masthead** only, using the **Masthead**, **Brand** and **IconBar** components with images. (items from 'Items as Objects').`
+  })(() => (
+    <MockFixedLayout>
+      <div className="layout-pf layout-pf-fixed faux-layout">
+        <VerticalNav
+          sessionKey="storybookCustomMasthead"
+          items={mockNavItems}
+          showBadges
+          mastHeadOnly
+        >
+          <Masthead>
+            <Brand iconImg={pfLogo} titleImg={pfBrand} />
+            <IconBar>
+              <MockIconBarChildren />
+            </IconBar>
+          </Masthead>
+        </VerticalNav>
+        {mockBodyContainer('nav-pf-vertical-with-badges')}
+      </div>
+    </MockFixedLayout>
+  ))
+);
+
+stories.add(
   'Custom Masthead',
   withInfo({
     propTablesExclude: [

--- a/packages/core/src/components/VerticalNav/VerticalNav.test.js
+++ b/packages/core/src/components/VerticalNav/VerticalNav.test.js
@@ -23,6 +23,12 @@ test('VerticalNav renders properly in mobile mode', () => {
   expect(component.render()).toMatchSnapshot();
 });
 
+test('VerticalNav renders as masthead only', () => {
+  const component = mount(basicExample({ mastHeadOnly: true }));
+
+  expect(component.render()).toMatchSnapshot();
+});
+
 test('VerticalNav renders without errors with persistence on', () => {
   const component = shallow(<VerticalNav persist />);
   expect(component.find(VerticalNav.WithPersist).exists()).toBe(true);

--- a/packages/core/src/components/VerticalNav/VerticalNavConstants.js
+++ b/packages/core/src/components/VerticalNav/VerticalNavConstants.js
@@ -108,6 +108,8 @@ const navContextTypes = {
   setControlledMobilePath: PropTypes.func,
   /** Notifies the main component that an item has used the selectedOnMobile prop. */
   setControlledPinnedPath: PropTypes.func,
+  /** Only display navigation masthead */
+  mastHeadOnly: PropTypes.bool,
   /** Reference to method of the same name in the VerticalNav container. */
   forceHideSecondaryMenu: PropTypes.func,
   /** (Internal helper value) */

--- a/packages/core/src/components/VerticalNav/VerticalNavMasthead.js
+++ b/packages/core/src/components/VerticalNav/VerticalNavMasthead.js
@@ -10,7 +10,7 @@ import { noop } from '../../common/helpers';
  * VerticalNavMasthead - the first child of a VerticalNav component
  */
 const BaseVerticalNavMasthead = props => {
-  const { children, href, iconImg, titleImg, title } = props;
+  const { children, href, mastHeadOnly, iconImg, titleImg, title } = props;
 
   const childrenArray =
     children &&
@@ -26,12 +26,14 @@ const BaseVerticalNavMasthead = props => {
   return (
     <React.Fragment>
       <Navbar.Header>
-        <Navbar.Toggle onClick={props.updateNavOnMenuToggleClick}>
-          <span className="sr-only">Toggle navigation</span>
-          <span className="icon-bar" />
-          <span className="icon-bar" />
-          <span className="icon-bar" />
-        </Navbar.Toggle>
+        {!mastHeadOnly && (
+          <Navbar.Toggle onClick={props.updateNavOnMenuToggleClick}>
+            <span className="sr-only">Toggle navigation</span>
+            <span className="icon-bar" />
+            <span className="icon-bar" />
+            <span className="icon-bar" />
+          </Navbar.Toggle>
+        )}
         {brandChildren && brandChildren.length > 0 ? (
           brandChildren
         ) : (
@@ -54,6 +56,8 @@ BaseVerticalNavMasthead.propTypes = {
   title: PropTypes.string,
   /** See VerticalNavBrand.propTypes */
   titleImg: PropTypes.string,
+  /** Hide iconBars (hamburger menu) */
+  mastHeadOnly: PropTypes.bool,
   /** See VerticalNavBrand.propTypes */
   iconImg: PropTypes.string,
   /** See VerticalNavBrand.propTypes */
@@ -66,6 +70,7 @@ BaseVerticalNavMasthead.propTypes = {
 BaseVerticalNavMasthead.defaultProps = {
   title: '',
   titleImg: '',
+  mastHeadOnly: false,
   iconImg: '',
   href: '',
   updateNavOnMenuToggleClick: noop,

--- a/packages/core/src/components/VerticalNav/__snapshots__/VerticalNav.test.js.snap
+++ b/packages/core/src/components/VerticalNav/__snapshots__/VerticalNav.test.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`VerticalNav renders as masthead only 1`] = `
+<nav
+  class="navbar navbar-pf-vertical"
+>
+  <div
+    class="navbar-header"
+  >
+    <span
+      class="navbar-brand"
+    >
+      <span>
+        <span
+          class="navbar-brand-txt"
+        >
+          Patternfly React
+        </span>
+      </span>
+    </span>
+  </div>
+</nav>
+`;
+
 exports[`VerticalNav renders properly in mobile mode 1`] = `
 <nav
   class="navbar navbar-pf-vertical"


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Quick iteration for implementing a "mastHeadOnly" display property for Vertical Navigation. Relates to PF design: [Masthead, tall option](http://www.patternfly.org/pattern-library/application-framework/masthead/#tall-option)

![screen shot 2018-05-16 at 1 05 04 am](https://user-images.githubusercontent.com/3761375/40097633-3ac13924-58a5-11e8-8506-6b0fff26db77.png)


<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
[Storybook, Masthead Only Vertical Nav](https://cdcabrera.github.io/patternfly-react/?selectedKind=patternfly-react%2FVertical%20Navigation&selectedStory=Custom%20Masthead%20Only&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
Partially relates to: https://github.com/patternfly/patternfly-react/pull/171

<!-- feel free to add additional comments -->
**Possible alternatives/additions to provided solution**:
- rename prop for clarity
- rearrange props
- long term, [context menu addition](http://www.patternfly.org/pattern-library/navigation/context-selector/)
- long term, share a version of masthead component between vertical and horizontal nav