### PR TITLE
fix(SerialConsole): Set console width based on columns and add auto-sizing option

### DIFF
--- a/packages/console/less/serial-console.less
+++ b/packages/console/less/serial-console.less
@@ -2,6 +2,10 @@
   SerialConsole styles
  */
 
+.serial-console-pf {
+  height: 100%;
+}
+
 .console-pf > .terminal {
   color: @color-pf-white;
   text-align: left;
@@ -18,6 +22,7 @@
   margin-bottom: 0;
   text-align: center;
   line-height: normal;
+  height: 100%;
 }
 
 .console-pf .terminal .terminal-cursor {
@@ -43,6 +48,7 @@
 
 .console-terminal-pf {
   width: 100%;
+  height: 100%;
   padding-right: 0px;
   padding-left: 0px;
 }

--- a/packages/console/sass/_serial-console.scss
+++ b/packages/console/sass/_serial-console.scss
@@ -2,6 +2,10 @@
   SerialConsole styles
 */
 
+.serial-console-pf {
+  height: 100%;
+}
+
 .console-pf > .terminal {
   color: $color-pf-white;
   text-align: left;
@@ -18,6 +22,7 @@
   margin-bottom: 0;
   text-align: center;
   line-height: normal;
+  height: 100%;
 }
 
 .console-pf .terminal .terminal-cursor {
@@ -43,7 +48,7 @@
 
 .console-terminal-pf {
   width: 100%;
-  height: 40%;
+  height: 100%;
   padding-right: 0;
   padding-left: 0;
 }

--- a/packages/console/src/SerialConsole/SerialConsole.js
+++ b/packages/console/src/SerialConsole/SerialConsole.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 import { EmptyState, Button, noop } from 'patternfly-react';
 import { CONNECTED, DISCONNECTED, LOADING } from './constants';
@@ -71,8 +72,10 @@ class SerialConsole extends React.Component {
             ref={c => {
               this.childTerminal = c;
             }}
+            className="serial-console-pf"
             cols={this.props.cols}
             rows={this.props.rows}
+            autoFit={this.props.autoFit}
             fontFamily={this.props.fontFamily}
             fontSize={this.props.fontSize}
             onConnect={this.props.onConnect}
@@ -109,8 +112,10 @@ class SerialConsole extends React.Component {
         break;
     }
 
+    const classes = classNames('serial-console-pf', topClassName);
+
     return (
-      <div className={topClassName} id={id}>
+      <div className={classes} id={id}>
         <SerialConsoleActions
           idPrefix={idPrefix}
           isDisconnectEnabled={isDisconnectEnabled}
@@ -144,6 +149,7 @@ SerialConsole.propTypes = {
   /** Size of the terminal component */
   rows: PropTypes.number,
   cols: PropTypes.number,
+  autoFit: PropTypes.bool,
 
   /** Font for text rendered to xterm canvas */
   fontFamily: PropTypes.string,
@@ -167,6 +173,7 @@ SerialConsole.defaultProps = {
   id: '',
   rows: 25,
   cols: 80,
+  autoFit: false,
 
   fontFamily: undefined /** Use xterm default: 'courier-new, courier, monospace' */,
   fontSize: undefined /** Use xterm default: 15 */,

--- a/packages/console/src/SerialConsole/SerialConsole.stories.js
+++ b/packages/console/src/SerialConsole/SerialConsole.stories.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { storiesOf } from '@storybook/react';
+import { withKnobs, boolean, number } from '@storybook/addon-knobs';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { storybookPackageName } from 'storybook/constants/siteConstants';
 
@@ -20,6 +22,7 @@ stories.addDecorator(
       'This is an example of the SerialConsole component. For the purpose of this example, there is just a mock backend.'
   })
 );
+stories.addDecorator(withKnobs);
 
 /* eslint no-console: ["warn", { allow: ["log"] }] */
 const { log } = console; // let's keep these trace messages for tutoring purposes
@@ -139,16 +142,37 @@ class SerialConsoleConnector extends React.Component {
       <SerialConsole
         onConnect={this.onConnect}
         onDisconnect={this.onDisconnect}
-        onResize={this.onResize()}
+        onResize={this.onResize}
         onData={this.onData}
         id="my-serialconsole"
         status={this.state.status}
         ref={c => {
           this.childSerialconsole = c;
         }}
+        autoFit={this.props.autoFit}
+        cols={this.props.cols}
+        rows={this.props.rows}
       />
     );
   }
 }
 
-stories.addWithInfo('SerialConsole', () => <SerialConsoleConnector />);
+SerialConsoleConnector.propTypes = {
+  autoFit: PropTypes.bool,
+  rows: PropTypes.number,
+  cols: PropTypes.number
+};
+
+SerialConsoleConnector.defaultProps = {
+  autoFit: false,
+  rows: undefined,
+  cols: undefined
+};
+
+stories.addWithInfo('SerialConsole', () => {
+  const autoFit = boolean('Auto fit', true);
+  const cols = autoFit ? undefined : number('Columns', 90);
+  const rows = autoFit ? undefined : number('Rows', 35);
+
+  return <SerialConsoleConnector autoFit={autoFit} cols={cols} rows={rows} />;
+});

--- a/packages/console/src/SerialConsole/SerialConsole.test.js
+++ b/packages/console/src/SerialConsole/SerialConsole.test.js
@@ -53,3 +53,27 @@ test('Render SerialConsole in the CONNECTED state', () => {
   const view = render(connectedState);
   expect(view).toMatchSnapshot();
 });
+
+test('Pass class to SerialConsole', () => {
+  const view = shallow(
+    <SerialConsole
+      onConnect={jest.fn()}
+      onDisconnect={jest.fn()}
+      status={LOADING}
+      topClassName="my-top-class"
+    />
+  );
+  expect(view).toMatchSnapshot();
+});
+
+test('Enable autoFit for SerialConsole', () => {
+  const view = shallow(
+    <SerialConsole
+      onConnect={jest.fn()}
+      onDisconnect={jest.fn()}
+      status={CONNECTED}
+      autoFit
+    />
+  );
+  expect(view).toMatchSnapshot();
+});

--- a/packages/console/src/SerialConsole/__snapshots__/SerialConsole.test.js.snap
+++ b/packages/console/src/SerialConsole/__snapshots__/SerialConsole.test.js.snap
@@ -1,8 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Enable autoFit for SerialConsole 1`] = `
+<div
+  className="serial-console-pf"
+  id=""
+>
+  <SerialConsoleActions
+    idPrefix="id-serialconsole"
+    isDisconnectEnabled={true}
+    onDisconnect={[Function]}
+    onReset={[Function]}
+    textDisconnect="Disconnect"
+    textReconnect="Reconnect"
+  />
+  <div
+    className="panel-body console-terminal-pf"
+  >
+    <XTerm
+      autoFit={true}
+      className="serial-console-pf"
+      cols={80}
+      onConnect={
+        [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+        }
+      }
+      onData={[Function]}
+      onDisconnect={[MockFunction]}
+      onResize={[Function]}
+      onTitleChanged={[Function]}
+      rows={25}
+    />
+  </div>
+</div>
+`;
+
+exports[`Pass class to SerialConsole 1`] = `
+<div
+  className="serial-console-pf my-top-class"
+  id=""
+>
+  <SerialConsoleActions
+    idPrefix="id-serialconsole"
+    isDisconnectEnabled={false}
+    onDisconnect={[Function]}
+    onReset={[Function]}
+    textDisconnect="Disconnect"
+    textReconnect="Reconnect"
+  />
+  <div
+    className="panel-body console-terminal-pf"
+  >
+    <span>
+      Loading ...
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Render SerialConsole in the CONNECTED state 1`] = `
 <div
-  class=""
+  class="serial-console-pf"
   id="myidprefix"
 >
   <div
@@ -33,7 +93,7 @@ exports[`Render SerialConsole in the CONNECTED state 1`] = `
 
 exports[`SerialConsole in the CONNECTED state 1`] = `
 <div
-  className=""
+  className="serial-console-pf"
   id="myidprefix"
 >
   <SerialConsoleActions
@@ -48,6 +108,8 @@ exports[`SerialConsole in the CONNECTED state 1`] = `
     className="panel-body console-terminal-pf"
   >
     <XTerm
+      autoFit={false}
+      className="serial-console-pf"
       cols={33}
       onConnect={
         [MockFunction] {
@@ -68,7 +130,7 @@ exports[`SerialConsole in the CONNECTED state 1`] = `
 
 exports[`SerialConsole in the DISCONNECTED state 1`] = `
 <div
-  className=""
+  className="serial-console-pf"
   id="myidprefix"
 >
   <SerialConsoleActions
@@ -124,7 +186,7 @@ exports[`SerialConsole in the DISCONNECTED state 1`] = `
 
 exports[`SerialConsole in the LOADING state 1`] = `
 <div
-  className=""
+  className="serial-console-pf"
   id=""
 >
   <SerialConsoleActions

--- a/packages/console/src/common/helpers.js
+++ b/packages/console/src/common/helpers.js
@@ -1,0 +1,10 @@
+/** Implementation of the debounce function */
+export const debounce = (func, wait) => {
+  let timeout;
+  function innerFunc(...args) {
+    const context = this;
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func.apply(context, args), wait);
+  }
+  return innerFunc;
+};

--- a/packages/console/src/index.js
+++ b/packages/console/src/index.js
@@ -1,2 +1,3 @@
+export * from './common/helpers';
 export * from './SerialConsole';
 export * from './VncConsole';


### PR DESCRIPTION
Addresses issue https://github.com/patternfly/patternfly-react/issues/380

If the number of columns forced the console to be wider than the viewport, then the parent container was not sizing correctly. Added a min-width style that makes the parent container as wide as the console. Also saw that there were issues with resizing, added an option to auto-size using the autoFit property.

Storybook:
https://jschuler.github.io/patternfly-react/
Navigate to react-console -> SerialConsole
