### PR TITLE
feat(pagination icons): let's reuse our new implementation of some FA icons and use them in paginati

### DIFF
--- a/packages/patternfly-3/patternfly-react/less/pagination.less
+++ b/packages/patternfly-3/patternfly-react/less/pagination.less
@@ -1,0 +1,11 @@
+.content-view-pf-pagination .pagination li a svg {
+  margin-top: 5px !important;
+}
+
+.pager:not(.pager-sm) li a svg {
+  margin-top: 6px !important;
+}
+
+.pager.pager-sm li a svg {
+  margin-top: 3px !important;
+}

--- a/packages/patternfly-3/patternfly-react/less/patternfly-react.less
+++ b/packages/patternfly-3/patternfly-react/less/patternfly-react.less
@@ -11,3 +11,4 @@
 @import 'type-ahead-select';
 @import 'verticalnavdivider';
 @import 'treeview';
+@import 'pagination';

--- a/packages/patternfly-3/patternfly-react/package.json
+++ b/packages/patternfly-3/patternfly-react/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "dependencies": {
+    "@patternfly/react-icons": "^2.4.0",
     "bootstrap-slider-without-jquery": "^10.0.0",
     "breakjs": "^1.0.0",
     "classnames": "^2.2.5",

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_pagination.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_pagination.scss
@@ -1,0 +1,11 @@
+.content-view-pf-pagination .pagination li a svg {
+  margin-top: 5px !important;
+}
+
+.pager:not(.pager-sm) li a svg {
+  margin-top: 6px !important;
+}
+
+.pager.pager-sm li a svg {
+  margin-top: 3px !important;
+}

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_patternfly-react.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_patternfly-react.scss
@@ -11,3 +11,4 @@
 @import 'type-ahead-select';
 @import 'verticalnavdivider';
 @import 'treeview';
+@import 'pagination';

--- a/packages/patternfly-3/patternfly-react/src/components/Pagination/Pager.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Pagination/Pager.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Icon } from '../Icon';
+import { AngleLeftIcon, AngleRightIcon } from '@patternfly/react-icons';
 import { noop } from '../../common/helpers';
 
 /**
@@ -22,7 +22,7 @@ const Pager = ({ baseClassName, className, messages, disableNext, onNextPage, di
             }
           }}
         >
-          <Icon className="i" name="angle-left" />
+          <AngleLeftIcon className="i" />
           {messages.previousPage}
         </a>
       </li>
@@ -38,7 +38,7 @@ const Pager = ({ baseClassName, className, messages, disableNext, onNextPage, di
           }}
         >
           {messages.nextPage}
-          <Icon className="i" name="angle-right" />
+          <AngleRightIcon className="i" />
         </a>
       </li>
     </ul>

--- a/packages/patternfly-3/patternfly-react/src/components/Pagination/PaginationRowArrowIcon.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Pagination/PaginationRowArrowIcon.js
@@ -1,16 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon } from '../Icon';
+import { AngleLeftIcon, AngleDoubleLeftIcon, AngleRightIcon, AngleDoubleRightIcon } from '@patternfly/react-icons';
+
+const arrowIcon = {
+  left: AngleLeftIcon,
+  'double-left': AngleDoubleLeftIcon,
+  right: AngleRightIcon,
+  'double-right': AngleDoubleRightIcon
+};
 
 /**
  * PaginationRowArrowIcon component for Patternfly React
  */
 const PaginationRowArrowIcon = ({ name, ...props }) => {
-  const iconName = `angle-${name}`;
-  return <Icon type="fa" name={iconName} className="i" />;
+  const Icon = arrowIcon[name];
+  return <Icon className="i" />;
 };
 PaginationRowArrowIcon.propTypes = {
   /** icon name */
-  name: PropTypes.oneOf(['left', 'double-left', 'right', 'double-right']).isRequired
+  name: PropTypes.oneOf(Object.keys(arrowIcon)).isRequired
 };
 export default PaginationRowArrowIcon;

