### PR TITLE
feat(Tag): create a tag like a CompoundLabel of key-value pair

### DIFF
--- a/packages/patternfly-react/less/patternfly-react.less
+++ b/packages/patternfly-react/less/patternfly-react.less
@@ -9,5 +9,6 @@
 @import 'notificationdrawer';
 @import 'inline-edit';
 @import 'field-level-help';
+@import 'tag';
 @import 'type-ahead-select';
 @import 'verticalnavdivider';

--- a/packages/patternfly-react/less/tag.less
+++ b/packages/patternfly-react/less/tag.less
@@ -1,0 +1,34 @@
+.tag-pair {
+  margin: 3px 2px 2px;
+  max-width: 100%;
+  float: left;
+  display: block;
+
+  .tag {
+    min-width: 50px;
+
+    &:first-child {
+      border-radius: 2px 0 0 2px;
+    }
+
+    &:last-child {
+      border-radius: 0 2px 2px 0;
+    }
+  }
+
+  .tag-key {
+    background-color: #bee1f4;
+    color: #00659c;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    margin-left: 0;
+  }
+
+  .tag-value {
+    background-color: #7dc3e8;
+    color: #FFF;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    margin-left: 0;
+  }
+}

--- a/packages/patternfly-react/sass/patternfly-react/_patternfly-react.scss
+++ b/packages/patternfly-react/sass/patternfly-react/_patternfly-react.scss
@@ -9,5 +9,6 @@
 @import 'notificationdrawer';
 @import 'inline-edit';
 @import 'field-level-help';
+@import 'tag';
 @import 'type-ahead-select';
 @import 'verticalnavdivider';

--- a/packages/patternfly-react/sass/patternfly-react/_tag.scss
+++ b/packages/patternfly-react/sass/patternfly-react/_tag.scss
@@ -1,0 +1,34 @@
+.tag-pair {
+  margin: 3px 2px 2px;
+  max-width: 100%;
+  float: left;
+  display: block;
+
+  .tag {
+    min-width: 50px;
+
+    &:first-child {
+      border-radius: 2px 0 0 2px;
+    }
+
+    &:last-child {
+      border-radius: 0 2px 2px 0;
+    }
+  }
+
+  .tag-key {
+    background-color: #bee1f4;
+    color: #00659c;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    margin-left: 0;
+  }
+
+  .tag-value {
+    background-color: #7dc3e8;
+    color: #fff;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    margin-left: 0;
+  }
+}

--- a/packages/patternfly-react/src/components/Tag/Tag.js
+++ b/packages/patternfly-react/src/components/Tag/Tag.js
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import Label from '../Label/Label';
+import PropTypes from 'prop-types';
+
+const Tag = ({ name, value }) => (
+  <span className="tag-pair">
+    <Label bsStyle="primary" className="tag-key">
+      {name}
+    </Label>
+    <Label bsStyle="primary" className="tag-value">
+      {value || ''}
+    </Label>
+  </span>
+);
+
+Tag.propTypes = {
+  /** Label name */
+  name: PropTypes.string,
+  /** Label value  */
+  value: PropTypes.string
+};
+
+Tag.defaultProps = {
+  name: '',
+  value: ''
+};
+
+export default Tag;

--- a/packages/patternfly-react/src/components/Tag/Tag.stories.js
+++ b/packages/patternfly-react/src/components/Tag/Tag.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+import { defaultTemplate } from 'storybook/decorators/storyTemplates';
+import {
+  storybookPackageName,
+  STORYBOOK_CATEGORY
+} from 'storybook/constants/siteConstants';
+import { Tag } from '../../index';
+import { name } from '../../../package.json';
+
+const stories = storiesOf(
+  `${storybookPackageName(name)}/${STORYBOOK_CATEGORY.WIDGETS}/Tags`,
+  module
+);
+const description = <p>No description.</p>;
+stories.addDecorator(withKnobs);
+stories.addDecorator(
+  defaultTemplate({
+    title: 'Tag',
+    description
+  })
+);
+
+stories.add(
+  'PatternFly Tag',
+  withInfo()(() => <Tag name="Patternfly-react version" value="2.10" />)
+);

--- a/packages/patternfly-react/src/components/Tag/Tag.test.js
+++ b/packages/patternfly-react/src/components/Tag/Tag.test.js
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Tag } from './index';
+
+describe('#Tag render correctly with data', () => {
+  it('should render tag', () => {
+    const key = 'Patternfly-react version';
+    const value = '2.10';
+    const wrapper = shallow(<Tag value={value} name={key} />);
+
+    expect(wrapper).toBeDefined();
+    expect(wrapper).toMatchSnapshot();
+
+    expect(wrapper.name()).toEqual('span');
+    expect(wrapper.props().className).toEqual('tag-pair');
+
+    const labelKey = wrapper.find('Label').getElements()[0];
+    const labelValue = wrapper.find('Label').getElements()[1];
+    expect(labelKey.props.className).toEqual('tag-key');
+    expect(labelValue.props.className).toEqual('tag-value');
+
+    expect(labelKey.props.children).toEqual(key);
+    expect(labelValue.props.children).toEqual(value);
+  });
+});

--- a/packages/patternfly-react/src/components/Tag/__snapshots__/Tag.test.js.snap
+++ b/packages/patternfly-react/src/components/Tag/__snapshots__/Tag.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#Tag render correctly with data should render tag 1`] = `
+<span
+  className="tag-pair"
+>
+  <Label
+    bsStyle="primary"
+    className="tag-key"
+    type="default"
+  >
+    Patternfly-react version
+  </Label>
+  <Label
+    bsStyle="primary"
+    className="tag-value"
+    type="default"
+  >
+    2.10
+  </Label>
+</span>
+`;

--- a/packages/patternfly-react/src/components/Tag/index.js
+++ b/packages/patternfly-react/src/components/Tag/index.js
@@ -1,0 +1,1 @@
+export { default as Tag } from './Tag';

--- a/packages/patternfly-react/src/index.js
+++ b/packages/patternfly-react/src/index.js
@@ -35,6 +35,7 @@ export * from './components/Sort';
 export * from './components/Slider';
 export * from './components/Spinner';
 export * from './components/Switch';
+export * from './components/Tag';
 export * from './components/Tabs';
 export * from './components/Table';
 export * from './components/ToastNotification';


### PR DESCRIPTION
affects: patternfly-react

based in : 
![41593083-280e2154-73bf-11e8-992e-1204e8d0028a](https://user-images.githubusercontent.com/3019213/42134201-dfef05a6-7d36-11e8-9182-65f8d8358a58.png)

**widgets/tag**
storybook: [here](https://rawgit.com/aljesusg/patternfly-react/tag_label_sortybook/index.html)

@serenamarie125 @jgiardino @jeff-phillips-18 I called the component tag because the CompoundLabel of issue https://github.com/patternfly/patternfly-react/issues/401 is different