### PR TITLE
feat(Font style for SerialConsole): allow customized font styling for the SerialConsole component

### DIFF
--- a/packages/console/src/SerialConsole/SerialConsole.js
+++ b/packages/console/src/SerialConsole/SerialConsole.js
@@ -73,6 +73,8 @@ class SerialConsole extends React.Component {
             }}
             cols={this.props.cols}
             rows={this.props.rows}
+            fontFamily={this.props.fontFamily}
+            fontSize={this.props.fontSize}
             onConnect={this.props.onConnect}
             onDisconnect={this.props.onDisconnect}
             onData={this.props.onData}
@@ -143,6 +145,10 @@ SerialConsole.propTypes = {
   rows: PropTypes.number,
   cols: PropTypes.number,
 
+  /** Font for text rendered to xterm canvas */
+  fontFamily: PropTypes.string,
+  fontSize: PropTypes.number,
+
   /** Enable customization */
   topClassName: PropTypes.string,
 
@@ -161,6 +167,9 @@ SerialConsole.defaultProps = {
   id: '',
   rows: 25,
   cols: 80,
+
+  fontFamily: undefined /** Use xterm default: 'courier-new, courier, monospace' */,
+  fontSize: undefined /** Use xterm default: 15 */,
 
   onTitleChanged: noop,
   onData: noop,

--- a/packages/console/src/SerialConsole/XTerm.js
+++ b/packages/console/src/SerialConsole/XTerm.js
@@ -16,7 +16,9 @@ class XTerm extends React.Component {
     const term = new Terminal({
       cols: this.props.cols,
       rows: this.props.rows,
-      screenKeys: true
+      screenKeys: true,
+      fontFamily: this.props.fontFamily,
+      fontSize: this.props.fontSize
     });
 
     if (this.props.onData) {
@@ -142,6 +144,9 @@ XTerm.propTypes = {
   cols: PropTypes.number,
   rows: PropTypes.number,
 
+  fontFamily: PropTypes.string,
+  fontSize: PropTypes.number,
+
   onTitleChanged: PropTypes.func, // (title) => {}
   onData: PropTypes.func, // Data to be sent from terminal to backend; (data) => {}
   onResize: PropTypes.func // (rows, cols) => {}
@@ -150,6 +155,9 @@ XTerm.propTypes = {
 XTerm.defaultProps = {
   cols: 80,
   rows: 25,
+
+  fontFamily: undefined,
+  fontSize: undefined,
 
   onTitleChanged: noop,
   onData: noop,


### PR DESCRIPTION
affects: @patternfly/react-console

Default font family and size can be changed for the SerialConsole.

Underlying xterm component uses html canvas to render text and seems not to support font style change via CSS.
