### PR TITLE
fix(Table): fix dual-imports between files

### DIFF
--- a/packages/core/src/components/Table/Formatters/actionHeaderCellFormatter.js
+++ b/packages/core/src/components/Table/Formatters/actionHeaderCellFormatter.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Table } from '../index';
+import TableHeading from '../TableHeading';
 
 const actionHeaderCellFormatter = (value, { column }) => (
-  <Table.Heading aria-label={column.header.label} {...column.header.props}>
+  <TableHeading aria-label={column.header.label} {...column.header.props}>
     {column.header.label}
-  </Table.Heading>
+  </TableHeading>
 );
 actionHeaderCellFormatter.propTypes = {
   /** cell value */

--- a/packages/core/src/components/Table/Formatters/selectionCellFormatter.js
+++ b/packages/core/src/components/Table/Formatters/selectionCellFormatter.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop } from '../../../common/helpers';
-import { Table } from '../index';
+import TableSelectionCell from '../TableSelectionCell';
+import TableCheckbox from '../TableCheckbox';
 
 const selectionCellFormatter = (
   { rowData, rowIndex },
@@ -12,8 +13,8 @@ const selectionCellFormatter = (
   const checkboxId = id || `select${rowIndex}`;
   const checkboxLabel = label || `Select row ${rowIndex}`;
   return (
-    <Table.SelectionCell>
-      <Table.Checkbox
+    <TableSelectionCell>
+      <TableCheckbox
         id={checkboxId}
         label={checkboxLabel}
         checked={rowData.selected}
@@ -21,7 +22,7 @@ const selectionCellFormatter = (
           onSelectRow(e, rowData);
         }}
       />
-    </Table.SelectionCell>
+    </TableSelectionCell>
   );
 };
 selectionCellFormatter.propTypes = {

--- a/packages/core/src/components/Table/Formatters/selectionHeaderCellFormatter.js
+++ b/packages/core/src/components/Table/Formatters/selectionHeaderCellFormatter.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Table } from '../index';
 import { noop } from '../../../common/helpers';
+import TableSelectionHeading from '../TableSelectionHeading';
+import TableCheckbox from '../TableCheckbox';
 
 const selectionHeaderCellFormatter = ({
   cellProps,
@@ -12,14 +13,14 @@ const selectionHeaderCellFormatter = ({
   const unselectedRows = rows.filter(r => !r.selected).length > 0;
   const id = cellProps.id || 'selectAll';
   return (
-    <Table.SelectionHeading aria-label={column.header.label} {...cellProps}>
-      <Table.Checkbox
+    <TableSelectionHeading aria-label={column.header.label} {...cellProps}>
+      <TableCheckbox
         id={id}
         label={column.header.label}
         checked={!unselectedRows}
         onChange={onSelectAllRows}
       />
-    </Table.SelectionHeading>
+    </TableSelectionHeading>
   );
 };
 selectionHeaderCellFormatter.propTypes = {

--- a/packages/core/src/components/Table/Formatters/sortableHeaderCellFormatter.js
+++ b/packages/core/src/components/Table/Formatters/sortableHeaderCellFormatter.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop } from '../../../common/helpers';
-import { Table } from '../index';
+import TableHeading from '../TableHeading';
 
 const sortableHeaderCellFormatter = ({
   cellProps,
@@ -13,7 +13,7 @@ const sortableHeaderCellFormatter = ({
     sortingColumns[column.property] &&
     sortingColumns[column.property].direction;
   return (
-    <Table.Heading
+    <TableHeading
       onClick={e => {
         onSort(e, column, sortDirection);
       }}
@@ -23,7 +23,7 @@ const sortableHeaderCellFormatter = ({
       {...cellProps}
     >
       {column.header.label}
-    </Table.Heading>
+    </TableHeading>
   );
 };
 sortableHeaderCellFormatter.propTypes = {

--- a/packages/core/src/components/Table/Formatters/tableCellFormatter.js
+++ b/packages/core/src/components/Table/Formatters/tableCellFormatter.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Table } from '../index';
+import TableCell from '../TableCell';
 
-const tableCellFormatter = value => <Table.Cell>{value}</Table.Cell>;
+const tableCellFormatter = value => <TableCell>{value}</TableCell>;
+
 tableCellFormatter.propTypes = {
   /** cell value */
   value: PropTypes.node // eslint-disable-line react/no-unused-prop-types

--- a/packages/core/src/components/Table/TablePfProvider.js
+++ b/packages/core/src/components/Table/TablePfProvider.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Table } from './index';
+import { Table } from './Table';
 /**
  * TablePfProvider component for Patternfly React
  */


### PR DESCRIPTION
affects: patternfly-react

**What**:
The `index.js` importing files that importing the `index.js` itself.
I don't think it's a good idea to do so and it may be dangerous.

Foreman nightlies assets are now broken at the moment, we are not sure why but I got some confidence it is related to the dual-importing issue.
https://community.theforeman.org/t/nightlies-assets-are-now-broken/9810

**Link to Storybook**:
https://rawgit.com/sharvit/patternfly-react/storybook/fix/table-importing/index.html?selectedKind=patternfly-react%2FContent%20Views%2FTable%20View&selectedStory=PatternFly%20Table%20Styles&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs
