### PR TITLE
fix(react-docs): publish react-docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,10 @@
   "workspaces": {
     "packages": [
       "packages/*"
+    ],
+    "nohoist": [
+      "**/gatsby*",
+      "@patternfly/react-docs/react*"
     ]
   },
   "lint-staged": {

--- a/packages/react-docs/.npmignore
+++ b/packages/react-docs/.npmignore
@@ -1,0 +1,3 @@
+.cache
+.babelrc
+.eslintrc

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@patternfly/react-docs",
-  "private": true,
   "description": "Patternfly React Docs",
-  "version": "6.0.0",
+  "version": "1.0.0",
   "author": "Red Hat",
   "license": "Apache-2.0",
   "dependencies": {
@@ -27,14 +26,6 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop"
-  },
-  "workspaces": {
-    "nohoist": [
-      "@patternfly/patternfly-next",
-      "gatsby",
-      "react",
-      "react-dom"
-    ]
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
affects: @patternfly/react-docs

**What**:
Publish react-docs to avoid versioning with every change this is a workaround for the pr here: https://github.com/atlassian/lerna-semantic-release/pull/86
