### PR TITLE
fix(react-docs): relax version for react-core in react-docs.

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "dependencies": {
-    "@patternfly/react-styles": "^1.0.0"
+    "@patternfly/react-styles": "^2.0.0"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@patternfly/patternfly-next": "^1.0.4",
-    "@patternfly/react-core": "^0.0.1",
-    "@patternfly/react-styles": "^1.0.0",
+    "@patternfly/react-core": "^0.x",
+    "@patternfly/react-styles": "^2.0.0",
     "@patternfly/react-tokens": "^1.0.0",
     "gatsby": "^1.9.247",
     "gatsby-link": "^1.6.40",

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,12 +115,6 @@
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.4.tgz#e95ccf5aa8f3fabbc96bca06ccb271715eda1df2"
 
-"@patternfly/react-core@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-0.0.1.tgz#9594d05aed3bcb5eba95992fbe4a7de879b1eab9"
-  dependencies:
-    "@patternfly/react-styles" "^1.0.0"
-
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"


### PR DESCRIPTION
affects: @patternfly/react-core, @patternfly/react-docs

Relaxing this version will allow the docs to stay more aligned with what is part of the build setup,
and avoid having to update react-core manually while it is in alpha.
