### PR TITLE
feat(CompoundLabel) Add CompoundLabel component

### DIFF
--- a/packages/patternfly-react/less/compound-label.less
+++ b/packages/patternfly-react/less/compound-label.less
@@ -1,25 +1,3 @@
-.compound-label-pf.compound-label-pf-text-color.pf-remove-button {
-  color: $color-pf-white;
-  vertical-align: middle;
-}
-
-.compound-label-pf {
-  font-size: 0.8em;
-  display: table-cell !important;
-  vertical-align: middle;
-
-  span {
-    background-color: $color-pf-blue-400;
-  }
-}
-
-.compound-label-pf-text-color {
-  color: $color-pf-white;
-  .pf-remove-button {
-    vertical-align: middle;
-  }
-}
-
 .category.list-inline {
   background-color: $color-pf-blue-500;
   padding: 3px 10px 3px 15px;
@@ -29,11 +7,26 @@
   margin-bottom: 5px;
   font-size: 14px;
   line-height: 24px;
-  display: table;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
   float: left;
 
+  li.value {
+    font-size: 0.8em;
+    display: table-cell;
+    vertical-align: middle;
+    span {
+      background-color: $color-pf-blue-400;
+    }
+  }
   li a span {
     color: $color-pf-white;
+    .pf-remove-button {
+      color: $color-pf-white;
+      vertical-align: middle;
+    }
   }
 }
 

--- a/packages/patternfly-react/less/compound-label.less
+++ b/packages/patternfly-react/less/compound-label.less
@@ -5,14 +5,12 @@
   color: $color-pf-white;
   margin-left: 5px;
   margin-right: 10px;
-  margin-bottom: 5px;
   font-size: 14px;
   display: inline-block;
   margin-bottom: .5em;
   // for wrapping:
   white-space: normal;
   text-align: left;
