### PR TITLE
Do not wrap Typeahed into functional component

### DIFF
--- a/packages/patternfly-react/src/components/TypeAheadSelect/TypeAheadSelect.js
+++ b/packages/patternfly-react/src/components/TypeAheadSelect/TypeAheadSelect.js
@@ -1,6 +1,1 @@
-import React from 'react';
-import { Typeahead } from 'react-bootstrap-typeahead';
-
-const TypeAheadSelect = props => <Typeahead {...props} />;
-
-export default TypeAheadSelect;
+export { Typeahead as TypeAheadSelect } from 'react-bootstrap-typeahead';

--- a/packages/patternfly-react/src/components/TypeAheadSelect/TypeAheadSelect.test.js
+++ b/packages/patternfly-react/src/components/TypeAheadSelect/TypeAheadSelect.test.js
@@ -4,12 +4,14 @@ import { TypeAheadSelect } from './TypeAheadSelect';
 
 test('TypeAheadSelect is working !!', () => {
   const component = shallow(
-    <TypeAheadSelect
-      clearButton
-      multiple
-      allowNew
-      options={['One', 'Two', 'Three']}
-    />
+    <p>
+      <TypeAheadSelect
+        clearButton
+        multiple
+        allowNew
+        options={['One', 'Two', 'Three']}
+      />
+    </p>
   );
 
   expect(component).toMatchSnapshot();

--- a/packages/patternfly-react/src/components/TypeAheadSelect/TypeAheadSelect.test.js
+++ b/packages/patternfly-react/src/components/TypeAheadSelect/TypeAheadSelect.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import TypeAheadSelect from './TypeAheadSelect';
+import { TypeAheadSelect } from './TypeAheadSelect';
 
 test('TypeAheadSelect is working !!', () => {
   const component = shallow(

--- a/packages/patternfly-react/src/components/TypeAheadSelect/__snapshots__/TypeAheadSelect.test.js.snap
+++ b/packages/patternfly-react/src/components/TypeAheadSelect/__snapshots__/TypeAheadSelect.test.js.snap
@@ -1,26 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TypeAheadSelect is working !! 1`] = `
-<OnClickOutside(TypeaheadContainer(WrappedTypeahead))
-  allowNew={true}
-  clearButton={true}
-  eventTypes={
-    Array [
-      "mousedown",
-      "touchstart",
-    ]
-  }
-  excludeScrollbar={false}
-  multiple={true}
-  options={
-    Array [
-      "One",
-      "Two",
-      "Three",
-    ]
-  }
-  outsideClickIgnoreClass="ignore-react-onclickoutside"
-  preventDefault={false}
-  stopPropagation={false}
-/>
+<p>
+  <OnClickOutside(TypeaheadContainer(WrappedTypeahead))
+    allowNew={true}
+    clearButton={true}
+    eventTypes={
+      Array [
+        "mousedown",
+        "touchstart",
+      ]
+    }
+    excludeScrollbar={false}
+    multiple={true}
+    options={
+      Array [
+        "One",
+        "Two",
+        "Three",
+      ]
+    }
+    outsideClickIgnoreClass="ignore-react-onclickoutside"
+    preventDefault={false}
+    stopPropagation={false}
+  />
+</p>
 `;

--- a/packages/patternfly-react/src/components/TypeAheadSelect/index.js
+++ b/packages/patternfly-react/src/components/TypeAheadSelect/index.js
@@ -1,4 +1,4 @@
-import TypeAheadSelect from './TypeAheadSelect';
+import { TypeAheadSelect } from './TypeAheadSelect';
 import AsyncTypeAheadSelect from './AsyncTypeAheadSelect';
 
 export { TypeAheadSelect, AsyncTypeAheadSelect };


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**: The original component is class-based and allows `ref` to be controlled and we want to preserve that behavior

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**: https://shaded-enmity.github.io/patternfly-react/
(note I had to disable the console component as it failed to build due to unrelated issue?)
```
[0] ERROR in ./packages/react-console/src/SerialConsole/SerialConsole.js                                                                                                                       
[0] Module not found: Error: Can't resolve 'patternfly-react'
```

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: #427


<!-- feel free to add additional comments -->