### PR TITLE
docs(README): Fix link to patternly-react.scss file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import { Alert } from 'patternfly-react'
 
 ## Using patterfly-react Sass files
 
-As an alernative to consuming the `patternfly-react.css` file (found in `dist/css`), you can build patternfly-react styles into your css by including the Sass partials from `dist/sass`. The partial `_patternfly-react.scss` will pull in all the partials required for the patternfly-react components. When using the patternfly-react Sass files, you **MUST** include bootstrap and patternfly variables and mixins. An example of the required imports can be found in [patternfly-react.scss](./sass/patternfly-react.scss).
+As an alernative to consuming the `patternfly-react.css` file (found in `dist/css`), you can build patternfly-react styles into your css by including the Sass partials from `dist/sass`. The partial `_patternfly-react.scss` will pull in all the partials required for the patternfly-react components. When using the patternfly-react Sass files, you **MUST** include bootstrap and patternfly variables and mixins. An example of the required imports can be found in [patternfly-react.scss](./packages/core/sass/patternfly-react.scss).
 
 ## Node Environment
 


### PR DESCRIPTION
affects: patternfly-react

ISSUES CLOSED: #366