-  float: left;
 
   .list-inline {
     margin-bottom: 0;

--- a/packages/patternfly-react/less/compound-label.less
+++ b/packages/patternfly-react/less/compound-label.less
@@ -1,35 +1,43 @@
-.category.list-inline {
+.compound-label-pf {
   background-color: $color-pf-blue-500;
-  padding: 3px 10px 3px 15px;
+  padding-left: 15px;
+  padding-right: 15px;
   color: $color-pf-white;
   margin-left: 5px;
   margin-right: 10px;
   margin-bottom: 5px;
   font-size: 14px;
-  line-height: 24px;
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
+  display: inline-block;
+  margin-bottom: .5em;
+  // for wrapping:
+  white-space: normal;
+  text-align: left;
   float: left;
 
-  li.value {
-    font-size: 0.8em;
-    display: table-cell;
-    vertical-align: middle;
-    span {
-      background-color: $color-pf-blue-400;
-    }
+  .list-inline {
+    margin-bottom: 0;
   }
-  li a span {
-    color: $color-pf-white;
-    .pf-remove-button {
-      color: $color-pf-white;
-      vertical-align: middle;
+
+  .label {
+    display: inline-block;
+    font-size: 0.8em;
+    vertical-align: middle;
+    }
+
+  .list-inline {
+    display: inline-block;
+    &>li {
+      margin-top: .1em; // added for case when wrapping
+      margin-bottom: .1em; // added for case when wrapping
     }
   }
 }
 
-.category-label {
+.category-label-pf {
   padding-right: 15px;
+  vertical-align: text-bottom;
+}
+
+.compound-label-inner-color-pf {
+  background-color: $color-pf-blue-400;
 }

--- a/packages/patternfly-react/less/compound-label.less
+++ b/packages/patternfly-react/less/compound-label.less
@@ -1,11 +1,9 @@
-@import 'patternfly/variables';
-
-.pf-remove-button {
+.compound-label-pf.compound-label-pf-text-color.pf-remove-button {
   color: $color-pf-white;
   vertical-align: middle;
 }
 
-.tag {
+.compound-label-pf {
   font-size: 0.8em;
   display: table-cell !important;
   vertical-align: middle;
@@ -15,13 +13,16 @@
   }
 }
 
-.tagColor {
+.compound-label-pf-text-color {
   color: $color-pf-white;
+  .pf-remove-button {
+    vertical-align: middle;
+  }
 }
 
 .category.list-inline {
   background-color: $color-pf-blue-500;
-  padding: 3px 10px 3px 15px !important;
+  padding: 3px 10px 3px 15px;
   color: $color-pf-white;
   margin-left: 5px;
   margin-right: 10px;
@@ -38,5 +39,4 @@
 
 .category-label {
   padding-right: 15px;
-  max-width: 50px;
 }

--- a/packages/patternfly-react/less/compound-label.less
+++ b/packages/patternfly-react/less/compound-label.less
@@ -1,0 +1,42 @@
+@import 'patternfly/variables';
+
+.pf-remove-button {
+  color: $color-pf-white;
+  vertical-align: middle;
+}
+
+.tag {
+  font-size: 0.8em;
+  display: table-cell !important;
+  vertical-align: middle;
+
+  span {
+    background-color: $color-pf-blue-400;
+  }
+}
+
+.tagColor {
+  color: $color-pf-white;
+}
+
+.category.list-inline {
+  background-color: $color-pf-blue-500;
+  padding: 3px 10px 3px 15px !important;
+  color: $color-pf-white;
+  margin-left: 5px;
+  margin-right: 10px;
+  margin-bottom: 5px;
+  font-size: 14px;
+  line-height: 24px;
+  display: table;
+  float: left;
+
+  li a span {
+    color: $color-pf-white;
+  }
+}
+
+.category-label {
+  padding-right: 15px;
+  max-width: 50px;
+}

--- a/packages/patternfly-react/sass/patternfly-react.scss
+++ b/packages/patternfly-react/sass/patternfly-react.scss
@@ -20,3 +20,4 @@ $icon-font-path: '~patternfly/dist/fonts/';
 */
 
 @import 'patternfly-react/patternfly-react';
+@import 'patternfly-react/compound-label';

--- a/packages/patternfly-react/sass/patternfly-react/_compound-label.scss
+++ b/packages/patternfly-react/sass/patternfly-react/_compound-label.scss
@@ -1,38 +1,44 @@
-.category.list-inline {
+.compound-label-pf {
   background-color: $color-pf-blue-500;
-  padding: 3px 10px 3px 15px;
+  padding-left: 15px;
+  padding-right: 15px;
   color: $color-pf-white;
   margin-left: 5px;
   margin-right: 10px;
   margin-bottom: 5px;
   font-size: 14px;
-  line-height: 24px;
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
+  display: inline-block;
+  margin-bottom: 0.5em;
+  // for wrapping:
+  white-space: normal;
+  text-align: left;
   float: left;
 
-  li.value {
-    font-size: 0.8em;
-    display: table-cell;
-    vertical-align: middle;
-
-    span {
-      background-color: $color-pf-blue-400;
-    }
+  .list-inline {
+    margin-bottom: 0;
   }
 
-  li a span {
-    color: $color-pf-white;
+  .label {
+    display: inline-block;
+    font-size: 0.8em;
+    vertical-align: middle;
+  }
 
-    .pf-remove-button {
-      color: $color-pf-white;
-      vertical-align: middle;
+  .list-inline {
+    display: inline-block;
+
+    &>li {
+      margin-top: 0.1em; // added for case when wrapping
+      margin-bottom: 0.1em; // added for case when wrapping
     }
   }
 }
 
-.category-label {
+.category-label-pf {
   padding-right: 15px;
+  vertical-align: text-bottom;
+}
+
+.compound-label-inner-color-pf {
+  background-color: $color-pf-blue-400;
 }

--- a/packages/patternfly-react/sass/patternfly-react/_compound-label.scss
+++ b/packages/patternfly-react/sass/patternfly-react/_compound-label.scss
@@ -1,0 +1,43 @@
+@import 'patternfly/variables';
+
+.pf-remove-button {
+  color: $color-pf-white;
+  vertical-align: middle;
+}
+
+.tag {
+  font-size: 0.8em;
+  display: table-cell !important;
+  vertical-align: middle;
+
+  span {
+    background-color: $color-pf-blue-400;
+  }
+}
+
+.tagColor {
+  color: $color-pf-white;
+  max-width: 150px;
+}
+
+.category.list-inline {
+  background-color: $color-pf-blue-500;
+  padding: 3px 10px 3px 15px !important;
+  color: $color-pf-white;
+  margin-left: 5px;
+  margin-right: 10px;
+  margin-bottom: 5px;
+  font-size: 14px;
+  line-height: 24px;
+  display: table;
+  float: left;
+
+  li a span {
+    color: $color-pf-white;
+  }
+}
+
+.category-label {
+  padding-right: 15px;
+  max-width: 200px;
+}

--- a/packages/patternfly-react/sass/patternfly-react/_compound-label.scss
+++ b/packages/patternfly-react/sass/patternfly-react/_compound-label.scss
@@ -1,21 +1,3 @@
-.compound-label-pf {
-  font-size: 0.8em;
-  display: table-cell !important;
-  vertical-align: middle;
-
-  span {
-    background-color: $color-pf-blue-400;
-  }
-}
-
-.compound-label-pf-text-color {
-  color: $color-pf-white;
-
-  .pf-remove-button {
-    vertical-align: middle;
-  }
-}
-
 .category.list-inline {
   background-color: $color-pf-blue-500;
   padding: 3px 10px 3px 15px;
@@ -25,11 +7,29 @@
   margin-bottom: 5px;
   font-size: 14px;
   line-height: 24px;
-  display: table;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   float: left;
+
+  li.value {
+    font-size: 0.8em;
+    display: table-cell;
+    vertical-align: middle;
+
+    span {
+      background-color: $color-pf-blue-400;
+    }
+  }
 
   li a span {
     color: $color-pf-white;
+
+    .pf-remove-button {
+      color: $color-pf-white;
+      vertical-align: middle;
+    }
   }
 }
 

--- a/packages/patternfly-react/sass/patternfly-react/_compound-label.scss
+++ b/packages/patternfly-react/sass/patternfly-react/_compound-label.scss
@@ -5,14 +5,12 @@
   color: $color-pf-white;
   margin-left: 5px;
   margin-right: 10px;
-  margin-bottom: 5px;
   font-size: 14px;
   display: inline-block;
   margin-bottom: 0.5em;
   // for wrapping:
   white-space: normal;
   text-align: left;
-  float: left;
 
   .list-inline {
     margin-bottom: 0;

--- a/packages/patternfly-react/sass/patternfly-react/_compound-label.scss
+++ b/packages/patternfly-react/sass/patternfly-react/_compound-label.scss
@@ -1,11 +1,4 @@
-@import 'patternfly/variables';
-
-.pf-remove-button {
-  color: $color-pf-white;
-  vertical-align: middle;
-}
-
-.tag {
+.compound-label-pf {
   font-size: 0.8em;
   display: table-cell !important;
   vertical-align: middle;
@@ -15,14 +8,17 @@
   }
 }
 
-.tagColor {
+.compound-label-pf-text-color {
   color: $color-pf-white;
-  max-width: 150px;
+
+  .pf-remove-button {
+    vertical-align: middle;
+  }
 }
 
 .category.list-inline {
   background-color: $color-pf-blue-500;
-  padding: 3px 10px 3px 15px !important;
+  padding: 3px 10px 3px 15px;
   color: $color-pf-white;
   margin-left: 5px;
   margin-right: 10px;
@@ -39,5 +35,4 @@
 
 .category-label {
   padding-right: 15px;
-  max-width: 200px;
 }

--- a/packages/patternfly-react/src/components/Label/CompoundLabel.js
+++ b/packages/patternfly-react/src/components/Label/CompoundLabel.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip } from '../Tooltip';
+import { OverlayTrigger } from '../OverlayTrigger';
+import LabelWithTooltip from './LabelWithTooltip';
+
+class CompoundLabel extends React.Component {
+  generateTag = value => (
+    <LabelWithTooltip
+      key={value.id}
+      category={this.props.category}
+      value={value}
+      onDeleteClick={this.props.onDeleteClick}
+      truncate={this.props.valueTruncate}
+    />
+  );
+
+  render() {
+    const values = [...this.props.values];
+    if (values.length === 0) return <div />;
+    const categoryTooltip = (
+      <Tooltip id="tooltip">{this.props.category.label}</Tooltip>
+    );
+    return (
+      <ul className="category list-inline">
+        <OverlayTrigger placement="bottom" overlay={categoryTooltip}>
+          <div className="category-label">
+            {this.props.categoryTruncate(this.props.category.label)}
+          </div>
+        </OverlayTrigger>
+        {values
+          .sort((a, b) => (a.label < b.label ? -1 : 1))
+          .map(tagValue => this.generateTag(tagValue))}
+      </ul>
+    );
+  }
+}
+
+CompoundLabel.propTypes = {
+  category: PropTypes.shape({
+    id: PropTypes.any.isRequired,
+    label: PropTypes.string.isRequired
+  }).isRequired,
+  values: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.any.isRequired,
+      label: PropTypes.string.isRequired
+    }).isRequired
+  ).isRequired,
+  onDeleteClick: PropTypes.func.isRequired,
+  categoryTruncate: PropTypes.func,
+  valueTruncate: PropTypes.func
+};
+
+CompoundLabel.defaultProps = {
+  categoryTruncate: str =>
+    str.length > 18 ? `${str.substring(0, 18)}...` : str,
+  valueTruncate: str => (str.length > 18 ? `${str.substring(0, 18)}...` : str)
+};
+
+export default CompoundLabel;

--- a/packages/patternfly-react/src/components/Label/CompoundLabel.js
+++ b/packages/patternfly-react/src/components/Label/CompoundLabel.js
@@ -21,23 +21,14 @@ class CompoundLabel extends React.Component {
   render() {
     const values = [...this.props.values];
     if (values.length === 0) return null;
-    const categoryTooltip = (
-      <Tooltip id="tooltip">{this.props.category.label}</Tooltip>
-    );
+    const categoryTooltip = <Tooltip id="tooltip">{this.props.category.label}</Tooltip>;
     return (
       <span className="label label-primary compound-label-pf">
-        <OverlayTrigger
-          placement={this.props.overlayPlacement}
-          overlay={categoryTooltip}
-        >
-          <span className="category-label-pf">
-            {this.props.categoryTruncate(this.props.category.label)}
-          </span>
+        <OverlayTrigger placement={this.props.overlayPlacement} overlay={categoryTooltip}>
+          <span className="category-label-pf">{this.props.categoryTruncate(this.props.category.label)}</span>
         </OverlayTrigger>
         <ul className={`list-inline ${this.props.className}`}>
-          {values
-            .sort((a, b) => (a.label < b.label ? -1 : 1))
-            .map(tagValue => this.generateTag(tagValue))}
+          {values.sort((a, b) => (a.label < b.label ? -1 : 1)).map(tagValue => this.generateTag(tagValue))}
         </ul>
       </span>
     );
@@ -76,8 +67,7 @@ CompoundLabel.propTypes = {
 };
 
 CompoundLabel.defaultProps = {
-  categoryTruncate: str =>
-    str.length > 18 ? `${str.substring(0, 18)}...` : str,
+  categoryTruncate: str => (str.length > 18 ? `${str.substring(0, 18)}...` : str),
   valueTruncate: str => (str.length > 18 ? `${str.substring(0, 18)}...` : str),
   className: '',
   bsStyle: 'primary',

--- a/packages/patternfly-react/src/components/Label/CompoundLabel.js
+++ b/packages/patternfly-react/src/components/Label/CompoundLabel.js
@@ -14,6 +14,7 @@ class CompoundLabel extends React.Component {
       truncate={this.props.valueTruncate}
       bsStyle={this.props.bsStyle}
       className={this.props.innerClassName}
+      overlayPlacement={this.props.overlayPlacement}
     />
   );
 
@@ -25,7 +26,10 @@ class CompoundLabel extends React.Component {
     );
     return (
       <span className="label label-primary compound-label-pf">
-        <OverlayTrigger placement="bottom" overlay={categoryTooltip}>
+        <OverlayTrigger
+          placement={this.props.overlayPlacement}
+          overlay={categoryTooltip}
+        >
           <span className="category-label-pf">
             {this.props.categoryTruncate(this.props.category.label)}
           </span>
@@ -41,22 +45,34 @@ class CompoundLabel extends React.Component {
 }
 
 CompoundLabel.propTypes = {
+  /** Category in CATEGORY: value(s) pair */
+  /**  Parent of label, it does not get displayed in this component */
   category: PropTypes.shape({
     id: PropTypes.any.isRequired,
     label: PropTypes.string.isRequired
   }).isRequired,
+  /** Array of Values in Category:VALUE(S) pair  */
+  /** id uniquily identify value within its category, label is text which is displayed */
   values: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.any.isRequired,
       label: PropTypes.string.isRequired
     }).isRequired
   ).isRequired,
+  /** Fuction callback called when X button is clicked */
   onDeleteClick: PropTypes.func.isRequired,
+  /** Function used to truncate category label */
   categoryTruncate: PropTypes.func,
+  /** Function used to truncate value label */
   valueTruncate: PropTypes.func,
+  /** Name of CSS class(es) which are set to outer label */
   className: PropTypes.string,
+  /** Bootstrap style which is set to label */
   bsStyle: PropTypes.string,
-  innerClassName: PropTypes.string
+  /** Name of CSS class(es) which are set to inner label(s) */
+  innerClassName: PropTypes.string,
+  /** Placement of the overlay */
+  overlayPlacement: PropTypes.oneOf(['top', 'right', 'bottom', 'left'])
 };
 
 CompoundLabel.defaultProps = {
@@ -65,7 +81,8 @@ CompoundLabel.defaultProps = {
   valueTruncate: str => (str.length > 18 ? `${str.substring(0, 18)}...` : str),
   className: '',
   bsStyle: 'primary',
-  innerClassName: ''
+  innerClassName: '',
+  overlayPlacement: 'bottom'
 };
 
 export default CompoundLabel;

--- a/packages/patternfly-react/src/components/Label/CompoundLabel.js
+++ b/packages/patternfly-react/src/components/Label/CompoundLabel.js
@@ -13,7 +13,7 @@ class CompoundLabel extends React.Component {
       onDeleteClick={this.props.onDeleteClick}
       truncate={this.props.valueTruncate}
       bsStyle={this.props.bsStyle}
-      className={this.props.valueClassName}
+      className={this.props.innerClassName}
     />
   );
 
@@ -24,18 +24,18 @@ class CompoundLabel extends React.Component {
       <Tooltip id="tooltip">{this.props.category.label}</Tooltip>
     );
     return (
-      <ul className={`category list-inline ${this.props.className}`}>
-        <li key={this.props.category.id}>
-          <OverlayTrigger placement="bottom" overlay={categoryTooltip}>
-            <div className="category-label">
-              {this.props.categoryTruncate(this.props.category.label)}
-            </div>
-          </OverlayTrigger>
-        </li>
-        {values
-          .sort((a, b) => (a.label < b.label ? -1 : 1))
-          .map(tagValue => this.generateTag(tagValue))}
-      </ul>
+      <span className="label label-primary compound-label-pf">
+        <OverlayTrigger placement="bottom" overlay={categoryTooltip}>
+          <span className="category-label-pf">
+            {this.props.categoryTruncate(this.props.category.label)}
+          </span>
+        </OverlayTrigger>
+        <ul className={`list-inline ${this.props.className}`}>
+          {values
+            .sort((a, b) => (a.label < b.label ? -1 : 1))
+            .map(tagValue => this.generateTag(tagValue))}
+        </ul>
+      </span>
     );
   }
 }
@@ -56,7 +56,7 @@ CompoundLabel.propTypes = {
   valueTruncate: PropTypes.func,
   className: PropTypes.string,
   bsStyle: PropTypes.string,
-  valueClassName: PropTypes.string
+  innerClassName: PropTypes.string
 };
 
 CompoundLabel.defaultProps = {
@@ -65,7 +65,7 @@ CompoundLabel.defaultProps = {
   valueTruncate: str => (str.length > 18 ? `${str.substring(0, 18)}...` : str),
   className: '',
   bsStyle: 'primary',
-  valueClassName: ''
+  innerClassName: ''
 };
 
 export default CompoundLabel;

--- a/packages/patternfly-react/src/components/Label/CompoundLabel.js
+++ b/packages/patternfly-react/src/components/Label/CompoundLabel.js
@@ -17,12 +17,12 @@ class CompoundLabel extends React.Component {
 
   render() {
     const values = [...this.props.values];
-    if (values.length === 0) return <div />;
+    if (values.length === 0) return null;
     const categoryTooltip = (
       <Tooltip id="tooltip">{this.props.category.label}</Tooltip>
     );
     return (
-      <ul className="category list-inline">
+      <ul className={`category list-inline ${this.props.className}`}>
         <OverlayTrigger placement="bottom" overlay={categoryTooltip}>
           <div className="category-label">
             {this.props.categoryTruncate(this.props.category.label)}
@@ -37,25 +37,33 @@ class CompoundLabel extends React.Component {
 }
 
 CompoundLabel.propTypes = {
+  /** Category, the key part in key:values pair */
   category: PropTypes.shape({
     id: PropTypes.any.isRequired,
     label: PropTypes.string.isRequired
   }).isRequired,
+  /** Values, the values part in key:values pair */
   values: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.any.isRequired,
       label: PropTypes.string.isRequired
     }).isRequired
   ).isRequired,
+  /** Callback when remove button is clicked */
   onDeleteClick: PropTypes.func.isRequired,
+  /** Truncate function used for category label */
   categoryTruncate: PropTypes.func,
-  valueTruncate: PropTypes.func
+  /** Truncate function used for value label */
+  valueTruncate: PropTypes.func,
+  /** Used for asign additional css classes */
+  className: PropTypes.string
 };
 
 CompoundLabel.defaultProps = {
   categoryTruncate: str =>
     str.length > 18 ? `${str.substring(0, 18)}...` : str,
-  valueTruncate: str => (str.length > 18 ? `${str.substring(0, 18)}...` : str)
+  valueTruncate: str => (str.length > 18 ? `${str.substring(0, 18)}...` : str),
+  className: ''
 };
 
 export default CompoundLabel;

--- a/packages/patternfly-react/src/components/Label/CompoundLabel.js
+++ b/packages/patternfly-react/src/components/Label/CompoundLabel.js
@@ -12,22 +12,26 @@ class CompoundLabel extends React.Component {
       value={value}
       onDeleteClick={this.props.onDeleteClick}
       truncate={this.props.valueTruncate}
+      bsStyle={this.props.bsStyle}
+      className={this.props.valueClassName}
     />
   );
 
   render() {
     const values = [...this.props.values];
-    if (values.length === 0) return null;
+    if (values.length === 0) return <div />;
     const categoryTooltip = (
       <Tooltip id="tooltip">{this.props.category.label}</Tooltip>
     );
     return (
       <ul className={`category list-inline ${this.props.className}`}>
-        <OverlayTrigger placement="bottom" overlay={categoryTooltip}>
-          <div className="category-label">
-            {this.props.categoryTruncate(this.props.category.label)}
-          </div>
-        </OverlayTrigger>
+        <li key={this.props.category.id}>
+          <OverlayTrigger placement="bottom" overlay={categoryTooltip}>
+            <div className="category-label">
+              {this.props.categoryTruncate(this.props.category.label)}
+            </div>
+          </OverlayTrigger>
+        </li>
         {values
           .sort((a, b) => (a.label < b.label ? -1 : 1))
           .map(tagValue => this.generateTag(tagValue))}
@@ -37,33 +41,31 @@ class CompoundLabel extends React.Component {
 }
 
 CompoundLabel.propTypes = {
-  /** Category, the key part in key:values pair */
   category: PropTypes.shape({
     id: PropTypes.any.isRequired,
     label: PropTypes.string.isRequired
   }).isRequired,
-  /** Values, the values part in key:values pair */
   values: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.any.isRequired,
       label: PropTypes.string.isRequired
     }).isRequired
   ).isRequired,
-  /** Callback when remove button is clicked */
   onDeleteClick: PropTypes.func.isRequired,
-  /** Truncate function used for category label */
   categoryTruncate: PropTypes.func,
-  /** Truncate function used for value label */
   valueTruncate: PropTypes.func,
-  /** Used for asign additional css classes */
-  className: PropTypes.string
+  className: PropTypes.string,
+  bsStyle: PropTypes.string,
+  valueClassName: PropTypes.string
 };
 
 CompoundLabel.defaultProps = {
   categoryTruncate: str =>
     str.length > 18 ? `${str.substring(0, 18)}...` : str,
   valueTruncate: str => (str.length > 18 ? `${str.substring(0, 18)}...` : str),
-  className: ''
+  className: '',
+  bsStyle: 'primary',
+  valueClassName: ''
 };
 
 export default CompoundLabel;

--- a/packages/patternfly-react/src/components/Label/CompoundLabel.js
+++ b/packages/patternfly-react/src/components/Label/CompoundLabel.js
@@ -20,7 +20,7 @@ class CompoundLabel extends React.Component {
 
   render() {
     const values = [...this.props.values];
-    if (values.length === 0) return <div />;
+    if (values.length === 0) return null;
     const categoryTooltip = (
       <Tooltip id="tooltip">{this.props.category.label}</Tooltip>
     );

--- a/packages/patternfly-react/src/components/Label/CompoundLabel.test.js
+++ b/packages/patternfly-react/src/components/Label/CompoundLabel.test.js
@@ -15,12 +15,7 @@ const tag = {
 
 test('snapshot test', () => {
   const view = shallow(
-    <CompoundLabel
-      key={tag.id}
-      category={{ id: tag.id, label: tag.label }}
-      values={tag.values}
-      onDeleteClick={noop}
-    />
+    <CompoundLabel key={tag.id} category={{ id: tag.id, label: tag.label }} values={tag.values} onDeleteClick={noop} />
   );
   expect(view).toMatchSnapshot();
 });

--- a/packages/patternfly-react/src/components/Label/CompoundLabel.test.js
+++ b/packages/patternfly-react/src/components/Label/CompoundLabel.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import CompoundLabel from './CompoundLabel';
+import { noop } from '../../common/helpers';
+
+const tag = {
+  id: 1,
+  label: 'Food - category with very long description',
+  values: [
+    { id: 11, label: 'Cake' },
+    { id: 12, label: 'Bloody Steak from the famous Purple Cow' },
+    { id: 13, label: 'Pineapple Pizza' }
+  ]
+};
+
+test('snapshot test', () => {
+  const view = shallow(
+    <CompoundLabel
+      key={tag.id}
+      category={{ id: tag.id, label: tag.label }}
+      values={tag.values}
+      onDeleteClick={noop}
+    />
+  );
+  expect(view).toMatchSnapshot();
+});

--- a/packages/patternfly-react/src/components/Label/Label.stories.js
+++ b/packages/patternfly-react/src/components/Label/Label.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
-import { defaultTemplate } from 'storybook/decorators/storyTemplates';
+import { inlineTemplate } from 'storybook/decorators/storyTemplates';
 import {
   storybookPackageName,
   DOCUMENTATION_URL,
@@ -20,23 +20,28 @@ import { name } from '../../../package.json';
 
 const stories = storiesOf(`${storybookPackageName(name)}/${STORYBOOK_CATEGORY.WIDGETS}/Label`, module);
 
-stories.addDecorator(
-  defaultTemplate({
-    title: 'Label',
-    documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_WIDGETS}#labels`,
-    reactBootstrapDocumentationLink: `${DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT}label/`
-  })
-);
-
 stories.add(
   'Label',
-  withInfo()(() => (
-    <div>
-      <Label bsStyle="default">Default</Label> <Label bsStyle="primary">Primary</Label>{' '}
-      <Label bsStyle="success">Success</Label> <Label bsStyle="info">Info</Label>{' '}
-      <Label bsStyle="warning">Warning</Label> <Label bsStyle="danger">Danger</Label>
-    </div>
-  ))
+  withInfo()(() => {
+    const story = (
+      <div>
+        <Label bsStyle="default">Default</Label>{' '}
+        <Label bsStyle="primary">Primary</Label>{' '}
+        <Label bsStyle="success">Success</Label>{' '}
+        <Label bsStyle="info">Info</Label>{' '}
+        <Label bsStyle="warning">Warning</Label>{' '}
+        <Label bsStyle="danger">Danger</Label>
+      </div>
+    );
+    return inlineTemplate({
+      title: 'Label',
+      documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_WIDGETS}#labels`,
+      story,
+      reactBootstrapDocumentationLink: `${
+        DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT
+      }label/`
+    });
+  })
 );
 
 stories.add(
@@ -51,7 +56,17 @@ stories.add(
         <pre>{mockLabelRemoveSource}</pre>
       </div>
     )
-  })(() => <MockLabelRemove />)
+  })(() => {
+    const story = <MockLabelRemove />;
+    return inlineTemplate({
+      title: 'Label with Remove',
+      documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_WIDGETS}#labels`,
+      story,
+      reactBootstrapDocumentationLink: `${
+        DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT
+      }label/`
+    });
+  })
 );
 
 stories.add(
@@ -66,5 +81,22 @@ stories.add(
         <pre>{mockCompoundLabelSource}</pre>
       </div>
     )
-  })(() => <MockCompoundLabel />)
+  })(() => {
+    const story = <MockCompoundLabel />;
+    return inlineTemplate({
+      title: 'Compound Label',
+      documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_WIDGETS}#labels`,
+      story,
+      reactBootstrapDocumentationLink: `${
+        DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT
+      }label/`,
+      description: (
+        <div>
+          Compound label helps to visualize key/value or key/n:value component.
+          Delete - Clicking on “X” deletes the compound label. Tooltip - When a
+          compound label is truncated, we use labels to show the text.
+        </div>
+      )
+    });
+  })
 );

--- a/packages/patternfly-react/src/components/Label/Label.stories.js
+++ b/packages/patternfly-react/src/components/Label/Label.stories.js
@@ -2,20 +2,10 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { inlineTemplate } from 'storybook/decorators/storyTemplates';
-import {
-  storybookPackageName,
-  DOCUMENTATION_URL,
-  STORYBOOK_CATEGORY
-} from 'storybook/constants/siteConstants';
+import { storybookPackageName, DOCUMENTATION_URL, STORYBOOK_CATEGORY } from 'storybook/constants/siteConstants';
 import { Label, DisposableLabel, RemoveButton, CompoundLabel } from './index';
-import {
-  MockCompoundLabel,
-  mockCompoundLabelSource
-} from './__mocks__/mockCompoundLabel';
-import {
-  MockLabelRemove,
-  mockLabelRemoveSource
-} from './__mocks__/mockLabelExamples';
+import { MockCompoundLabel, mockCompoundLabelSource } from './__mocks__/mockCompoundLabel';
+import { MockLabelRemove, mockLabelRemoveSource } from './__mocks__/mockLabelExamples';
 import { name } from '../../../package.json';
 
 const stories = storiesOf(`${storybookPackageName(name)}/${STORYBOOK_CATEGORY.WIDGETS}/Label`, module);
@@ -25,21 +15,16 @@ stories.add(
   withInfo()(() => {
     const story = (
       <div>
-        <Label bsStyle="default">Default</Label>{' '}
-        <Label bsStyle="primary">Primary</Label>{' '}
-        <Label bsStyle="success">Success</Label>{' '}
-        <Label bsStyle="info">Info</Label>{' '}
-        <Label bsStyle="warning">Warning</Label>{' '}
-        <Label bsStyle="danger">Danger</Label>
+        <Label bsStyle="default">Default</Label> <Label bsStyle="primary">Primary</Label>{' '}
+        <Label bsStyle="success">Success</Label> <Label bsStyle="info">Info</Label>{' '}
+        <Label bsStyle="warning">Warning</Label> <Label bsStyle="danger">Danger</Label>
       </div>
     );
     return inlineTemplate({
       title: 'Label',
       documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_WIDGETS}#labels`,
       story,
-      reactBootstrapDocumentationLink: `${
-        DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT
-      }label/`
+      reactBootstrapDocumentationLink: `${DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT}label/`
     });
   })
 );
@@ -62,9 +47,7 @@ stories.add(
       title: 'Label with Remove',
       documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_WIDGETS}#labels`,
       story,
-      reactBootstrapDocumentationLink: `${
-        DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT
-      }label/`
+      reactBootstrapDocumentationLink: `${DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT}label/`
     });
   })
 );
