### PR TITLE
feat(react-icons icon suffix): add icon suffix to all autogenerated icons

### DIFF
--- a/packages/react-core/src/components/Alert/AlertIcon.js
+++ b/packages/react-core/src/components/Alert/AlertIcon.js
@@ -4,17 +4,17 @@ import PropTypes from 'prop-types';
 import styles from '@patternfly/patternfly-next/components/Alert/styles.css';
 
 import {
-  CheckCircle,
-  ExclamationCircle,
-  ExclamationTriangle,
-  InfoCircle
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InfoCircleIcon
 } from '@patternfly/react-icons';
 
 export const variantIcons = {
-  success: CheckCircle,
-  danger: ExclamationCircle,
-  warning: ExclamationTriangle,
-  info: InfoCircle
+  success: CheckCircleIcon,
+  danger: ExclamationCircleIcon,
+  warning: ExclamationTriangleIcon,
+  info: InfoCircleIcon
 };
 
 const propTypes = {

--- a/packages/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -71,7 +71,7 @@ exports[`Alert - danger Action 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <ExclamationCircle
+        <ExclamationCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -89,7 +89,7 @@ exports[`Alert - danger Action 1`] = `
               d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
             />
           </svg>
-        </ExclamationCircle>
+        </ExclamationCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -227,7 +227,7 @@ exports[`Alert - danger Action and Title 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <ExclamationCircle
+        <ExclamationCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -245,7 +245,7 @@ exports[`Alert - danger Action and Title 1`] = `
               d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
             />
           </svg>
-        </ExclamationCircle>
+        </ExclamationCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -352,7 +352,7 @@ exports[`Alert - danger Body 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <ExclamationCircle
+        <ExclamationCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -370,7 +370,7 @@ exports[`Alert - danger Body 1`] = `
               d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
             />
           </svg>
-        </ExclamationCircle>
+        </ExclamationCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -481,7 +481,7 @@ exports[`Alert - danger Custom aria label 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <ExclamationCircle
+        <ExclamationCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -499,7 +499,7 @@ exports[`Alert - danger Custom aria label 1`] = `
               d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
             />
           </svg>
-        </ExclamationCircle>
+        </ExclamationCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -606,7 +606,7 @@ exports[`Alert - danger Title 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <ExclamationCircle
+        <ExclamationCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -624,7 +624,7 @@ exports[`Alert - danger Title 1`] = `
               d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
             />
           </svg>
-        </ExclamationCircle>
+        </ExclamationCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -735,7 +735,7 @@ exports[`Alert - info Action 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <InfoCircle
+        <InfoCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -753,7 +753,7 @@ exports[`Alert - info Action 1`] = `
               d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
             />
           </svg>
-        </InfoCircle>
+        </InfoCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -891,7 +891,7 @@ exports[`Alert - info Action and Title 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <InfoCircle
+        <InfoCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -909,7 +909,7 @@ exports[`Alert - info Action and Title 1`] = `
               d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
             />
           </svg>
-        </InfoCircle>
+        </InfoCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -1016,7 +1016,7 @@ exports[`Alert - info Body 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <InfoCircle
+        <InfoCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -1034,7 +1034,7 @@ exports[`Alert - info Body 1`] = `
               d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
             />
           </svg>
-        </InfoCircle>
+        </InfoCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -1145,7 +1145,7 @@ exports[`Alert - info Custom aria label 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <InfoCircle
+        <InfoCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -1163,7 +1163,7 @@ exports[`Alert - info Custom aria label 1`] = `
               d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
             />
           </svg>
-        </InfoCircle>
+        </InfoCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -1270,7 +1270,7 @@ exports[`Alert - info Title 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <InfoCircle
+        <InfoCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -1288,7 +1288,7 @@ exports[`Alert - info Title 1`] = `
               d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
             />
           </svg>
-        </InfoCircle>
+        </InfoCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -1399,7 +1399,7 @@ exports[`Alert - success Action 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <CheckCircle
+        <CheckCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -1417,7 +1417,7 @@ exports[`Alert - success Action 1`] = `
               d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
             />
           </svg>
-        </CheckCircle>
+        </CheckCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -1555,7 +1555,7 @@ exports[`Alert - success Action and Title 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <CheckCircle
+        <CheckCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -1573,7 +1573,7 @@ exports[`Alert - success Action and Title 1`] = `
               d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
             />
           </svg>
-        </CheckCircle>
+        </CheckCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -1680,7 +1680,7 @@ exports[`Alert - success Body 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <CheckCircle
+        <CheckCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -1698,7 +1698,7 @@ exports[`Alert - success Body 1`] = `
               d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
             />
           </svg>
-        </CheckCircle>
+        </CheckCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -1809,7 +1809,7 @@ exports[`Alert - success Custom aria label 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <CheckCircle
+        <CheckCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -1827,7 +1827,7 @@ exports[`Alert - success Custom aria label 1`] = `
               d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
             />
           </svg>
-        </CheckCircle>
+        </CheckCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -1934,7 +1934,7 @@ exports[`Alert - success Title 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <CheckCircle
+        <CheckCircleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -1952,7 +1952,7 @@ exports[`Alert - success Title 1`] = `
               d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
             />
           </svg>
-        </CheckCircle>
+        </CheckCircleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -2063,7 +2063,7 @@ exports[`Alert - warning Action 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <ExclamationTriangle
+        <ExclamationTriangleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -2081,7 +2081,7 @@ exports[`Alert - warning Action 1`] = `
               d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
             />
           </svg>
-        </ExclamationTriangle>
+        </ExclamationTriangleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -2219,7 +2219,7 @@ exports[`Alert - warning Action and Title 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <ExclamationTriangle
+        <ExclamationTriangleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -2237,7 +2237,7 @@ exports[`Alert - warning Action and Title 1`] = `
               d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
             />
           </svg>
-        </ExclamationTriangle>
+        </ExclamationTriangleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -2344,7 +2344,7 @@ exports[`Alert - warning Body 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <ExclamationTriangle
+        <ExclamationTriangleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -2362,7 +2362,7 @@ exports[`Alert - warning Body 1`] = `
               d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
             />
           </svg>
-        </ExclamationTriangle>
+        </ExclamationTriangleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -2473,7 +2473,7 @@ exports[`Alert - warning Custom aria label 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <ExclamationTriangle
+        <ExclamationTriangleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -2491,7 +2491,7 @@ exports[`Alert - warning Custom aria label 1`] = `
               d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
             />
           </svg>
-        </ExclamationTriangle>
+        </ExclamationTriangleIcon>
       </div>
     </AlertIcon>
     <AlertBody
@@ -2598,7 +2598,7 @@ exports[`Alert - warning Title 1`] = `
       <div
         className="pf-c-alert__icon"
       >
-        <ExclamationTriangle
+        <ExclamationTriangleIcon
           color="currentColor"
           size="md"
           title={null}
@@ -2616,7 +2616,7 @@ exports[`Alert - warning Title 1`] = `
               d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
             />
           </svg>
-        </ExclamationTriangle>
+        </ExclamationTriangleIcon>
       </div>
     </AlertIcon>
     <AlertBody

--- a/packages/react-docs/src/components/navigation/navigationItemGroup.js
+++ b/packages/react-docs/src/components/navigation/navigationItemGroup.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@patternfly/react-styles';
-import { AngleRight, AngleDown } from '@patternfly/react-icons';
+import { AngleRightIcon, AngleDownIcon } from '@patternfly/react-icons';
 import styles from './navigationItemGroup.styles';
 
 const propTypes = {
@@ -36,7 +36,7 @@ class NavigationItemGroup extends React.Component {
               justifyContent: 'space-between'
             }}
           >
-            {title} {isExpanded ? <AngleDown /> : <AngleRight />}
+            {title} {isExpanded ? <AngleRightIcon /> : <AngleDownIcon />}
           </div>
         </button>
         <ul

--- a/packages/react-icons/build/generateIcons.js
+++ b/packages/react-icons/build/generateIcons.js
@@ -19,7 +19,7 @@ function getFontAwesomeIcon(name) {
 
   return {
     id: name,
-    name: pascalCase(name),
+    name: pascalCase(`${name}-icon`),
     width: faIconDef.width,
     height: faIconDef.height,
     svgPath: faIconDef.svgPathData


### PR DESCRIPTION
affects: @patternfly/react-core, @patternfly/react-docs, @patternfly/react-icons

**What**:
When auto generating some icons (Map, Server) we'd cause a lot of problems because these are registered functions. Adding suffix to each icon is nice way to overcome this problem.

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to docs**:
https://5b4ca96cc6aed6621abdbe38--zen-swanson-2d3350.netlify.com/