### PR TITLE
fix(react-styles): specify publishConfig in package.json

### DIFF
--- a/packages/react-core/README.md
+++ b/packages/react-core/README.md
@@ -45,7 +45,7 @@ You can also find how each component is meant to be used from a design perspecti
 
 
 # Contributing Components
-This library makes use of the babel plugin from [@patternfly/react-styles](../styles/README.md) to enable providing the CSS alongside the components.  This removes the need for consumers to use (style|css|sass)-loaders. For an example of using CSS from core you can reference [Button.js](./src/components/Button.js). For any CSS not provided by core please use the `StyleSheet.create` utility from [@patternfly/react-styles](../styles/README.md). This will prevent collisions with any consumers, and allow the CSS to be bundled with the component.
+This library makes use of the babel plugin from [@patternfly/react-styles](../react-styles/README.md) to enable providing the CSS alongside the components.  This removes the need for consumers to use (style|css|sass)-loaders. For an example of using CSS from core you can reference [Button.js](./src/components/Button/Button.js). For any CSS not provided by core please use the `StyleSheet.create` utility from [@patternfly/react-styles](../react-styles/README.md). This will prevent collisions with any consumers, and allow the CSS to be bundled with the component.
 
 ### Building
 
@@ -60,7 +60,7 @@ Note the build scripts for this are located in the root package.json under `yarn
 Testing is done at the root of this repo. To only run the patternfly-react tests:
 
 ```
-yarn test packages/next/core
+yarn test packages/react-core
 ```
 
 [patternfly-4]: https://github.com/patternfly/patternfly-next

--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "dependencies": {
-    "@patternfly/react-styles": "^0.0.1"
+    "@patternfly/react-styles": "^1.0.0"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@patternfly/patternfly-next": "^1.0.4",
     "@patternfly/react-core": "^0.0.1",
-    "@patternfly/react-styles": "^0.0.1",
+    "@patternfly/react-styles": "^1.0.0",
     "@patternfly/react-tokens": "^1.0.0",
     "gatsby": "^1.9.247",
     "gatsby-link": "^1.6.40",

--- a/packages/react-styles/README.md
+++ b/packages/react-styles/README.md
@@ -141,7 +141,7 @@ const Buttton = ({ isActive, isDisabled, children }) => (
 
 ### `getModifier(styles: { [key: string]: PFStyleObject }, modifier: string, defaultModifer?: string): PFStyleObject | null;`
 
-Since pf-next-core is maintaining a pattern of using `pf-m-modifier` for modifiers we will provide a utility for consumers to easily get the modifier given the style object and the desired modifier. A default can be provided as well if the given variant does not exist.  Returns `null` if none are found.
+Since PatternFly 4 Core is maintaining a pattern of using `pf-m-modifier` for modifiers we will provide a utility for consumers to easily get the modifier given the style object and the desired modifier. A default can be provided as well if the given variant does not exist.  Returns `null` if none are found.
 
 #### Example
 

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -7,6 +7,9 @@
   "sideEffects": false,
   "description": "",
   "author": "Red Hat",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0-beta.48",
     "aphrodite": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,6 +115,12 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.4.tgz#e95ccf5aa8f3fabbc96bca06ccb271715eda1df2"
 
+"@patternfly/react-core@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-0.0.1.tgz#9594d05aed3bcb5eba95992fbe4a7de879b1eab9"
+  dependencies:
+    "@patternfly/react-styles" "^1.0.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"


### PR DESCRIPTION
affects: @patternfly/react-core, @patternfly/react-docs, @patternfly/react-styles

publishConfig is required for scoped packages to publish.

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- feel free to add additional comments -->