### PR TITLE
fix link to patternfly-react.scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import { Alert } from 'patternfly-react'
 
 ## Using patterfly-react Sass files
 
-As an alernative to consuming the `patternfly-react.css` file (found in `dist/css`), you can build patternfly-react styles into your css by including the Sass partials from `dist/sass`. The partial `_patternfly-react.scss` will pull in all the partials required for the patternfly-react components. When using the patternfly-react Sass files, you **MUST** include bootstrap and patternfly variables and mixins. An example of the required imports can be found in [patternfly-react.scss](./packages/core/sass/patternfly-react.scss).
+As an alernative to consuming the `patternfly-react.css` file (found in `dist/css`), you can build patternfly-react styles into your css by including the Sass partials from `dist/sass`. The partial `_patternfly-react.scss` will pull in all the partials required for the patternfly-react components. When using the patternfly-react Sass files, you **MUST** include bootstrap and patternfly variables and mixins. An example of the required imports can be found in [patternfly-react.scss](./packages/patternfly-react/sass/patternfly-react.scss).
 
 ## Node Environment
 


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**: Fix broken link in README.md

The change can be seen here: https://github.com/tomer/patternfly-react/blob/patch-1/README.md#using-patterfly-react-sass-files ; the link at the end of the paragraph should be clickable.