--- a/packages/patternfly-3/patternfly-react/src/components/Pagination/__snapshots__/Pager.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/Pagination/__snapshots__/Pager.test.js.snap
@@ -11,10 +11,19 @@ exports[`Pager default renders properly 1`] = `
       class=""
       href="#"
     >
-      <span
+      <svg
         aria-hidden="true"
-        class="fa fa-angle-left i"
-      />
+        class="i"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        viewBox="0 0 256 512"
+        width="1em"
+      >
+        <path
+          d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+        />
+      </svg>
       Previous
     </a>
   </li>
@@ -26,10 +35,19 @@ exports[`Pager default renders properly 1`] = `
       href="#"
     >
       Next
-      <span
+      <svg
         aria-hidden="true"
-        class="fa fa-angle-right i"
-      />
+        class="i"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        viewBox="0 0 256 512"
+        width="1em"
+      >
+        <path
+          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+        />
+      </svg>
     </a>
   </li>
 </ul>
@@ -46,10 +64,19 @@ exports[`Pager mini size renders properly 1`] = `
       class="disabled"
       href="#"
     >
-      <span
+      <svg
         aria-hidden="true"
-        class="fa fa-angle-left i"
-      />
+        class="i"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        viewBox="0 0 256 512"
+        width="1em"
+      >
+        <path
+          d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+        />
+      </svg>
       The Previous Page
     </a>
   </li>
@@ -61,10 +88,19 @@ exports[`Pager mini size renders properly 1`] = `
       href="#"
     >
       The Next Page
-      <span
+      <svg
         aria-hidden="true"
-        class="fa fa-angle-right i"
-      />
+        class="i"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        viewBox="0 0 256 512"
+        width="1em"
+      >
+        <path
+          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+        />
+      </svg>
     </a>
   </li>
 </ul>

--- a/packages/patternfly-3/patternfly-react/src/components/Pagination/__snapshots__/Paginate.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/Pagination/__snapshots__/Paginate.test.js.snap
@@ -120,10 +120,19 @@ exports[`PaginationRow card renders properly 1`] = `
           href="#"
           title="עמוד ראשון"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -133,10 +142,19 @@ exports[`PaginationRow card renders properly 1`] = `
           href="#"
           title="עמוד קודם"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -166,10 +184,19 @@ exports[`PaginationRow card renders properly 1`] = `
           href="#"
           title="עמוד הבא"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -179,10 +206,19 @@ exports[`PaginationRow card renders properly 1`] = `
           href="#"
           title="עמוד אחרון"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -310,10 +346,19 @@ exports[`PaginationRow list renders properly 1`] = `
           href="#"
           title="עמוד ראשון"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -323,10 +368,19 @@ exports[`PaginationRow list renders properly 1`] = `
           href="#"
           title="עמוד קודם"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -356,10 +410,19 @@ exports[`PaginationRow list renders properly 1`] = `
           href="#"
           title="עמוד הבא"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -369,10 +432,19 @@ exports[`PaginationRow list renders properly 1`] = `
           href="#"
           title="עמוד אחרון"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -500,10 +572,19 @@ exports[`PaginationRow renders with dropdown page size selector 1`] = `
           href="#"
           title="עמוד ראשון"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -513,10 +594,19 @@ exports[`PaginationRow renders with dropdown page size selector 1`] = `
           href="#"
           title="עמוד קודם"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -546,10 +636,19 @@ exports[`PaginationRow renders with dropdown page size selector 1`] = `
           href="#"
           title="עמוד הבא"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -559,10 +658,19 @@ exports[`PaginationRow renders with dropdown page size selector 1`] = `
           href="#"
           title="עמוד אחרון"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -690,10 +798,19 @@ exports[`PaginationRow table renders properly 1`] = `
           href="#"
           title="עמוד ראשון"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -703,10 +820,19 @@ exports[`PaginationRow table renders properly 1`] = `
           href="#"
           title="עמוד קודם"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -736,10 +862,19 @@ exports[`PaginationRow table renders properly 1`] = `
           href="#"
           title="עמוד הבא"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -749,10 +884,19 @@ exports[`PaginationRow table renders properly 1`] = `
           href="#"
           title="עמוד אחרון"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -782,10 +926,19 @@ exports[`PaginationRow.Back renders 1`] = `
       href="#"
       title="first page"
     >
-      <span
+      <svg
         aria-hidden="true"
-        class="fa fa-angle-double-left i"
-      />
+        class="i"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        viewBox="0 0 448 512"
+        width="1em"
+      >
+        <path
+          d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+        />
+      </svg>
     </a>
   </li>
   <li
@@ -795,10 +948,19 @@ exports[`PaginationRow.Back renders 1`] = `
       href="#"
       title="previous page"
     >