@@ -87,14 +70,11 @@ stories.add(
       title: 'Compound Label',
       documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_WIDGETS}#labels`,
       story,
-      reactBootstrapDocumentationLink: `${
-        DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT
-      }label/`,
+      reactBootstrapDocumentationLink: `${DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT}label/`,
       description: (
         <div>
-          Compound label helps to visualize key/value or key/n:value component.
-          Delete - Clicking on “X” deletes the compound label. Tooltip - When a
-          compound label is truncated, we use labels to show the text.
+          Compound label helps to visualize key/value or key/n:value component. Delete - Clicking on “X” deletes the
+          compound label. Tooltip - When a compound label is truncated, we use labels to show the text.
         </div>
       )
     });

--- a/packages/patternfly-react/src/components/Label/Label.stories.js
+++ b/packages/patternfly-react/src/components/Label/Label.stories.js
@@ -41,7 +41,7 @@ stories.add(
 
 stories.add(
   'Label with Remove',
-  withInfo()(() => <MockLabelRemove />, {
+  withInfo({
     source: false,
     propTables: [DisposableLabel, RemoveButton],
     propTablesExclude: [MockLabelRemove],
@@ -51,12 +51,12 @@ stories.add(
         <pre>{mockLabelRemoveSource}</pre>
       </div>
     )
-  })
+  })(() => <MockLabelRemove />)
 );
 
 stories.add(
   'Compound Label',
-  withInfo()(() => <MockCompoundLabel />, {
+  withInfo({
     source: false,
     propTables: [CompoundLabel],
     propTablesExclude: [MockCompoundLabel],
@@ -66,5 +66,5 @@ stories.add(
         <pre>{mockCompoundLabelSource}</pre>
       </div>
     )
-  })
+  })(() => <MockCompoundLabel />)
 );

--- a/packages/patternfly-react/src/components/Label/Label.stories.js
+++ b/packages/patternfly-react/src/components/Label/Label.stories.js
@@ -2,9 +2,20 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
-import { storybookPackageName, DOCUMENTATION_URL, STORYBOOK_CATEGORY } from 'storybook/constants/siteConstants';
-import { Label, DisposableLabel, RemoveButton } from './index';
-import { MockLabelRemove, mockLabelRemoveSource } from './__mocks__/mockLabelExamples';
+import {
+  storybookPackageName,
+  DOCUMENTATION_URL,
+  STORYBOOK_CATEGORY
+} from 'storybook/constants/siteConstants';
+import { Label, DisposableLabel, RemoveButton, CompoundLabel } from './index';
+import {
+  MockCompoundLabel,
+  mockCompoundLabelSource
+} from './__mocks__/mockCompoundLabel';
+import {
+  MockLabelRemove,
+  mockLabelRemoveSource
+} from './__mocks__/mockLabelExamples';
 import { name } from '../../../package.json';
 
 const stories = storiesOf(`${storybookPackageName(name)}/${STORYBOOK_CATEGORY.WIDGETS}/Label`, module);
@@ -29,7 +40,7 @@ stories.add(
 );
 
 stories.add(
-  'Label with remove',
+  'Label with Remove',
   withInfo()(() => <MockLabelRemove />, {
     source: false,
     propTables: [DisposableLabel, RemoveButton],
@@ -38,6 +49,21 @@ stories.add(
       <div>
         <h1>Story Source</h1>
         <pre>{mockLabelRemoveSource}</pre>
+      </div>
+    )
+  })
+);
+
+stories.add(
+  'Compound Label',
+  withInfo()(() => <MockCompoundLabel />, {
+    source: false,
+    propTables: [CompoundLabel],
+    propTablesExclude: [MockCompoundLabel],
+    text: (
+      <div>
+        <h1>Story Source</h1>
+        <pre>{mockCompoundLabelSource}</pre>
       </div>
     )
   })

--- a/packages/patternfly-react/src/components/Label/LabelWithTooltip.js
+++ b/packages/patternfly-react/src/components/Label/LabelWithTooltip.js
@@ -7,13 +7,13 @@ import { Tooltip } from '../Tooltip';
 const tooltip = text => <Tooltip id="tooltip">{text}</Tooltip>;
 
 const LabelWithTooltip = ({ onDeleteClick, category, value, truncate }) => (
-  <li key={value.id} className="tag">
+  <li key={value.id} className="compound-label-pf">
     <OverlayTrigger placement="bottom" overlay={tooltip(value.label)}>
       <Label
         key={value.id}
         bsStyle="primary"
         onRemoveClick={() => onDeleteClick(category, value)}
-        className="tagColor"
+        className="compound-label-pf-text-color"
       >
         {truncate(value.label)}
       </Label>

--- a/packages/patternfly-react/src/components/Label/LabelWithTooltip.js
+++ b/packages/patternfly-react/src/components/Label/LabelWithTooltip.js
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { Label } from '../Label';
+import { OverlayTrigger } from '../OverlayTrigger';
+import { Tooltip } from '../Tooltip';
+
+const tooltip = text => <Tooltip id="tooltip">{text}</Tooltip>;
+
+const LabelWithTooltip = ({ onDeleteClick, category, value, truncate }) => (
+  <li key={value.id} className="tag">
+    <OverlayTrigger placement="bottom" overlay={tooltip(value.label)}>
+      <Label
+        key={value.id}
+        bsStyle="primary"
+        onRemoveClick={() => onDeleteClick(category, value)}
+        className="tagColor"
+      >
+        {truncate(value.label)}
+      </Label>
+    </OverlayTrigger>
+  </li>
+);
+
+LabelWithTooltip.propTypes = {
+  onDeleteClick: PropTypes.func.isRequired,
+  category: PropTypes.shape({
+    id: PropTypes.any.isRequired,
+    label: PropTypes.string.isRequired
+  }).isRequired,
+  value: PropTypes.PropTypes.shape({
+    id: PropTypes.any.isRequired,
+    label: PropTypes.string.isRequired
+  }).isRequired,
+  truncate: PropTypes.func.isRequired
+};
+
+export default LabelWithTooltip;

--- a/packages/patternfly-react/src/components/Label/LabelWithTooltip.js
+++ b/packages/patternfly-react/src/components/Label/LabelWithTooltip.js
@@ -6,15 +6,7 @@ import { Tooltip } from '../Tooltip';
 
 const tooltip = text => <Tooltip id="tooltip">{text}</Tooltip>;
 
-const LabelWithTooltip = ({
-  onDeleteClick,
-  category,
-  value,
-  truncate,
-  bsStyle,
-  className,
-  overlayPlacement
-}) => (
+const LabelWithTooltip = ({ onDeleteClick, category, value, truncate, bsStyle, className, overlayPlacement }) => (
   <li key={value.id}>
     <OverlayTrigger placement={overlayPlacement} overlay={tooltip(value.label)}>
       <Label

--- a/packages/patternfly-react/src/components/Label/LabelWithTooltip.js
+++ b/packages/patternfly-react/src/components/Label/LabelWithTooltip.js
@@ -6,14 +6,21 @@ import { Tooltip } from '../Tooltip';
 
 const tooltip = text => <Tooltip id="tooltip">{text}</Tooltip>;
 
-const LabelWithTooltip = ({ onDeleteClick, category, value, truncate }) => (
-  <li key={value.id} className="compound-label-pf">
+const LabelWithTooltip = ({
+  onDeleteClick,
+  category,
+  value,
+  truncate,
+  bsStyle,
+  className
+}) => (
+  <li key={value.id} className="value">
     <OverlayTrigger placement="bottom" overlay={tooltip(value.label)}>
       <Label
         key={value.id}
-        bsStyle="primary"
+        bsStyle={bsStyle}
         onRemoveClick={() => onDeleteClick(category, value)}
-        className="compound-label-pf-text-color"
+        className={`${className}`}
       >
         {truncate(value.label)}
       </Label>
@@ -31,7 +38,13 @@ LabelWithTooltip.propTypes = {
     id: PropTypes.any.isRequired,
     label: PropTypes.string.isRequired
   }).isRequired,
-  truncate: PropTypes.func.isRequired
+  truncate: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  bsStyle: PropTypes.string
 };
 
+LabelWithTooltip.defaultProps = {
+  className: '',
+  bsStyle: 'primary'
+};
 export default LabelWithTooltip;

--- a/packages/patternfly-react/src/components/Label/LabelWithTooltip.js
+++ b/packages/patternfly-react/src/components/Label/LabelWithTooltip.js
@@ -12,10 +12,11 @@ const LabelWithTooltip = ({
   value,
   truncate,
   bsStyle,
-  className
+  className,
+  overlayPlacement
 }) => (
   <li key={value.id}>
-    <OverlayTrigger placement="bottom" overlay={tooltip(value.label)}>
+    <OverlayTrigger placement={overlayPlacement} overlay={tooltip(value.label)}>
       <Label
         key={value.id}
         onRemoveClick={() => onDeleteClick(category, value)}
@@ -29,22 +30,33 @@ const LabelWithTooltip = ({
 );
 
 LabelWithTooltip.propTypes = {
+  /** Fuction callback called when X button is clicked */
   onDeleteClick: PropTypes.func.isRequired,
+  /** Category in CATEGORY: value(s) pair */
+  /**  Parent of label, it does not get displayed in this component */
   category: PropTypes.shape({
     id: PropTypes.any.isRequired,
     label: PropTypes.string.isRequired
   }).isRequired,
+  /** Individual Value in Category:VALUE(s) pair  */
+  /** id uniquily identify value within its category, label is text which is displayed */
   value: PropTypes.PropTypes.shape({
     id: PropTypes.any.isRequired,
     label: PropTypes.string.isRequired
   }).isRequired,
+  /** Function used to truncate value label */
   truncate: PropTypes.func.isRequired,
+  /** Name of CSS class(es) which are set to label */
   className: PropTypes.string,
-  bsStyle: PropTypes.string
+  /** Bootstrap style which is set to label */
+  bsStyle: PropTypes.string,
+  /** Placement of the overlay */
+  overlayPlacement: PropTypes.oneOf(['top', 'right', 'bottom', 'left'])
 };
 
 LabelWithTooltip.defaultProps = {
   className: '',
-  bsStyle: 'primary'
+  bsStyle: 'primary',
+  overlayPlacement: 'bottom'
 };
 export default LabelWithTooltip;

--- a/packages/patternfly-react/src/components/Label/LabelWithTooltip.js
+++ b/packages/patternfly-react/src/components/Label/LabelWithTooltip.js
@@ -14,13 +14,13 @@ const LabelWithTooltip = ({
   bsStyle,
   className
 }) => (
-  <li key={value.id} className="value">
+  <li key={value.id}>
     <OverlayTrigger placement="bottom" overlay={tooltip(value.label)}>
       <Label
         key={value.id}
-        bsStyle={bsStyle}
         onRemoveClick={() => onDeleteClick(category, value)}
-        className={`${className}`}
+        bsStyle={bsStyle}
+        className={`compound-label-inner-color-pf ${className}`}
       >
         {truncate(value.label)}
       </Label>

--- a/packages/patternfly-react/src/components/Label/LabelWithTooltip.test.js
+++ b/packages/patternfly-react/src/components/Label/LabelWithTooltip.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import LabelWithTooltip from './LabelWithTooltip';
+import { noop } from '../../common/helpers';
+
+test('snapshot test', () => {
+  const view = shallow(
+    <LabelWithTooltip
+      key={11}
+      category={{ label: 'food', id: 1 }}
+      value={{ label: 'Salad', id: 11 }}
+      onDeleteClick={noop}
+      truncate={noop}
+    />
+  );
+  expect(view).toMatchSnapshot();
+});

--- a/packages/patternfly-react/src/components/Label/__mocks__/mockCompoundLabel.js
+++ b/packages/patternfly-react/src/components/Label/__mocks__/mockCompoundLabel.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { CompoundLabel } from '../index';
+
+export class MockCompoundLabel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      tag: {
+        id: 1,
+        label: 'Food - category with very long description',
+        values: [
+          { id: 11, label: 'Cake' },
+          { id: 12, label: 'Bloody Steak from the famous Purple Cow' },
+          { id: 13, label: 'Pineapple Pizza' }
+        ]
+      }
+    };
+  }
+
+  removeMe = (category, value) => {
+    const values = this.state.tag.values.filter(val => val.id !== value.id);
+    const state = { tag: { ...this.state.tag, values } };
+    this.setState(state);
+  };
+
+  render() {
+    return (
+      <CompoundLabel
+        key={this.state.tag.id}
+        category={{ id: this.state.tag.id, label: this.state.tag.label }}
+        values={this.state.tag.values}
+        onDeleteClick={this.removeMe}
+      />
+    );
+  }
+}
+
+export const mockCompoundLabelSource = `
+import React from 'react';
+import { CompoundLabel } from '../index';
+
+export class MockCompoundLabel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      tag: {
+        id: 1,
+        label: 'Food - category with very long description',
+        values: [
+          { id: 11, label: 'Cake' },
+          { id: 12, label: 'Bloody Steak from the famous Purple Cow' },
+          { id: 13, label: 'Pineapple Pizza' }
+        ]
+      }
+    };
+  }
+
+  removeMe = (category, value) => {
+    const values = this.state.tag.values.filter(val => val.id !== value.id);
+    const state = { tag: { ...this.state.tag, values } };
+    this.setState(state);
+  };
+
+  render() {
+    return (
+      <CompoundLabel
+        key={this.state.tag.id}
+        category={{ id: this.state.tag.id, label: this.state.tag.label }}
+        values={this.state.tag.values}
+        onDeleteClick={this.removeMe}
+      />
+    );
+  }
+}
+`;

--- a/packages/patternfly-react/src/components/Label/__mocks__/mockCompoundLabel.js
+++ b/packages/patternfly-react/src/components/Label/__mocks__/mockCompoundLabel.js
@@ -7,11 +7,12 @@ export class MockCompoundLabel extends React.Component {
     this.state = {
       tag: {
         id: 1,
-        label: 'Food - category with very long description',
+        label: 'Most delicious food you will ever eat',
         values: [
-          { id: 11, label: 'Cake' },
-          { id: 12, label: 'Bloody Steak from the famous Purple Cow' },
-          { id: 13, label: 'Pineapple Pizza' }
+          { id: 11, label: 'Strawberries harvested under full moon light' },
+          { id: 12, label: 'Argentinian beef steak from hand massaged cow' },
+          { id: 13, label: 'Enchanted cookies baked by insane chef' },
+          { id: 14, label: 'Dumplings' }
         ]
       }
     };
@@ -45,11 +46,12 @@ export class MockCompoundLabel extends React.Component {
     this.state = {
       tag: {
         id: 1,
-        label: 'Food - category with very long description',
+        label: 'Most delicious food you will ever eat',
         values: [
-          { id: 11, label: 'Cake' },
-          { id: 12, label: 'Bloody Steak from the famous Purple Cow' },
-          { id: 13, label: 'Pineapple Pizza' }
+          { id: 11, label: 'Strawberries harvested under full moon light' },
+          { id: 12, label: 'Argentinian beef steak from hand massaged cow' },
+          { id: 13, label: 'Enchanted cookies baked by insane chef' },
+          { id: 14, label: 'Dumplings' }
         ]
       }
     };

--- a/packages/patternfly-react/src/components/Label/__mocks__/mockLabelExamples.js
+++ b/packages/patternfly-react/src/components/Label/__mocks__/mockLabelExamples.js
@@ -39,7 +39,7 @@ export class MockLabelRemove extends React.Component {
 export const mockLabelRemoveSource = `
   import React from 'react';
   import { Label } from '../index';
-  
+
   export class MockLabelRemove extends React.Component {
     constructor(props) {
       super(props);
@@ -56,7 +56,7 @@ export const mockLabelRemoveSource = `
     removeMe = index => {
       this.setState(this.state.types.splice(index, 1));
     };
-    
+
     render() {
       return (
         <div>

--- a/packages/patternfly-react/src/components/Label/__snapshots__/CompoundLabel.test.js.snap
+++ b/packages/patternfly-react/src/components/Label/__snapshots__/CompoundLabel.test.js.snap
@@ -4,38 +4,44 @@ exports[`snapshot test 1`] = `
 <ul
   className="category list-inline "
 >
-  <OverlayTrigger
-    defaultOverlayShown={false}
-    overlay={
-      <Tooltip
-        bsClass="tooltip"
-        id="tooltip"
-        placement="right"
-      >
-        Food - category with very long description
-      </Tooltip>
-    }
-    placement="bottom"
-    trigger={
-      Array [
-        "hover",
-        "focus",
-      ]
-    }
+  <li
+    key="1"
   >
-    <div
-      className="category-label"
+    <OverlayTrigger
+      defaultOverlayShown={false}
+      overlay={
+        <Tooltip
+          bsClass="tooltip"
+          id="tooltip"
+          placement="right"
+        >
+          Food - category with very long description
+        </Tooltip>
+      }
+      placement="bottom"
+      trigger={
+        Array [
+          "hover",
+          "focus",
+        ]
+      }
     >
-      Food - category wi...
-    </div>
-  </OverlayTrigger>
+      <div
+        className="category-label"
+      >
+        Food - category wi...
+      </div>
+    </OverlayTrigger>
+  </li>
   <LabelWithTooltip
+    bsStyle="info"
     category={
       Object {
         "id": 1,
         "label": "Food - category with very long description",
       }
     }
+    className=""
     key="12"
     onDeleteClick={[Function]}
     truncate={[Function]}
@@ -47,12 +53,14 @@ exports[`snapshot test 1`] = `
     }
   />
   <LabelWithTooltip
+    bsStyle="info"
     category={
       Object {
         "id": 1,
         "label": "Food - category with very long description",
       }
     }
+    className=""
     key="11"
     onDeleteClick={[Function]}
     truncate={[Function]}
@@ -64,12 +72,14 @@ exports[`snapshot test 1`] = `
     }
   />
   <LabelWithTooltip
+    bsStyle="info"
     category={
       Object {
         "id": 1,
         "label": "Food - category with very long description",
       }
     }
+    className=""
     key="13"
     onDeleteClick={[Function]}
     truncate={[Function]}

--- a/packages/patternfly-react/src/components/Label/__snapshots__/CompoundLabel.test.js.snap
+++ b/packages/patternfly-react/src/components/Label/__snapshots__/CompoundLabel.test.js.snap
@@ -43,6 +43,7 @@ exports[`snapshot test 1`] = `
       className=""
       key="12"
       onDeleteClick={[Function]}
+      overlayPlacement="bottom"
       truncate={[Function]}
       value={
         Object {
@@ -62,6 +63,7 @@ exports[`snapshot test 1`] = `
       className=""
       key="11"
       onDeleteClick={[Function]}
+      overlayPlacement="bottom"
       truncate={[Function]}
       value={
         Object {
@@ -81,6 +83,7 @@ exports[`snapshot test 1`] = `
       className=""
       key="13"
       onDeleteClick={[Function]}
+      overlayPlacement="bottom"
       truncate={[Function]}
       value={
         Object {

--- a/packages/patternfly-react/src/components/Label/__snapshots__/CompoundLabel.test.js.snap
+++ b/packages/patternfly-react/src/components/Label/__snapshots__/CompoundLabel.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`snapshot test 1`] = `
 <ul
-  className="category list-inline"
+  className="category list-inline "
 >
   <OverlayTrigger
     defaultOverlayShown={false}

--- a/packages/patternfly-react/src/components/Label/__snapshots__/CompoundLabel.test.js.snap
+++ b/packages/patternfly-react/src/components/Label/__snapshots__/CompoundLabel.test.js.snap
@@ -1,94 +1,94 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snapshot test 1`] = `
-<ul
-  className="category list-inline "
+<span
+  className="label label-primary compound-label-pf"
 >
-  <li
-    key="1"
-  >
-    <OverlayTrigger
-      defaultOverlayShown={false}
-      overlay={
-        <Tooltip
-          bsClass="tooltip"
-          id="tooltip"
-          placement="right"
-        >
-          Food - category with very long description
-        </Tooltip>
-      }
-      placement="bottom"
-      trigger={
-        Array [
-          "hover",
-          "focus",
-        ]
-      }
-    >
-      <div
-        className="category-label"
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="tooltip"
+        placement="right"
       >
-        Food - category wi...
-      </div>
-    </OverlayTrigger>
-  </li>
-  <LabelWithTooltip
-    bsStyle="info"
-    category={
-      Object {
-        "id": 1,
-        "label": "Food - category with very long description",
-      }
+        Food - category with very long description
+      </Tooltip>
     }
-    className=""
-    key="12"
-    onDeleteClick={[Function]}
-    truncate={[Function]}
-    value={
-      Object {
-        "id": 12,
-        "label": "Bloody Steak from the famous Purple Cow",
-      }
+    placement="bottom"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
     }
-  />
-  <LabelWithTooltip
-    bsStyle="info"
-    category={
-      Object {
-        "id": 1,
-        "label": "Food - category with very long description",
+  >
+    <span
+      className="category-label-pf"
+    >
+      Food - category wi...
+    </span>
+  </OverlayTrigger>
+  <ul
+    className="list-inline "
+  >
+    <LabelWithTooltip
+      bsStyle="primary"
+      category={
+        Object {
+          "id": 1,
+          "label": "Food - category with very long description",
+        }
       }
-    }
-    className=""
-    key="11"
-    onDeleteClick={[Function]}
-    truncate={[Function]}
-    value={
-      Object {
-        "id": 11,
-        "label": "Cake",
+      className=""
+      key="12"
+      onDeleteClick={[Function]}
+      truncate={[Function]}
+      value={
+        Object {
+          "id": 12,
+          "label": "Bloody Steak from the famous Purple Cow",
+        }
       }
-    }
-  />
-  <LabelWithTooltip
-    bsStyle="info"
-    category={
-      Object {
-        "id": 1,
-        "label": "Food - category with very long description",
+    />
+    <LabelWithTooltip
+      bsStyle="primary"
+      category={
+        Object {
+          "id": 1,
+          "label": "Food - category with very long description",
+        }
       }
-    }
-    className=""
-    key="13"
-    onDeleteClick={[Function]}
-    truncate={[Function]}
-    value={
-      Object {
-        "id": 13,
-        "label": "Pineapple Pizza",
+      className=""
+      key="11"
+      onDeleteClick={[Function]}
+      truncate={[Function]}
+      value={
+        Object {
+          "id": 11,
+          "label": "Cake",
+        }
       }
-    }
-  />
-</ul>
+    />
+    <LabelWithTooltip
+      bsStyle="primary"
+      category={
+        Object {
+          "id": 1,
+          "label": "Food - category with very long description",
+        }
+      }
+      className=""
+      key="13"
+      onDeleteClick={[Function]}
+      truncate={[Function]}
+      value={
+        Object {
+          "id": 13,
+          "label": "Pineapple Pizza",
+        }
+      }
+    />
+  </ul>
+</span>
 `;

--- a/packages/patternfly-react/src/components/Label/__snapshots__/CompoundLabel.test.js.snap
+++ b/packages/patternfly-react/src/components/Label/__snapshots__/CompoundLabel.test.js.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot test 1`] = `
+<ul
+  className="category list-inline"
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="tooltip"
+        placement="right"
+      >
+        Food - category with very long description
+      </Tooltip>
+    }
+    placement="bottom"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <div
+      className="category-label"
+    >
+      Food - category wi...
+    </div>
+  </OverlayTrigger>
+  <LabelWithTooltip
+    category={
+      Object {
+        "id": 1,
+        "label": "Food - category with very long description",
+      }
+    }
+    key="12"
+    onDeleteClick={[Function]}
+    truncate={[Function]}
+    value={
+      Object {
+        "id": 12,
+        "label": "Bloody Steak from the famous Purple Cow",
+      }
+    }
+  />
+  <LabelWithTooltip
+    category={
+      Object {
+        "id": 1,
+        "label": "Food - category with very long description",
+      }
+    }
+    key="11"
+    onDeleteClick={[Function]}
+    truncate={[Function]}
+    value={
+      Object {
+        "id": 11,
+        "label": "Cake",
+      }
+    }
+  />
+  <LabelWithTooltip
+    category={
+      Object {
+        "id": 1,
+        "label": "Food - category with very long description",
+      }
+    }
+    key="13"
+    onDeleteClick={[Function]}
+    truncate={[Function]}
+    value={
+      Object {
+        "id": 13,
+        "label": "Pineapple Pizza",
+      }
+    }
+  />
+</ul>
+`;

--- a/packages/patternfly-react/src/components/Label/__snapshots__/LabelWithTooltip.test.js.snap
+++ b/packages/patternfly-react/src/components/Label/__snapshots__/LabelWithTooltip.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`snapshot test 1`] = `
 <li
-  className="value"
   key="11"
 >
   <OverlayTrigger
@@ -25,8 +24,8 @@ exports[`snapshot test 1`] = `
     }
   >
     <Label
-      bsStyle=""
-      className=""
+      bsStyle="primary"
+      className="compound-label-inner-color-pf "
       key="11"
       onRemoveClick={[Function]}
       type="default"

--- a/packages/patternfly-react/src/components/Label/__snapshots__/LabelWithTooltip.test.js.snap
+++ b/packages/patternfly-react/src/components/Label/__snapshots__/LabelWithTooltip.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`snapshot test 1`] = `
 <li
-  className="tag"
+  className="compound-label-pf"
   key="11"
 >
   <OverlayTrigger
@@ -26,7 +26,7 @@ exports[`snapshot test 1`] = `
   >
     <Label
       bsStyle="primary"
-      className="tagColor"
+      className="compound-label-pf-text-color"
       key="11"
       onRemoveClick={[Function]}
       type="default"

--- a/packages/patternfly-react/src/components/Label/__snapshots__/LabelWithTooltip.test.js.snap
+++ b/packages/patternfly-react/src/components/Label/__snapshots__/LabelWithTooltip.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot test 1`] = `
+<li
+  className="tag"
+  key="11"
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    overlay={
+      <Tooltip
+        bsClass="tooltip"
+        id="tooltip"
+        placement="right"
+      >
+        Salad
+      </Tooltip>
+    }
+    placement="bottom"
+    trigger={
+      Array [
+        "hover",
+        "focus",
+      ]
+    }
+  >
+    <Label
+      bsStyle="primary"
+      className="tagColor"
+      key="11"
+      onRemoveClick={[Function]}
+      type="default"
+    />
+  </OverlayTrigger>
+</li>
+`;

--- a/packages/patternfly-react/src/components/Label/__snapshots__/LabelWithTooltip.test.js.snap
+++ b/packages/patternfly-react/src/components/Label/__snapshots__/LabelWithTooltip.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`snapshot test 1`] = `
 <li
-  className="compound-label-pf"
+  className="value"
   key="11"
 >
   <OverlayTrigger
@@ -25,8 +25,8 @@ exports[`snapshot test 1`] = `
     }
   >
     <Label
-      bsStyle="primary"
-      className="compound-label-pf-text-color"
+      bsStyle=""
+      className=""
       key="11"
       onRemoveClick={[Function]}
       type="default"

--- a/packages/patternfly-react/src/components/Label/index.js
+++ b/packages/patternfly-react/src/components/Label/index.js
@@ -1,5 +1,6 @@
 import DisposableLabel from './DisposableLabel';
 import RemoveButton from './RemoveButton';
+import CompoundLabel from './CompoundLabel';
 
 export { default as Label } from './Label';
-export { DisposableLabel, RemoveButton };
+export { DisposableLabel, RemoveButton, CompoundLabel };


### PR DESCRIPTION
In this PR I am creating component for showing `key:values` pair with delete capability. It can be used for [filters](http://www.patternfly.org/pattern-library/forms-and-controls/filter/#overview) or [tagging](https://github.com/patternfly/patternfly-react/pull/351)

#### Issue
https://github.com/patternfly/patternfly-react/issues/401

#### Google design doc
https://docs.google.com/document/d/19Vu9Q_lfCQDkwO3LQuwsImSH0rH9i0o9AF24Uer6WqA/edit

#### Storybook
https://panspagetka.github.io/patternfly-react/?selectedKind=patternfly-react%2FWidgets%2FLabel&selectedStory=CompoundLabel&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs

@terezanovotna 