### PR TITLE
fix(react-core/release): start on v1.0.0 since 0.x is not supported by semantic release

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-core",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "This library provides a set of common React components for use with the PatternFly reference implementation.",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@patternfly/react-core": "^0.x",
+    "@patternfly/react-core": "*",
     "@patternfly/react-icons": "*",
     "@patternfly/react-styles": "^2.0.0",
     "@patternfly/react-tokens": "^1.0.0",


### PR DESCRIPTION
affects: @patternfly/react-core, @patternfly/react-docs

react-core is not releasing. I assume this is because of this:
https://github.com/semantic-release/semantic-release/blob/caribou/docs/support/FAQ.md#can-i-set-the-initial-release-version-of-my-package-to-001
The previous releases were manual due to other issues which is why they worked before.
