### PR TITLE
fix(FieldLevelHelp): add style to align better with patternfly core

### DIFF
--- a/packages/core/less/field-level-help.less
+++ b/packages/core/less/field-level-help.less
@@ -1,0 +1,4 @@
+.popover-pf-info {
+  margin-left: 3px;
+  padding: 0;
+}

--- a/packages/core/less/patternfly-react.less
+++ b/packages/core/less/patternfly-react.less
@@ -7,3 +7,4 @@
 @import 'label-remove';
 @import 'notificationdrawer';
 @import 'inline-edit';
+@import 'field-level-help';

--- a/packages/core/sass/patternfly-react/_field-level-help.scss
+++ b/packages/core/sass/patternfly-react/_field-level-help.scss
@@ -1,0 +1,4 @@
+.popover-pf-info {
+  margin-left: 3px;
+  padding: 0;
+}

--- a/packages/core/sass/patternfly-react/_patternfly-react.scss
+++ b/packages/core/sass/patternfly-react/_patternfly-react.scss
@@ -7,3 +7,4 @@
 @import 'label-remove';
 @import 'notificationdrawer';
 @import "inline-edit";
+@import "field-level-help";

--- a/packages/core/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/packages/core/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -20,7 +20,7 @@ const FieldLevelHelp = ({ children, content, close, ...props }) => {
       trigger={trigger.split(' ')}
       rootClose={rootClose}
     >
-      <Button bsStyle="link">
+      <Button bsStyle="link" className="popover-pf-info">
         <Icon type="pf" name="info" />
       </Button>
     </OverlayTrigger>

--- a/packages/core/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
+++ b/packages/core/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
@@ -35,11 +35,12 @@ exports[`FieldLevelHelp allows to specify mode content and close 1`] = `
         block={false}
         bsClass="btn"
         bsStyle="link"
+        className="popover-pf-info"
         disabled={false}
         onClick={[Function]}
       >
         <button
-          className="btn btn-link"
+          className="popover-pf-info btn btn-link"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -93,11 +94,12 @@ exports[`FieldLevelHelp renders properly 1`] = `
       block={false}
       bsClass="btn"
       bsStyle="link"
+      className="popover-pf-info"
       disabled={false}
       onClick={[Function]}
     >
       <button
-        className="btn btn-link"
+        className="popover-pf-info btn btn-link"
         disabled={false}
         onClick={[Function]}
         type="button"


### PR DESCRIPTION
affects: patternfly-react

ISSUES CLOSED: [#354](https://github.com/patternfly/patternfly-react/issues/354)

**What**:
The field level help styling was inconsistent between patternfly and patternfly-react. Updated pf-react to use the same style, and added to the existing style to add space between the icon and label.

**Link to Storybook**:
https://mfrances17.github.io/patternfly-react/?knob-content=Enter%20the%20hostname%20in%20a%20valid%20format%20%3Cbr%3E%20%20%3Ca%20target%3D%22_blank%22%20href%3D%22http%3A%2F%2Fwww.test.example.com%22%3EClick%20here%20for%20examples%20of%20valid%20hostnames%3C%2Fa%3E&knob-Field%20Label=Hostname&selectedKind=patternfly-react%2FForms%20and%20Controls%2FHelp%20On%20Forms&selectedStory=FieldLevelHelp&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs
