### PR TITLE
fix(react-console): Fix racy null dereference in addMinWidth

### DIFF
--- a/packages/react-console/src/SerialConsole/XTerm.js
+++ b/packages/react-console/src/SerialConsole/XTerm.js
@@ -156,7 +156,7 @@ class XTerm extends React.Component {
    * @param {Number} cols Number of columns
    */
   addMinWidth(cols) {
-    if (this.childTerminal) {
+    if (this.childTerminal && this.state.terminal.renderer) {
       const padding = 2 * 11;
       const { actualCellWidth } = this.state.terminal.renderer.dimensions;
       const minWidth = actualCellWidth * cols + padding;


### PR DESCRIPTION
There is a race condition, where during disconnection, certain
events can cause addMinWidth to dereference a null renderer object.
And we see an error like:

     Cannot read property 'dimensions' of undefined

This has happened reproducibly in Cockpit's integration testing. See:

https://github.com/cockpit-project/cockpit/issues/9641

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**: A Fix.

Whattafix!

