### PR TITLE
feat(react-core-button): support using a custom element or component for buttons

### DIFF
--- a/packages/react-core/package.json
+++ b/packages/react-core/package.json
@@ -37,7 +37,7 @@
     "postbuild": "node ./build/copyStyles.js"
   },
   "devDependencies": {
-    "@patternfly/patternfly-next": "1.0.8",
+    "@patternfly/patternfly-next": "1.0.13",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1"
   }

--- a/packages/react-core/src/components/Alert/Alert.test.js
+++ b/packages/react-core/src/components/Alert/Alert.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import Alert, { AlertVariant } from './Alert';
-import Button, { ButtonVariant } from '../Button/Button';
 import { StyleSheetTestUtils } from 'aphrodite';
 
 beforeEach(() => {
@@ -30,10 +29,7 @@ Object.keys(AlertVariant).forEach(variant => {
 
     test('Action', () => {
       const view = mount(
-        <Alert
-          variant={variant}
-          action={<Button variant={ButtonVariant.secondary}>Title</Button>}
-        >
+        <Alert variant={variant} action="action">
           Some alert
         </Alert>
       );
@@ -42,11 +38,7 @@ Object.keys(AlertVariant).forEach(variant => {
 
     test('Action and Title', () => {
       const view = mount(
-        <Alert
-          variant={variant}
-          action={<Button variant={ButtonVariant.secondary}>Title</Button>}
-          title="Some title"
-        >
+        <Alert variant={variant} action="action" title="Some title">
           Some alert
         </Alert>
       );
@@ -58,7 +50,7 @@ Object.keys(AlertVariant).forEach(variant => {
         <Alert
           variant={variant}
           ariaLabel={`Custom aria label for ${variant}`}
-          action={<Button variant={ButtonVariant.secondary}>Title</Button>}
+          action="action"
           title="Some title"
         >
           Some alert

--- a/packages/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -16,20 +16,6 @@ exports[`Alert - danger Action 1`] = `
   display: block;
   padding: 1rem;
 }
-.pf-c-button.pf-m-secondary {
-  display: inline-block;
-  position: relative;
-  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #00659c;
-  text-align: center;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0px;
-  border-radius: 30em;
-}
 .pf-c-alert__action {
   display: block;
   padding: 1rem 1.5rem 1rem 1.5rem;
@@ -41,21 +27,7 @@ exports[`Alert - danger Action 1`] = `
 }
 
 <Alert
-  action={
-    <Button
-      className=""
-      isActive={false}
-      isBlock={false}
-      isDisabled={false}
-      isFocus={false}
-      isHover={false}
-      label=""
-      type="button"
-      variant="secondary"
-    >
-      Title
-    </Button>
-  }
+  action="action"
   className=""
   title=""
   variant="danger"
@@ -130,26 +102,7 @@ exports[`Alert - danger Action 1`] = `
       <div
         className="pf-c-alert__action"
       >
-        <Button
-          className=""
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          label=""
-          type="button"
-          variant="secondary"
-        >
-          <button
-            aria-label={null}
-            className="pf-c-button pf-m-secondary"
-            disabled={false}
-            type="button"
-          >
-            Title
-          </button>
-        </Button>
+        action
       </div>
     </AlertAction>
   </div>
@@ -172,20 +125,6 @@ exports[`Alert - danger Action and Title 1`] = `
   display: block;
   padding: 1rem;
 }
-.pf-c-button.pf-m-secondary {
-  display: inline-block;
-  position: relative;
-  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #00659c;
-  text-align: center;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0px;
-  border-radius: 30em;
-}
 .pf-c-alert__action {
   display: block;
   padding: 1rem 1.5rem 1rem 1.5rem;
@@ -197,21 +136,7 @@ exports[`Alert - danger Action and Title 1`] = `
 }
 
 <Alert
-  action={
-    <Button
-      className=""
-      isActive={false}
-      isBlock={false}
-      isDisabled={false}
-      isFocus={false}
-      isHover={false}
-      label=""
-      type="button"
-      variant="secondary"
-    >
-      Title
-    </Button>
-  }
+  action="action"
   className=""
   title="Some title"
   variant="danger"
@@ -287,26 +212,7 @@ exports[`Alert - danger Action and Title 1`] = `
       <div
         className="pf-c-alert__action"
       >
-        <Button
-          className=""
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          label=""
-          type="button"
-          variant="secondary"
-        >
-          <button
-            aria-label={null}
-            className="pf-c-button pf-m-secondary"
-            disabled={false}
-            type="button"
-          >
-            Title
-          </button>
-        </Button>
+        action
       </div>
     </AlertAction>
   </div>
@@ -425,20 +331,6 @@ exports[`Alert - danger Custom aria label 1`] = `
   display: block;
   padding: 1rem;
 }
-.pf-c-button.pf-m-secondary {
-  display: inline-block;
-  position: relative;
-  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #00659c;
-  text-align: center;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0px;
-  border-radius: 30em;
-}
 .pf-c-alert__action {
   display: block;
   padding: 1rem 1.5rem 1rem 1.5rem;
@@ -450,21 +342,7 @@ exports[`Alert - danger Custom aria label 1`] = `
 }
 
 <Alert
-  action={
-    <Button
-      className=""
-      isActive={false}
-      isBlock={false}
-      isDisabled={false}
-      isFocus={false}
-      isHover={false}
-      label=""
-      type="button"
-      variant="secondary"
-    >
-      Title
-    </Button>
-  }
+  action="action"
   ariaLabel="Custom aria label for danger"
   className=""
   title="Some title"
@@ -541,26 +419,7 @@ exports[`Alert - danger Custom aria label 1`] = `
       <div
         className="pf-c-alert__action"
       >
-        <Button
-          className=""
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          label=""
-          type="button"
-          variant="secondary"
-        >
-          <button
-            aria-label={null}
-            className="pf-c-button pf-m-secondary"
-            disabled={false}
-            type="button"
-          >
-            Title
-          </button>
-        </Button>
+        action
       </div>
     </AlertAction>
   </div>
@@ -680,20 +539,6 @@ exports[`Alert - info Action 1`] = `
   display: block;
   padding: 1rem;
 }
-.pf-c-button.pf-m-secondary {
-  display: inline-block;
-  position: relative;
-  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #00659c;
-  text-align: center;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0px;
-  border-radius: 30em;
-}
 .pf-c-alert__action {
   display: block;
   padding: 1rem 1.5rem 1rem 1.5rem;
@@ -705,21 +550,7 @@ exports[`Alert - info Action 1`] = `
 }
 
 <Alert
-  action={
-    <Button
-      className=""
-      isActive={false}
-      isBlock={false}
-      isDisabled={false}
-      isFocus={false}
-      isHover={false}
-      label=""
-      type="button"
-      variant="secondary"
-    >
-      Title
-    </Button>
-  }
+  action="action"
   className=""
   title=""
   variant="info"
@@ -794,26 +625,7 @@ exports[`Alert - info Action 1`] = `
       <div
         className="pf-c-alert__action"
       >
-        <Button
-          className=""
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          label=""
-          type="button"
-          variant="secondary"
-        >
-          <button
-            aria-label={null}
-            className="pf-c-button pf-m-secondary"
-            disabled={false}
-            type="button"
-          >
-            Title
-          </button>
-        </Button>
+        action
       </div>
     </AlertAction>
   </div>
@@ -836,20 +648,6 @@ exports[`Alert - info Action and Title 1`] = `
   display: block;
   padding: 1rem;
 }
-.pf-c-button.pf-m-secondary {
-  display: inline-block;
-  position: relative;
-  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #00659c;
-  text-align: center;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0px;
-  border-radius: 30em;
-}
 .pf-c-alert__action {
   display: block;
   padding: 1rem 1.5rem 1rem 1.5rem;
@@ -861,21 +659,7 @@ exports[`Alert - info Action and Title 1`] = `
 }
 
 <Alert
-  action={
-    <Button
-      className=""
-      isActive={false}
-      isBlock={false}
-      isDisabled={false}
-      isFocus={false}
-      isHover={false}
-      label=""
-      type="button"
-      variant="secondary"
-    >
-      Title
-    </Button>
-  }
+  action="action"
   className=""
   title="Some title"
   variant="info"
@@ -951,26 +735,7 @@ exports[`Alert - info Action and Title 1`] = `
       <div
         className="pf-c-alert__action"
       >
-        <Button
-          className=""
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          label=""
-          type="button"
-          variant="secondary"
-        >
-          <button
-            aria-label={null}
-            className="pf-c-button pf-m-secondary"
-            disabled={false}
-            type="button"
-          >
-            Title
-          </button>
-        </Button>
+        action
       </div>
     </AlertAction>
   </div>
@@ -1089,20 +854,6 @@ exports[`Alert - info Custom aria label 1`] = `
   display: block;
   padding: 1rem;
 }
-.pf-c-button.pf-m-secondary {
-  display: inline-block;
-  position: relative;
-  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #00659c;
-  text-align: center;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0px;
-  border-radius: 30em;
-}
 .pf-c-alert__action {
   display: block;
   padding: 1rem 1.5rem 1rem 1.5rem;
@@ -1114,21 +865,7 @@ exports[`Alert - info Custom aria label 1`] = `
 }
 
 <Alert
-  action={
-    <Button
-      className=""
-      isActive={false}
-      isBlock={false}
-      isDisabled={false}
-      isFocus={false}
-      isHover={false}
-      label=""
-      type="button"
-      variant="secondary"
-    >
-      Title
-    </Button>
-  }
+  action="action"
   ariaLabel="Custom aria label for info"
   className=""
   title="Some title"
@@ -1205,26 +942,7 @@ exports[`Alert - info Custom aria label 1`] = `
       <div
         className="pf-c-alert__action"
       >
-        <Button
-          className=""
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          label=""
-          type="button"
-          variant="secondary"
-        >
-          <button
-            aria-label={null}
-            className="pf-c-button pf-m-secondary"
-            disabled={false}
-            type="button"
-          >
-            Title
-          </button>
-        </Button>
+        action
       </div>
     </AlertAction>
   </div>
@@ -1344,20 +1062,6 @@ exports[`Alert - success Action 1`] = `
   display: block;
   padding: 1rem;
 }
-.pf-c-button.pf-m-secondary {
-  display: inline-block;
-  position: relative;
-  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #00659c;
-  text-align: center;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0px;
-  border-radius: 30em;
-}
 .pf-c-alert__action {
   display: block;
   padding: 1rem 1.5rem 1rem 1.5rem;
@@ -1369,21 +1073,7 @@ exports[`Alert - success Action 1`] = `
 }
 
 <Alert
-  action={
-    <Button
-      className=""
-      isActive={false}
-      isBlock={false}
-      isDisabled={false}
-      isFocus={false}
-      isHover={false}
-      label=""
-      type="button"
-      variant="secondary"
-    >
-      Title
-    </Button>
-  }
+  action="action"
   className=""
   title=""
   variant="success"
@@ -1458,26 +1148,7 @@ exports[`Alert - success Action 1`] = `
       <div
         className="pf-c-alert__action"
       >
-        <Button
-          className=""
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          label=""
-          type="button"
-          variant="secondary"
-        >
-          <button
-            aria-label={null}
-            className="pf-c-button pf-m-secondary"
-            disabled={false}
-            type="button"
-          >
-            Title
-          </button>
-        </Button>
+        action
       </div>
     </AlertAction>
   </div>
@@ -1500,20 +1171,6 @@ exports[`Alert - success Action and Title 1`] = `
   display: block;
   padding: 1rem;
 }
-.pf-c-button.pf-m-secondary {
-  display: inline-block;
-  position: relative;
-  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #00659c;
-  text-align: center;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0px;
-  border-radius: 30em;
-}
 .pf-c-alert__action {
   display: block;
   padding: 1rem 1.5rem 1rem 1.5rem;
@@ -1525,21 +1182,7 @@ exports[`Alert - success Action and Title 1`] = `
 }
 
 <Alert
-  action={
-    <Button
-      className=""
-      isActive={false}
-      isBlock={false}
-      isDisabled={false}
-      isFocus={false}
-      isHover={false}
-      label=""
-      type="button"
-      variant="secondary"
-    >
-      Title
-    </Button>
-  }
+  action="action"
   className=""
   title="Some title"
   variant="success"
@@ -1615,26 +1258,7 @@ exports[`Alert - success Action and Title 1`] = `
       <div
         className="pf-c-alert__action"
       >
-        <Button
-          className=""
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          label=""
-          type="button"
-          variant="secondary"
-        >
-          <button
-            aria-label={null}
-            className="pf-c-button pf-m-secondary"
-            disabled={false}
-            type="button"
-          >
-            Title
-          </button>
-        </Button>
+        action
       </div>
     </AlertAction>
   </div>
@@ -1753,20 +1377,6 @@ exports[`Alert - success Custom aria label 1`] = `
   display: block;
   padding: 1rem;
 }
-.pf-c-button.pf-m-secondary {
-  display: inline-block;
-  position: relative;
-  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #00659c;
-  text-align: center;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0px;
-  border-radius: 30em;
-}
 .pf-c-alert__action {
   display: block;
   padding: 1rem 1.5rem 1rem 1.5rem;
@@ -1778,21 +1388,7 @@ exports[`Alert - success Custom aria label 1`] = `
 }
 
 <Alert
-  action={
-    <Button
-      className=""
-      isActive={false}
-      isBlock={false}
-      isDisabled={false}
-      isFocus={false}
-      isHover={false}
-      label=""
-      type="button"
-      variant="secondary"
-    >
-      Title
-    </Button>
-  }
+  action="action"
   ariaLabel="Custom aria label for success"
   className=""
   title="Some title"
@@ -1869,26 +1465,7 @@ exports[`Alert - success Custom aria label 1`] = `
       <div
         className="pf-c-alert__action"
       >
-        <Button
-          className=""
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          label=""
-          type="button"
-          variant="secondary"
-        >
-          <button
-            aria-label={null}
-            className="pf-c-button pf-m-secondary"
-            disabled={false}
-            type="button"
-          >
-            Title
-          </button>
-        </Button>
+        action
       </div>
     </AlertAction>
   </div>
@@ -2008,20 +1585,6 @@ exports[`Alert - warning Action 1`] = `
   display: block;
   padding: 1rem;
 }
-.pf-c-button.pf-m-secondary {
-  display: inline-block;
-  position: relative;
-  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #00659c;
-  text-align: center;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0px;
-  border-radius: 30em;
-}
 .pf-c-alert__action {
   display: block;
   padding: 1rem 1.5rem 1rem 1.5rem;
@@ -2033,21 +1596,7 @@ exports[`Alert - warning Action 1`] = `
 }
 
 <Alert
-  action={
-    <Button
-      className=""
-      isActive={false}
-      isBlock={false}
-      isDisabled={false}
-      isFocus={false}
-      isHover={false}
-      label=""
-      type="button"
-      variant="secondary"
-    >
-      Title
-    </Button>
-  }
+  action="action"
   className=""
   title=""
   variant="warning"
@@ -2122,26 +1671,7 @@ exports[`Alert - warning Action 1`] = `
       <div
         className="pf-c-alert__action"
       >
-        <Button
-          className=""
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          label=""
-          type="button"
-          variant="secondary"
-        >
-          <button
-            aria-label={null}
-            className="pf-c-button pf-m-secondary"
-            disabled={false}
-            type="button"
-          >
-            Title
-          </button>
-        </Button>
+        action
       </div>
     </AlertAction>
   </div>
@@ -2164,20 +1694,6 @@ exports[`Alert - warning Action and Title 1`] = `
   display: block;
   padding: 1rem;
 }
-.pf-c-button.pf-m-secondary {
-  display: inline-block;
-  position: relative;
-  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #00659c;
-  text-align: center;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0px;
-  border-radius: 30em;
-}
 .pf-c-alert__action {
   display: block;
   padding: 1rem 1.5rem 1rem 1.5rem;
@@ -2189,21 +1705,7 @@ exports[`Alert - warning Action and Title 1`] = `
 }
 
 <Alert
-  action={
-    <Button
-      className=""
-      isActive={false}
-      isBlock={false}
-      isDisabled={false}
-      isFocus={false}
-      isHover={false}
-      label=""
-      type="button"
-      variant="secondary"
-    >
-      Title
-    </Button>
-  }
+  action="action"
   className=""
   title="Some title"
   variant="warning"
@@ -2279,26 +1781,7 @@ exports[`Alert - warning Action and Title 1`] = `
       <div
         className="pf-c-alert__action"
       >
-        <Button
-          className=""
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          label=""
-          type="button"
-          variant="secondary"
-        >
-          <button
-            aria-label={null}
-            className="pf-c-button pf-m-secondary"
-            disabled={false}
-            type="button"
-          >
-            Title
-          </button>
-        </Button>
+        action
       </div>
     </AlertAction>
   </div>
@@ -2417,20 +1900,6 @@ exports[`Alert - warning Custom aria label 1`] = `
   display: block;
   padding: 1rem;
 }
-.pf-c-button.pf-m-secondary {
-  display: inline-block;
-  position: relative;
-  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #00659c;
-  text-align: center;
-  white-space: nowrap;
-  background-color: transparent;
-  border: 0px;
-  border-radius: 30em;
-}
 .pf-c-alert__action {
   display: block;
   padding: 1rem 1.5rem 1rem 1.5rem;
@@ -2442,21 +1911,7 @@ exports[`Alert - warning Custom aria label 1`] = `
 }
 
 <Alert
-  action={
-    <Button
-      className=""
-      isActive={false}
-      isBlock={false}
-      isDisabled={false}
-      isFocus={false}
-      isHover={false}
-      label=""
-      type="button"
-      variant="secondary"
-    >
-      Title
-    </Button>
-  }
+  action="action"
   ariaLabel="Custom aria label for warning"
   className=""
   title="Some title"
@@ -2533,26 +1988,7 @@ exports[`Alert - warning Custom aria label 1`] = `
       <div
         className="pf-c-alert__action"
       >
-        <Button
-          className=""
-          isActive={false}
-          isBlock={false}
-          isDisabled={false}
-          isFocus={false}
-          isHover={false}
-          label=""
-          type="button"
-          variant="secondary"
-        >
-          <button
-            aria-label={null}
-            className="pf-c-button pf-m-secondary"
-            disabled={false}
-            type="button"
-          >
-            Title
-          </button>
-        </Button>
+        action
       </div>
     </AlertAction>
   </div>

--- a/packages/react-core/src/components/Button/Button.d.ts
+++ b/packages/react-core/src/components/Button/Button.d.ts
@@ -1,4 +1,4 @@
-import { HTMLProps, SFC } from 'react';
+import { HTMLProps, SFC, ReactType, ReactNode } from 'react';
 import { OneOf } from '../../typeUtils';
 
 export const ButtonVariant: {
@@ -16,7 +16,9 @@ export const ButtonType: {
 };
 
 export interface ButtonProps extends HTMLProps<HTMLButtonElement> {
-  children?: React.ReactNode;
+  ariaLabel?: string;
+  children?: ReactNode;
+  component?: ReactType<ButtonProps>;
   isActive?: boolean;
   isBlock?: boolean;
   isDisabled?: boolean;

--- a/packages/react-core/src/components/Button/Button.js
+++ b/packages/react-core/src/components/Button/Button.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css, getModifier } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
+import { componentShape } from '../../internal/componentShape';
 import styles from '@patternfly/patternfly-next/components/Button/styles.css';
 
 export const ButtonVariant = {
@@ -22,6 +23,8 @@ const propTypes = {
   children: PropTypes.node,
   /** additional classes added to the button */
   className: PropTypes.string,
+  /** Sets the base component to render. defaults to button */
+  component: componentShape,
   /**  Adds active styling to button. */
   isActive: PropTypes.bool,
   /** Adds block styling to button */
@@ -33,7 +36,7 @@ const propTypes = {
   /** Adds hove styling to the button */
   isHover: PropTypes.bool,
   /* Aria label used for action buttons that only use icons */
-  label: PropTypes.string,
+  ariaLabel: PropTypes.string,
   /** Sets button type */
   type: PropTypes.oneOf(Object.keys(ButtonType)),
   /* Adds button variant styles */
@@ -43,46 +46,56 @@ const propTypes = {
 const defaultProps = {
   children: '',
   className: '',
+  component: 'button',
   isActive: false,
   isBlock: false,
   isDisabled: false,
   isFocus: false,
   isHover: false,
-  label: '',
+  ariaLabel: null,
   type: ButtonType.button,
   variant: ButtonVariant.primary
 };
 
 const Button = ({
+  ariaLabel,
   children,
   className,
+  component: Component,
   isActive,
   isBlock,
   isDisabled,
   isFocus,
   isHover,
-  label,
   variant,
+  type,
   ...props
-}) => (
-  <button
-    {...props}
-    disabled={isDisabled}
-    aria-label={variant === ButtonVariant.action ? label : null}
-    className={css(
-      styles.button,
-      getModifier(styles.modifiers, variant),
-      isBlock && styles.modifiers.block,
-      isDisabled && styles.modifiers.disabled,
-      isActive && styles.modifiers.active,
-      isFocus && styles.modifiers.focus,
-      isHover && styles.modifiers.hover,
-      className
-    )}
-  >
-    {children}
-  </button>
-);
+}) => {
+  const isButtonElement = Component === 'button';
+
+  return (
+    <Component
+      {...props}
+      aria-label={ariaLabel}
+      aria-disabled={isButtonElement ? null : isDisabled}
+      className={css(
+        styles.button,
+        getModifier(styles.modifiers, variant),
+        isBlock && styles.modifiers.block,
+        isDisabled && styles.modifiers.disabled,
+        isActive && styles.modifiers.active,
+        isFocus && styles.modifiers.focus,
+        isHover && styles.modifiers.hover,
+        className
+      )}
+      disabled={isButtonElement ? isDisabled : null}
+      tabIndex={isDisabled && !isButtonElement ? -1 : null}
+      type={isButtonElement ? type : null}
+    >
+      {children}
+    </Component>
+  );
+};
 
 Button.propTypes = propTypes;
 Button.defaultProps = defaultProps;

--- a/packages/react-core/src/components/Button/Button.test.js
+++ b/packages/react-core/src/components/Button/Button.test.js
@@ -11,7 +11,9 @@ Object.values(ButtonVariant).forEach(variant => {
 
 test('it adds an aria-label to action buttons', () => {
   const label = 'aria-label test';
-  const view = shallow(<Button variant={ButtonVariant.action} label={label} />);
+  const view = shallow(
+    <Button variant={ButtonVariant.action} ariaLabel={label} />
+  );
   expect(view.find('button').props()['aria-label']).toBe(label);
 });
 
@@ -32,5 +34,26 @@ test('isFocus', () => {
 
 test('isHover', () => {
   const view = shallow(<Button isHover>Hovered Button</Button>);
+  expect(view).toMatchSnapshot();
+});
+
+test('allows passing in a string as the component', () => {
+  const component = 'a';
+  const view = shallow(<Button component={component} />);
+  expect(view.type()).toBe(component);
+});
+
+test('allows passing in a React Component as the component', () => {
+  const Component = () => null;
+  const view = shallow(<Button component={Component} />);
+  expect(view.type()).toBe(Component);
+});
+
+test('aria-disabled is set to true and tabIndex to -1 if component is not a button and is disabled', () => {
+  const view = shallow(
+    <Button component="a" isDisabled>
+      Disabled Anchor Button
+    </Button>
+  );
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/packages/react-core/src/components/Button/__snapshots__/Button.test.js.snap
@@ -14,17 +14,50 @@ exports[`action button 1`] = `
   background-color: transparent;
   border: 0px;
   border-radius: 30em;
+  text-decoration: none;
 }
 
 <button
-  aria-label=""
+  aria-disabled={null}
+  aria-label={null}
   className="pf-c-button pf-m-action"
   disabled={false}
+  tabIndex={null}
   type="button"
 >
   action
    Button
 </button>
+`;
+
+exports[`aria-disabled is set to true and tabIndex to -1 if component is not a button and is disabled 1`] = `
+.pf-c-button.pf-m-primary.pf-m-disabled {
+  display: inline-block;
+  position: relative;
+  padding: 0.25rem 1.5rem 0.25rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #72767b;
+  text-align: center;
+  white-space: nowrap;
+  background-color: #d1d1d1;
+  border: 0px;
+  border-radius: 30em;
+  text-decoration: none;
+  pointer-events: none;
+}
+
+<a
+  aria-disabled={true}
+  aria-label={null}
+  className="pf-c-button pf-m-primary pf-m-disabled"
+  disabled={null}
+  tabIndex={-1}
+  type={null}
+>
+  Disabled Anchor Button
+</a>
 `;
 
 exports[`danger button 1`] = `
@@ -41,12 +74,15 @@ exports[`danger button 1`] = `
   background-color: #a30000;
   border: 0px;
   border-radius: 30em;
+  text-decoration: none;
 }
 
 <button
+  aria-disabled={null}
   aria-label={null}
   className="pf-c-button pf-m-danger"
   disabled={false}
+  tabIndex={null}
   type="button"
 >
   danger
@@ -68,13 +104,16 @@ exports[`isBlock 1`] = `
   background-color: #00659c;
   border: 0px;
   border-radius: 30em;
+  text-decoration: none;
   width: 100%;
 }
 
 <button
+  aria-disabled={null}
   aria-label={null}
   className="pf-c-button pf-m-primary pf-m-block"
   disabled={false}
+  tabIndex={null}
   type="button"
 >
   Block Button
@@ -95,13 +134,16 @@ exports[`isDisabled 1`] = `
   background-color: #d1d1d1;
   border: 0px;
   border-radius: 30em;
+  text-decoration: none;
   pointer-events: none;
 }
 
 <button
+  aria-disabled={null}
   aria-label={null}
   className="pf-c-button pf-m-primary pf-m-disabled"
   disabled={true}
+  tabIndex={null}
   type="button"
 >
   Disabled Button
@@ -122,12 +164,15 @@ exports[`isFocus 1`] = `
   background-color: #00659c;
   border: 0px;
   border-radius: 30em;
+  text-decoration: none;
 }
 
 <button
+  aria-disabled={null}
   aria-label={null}
   className="pf-c-button pf-m-primary pf-m-focus"
   disabled={false}
+  tabIndex={null}
   type="button"
 >
   Focused Button
@@ -148,12 +193,15 @@ exports[`isHover 1`] = `
   background-color: #00659c;
   border: 0px;
   border-radius: 30em;
+  text-decoration: none;
 }
 
 <button
+  aria-disabled={null}
   aria-label={null}
   className="pf-c-button pf-m-primary pf-m-hover"
   disabled={false}
+  tabIndex={null}
   type="button"
 >
   Hovered Button
@@ -174,12 +222,15 @@ exports[`link button 1`] = `
   background-color: transparent;
   border: 0px;
   border-radius: 30em;
+  text-decoration: none;
 }
 
 <button
+  aria-disabled={null}
   aria-label={null}
   className="pf-c-button pf-m-link"
   disabled={false}
+  tabIndex={null}
   type="button"
 >
   link
@@ -201,12 +252,15 @@ exports[`primary button 1`] = `
   background-color: #00659c;
   border: 0px;
   border-radius: 30em;
+  text-decoration: none;
 }
 
 <button
+  aria-disabled={null}
   aria-label={null}
   className="pf-c-button pf-m-primary"
   disabled={false}
+  tabIndex={null}
   type="button"
 >
   primary
@@ -228,12 +282,15 @@ exports[`secondary button 1`] = `
   background-color: transparent;
   border: 0px;
   border-radius: 30em;
+  text-decoration: none;
 }
 
 <button
+  aria-disabled={null}
   aria-label={null}
   className="pf-c-button pf-m-secondary"
   disabled={false}
+  tabIndex={null}
   type="button"
 >
   secondary
@@ -255,12 +312,15 @@ exports[`tertiary button 1`] = `
   background-color: transparent;
   border: 0px;
   border-radius: 30em;
+  text-decoration: none;
 }
 
 <button
+  aria-disabled={null}
   aria-label={null}
   className="pf-c-button pf-m-tertiary"
   disabled={false}
+  tabIndex={null}
   type="button"
 >
   tertiary

--- a/packages/react-core/src/layouts/Grid/Grid.js
+++ b/packages/react-core/src/layouts/Grid/Grid.js
@@ -20,7 +20,7 @@ const Grid = ({ children, className, gutter, ...props }) => (
   <div
     className={css(
       styles.grid,
-      gutter && getGutterModifier(styles, gutter, styles.modifiers.gutters),
+      gutter && getGutterModifier(styles, gutter, styles.modifiers.gutter),
       className
     )}
     {...props}

--- a/packages/react-core/src/layouts/Grid/__snapshots__/Grid.test.js.snap
+++ b/packages/react-core/src/layouts/Grid/__snapshots__/Grid.test.js.snap
@@ -1,37 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`gutter lg 1`] = `
-.pf-l-grid.pf-m-gutters {
+.pf-l-grid.pf-m-gutter {
   display: grid;
   grid-template-columns: repeat(12, [col-start] 1fr);
   grid-gap: 1.5rem;
 }
 
 <div
-  className="pf-l-grid pf-m-gutters"
+  className="pf-l-grid pf-m-gutter"
 />
 `;
 
 exports[`gutter md 1`] = `
-.pf-l-grid.pf-m-gutters {
+.pf-l-grid.pf-m-gutter {
   display: grid;
   grid-template-columns: repeat(12, [col-start] 1fr);
   grid-gap: 1.5rem;
 }
 
 <div
-  className="pf-l-grid pf-m-gutters"
+  className="pf-l-grid pf-m-gutter"
 />
 `;
 
 exports[`gutter sm 1`] = `
-.pf-l-grid.pf-m-gutters {
+.pf-l-grid.pf-m-gutter {
   display: grid;
   grid-template-columns: repeat(12, [col-start] 1fr);
   grid-gap: 1.5rem;
 }
 
 <div
-  className="pf-l-grid pf-m-gutters"
+  className="pf-l-grid pf-m-gutter"
 />
 `;

--- a/packages/react-docs/src/components/example/example.js
+++ b/packages/react-docs/src/components/example/example.js
@@ -6,14 +6,22 @@ import { Title } from '@patternfly/react-core';
 
 const propTypes = {
   children: PropTypes.node.isRequired,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string
 };
 
-const Example = ({ children, title, ...props }) => (
+const defaultProps = {
+  description: ''
+};
+
+const Example = ({ children, title, description, ...props }) => (
   <div>
     <Title size="lg" withMargins>
       {title}
     </Title>
+    {Boolean(description) && (
+      <p className={css(styles.description)}>{description}</p>
+    )}
     <div className={css(styles.example)} {...props}>
       {React.Children.map(
         children,
@@ -28,5 +36,6 @@ const Example = ({ children, title, ...props }) => (
 );
 
 Example.propTypes = propTypes;
+Example.defaultProps = defaultProps;
 
 export default Example;

--- a/packages/react-docs/src/components/example/example.styles.js
+++ b/packages/react-docs/src/components/example/example.styles.js
@@ -13,5 +13,8 @@ export default StyleSheet.create({
   },
   spacing: {
     margin: spacerSm.var
+  },
+  description: {
+    marginBottom: spacerMd.var
   }
 });

--- a/packages/react-docs/src/pages/components/button.js
+++ b/packages/react-docs/src/pages/components/button.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import ComponentDocs from '../../components/componentDocs';
 import PropTypes from 'prop-types';
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
 import Example from '../../components/example';
 
 const propTypes = {
@@ -11,18 +12,33 @@ const propTypes = {
 const ButtonDocs = ({ data }) => (
   <ComponentDocs data={data}>
     <Example title="Variants">
-      {Object.values(ButtonVariant).map(variant => (
-        <Button
-          key={variant}
-          variant={variant}
-          label={`${variant} button example`}
-        >
-          {variant}
-        </Button>
-      ))}
+      <Button variant="primary">Primary</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="tertiary">Tertiary</Button>
+      <Button variant="danger">Danger</Button>
+      <Button variant="link">Link</Button>
+      <Button variant="action" ariaLabel="Action Button">
+        <TimesIcon />
+      </Button>
     </Example>
     <Example title="Block Button">
       <Button isBlock>Block Button</Button>
+    </Example>
+    <Example
+      title="Links"
+      description={`Links with button styling. Semantic buttons and links are important for usability as well as accessibility. Using an "a" instead of a "button" element to perform user initiated actions should be avoided, unless absolutely necessary.`}
+    >
+      <Button component="a" href="https://pf-next.com/" target="_blank">
+        Link to Core Docs
+      </Button>
+      <Button
+        component="a"
+        isDisabled
+        href="https://pf-next.com/"
+        target="_blank"
+      >
+        Disabled Link
+      </Button>
     </Example>
   </ComponentDocs>
 );

--- a/packages/react-tokens/package.json
+++ b/packages/react-tokens/package.json
@@ -27,7 +27,7 @@
     "build": "node build/generateTokens.js"
   },
   "devDependencies": {
-    "@patternfly/patternfly-next": "1.0.8",
+    "@patternfly/patternfly-next": "1.0.13",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,9 +134,9 @@
     node-fetch "^2.1.1"
     url-template "^2.0.8"
 
-"@patternfly/patternfly-next@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.8.tgz#336f0692f84bbde486ec8ea144d9baa633873fcd"
+"@patternfly/patternfly-next@1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.13.tgz#a2f295b76790e6fde8c7be7899244c3d7bfc35aa"
 
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
affects: @patternfly/react-core, @patternfly/react-docs, @patternfly/react-tokens

Added support for using anchor tags or custom components for button.  Added aria support for
disabled buttons that are not rendered as HTML buttons.

Updated alert tests to use a string for actions.  The tests only needed to verify that the element passed is rendered in the correct place.  Using buttons will cause unnecessarily large snapshots.

See Core change here: https://github.com/patternfly/patternfly-next/pull/454