### PR TITLE
fix(field-level-help): expose the field level help placement

### DIFF
--- a/packages/patternfly-react/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/packages/patternfly-react/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -8,19 +8,24 @@ import { OverlayTrigger } from '../OverlayTrigger';
 /**
  * FieldLevelHelp Component for Patternfly React
  */
-const FieldLevelHelp = ({ children, content, close, ...props }) => {
-  const trigger = 'click';
+const FieldLevelHelp = ({
+  children,
+  content,
+  rootClose,
+  placement,
+  buttonClass,
+  ...props
+}) => {
   const overlay = <Popover id="popover">{content}</Popover>;
-  const rootClose = close === 'true';
 
   return (
     <OverlayTrigger
       overlay={overlay}
-      placement="top"
-      trigger={trigger.split(' ')}
+      placement={placement}
+      trigger={['click']}
       rootClose={rootClose}
     >
-      <Button bsStyle="link" className="popover-pf-info">
+      <Button bsStyle="link" className={buttonClass}>
         <Icon type="pf" name="info" />
       </Button>
     </OverlayTrigger>
@@ -31,13 +36,19 @@ FieldLevelHelp.propTypes = {
   /** additional fieldlevelhelp classes */
   content: PropTypes.node,
   /** leave popover/tooltip open  */
-  close: PropTypes.string,
+  rootClose: PropTypes.bool,
+  /** overlay placement */
+  placement: PropTypes.string,
+  /** button class */
+  buttonClass: PropTypes.string,
   /** children nodes  */
   children: PropTypes.node
 };
 FieldLevelHelp.defaultProps = {
   content: null,
-  close: 'true',
+  rootClose: true,
+  placement: 'top',
+  buttonClass: 'popover-pf-info',
   children: null
 };
 

--- a/packages/patternfly-react/src/components/FieldLevelHelp/FieldLevelHelp.js
+++ b/packages/patternfly-react/src/components/FieldLevelHelp/FieldLevelHelp.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { Icon } from '../Icon';
 import { Button } from '../Button';
 import { Popover } from '../Popover';
@@ -11,21 +12,25 @@ import { OverlayTrigger } from '../OverlayTrigger';
 const FieldLevelHelp = ({
   children,
   content,
+  close,
   rootClose,
   placement,
   buttonClass,
   ...props
 }) => {
+  // backwards compatibility of the existing `close` prop - use that prop if it exists
+  const closeProp = typeof close !== 'undefined' ? close : rootClose;
   const overlay = <Popover id="popover">{content}</Popover>;
+  const buttonClasses = classNames('popover-pf-info', buttonClass);
 
   return (
     <OverlayTrigger
       overlay={overlay}
       placement={placement}
       trigger={['click']}
-      rootClose={rootClose}
+      rootClose={closeProp}
     >
-      <Button bsStyle="link" className={buttonClass}>
+      <Button bsStyle="link" className={buttonClasses}>
         <Icon type="pf" name="info" />
       </Button>
     </OverlayTrigger>
@@ -35,6 +40,8 @@ const FieldLevelHelp = ({
 FieldLevelHelp.propTypes = {
   /** additional fieldlevelhelp classes */
   content: PropTypes.node,
+  /** close prop */
+  close: PropTypes.bool,
   /** leave popover/tooltip open  */
   rootClose: PropTypes.bool,
   /** overlay placement */
@@ -46,9 +53,10 @@ FieldLevelHelp.propTypes = {
 };
 FieldLevelHelp.defaultProps = {
   content: null,
+  close: undefined,
   rootClose: true,
   placement: 'top',
-  buttonClass: 'popover-pf-info',
+  buttonClass: '',
   children: null
 };
 

--- a/packages/patternfly-react/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
+++ b/packages/patternfly-react/src/components/FieldLevelHelp/FieldLevelHelp.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, select } from '@storybook/addon-knobs';
+import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import {
@@ -30,10 +30,15 @@ stories.addDecorator(
 stories.add(
   'FieldLevelHelp',
   withInfo()(() => {
-    const close = select('Close Popover', ['true', 'false']);
+    const rootClose = boolean('Root Close', true);
     const content = text(
       'content',
       'Enter the hostname in a valid format <br>  <a target="_blank" href="http://www.test.example.com">Click here for examples of valid hostnames</a>'
+    );
+    const placement = select(
+      'Placement',
+      ['top', 'bottom', 'left', 'right'],
+      'top'
     );
     const fieldLabel = text('Field Label', 'Hostname');
 
@@ -48,7 +53,11 @@ stories.add(
     return (
       <div style={{ textAlign: 'center' }}>
         {fieldLabel}
-        <FieldLevelHelp content={htmlContent} close={close} />
+        <FieldLevelHelp
+          content={htmlContent}
+          rootClose={rootClose}
+          placement={placement}
+        />
       </div>
     );
   })

--- a/packages/patternfly-react/src/components/FieldLevelHelp/FieldLevelHelp.test.js
+++ b/packages/patternfly-react/src/components/FieldLevelHelp/FieldLevelHelp.test.js
@@ -20,8 +20,9 @@ test('FieldLevelHelp allows to specify mode content and close', () => {
         mode="popover"
         content="Enter Port number between the 4000-5000 range"
         rootClose
+        close
         placement="top"
-        buttonClass="popover-pf-info"
+        buttonClass="additionl-button-class"
       />
     </div>
   );

--- a/packages/patternfly-react/src/components/FieldLevelHelp/FieldLevelHelp.test.js
+++ b/packages/patternfly-react/src/components/FieldLevelHelp/FieldLevelHelp.test.js
@@ -19,7 +19,9 @@ test('FieldLevelHelp allows to specify mode content and close', () => {
         id="fieldlevelname1"
         mode="popover"
         content="Enter Port number between the 4000-5000 range"
-        close="true"
+        rootClose
+        placement="top"
+        buttonClass="popover-pf-info"
       />
     </div>
   );

--- a/packages/patternfly-react/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
+++ b/packages/patternfly-react/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
@@ -6,10 +6,12 @@ exports[`FieldLevelHelp allows to specify mode content and close 1`] = `
     Port Number
   </label>
   <FieldLevelHelp
-    close="true"
+    buttonClass="popover-pf-info"
     content="Enter Port number between the 4000-5000 range"
     id="fieldlevelname1"
     mode="popover"
+    placement="top"
+    rootClose={true}
   >
     <OverlayTrigger
       defaultOverlayShown={false}
@@ -68,9 +70,11 @@ exports[`FieldLevelHelp allows to specify mode content and close 1`] = `
 
 exports[`FieldLevelHelp renders properly 1`] = `
 <FieldLevelHelp
-  close="true"
+  buttonClass="popover-pf-info"
   content={null}
   id="fieldlevelname1"
+  placement="top"
+  rootClose={true}
 >
   <OverlayTrigger
     defaultOverlayShown={false}

--- a/packages/patternfly-react/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
+++ b/packages/patternfly-react/src/components/FieldLevelHelp/__snapshots__/FieldLevelHelp.test.js.snap
@@ -6,7 +6,8 @@ exports[`FieldLevelHelp allows to specify mode content and close 1`] = `
     Port Number
   </label>
   <FieldLevelHelp
-    buttonClass="popover-pf-info"
+    buttonClass="additionl-button-class"
+    close={true}
     content="Enter Port number between the 4000-5000 range"
     id="fieldlevelname1"
     mode="popover"
@@ -37,12 +38,12 @@ exports[`FieldLevelHelp allows to specify mode content and close 1`] = `
         block={false}
         bsClass="btn"
         bsStyle="link"
-        className="popover-pf-info"
+        className="popover-pf-info additionl-button-class"
         disabled={false}
         onClick={[Function]}
       >
         <button
-          className="popover-pf-info btn btn-link"
+          className="popover-pf-info additionl-button-class btn btn-link"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -70,7 +71,7 @@ exports[`FieldLevelHelp allows to specify mode content and close 1`] = `
 
 exports[`FieldLevelHelp renders properly 1`] = `
 <FieldLevelHelp
-  buttonClass="popover-pf-info"
+  buttonClass=""
   content={null}
   id="fieldlevelname1"
   placement="top"


### PR DESCRIPTION
affects: `patternfly-react`

ISSUES CLOSED: #418 

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Exposes the Field Level Help overlay placement and button class. This flexibility may be desirable in certain cases downstream. Rename the `close` prop to `rootClose` to match the API surface a bit better. 

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
https://priley86.github.io/patternfly-react/

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- feel free to add additional comments -->