### PR TITLE
fix(masthead dropdown): update patternfly dependency and masthead tweak

### DIFF
--- a/packages/patternfly-react/package.json
+++ b/packages/patternfly-react/package.json
@@ -28,7 +28,7 @@
     "breakjs": "^1.0.0",
     "classnames": "^2.2.5",
     "css-element-queries": "^1.0.1",
-    "patternfly": "^3.51.0",
+    "patternfly": "^3.52.1",
     "react-bootstrap": "^0.32.1",
     "react-bootstrap-switch": "^15.5.3",
     "react-bootstrap-typeahead": "^3.1.3",

--- a/packages/patternfly-react/src/components/Masthead/InnerComponents/CustomMastheadDropdown.js
+++ b/packages/patternfly-react/src/components/Masthead/InnerComponents/CustomMastheadDropdown.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Custom Masthead Dropdown
+ */
+const CustomMastheadDropdown = ({ className, children }) => (
+  <li className={className}>{children}</li>
+);
+
+CustomMastheadDropdown.propTypes = {
+  /** Additional element css classes */
+  className: PropTypes.string,
+  /** Children elements */
+  children: PropTypes.node
+};
+
+CustomMastheadDropdown.defaultProps = {
+  className: '',
+  children: null
+};
+
+export default CustomMastheadDropdown;

--- a/packages/patternfly-react/src/components/Masthead/Masthead.stories.js
+++ b/packages/patternfly-react/src/components/Masthead/Masthead.stories.js
@@ -4,6 +4,7 @@ import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
 
+import { Icon } from '../Icon';
 import { MenuItem } from '../../index';
 import { Masthead } from './index';
 
@@ -65,6 +66,7 @@ stories.add(
       <Masthead.Collapse>
         <Masthead.Dropdown
           id="app-help-dropdown"
+          noCaret
           title={<span title="Help" className="pficon pficon-help" />}
         >
           <MenuItem eventKey="1">Help</MenuItem>
@@ -72,12 +74,12 @@ stories.add(
         </Masthead.Dropdown>
         <Masthead.Dropdown
           id="app-user-dropdown"
-          title={
-            <span>
-              <span title="Help" className="pficon pficon-user" />
-              <span className="dropdown-title"> Brian Johnson</span>
+          title={[
+            <Icon type="pf" name="user" key="user-icon" />,
+            <span className="dropdown-title" key="dropdown-title">
+              Brian Johnson
             </span>
-          }
+          ]}
         >
           <MenuItem eventKey="1">User Preferences</MenuItem>
           <MenuItem eventKey="2">Logout</MenuItem>

--- a/packages/patternfly-react/src/components/Masthead/Masthead.test.js
+++ b/packages/patternfly-react/src/components/Masthead/Masthead.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { MenuItem } from '../../index';
 import { Masthead } from './index';
+import CustomMastheadDropdown from './InnerComponents/CustomMastheadDropdown';
 
 test('Masthead renders properly', () => {
   const onNavToggleMock = jest.fn();
@@ -126,4 +127,13 @@ test('MastheadDropdown renders properly', () => {
     </Masthead.Dropdown>
   );
   expect(component).toMatchSnapshot('MastheadDropdown snapshot');
+});
+
+test('CustomMastheadDropdown renders properly', () => {
+  const component = shallow(
+    <CustomMastheadDropdown className="dropdown">
+      children
+    </CustomMastheadDropdown>
+  );
+  expect(component).toMatchSnapshot('CustomMastheadDropdown snapshot');
 });

--- a/packages/patternfly-react/src/components/Masthead/MastheadDropdown.js
+++ b/packages/patternfly-react/src/components/Masthead/MastheadDropdown.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown } from '../Dropdown';
+import CustomMastheadDropdown from './InnerComponents/CustomMastheadDropdown';
 
 /**
  * Masthead
@@ -12,29 +13,23 @@ const MastheadDropdown = ({
   noCaret,
   children,
   ...props
-}) => {
-  const dropdownComponentClass = dropdownProps => (
-    <li className={dropdownProps.className}>{dropdownProps.children}</li>
-  );
-
-  return (
-    <Dropdown
-      id={id}
-      componentClass={dropdownComponentClass}
-      className={className}
-      {...props}
+}) => (
+  <Dropdown
+    id={id}
+    componentClass={CustomMastheadDropdown}
+    className={className}
+    {...props}
+  >
+    <Dropdown.Toggle
+      className="nav-item-iconic"
+      bsStyle="link"
+      noCaret={noCaret}
     >
-      <Dropdown.Toggle
-        className="nav-item-iconic"
-        bsStyle="link"
-        noCaret={noCaret}
-      >
-        {title}
-      </Dropdown.Toggle>
-      <Dropdown.Menu>{children}</Dropdown.Menu>
-    </Dropdown>
-  );
-};
+      {title}
+    </Dropdown.Toggle>
+    <Dropdown.Menu>{children}</Dropdown.Menu>
+  </Dropdown>
+);
 
 MastheadDropdown.propTypes = {
   /** Additional element css classes */
@@ -51,7 +46,7 @@ MastheadDropdown.propTypes = {
 
 MastheadDropdown.defaultProps = {
   className: '',
-  title: '',
+  title: null,
   children: null,
   noCaret: false
 };

--- a/packages/patternfly-react/src/components/Masthead/__snapshots__/Masthead.test.js.snap
+++ b/packages/patternfly-react/src/components/Masthead/__snapshots__/Masthead.test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CustomMastheadDropdown renders properly: CustomMastheadDropdown snapshot 1`] = `
+<li
+  className="dropdown"
+>
+  children
+</li>
+`;
+
 exports[`Masthead renders properly: Masthead snapshot 1`] = `
 <nav
   className="navbar navbar-pf-vertical"

--- a/packages/react-console/package.json
+++ b/packages/react-console/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@novnc/novnc": "^1.0.0",
     "classnames": "^2.2.5",
-    "patternfly": "^3.51.0",
+    "patternfly": "^3.52.1",
     "patternfly-react": "^2.10.0",
     "xterm": "^3.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11001,9 +11001,9 @@ patternfly-bootstrap-treeview@~2.1.0:
     bootstrap "3.3.x"
     jquery ">= 2.1.x"
 
-patternfly@^3.51.0:
-  version "3.51.0"
-  resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.51.0.tgz#210deac861e0734927fb5d61d7353a5a40d9c0ff"
+patternfly@^3.52.1:
+  version "3.52.1"
+  resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.52.1.tgz#0c6f067ec987f4f16b93acb54e8f7de02300eead"
   dependencies:
     bootstrap "~3.3.7"
     font-awesome "^4.7.0"


### PR DESCRIPTION
affects: patternfly-react, @patternfly/react-console

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Updates patternfly dependency to 3.52.1 and tweaks MastHead Dropdown component.

We need this upgrade to include the Sass for navbar icon. See [1084](https://github.com/patternfly/patternfly/pull/1084)

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
https://priley86.github.io/patternfly-react/?knob-Nav%20Toggle=true&selectedKind=patternfly-react%2FApplication%20Framework%2FMasthead&selectedStory=Vertical%20Menu&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
fixes #462 

<!-- feel free to add additional comments -->