-      <span
+      <svg
         aria-hidden="true"
-        class="fa fa-angle-left i"
-      />
+        class="i"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        viewBox="0 0 256 512"
+        width="1em"
+      >
+        <path
+          d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+        />
+      </svg>
     </a>
   </li>
 </ul>
@@ -821,10 +983,19 @@ exports[`PaginationRow.Forward renders 1`] = `
       href="#"
       title="Next Page"
     >
-      <span
+      <svg
         aria-hidden="true"
-        class="fa fa-angle-right i"
-      />
+        class="i"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        viewBox="0 0 256 512"
+        width="1em"
+      >
+        <path
+          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+        />
+      </svg>
     </a>
   </li>
   <li
@@ -834,10 +1005,19 @@ exports[`PaginationRow.Forward renders 1`] = `
       href="#"
       title="Last Page"
     >
-      <span
+      <svg
         aria-hidden="true"
-        class="fa fa-angle-double-right i"
-      />
+        class="i"
+        fill="currentColor"
+        height="1em"
+        role="img"
+        viewBox="0 0 448 512"
+        width="1em"
+      >
+        <path
+          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+        />
+      </svg>
     </a>
   </li>
 </ul>
@@ -955,10 +1135,19 @@ exports[`Paginator renders properly a middle page 1`] = `
           href="#"
           title="First Page"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -968,10 +1157,19 @@ exports[`Paginator renders properly a middle page 1`] = `
           href="#"
           title="Previous Page"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -1003,10 +1201,19 @@ exports[`Paginator renders properly a middle page 1`] = `
           href="#"
           title="Next Page"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -1016,10 +1223,19 @@ exports[`Paginator renders properly a middle page 1`] = `
           href="#"
           title="Last Page"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -1123,10 +1339,19 @@ exports[`Paginator renders properly the first page 1`] = `
           href="#"
           title="First Page"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -1136,10 +1361,19 @@ exports[`Paginator renders properly the first page 1`] = `
           href="#"
           title="Previous Page"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -1171,10 +1405,19 @@ exports[`Paginator renders properly the first page 1`] = `
           href="#"
           title="Next Page"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -1184,10 +1427,19 @@ exports[`Paginator renders properly the first page 1`] = `
           href="#"
           title="Last Page"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -1291,10 +1543,19 @@ exports[`Paginator renders properly the last page 1`] = `
           href="#"
           title="First Page"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -1304,10 +1565,19 @@ exports[`Paginator renders properly the last page 1`] = `
           href="#"
           title="Previous Page"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-left i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+            />
+          </svg>
         </a>
       </li>
     </ul>
@@ -1339,10 +1609,19 @@ exports[`Paginator renders properly the last page 1`] = `
           href="#"
           title="Next Page"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 256 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+            />
+          </svg>
         </a>
       </li>
       <li
@@ -1352,10 +1631,19 @@ exports[`Paginator renders properly the last page 1`] = `
           href="#"
           title="Last Page"
         >
-          <span
+          <svg
             aria-hidden="true"
-            class="fa fa-angle-double-right i"
-          />
+            class="i"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 448 512"
+            width="1em"
+          >
+            <path
+              d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+            />
+          </svg>
         </a>
       </li>
     </ul>

--- a/packages/patternfly-3/patternfly-react/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/Table/__snapshots__/Table.test.js.snap
@@ -1801,10 +1801,19 @@ exports[`Mock Client Pagination table renders 1`] = `
             href="#"
             title="First Page"
           >
-            <span
+            <svg
               aria-hidden="true"
-              class="fa fa-angle-double-left i"
-            />
+              class="i"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 448 512"
+              width="1em"
+            >
+              <path
+                d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+              />
+            </svg>
           </a>
         </li>
         <li
@@ -1814,10 +1823,19 @@ exports[`Mock Client Pagination table renders 1`] = `
             href="#"
             title="Previous Page"
           >
