### PR TITLE
fix(react-docs/navigation): change how navigation links are generated

### DIFF
--- a/packages/react-docs/gatsby-node.js
+++ b/packages/react-docs/gatsby-node.js
@@ -1,4 +1,5 @@
 const path = require(`path`);
+const pascalCase = require('pascal-case');
 
 exports.modifyWebpackConfig = ({ config, stage }) => {
   const oldCSSLoader = config._loaders.css;
@@ -41,4 +42,22 @@ exports.modifyWebpackConfig = ({ config, stage }) => {
   });
 
   return config;
+};
+
+const componentPathRegEx = /components\//;
+
+exports.onCreateNode = ({ node, boundActionCreators }) => {
+  const { createNodeField } = boundActionCreators;
+  if (node.internal.type === 'SitePage' && componentPathRegEx.test(node.path)) {
+    const pathLabel = node.path
+      .split('/')
+      .filter(Boolean)
+      .pop();
+
+    createNodeField({
+      node,
+      name: 'label',
+      value: pascalCase(pathLabel)
+    });
+  }
 };

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -18,6 +18,7 @@
     "gatsby-plugin-react-next": "^1.0.11",
     "gatsby-source-filesystem": "^1.5.36",
     "gatsby-transformer-react-docgen": "^1.0.17",
+    "pascal-case": "^2.0.1",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",

--- a/packages/react-docs/src/components/navigation/navigation.js
+++ b/packages/react-docs/src/components/navigation/navigation.js
@@ -9,15 +9,16 @@ import NavigationItem from './navigationItem';
 import ValueToggle from '../valueToggle';
 
 const propTypes = {
-  components: PropTypes.arrayOf(
+  componentRoutes: PropTypes.arrayOf(
     PropTypes.shape({
-      displayName: PropTypes.string.isRequired
+      to: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired
     })
   )
 };
 
 const defaultProps = {
-  components: []
+  componentRoutes: []
 };
 class Navigation extends React.Component {
   static propTypes = propTypes;
@@ -34,12 +35,12 @@ class Navigation extends React.Component {
   };
 
   render() {
-    const { components } = this.props;
+    const { componentRoutes } = this.props;
     const { searchValue } = this.state;
     const searchRE = new RegExp(searchValue, 'i');
 
-    const filteredComponents = components.filter(c =>
-      searchRE.test(c.displayName)
+    const filteredComponentRoutes = componentRoutes.filter(c =>
+      searchRE.test(c.label)
     );
 
     return (
@@ -77,12 +78,9 @@ class Navigation extends React.Component {
                 onToggleExpand={toggle}
                 title="Components"
               >
-                {filteredComponents.map(comp => (
-                  <NavigationItem
-                    key={comp.displayName}
-                    to={`/components/${comp.displayName}`}
-                  >
-                    {comp.displayName}
+                {filteredComponentRoutes.map(route => (
+                  <NavigationItem key={route.label} to={route.to}>
+                    {route.label}
                   </NavigationItem>
                 ))}
               </NavigationItemGroup>

--- a/packages/react-docs/src/layouts/index.js
+++ b/packages/react-docs/src/layouts/index.js
@@ -13,37 +13,43 @@ const propTypes = {
   data: PropTypes.any.isRequired
 };
 
-const Layout = ({ children, data }) => (
-  <React.Fragment>
-    <Helmet
-      meta={[
-        { name: 'description', content: 'Sample' },
-        { name: 'keywords', content: 'sample, something' }
-      ]}
-    />
-    <Page
-      title="Patternfly React"
-      navigation={
-        <Navigation
-          components={data.allComponentMetadata.edges.map(e => e.node)}
-        />
-      }
-    >
-      {children()}
-    </Page>
-  </React.Fragment>
-);
+const Layout = ({ children, data }) => {
+  const componentRoutes = data.componentPages.edges.map(e => ({
+    to: e.node.path,
+    label: e.node.fields.label
+  }));
+
+  return (
+    <React.Fragment>
+      <Helmet
+        meta={[
+          { name: 'description', content: 'PatternFly React Documentation' },
+          { name: 'keywords', content: 'React, PatternFly, Red Hat' }
+        ]}
+      />
+      <Page
+        title="Patternfly React"
+        navigation={<Navigation componentRoutes={componentRoutes} />}
+      >
+        {children()}
+      </Page>
+    </React.Fragment>
+  );
+};
 
 Layout.propTypes = propTypes;
 
 export default Layout;
 
 export const query = graphql`
-  query SiteTitleQuery {
-    allComponentMetadata(sort: { fields: [displayName], order: ASC }) {
+  query SiteLayoutQuery {
+    componentPages: allSitePage(filter: { path: { regex: "/components/" } }) {
       edges {
         node {
-          displayName
+          path
+          fields {
+            label
+          }
         }
       }
     }

--- a/packages/react-styles/package.json
+++ b/packages/react-styles/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@babel/helper-plugin-utils": "^7.0.0-beta.48",
     "aphrodite": "^2.2.1",
-    "camelcase": "^5.0.0",
+    "camel-case": "^3.0.0",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "jsdom": "^11.11.0",

--- a/packages/react-styles/src/utils.js
+++ b/packages/react-styles/src/utils.js
@@ -1,4 +1,4 @@
-import camelcase from 'camelcase';
+import camelcase from 'camel-case';
 import { inject } from './inject';
 
 export function isValidStyleDeclaration(styleObj) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10888,7 +10888,7 @@ parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
-pascal-case@^2.0.0:
+pascal-case@^2.0.0, pascal-case@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-2.0.1.tgz#2d578d3455f660da65eca18ef95b4e0de912761e"
   dependencies:


### PR DESCRIPTION
affects: @patternfly/react-docs, @patternfly/react-styles

Change how navigation links are generated so that secondary components do not have links generated.
