### PR TITLE
refactor(Add mathead to verticalnav):

### DIFF
--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNav.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNav.js
@@ -335,11 +335,6 @@ class BaseVerticalNav extends React.Component {
       ));
     const itemComponents = itemsFromProps || itemsFromChildren || [];
 
-    const masthead = findChild(
-      children,
-      child => child.type === VerticalNavMasthead
-    );
-
     const {
       hiddenIcons,
       pinnableMenus,
@@ -351,12 +346,19 @@ class BaseVerticalNav extends React.Component {
       blurDelay,
       isMobile,
       showMobileNav,
+      masthead,
       navCollapsed,
       activePath,
       hoverPath,
       mobilePath,
       pinnedPath
     } = this.props;
+
+    const mastheadElem = masthead || (
+      <nav className={classNames('navbar navbar-pf-vertical')}>
+        {findChild(children, child => child.type === VerticalNavMasthead)}
+      </nav>
+    );
 
     const getPathDepth = path =>
       path && path.split('/').filter(s => s !== '').length;
@@ -402,9 +404,7 @@ class BaseVerticalNav extends React.Component {
         hoverDelay={hoverDelay}
         blurDelay={blurDelay}
       >
-        <nav className={classNames('navbar navbar-pf-vertical')}>
-          {!hideMasthead && masthead}
-        </nav>
+        {!hideMasthead && mastheadElem}
         <div
           className={classNames(
             'nav-pf-vertical nav-pf-vertical-with-sub-menus',
@@ -489,6 +489,8 @@ BaseVerticalNav.propTypes = {
   hoverDelay: PropTypes.number,
   /** Delay between mouse blur and menu hide in ms */
   blurDelay: PropTypes.number,
+  /**  */
+  masthead: PropTypes.node,
   /** Optional callback for updating isMobile prop */
   onLayoutChange: PropTypes.func, // eslint-disable-line react/require-default-props
   /** Optional callback for updating navCollapsed and showMobileNav props (option 1) */
@@ -528,6 +530,7 @@ BaseVerticalNav.defaultProps = {
   persistentSecondary: true,
   hoverDelay: 500,
   blurDelay: 700,
+  masthead: null,
   onMenuToggleClick: null,
   onCollapse: null,
   onExpand: null,

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNav.stories.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNav.stories.js
@@ -14,6 +14,10 @@ import {
 import { mockNavItems } from './__mocks__/mockNavItems';
 import { MockIconBarChildren } from './__mocks__/mockIconBarChildren';
 import { basicExample } from './__mocks__/basicExample';
+import {
+  MockWithMastHeadComponent,
+  mockWithMastHeadSource
+} from './__mocks__/mockWithMastHeadComponent';
 
 import pfLogo from 'storybook/img/logo-alt.svg';
 import pfBrand from 'storybook/img/brand-alt.svg';
@@ -258,6 +262,27 @@ stories.add(
             </IconBar>
           </Masthead>
         </VerticalNav>
+        {mockBodyContainer('nav-pf-vertical-with-badges')}
+      </div>
+    </MockFixedLayout>
+  ))
+);
+
+stories.add(
+  'With Masthead component no collapse',
+  withInfo({
+    propTablesExclude: [MockFixedLayout],
+    text: (
+      <div>
+        <h1>Example using the **Masthead** component</h1>
+        <h2>Story Source</h2>
+        <pre>{mockWithMastHeadSource}</pre>
+      </div>
+    )
+  })(() => (
+    <MockFixedLayout>
+      <div className="layout-pf layout-pf-fixed faux-layout">
+        <MockWithMastHeadComponent />
         {mockBodyContainer('nav-pf-vertical-with-badges')}
       </div>
     </MockFixedLayout>

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNav.test.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNav.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 
 import { VerticalNav } from './index';
+import { Masthead as MastheadPf } from '../Masthead';
 
 import { mockNavItems } from './__mocks__/mockNavItems';
 import { MockIconBarChildren } from './__mocks__/mockIconBarChildren';
@@ -57,4 +58,11 @@ test('VerticalNav renders properly with item objects', () => {
   expect(component.render()).toMatchSnapshot();
 });
 
+test('VerticalNav renders properly with masthead PF component', () => {
+  const component = mount(
+    <VerticalNav items={mockNavItems} masthead={<MastheadPf />} />
+  );
+
+  expect(component.render()).toMatchSnapshot();
+});
 // Note: in the future it would be nice to unit test all those component class methods too...

--- a/packages/patternfly-react/src/components/VerticalNav/__mocks__/mockWithMastHeadComponent.js
+++ b/packages/patternfly-react/src/components/VerticalNav/__mocks__/mockWithMastHeadComponent.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { VerticalNav, Masthead } from '../../../index';
+import { mockNavItems } from './mockNavItems';
+
+export class MockWithMastHeadComponent extends React.Component {
+  state = {
+    collapse: false
+  };
+
+  onCollapse = () => {
+    this.setState({ collapse: !this.state.collapse });
+  };
+
+  render() {
+    return (
+      <VerticalNav
+        sessionKey="storybookCustomMasthead"
+        items={mockNavItems}
+        masthead={<Masthead onNavToggleClick={() => this.onCollapse()} />}
+        navCollapsed={this.state.collapse}
+        showBadges
+      />
+    );
+  }
+}
+
+export const mockWithMastHeadSource = `
+import React from 'react';
+import { VerticalNav, MastHead as MastheadPf } from '../../../index';
+import { mockNavItems } from './mockNavItems';
+
+export class MockWithMastHeadComponent extends React.Component {
+  state = {
+    collapse: false
+  };
+
+  onCollapse = () => {
+    this.setState({ collapse: !this.state.collapse });
+  };
+
+  render() {
+    return (
+      <VerticalNav
+        sessionKey="storybookCustomMasthead"
+        items={mockNavItems}
+        masthead={<Masthead onNavToggleClick={() => this.onCollapse()} />}
+        navCollapsed={this.state.collapse}
+        showBadges
+      />
+    );
+  }
+}
+`;

--- a/packages/patternfly-react/src/components/VerticalNav/__snapshots__/VerticalNav.test.js.snap
+++ b/packages/patternfly-react/src/components/VerticalNav/__snapshots__/VerticalNav.test.js.snap
@@ -290,3 +290,40 @@ exports[`VerticalNav renders properly with item objects 1`] = `
   </nav>
 </nav>
 `;
+
+exports[`VerticalNav renders properly with masthead PF component 1`] = `
+<nav
+  class="navbar navbar-pf-vertical"
+>
+  <div
+    class="navbar-header"
+  >
+    <button
+      class="navbar-toggle"
+    >
+      <span
+        class="sr-only"
+      >
+        Toggle navigation
+      </span>
+      <span
+        aria-hidden="true"
+        class="icon-bar"
+      />
+      <span
+        aria-hidden="true"
+        class="icon-bar"
+      />
+      <span
+        aria-hidden="true"
+        class="icon-bar"
+      />
+    </button>
+    <a
+      class="navbar-brand"
+      href="#"
+      role="button"
+    />
+  </div>
+</nav>
+`;


### PR DESCRIPTION
affects: patternfly-react

ISSUES CLOSED: #429

**Navigation/Vertical Navigation/With Masthead Component**
See storybook here : [here](https://rawgit.com/aljesusg/patternfly-react/issue_429_story/index.html)