-            <span
+            <svg
               aria-hidden="true"
-              class="fa fa-angle-left i"
-            />
+              class="i"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 256 512"
+              width="1em"
+            >
+              <path
+                d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+              />
+            </svg>
           </a>
         </li>
       </ul>
@@ -1849,10 +1867,19 @@ exports[`Mock Client Pagination table renders 1`] = `
             href="#"
             title="Next Page"
           >
-            <span
+            <svg
               aria-hidden="true"
-              class="fa fa-angle-right i"
-            />
+              class="i"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 256 512"
+              width="1em"
+            >
+              <path
+                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+              />
+            </svg>
           </a>
         </li>
         <li
@@ -1862,10 +1889,19 @@ exports[`Mock Client Pagination table renders 1`] = `
             href="#"
             title="Last Page"
           >
-            <span
+            <svg
               aria-hidden="true"
-              class="fa fa-angle-double-right i"
-            />
+              class="i"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 448 512"
+              width="1em"
+            >
+              <path
+                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+              />
+            </svg>
           </a>
         </li>
       </ul>
@@ -2055,10 +2091,19 @@ exports[`Mock Server Pagination table renders 1`] = `
             href="#"
             title="First Page"
           >
-            <span
+            <svg
               aria-hidden="true"
-              class="fa fa-angle-double-left i"
-            />
+              class="i"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 448 512"
+              width="1em"
+            >
+              <path
+                d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+              />
+            </svg>
           </a>
         </li>
         <li
@@ -2068,10 +2113,19 @@ exports[`Mock Server Pagination table renders 1`] = `
             href="#"
             title="Previous Page"
           >
-            <span
+            <svg
               aria-hidden="true"
-              class="fa fa-angle-left i"
-            />
+              class="i"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 256 512"
+              width="1em"
+            >
+              <path
+                d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+              />
+            </svg>
           </a>
         </li>
       </ul>
@@ -2103,10 +2157,19 @@ exports[`Mock Server Pagination table renders 1`] = `
             href="#"
             title="Next Page"
           >
-            <span
+            <svg
               aria-hidden="true"
-              class="fa fa-angle-right i"
-            />
+              class="i"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 256 512"
+              width="1em"
+            >
+              <path
+                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+              />
+            </svg>
           </a>
         </li>
         <li
@@ -2116,10 +2179,19 @@ exports[`Mock Server Pagination table renders 1`] = `
             href="#"
             title="Last Page"
           >
-            <span
+            <svg
               aria-hidden="true"
-              class="fa fa-angle-double-right i"
-            />
+              class="i"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 448 512"
+              width="1em"
+            >
+              <path
+                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+              />
+            </svg>
           </a>
         </li>
       </ul>


### PR DESCRIPTION
affects: patternfly-react

**What**:
With @patternfly/react-icons we can use these icons in various places and there is no longer need to include FA fonts, styles and JS, but rather use icons directly. No need to force users to install FA, include it in bundle and all those shenanigans.

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:
[Storybook@pagination](https://5b4a32263813f06b119c0369--kind-brattain-453060.netlify.com/?knob-View%20Type%3A=list&knob-Page=1&knob-Number%20of%20Pages=5&knob-Page%20Size%20Drop%20Up=true&knob-Item%20Count%3A=75&knob-Items%20Start%3A=1&knob-Items%20End=15&selectedKind=patternfly-react%2FWidgets%2FPagination&selectedStory=Pagination%20row&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)

**Before**
![screenshot from 2018-07-14 19-36-48](https://user-images.githubusercontent.com/3439771/42726940-56811df6-879d-11e8-94e2-433ad6e5fe1a.png)

**After**
![screenshot from 2018-07-14 19-36-38](https://user-images.githubusercontent.com/3439771/42726943-5ab6fb2a-879d-11e8-8782-4636882201e7.png)
