### PR TITLE
fix(react-core/typings): relax typings for button. Correct typings for title

### DIFF
--- a/packages/react-core/src/components/Button/Button.d.ts
+++ b/packages/react-core/src/components/Button/Button.d.ts
@@ -1,18 +1,19 @@
 import { HTMLProps } from 'react';
+import { OneOf } from '../../typeUtils';
 
-export enum ButtonVariant {
-  primary = 'primary',
-  secondary = 'secondary',
-  tertiary = 'tertiary',
-  danger = 'danger',
-  link = 'link',
-  action = 'action'
-}
+export const ButtonVariant: {
+  primary: 'primary';
+  secondary: 'secondary';
+  tertiary: 'tertiary';
+  danger: 'danger';
+  link: 'link';
+  action: 'action';
+};
 
-export enum ButtonType {
-  button = 'button',
-  submit = 'submit'
-}
+export const ButtonType: {
+  button: 'button';
+  submit: 'submit';
+};
 
 export interface ButtonProps extends HTMLProps<HTMLButtonElement> {
   children?: React.ReactNode;
@@ -21,8 +22,8 @@ export interface ButtonProps extends HTMLProps<HTMLButtonElement> {
   isDisabled?: boolean;
   isFocus?: boolean;
   isHover?: boolean;
-  variant?: ButtonVariant;
-  type?: ButtonType;
+  variant?: OneOf<typeof ButtonVariant, keyof typeof ButtonVariant>;
+  type?: OneOf<typeof ButtonType, keyof typeof ButtonType>;
 }
 
 declare const Button: React.SFC<ButtonProps>;

--- a/packages/react-core/src/components/Title/Title.d.ts
+++ b/packages/react-core/src/components/Title/Title.d.ts
@@ -1,20 +1,21 @@
 import { SFC, HTMLProps, ReactNode } from 'react';
+import { Omit, OneOf } from '../../util';
 
-export enum TitleSize {
-  xxxxl = 'xxxxl',
-  xxxl = 'xxxl',
-  xxl = 'xxl',
-  xl = 'xl',
-  lg = 'lg',
-  md = 'md'
-}
-
-export interface TitleProps extends HTMLProps<HTMLHeadingElement> {
-  size: TitleSize;
+export const TitleSize: {
+  xxxxl: 'xxxxl';
+  xxxl: 'xxxl';
+  xxl: 'xxl';
+  xl: 'xl';
+  lg: 'lg';
+  md: 'md';
+};
+export interface TitleProps
+  extends Omit<HTMLProps<HTMLHeadingElement>, 'size'> {
+  size: OneOf<typeof TitleSize, keyof typeof TitleSize>;
   withMargins?: boolean;
   children?: ReactNode;
 }
 
-declare const Title: SFC<Props>;
+declare const Title: SFC<TitleProps>;
 
 export default Title;

--- a/packages/react-core/src/typeUtils.d.ts
+++ b/packages/react-core/src/typeUtils.d.ts
@@ -1,0 +1,8 @@
+export type OneOf<T, K extends keyof T> = T[K];
+
+// Diff / Omit taken from https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-311923766
+export type Omit<T, K extends keyof T> = Pick<
+  T,
+  ({ [P in keyof T]: P } &
+    { [P in K]: never } & { [x: string]: never; [x: number]: never })[keyof T]
+>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "lib": ["es6", "dom"],
+    "module": "es2015",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noImplicitAny": true,
+    "target": "esnext"
+  },
+  "include": ["packages/**/src/**/*"]
+}


### PR DESCRIPTION
affects: @patternfly/react-core

Relaxed typings for the button so that string literals can be passed in. Corrected typings for
Title.  Added a tsconfig.json at the base to allow any errors to show up.
