### PR TITLE
docs(pf4/generator): improve pf4 layout/component generator

### DIFF
--- a/scripts/generators/patternfly-4-component/templates/component/{{componentName}}.js
+++ b/scripts/generators/patternfly-4-component/templates/component/{{componentName}}.js
@@ -1,12 +1,25 @@
 import React from 'react';
+import styles from '@patternfly/patternfly-next/{{typeDir}}/{{componentName}}/styles.css';
+import { css } from '@patternfly/react-styles';
+import PropTypes from 'prop-types';
 
-const propTypes = {};
+const propTypes = {
+  children: PropTypes.node,
+  className: PropTypes.string
+};
 
-const defaultProps = {};
+const defaultProps = {
+  children: null,
+  className: ''
+};
 
-const {{componentName}} = () => <div />;
+const {{componentName}} = ({ className, children, ...props }) => (
+  <div {...props} className={css(styles.{{camelCase componentName}}, className)}>
+    {children}
+  </div>
+);
 
 {{componentName}}.propTypes = propTypes;
-{{componentName}}.propTypes = defaultProps;
+{{componentName}}.defaultProps = defaultProps;
 
 export default {{componentName}};


### PR DESCRIPTION
Change generation of PF4 components/layouts so they include general stuff alongisde with styles and basic styling.

No storybook.