### PR TITLE
feat(pf4-split): introduce split layout for PF 4

### DIFF
--- a/packages/react-core/src/layouts/Split/Split.d.ts
+++ b/packages/react-core/src/layouts/Split/Split.d.ts
@@ -1,0 +1,12 @@
+import { SFC, HTMLProps, ReactType } from 'react';
+import { OneOf } from '../../typeUtils';
+import { GutterSize, getGutterModifier } from '../../styles/gutters';
+
+export interface SplitProps extends HTMLProps<HTMLDivElement> {
+  component?: ReactType<SplitProps>;
+  gutter?: OneOf<typeof GutterSize, keyof typeof GutterSize>;
+}
+
+declare const Split: SFC<SplitProps>;
+
+export default Split;

--- a/packages/react-core/src/layouts/Split/Split.js
+++ b/packages/react-core/src/layouts/Split/Split.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from '@patternfly/patternfly-next/layouts/Split/styles.css';
+import { componentShape } from '../../internal/componentShape';
+import { GutterSize, getGutterModifier } from '../../styles/gutters';
+import { css } from '@patternfly/react-styles';
+
+const propTypes = {
+  gutter: PropTypes.oneOf(Object.keys(GutterSize)),
+  children: PropTypes.node,
+  className: PropTypes.string,
+  component: componentShape
+};
+
+const defaultProps = {
+  gutter: null,
+  className: '',
+  children: null,
+  component: 'div'
+};
+
+const Split = ({
+  gutter,
+  className,
+  children,
+  component: Component,
+  ...props
+}) => (
+  <Component
+    {...props}
+    className={css(
+      styles.split,
+      gutter && getGutterModifier(styles, gutter, styles.modifiers.gutter),
+      className
+    )}
+  >
+    {children}
+  </Component>
+);
+
+Split.propTypes = propTypes;
+Split.defaultProps = defaultProps;
+
+export default Split;

--- a/packages/react-core/src/layouts/Split/Split.test.js
+++ b/packages/react-core/src/layouts/Split/Split.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Split from './Split';
+import SplitItem, { SplitItemVariant } from './SplitItem';
+import { GutterSize } from '../../styles/gutters';
+
+test('Secondary and primary set', () => {
+  const view = mount(
+    <Split>
+      <SplitItem variant={SplitItemVariant.secondary}>
+        Secondary content
+      </SplitItem>
+      <SplitItem variant={SplitItemVariant.primary}>Primary content</SplitItem>
+      <SplitItem variant={SplitItemVariant.secondary}>
+        Secondary content
+      </SplitItem>
+    </Split>
+  );
+  // Add a useful assertion here.
+  expect(view).toMatchSnapshot();
+});
+
+test('No variant set', () => {
+  const view = mount(
+    <Split>
+      <SplitItem>Secondary content</SplitItem>
+      <SplitItem>Primary content</SplitItem>
+      <SplitItem>Secondary content</SplitItem>
+    </Split>
+  );
+  // Add a useful assertion here.
+  expect(view).toMatchSnapshot();
+});
+
+Object.values(GutterSize).forEach(gutter => {
+  test(`Gutter ${gutter}`, () => {
+    const view = mount(
+      <Split gutter={gutter}>
+        <SplitItem>Secondary content</SplitItem>
+        <SplitItem>Primary content</SplitItem>
+        <SplitItem>Secondary content</SplitItem>
+      </Split>
+    );
+    expect(view).toMatchSnapshot();
+  });
+});

--- a/packages/react-core/src/layouts/Split/SplitItem.d.ts
+++ b/packages/react-core/src/layouts/Split/SplitItem.d.ts
@@ -1,0 +1,15 @@
+import { SFC, HTMLProps } from 'react';
+import { Omit, OneOf } from '../../typeUtils';
+
+export const SplitItemVariant: {
+  primary: 'primary';
+  secondary: 'secondary';
+}
+
+export interface SplitItemProps extends HTMLProps<HTMLDivElement> {
+  variant?: OneOf<typeof SplitItemVariant, keyof typeof SplitItemVariant>;
+}
+
+declare const SplitItem: SFC<SplitItemProps>;
+
+export default SplitItem;

--- a/packages/react-core/src/layouts/Split/SplitItem.js
+++ b/packages/react-core/src/layouts/Split/SplitItem.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from '@patternfly/patternfly-next/layouts/Split/styles.css';
+import { css, getModifier } from '@patternfly/react-styles';
+
+export const SplitItemVariant = {
+  primary: 'primary',
+  secondary: 'secondary'
+};
+
+const propTypes = {
+  variant: PropTypes.oneOf(Object.keys(SplitItemVariant)),
+  children: PropTypes.node,
+  className: PropTypes.string
+};
+
+const defaultProps = {
+  variant: null,
+  className: '',
+  children: null
+};
+
+const SplitItem = ({ variant, className, children, ...props }) => (
+  <div
+    {...props}
+    className={css(
+      styles.splitItem,
+      getModifier(styles.modifiers, variant),
+      className
+    )}
+  >
+    {children}
+  </div>
+);
+
+SplitItem.propTypes = propTypes;
+SplitItem.defaultProps = defaultProps;
+
+export default SplitItem;

--- a/packages/react-core/src/layouts/Split/__snapshots__/Split.test.js.snap
+++ b/packages/react-core/src/layouts/Split/__snapshots__/Split.test.js.snap
@@ -1,0 +1,296 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Gutter lg 1`] = `
+.pf-l-split__item {
+  display: block;
+}
+.pf-l-split__item {
+  display: block;
+}
+.pf-l-split__item {
+  display: block;
+}
+.pf-l-split.pf-m-gutter {
+  display: flex;
+  flex-wrap: nowrap;
+  padding: 0px;
+  margin: 0px;
+}
+
+<Split
+  className=""
+  component="div"
+  gutter="lg"
+>
+  <div
+    className="pf-l-split pf-m-gutter"
+  >
+    <SplitItem
+      className=""
+      variant={null}
+    >
+      <div
+        className="pf-l-split__item"
+      >
+        Secondary content
+      </div>
+    </SplitItem>
+    <SplitItem
+      className=""
+      variant={null}
+    >
+      <div
+        className="pf-l-split__item"
+      >
+        Primary content
+      </div>
+    </SplitItem>
+    <SplitItem
+      className=""
+      variant={null}
+    >
+      <div
+        className="pf-l-split__item"
+      >
+        Secondary content
+      </div>
+    </SplitItem>
+  </div>
+</Split>
+`;
+
+exports[`Gutter md 1`] = `
+.pf-l-split__item {
+  display: block;
+}
+.pf-l-split__item {
+  display: block;
+}
+.pf-l-split__item {
+  display: block;
+}
+.pf-l-split.pf-m-gutter {
+  display: flex;
+  flex-wrap: nowrap;
+  padding: 0px;
+  margin: 0px;
+}
+
+<Split
+  className=""
+  component="div"
+  gutter="md"
+>
+  <div
+    className="pf-l-split pf-m-gutter"
+  >
+    <SplitItem
+      className=""
+      variant={null}
+    >
+      <div
+        className="pf-l-split__item"
+      >
+        Secondary content
+      </div>
+    </SplitItem>
+    <SplitItem
+      className=""
+      variant={null}
+    >
+      <div
+        className="pf-l-split__item"
+      >
+        Primary content
+      </div>
+    </SplitItem>
+    <SplitItem
+      className=""
+      variant={null}
+    >
+      <div
+        className="pf-l-split__item"
+      >
+        Secondary content
+      </div>
+    </SplitItem>
+  </div>
+</Split>
+`;
+
+exports[`Gutter sm 1`] = `
+.pf-l-split__item {
+  display: block;
+}
+.pf-l-split__item {
+  display: block;
+}
+.pf-l-split__item {
+  display: block;
+}
+.pf-l-split.pf-m-gutter {
+  display: flex;
+  flex-wrap: nowrap;
+  padding: 0px;
+  margin: 0px;
+}
+
+<Split
+  className=""
+  component="div"
+  gutter="sm"
+>
+  <div
+    className="pf-l-split pf-m-gutter"
+  >
+    <SplitItem
+      className=""
+      variant={null}
+    >
+      <div
+        className="pf-l-split__item"
+      >
+        Secondary content
+      </div>
+    </SplitItem>
+    <SplitItem
+      className=""
+      variant={null}
+    >
+      <div
+        className="pf-l-split__item"
+      >
+        Primary content
+      </div>
+    </SplitItem>
+    <SplitItem
+      className=""
+      variant={null}
+    >
+      <div
+        className="pf-l-split__item"
+      >
+        Secondary content
+      </div>
+    </SplitItem>
+  </div>
+</Split>
+`;
+
+exports[`No variant set 1`] = `
+.pf-l-split__item {
+  display: block;
+}
+.pf-l-split__item {
+  display: block;
+}
+.pf-l-split__item {
+  display: block;
+}
+.pf-l-split {
+  display: flex;
+  flex-wrap: nowrap;
+  padding: 0px;
+  margin: 0px;
+}
+
+<Split
+  className=""
+  component="div"
+  gutter={null}
+>
+  <div
+    className="pf-l-split"
+  >
+    <SplitItem
+      className=""
+      variant={null}
+    >
+      <div
+        className="pf-l-split__item"
+      >
+        Secondary content
+      </div>
+    </SplitItem>
+    <SplitItem
+      className=""
+      variant={null}
+    >
+      <div
+        className="pf-l-split__item"
+      >
+        Primary content
+      </div>
+    </SplitItem>
+    <SplitItem
+      className=""
+      variant={null}
+    >
+      <div
+        className="pf-l-split__item"
+      >
+        Secondary content
+      </div>
+    </SplitItem>
+  </div>
+</Split>
+`;
+
+exports[`Secondary and primary set 1`] = `
+.pf-l-split__item.pf-m-secondary {
+  display: block;
+}
+.pf-l-split__item.pf-m-primary {
+  display: block;
+}
+.pf-l-split__item.pf-m-secondary {
+  display: block;
+}
+.pf-l-split {
+  display: flex;
+  flex-wrap: nowrap;
+  padding: 0px;
+  margin: 0px;
+}
+
+<Split
+  className=""
+  component="div"
+  gutter={null}
+>
+  <div
+    className="pf-l-split"
+  >
+    <SplitItem
+      className=""
+      variant="secondary"
+    >
+      <div
+        className="pf-l-split__item pf-m-secondary"
+      >
+        Secondary content
+      </div>
+    </SplitItem>
+    <SplitItem
+      className=""
+      variant="primary"
+    >
+      <div
+        className="pf-l-split__item pf-m-primary"
+      >
+        Primary content
+      </div>
+    </SplitItem>
+    <SplitItem
+      className=""
+      variant="secondary"
+    >
+      <div
+        className="pf-l-split__item pf-m-secondary"
+      >
+        Secondary content
+      </div>
+    </SplitItem>
+  </div>
+</Split>
+`;

--- a/packages/react-core/src/layouts/Split/index.d.ts
+++ b/packages/react-core/src/layouts/Split/index.d.ts
@@ -1,0 +1,2 @@
+export { default as Split, SplitProps } from './Split';
+export { default as SplitItem, SplitItemProps, SplitItemVariant } from './SplitItem';

--- a/packages/react-core/src/layouts/Split/index.js
+++ b/packages/react-core/src/layouts/Split/index.js
@@ -1,0 +1,2 @@
+export { default as Split } from './Split';
+export { default as SplitItem, SplitItemVariant } from './SplitItem';

--- a/packages/react-core/src/layouts/index.d.ts
+++ b/packages/react-core/src/layouts/index.d.ts
@@ -2,3 +2,4 @@ export * from './Bullseye';
 export * from './Gallery';
 export * from './Grid';
 export * from './Level';
+export * from './Split';

--- a/packages/react-core/src/layouts/index.js
+++ b/packages/react-core/src/layouts/index.js
@@ -2,3 +2,4 @@ export * from './Bullseye';
 export * from './Gallery';
 export * from './Grid';
 export * from './Level';
+export * from './Split';

--- a/packages/react-docs/src/pages/layouts/split.js
+++ b/packages/react-docs/src/pages/layouts/split.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import ComponentDocs from '../../components/componentDocs';
+import PropTypes from 'prop-types';
+import { Split, SplitItem, SplitItemVariant } from '@patternfly/react-core';
+import {
+  global_BorderColor as borderColor,
+  global_BorderWidth_md as borderWidth,
+  global_spacer_sm as padding
+} from '@patternfly/react-tokens';
+import { css, StyleSheet } from '@patternfly/react-styles';
+import Example from '../../components/example';
+
+const propTypes = {
+  data: PropTypes.any.isRequired
+};
+
+const styles = StyleSheet.create({
+  item: {
+    padding: padding.var,
+    border: `${borderWidth.var} dashed ${borderColor.var}`
+  }
+});
+
+const StyledSplitItem = props => (
+  <SplitItem {...props} className={css(styles.item)} />
+);
+
+const SplitDocs = ({ data }) => (
+  <ComponentDocs data={data}>
+    <Example title="Split with variant">
+      <Split>
+        <StyledSplitItem variant={SplitItemVariant.secondary}>
+          Secondary content
+        </StyledSplitItem>
+        <StyledSplitItem variant={SplitItemVariant.primary}>
+          Primary content
+        </StyledSplitItem>
+        <StyledSplitItem variant={SplitItemVariant.secondary}>
+          Secondary content
+        </StyledSplitItem>
+      </Split>
+    </Example>
+    <Example title="Split with gutter">
+      <Split gutter="sm">
+        <StyledSplitItem>Secondary content</StyledSplitItem>
+        <StyledSplitItem>Primary content</StyledSplitItem>
+        <StyledSplitItem>Secondary content</StyledSplitItem>
+      </Split>
+    </Example>
+    <Example title="Split without variant">
+      <Split>
+        <StyledSplitItem>Secondary content</StyledSplitItem>
+        <StyledSplitItem>Primary content</StyledSplitItem>
+        <StyledSplitItem>Secondary content</StyledSplitItem>
+      </Split>
+    </Example>
+    <Example title="Multiple primary">
+      <Split>
+        <StyledSplitItem variant={SplitItemVariant.secondary}>
+          Secondary content
+        </StyledSplitItem>
+        <StyledSplitItem variant={SplitItemVariant.primary}>
+          Primary content
+        </StyledSplitItem>
+        <StyledSplitItem variant={SplitItemVariant.primary}>
+          Primary content
+        </StyledSplitItem>
+        <StyledSplitItem variant={SplitItemVariant.primary}>
+          Primary content
+        </StyledSplitItem>
+      </Split>
+    </Example>
+  </ComponentDocs>
+);
+
+SplitDocs.propTypes = propTypes;
+
+export const query = graphql`
+  query SplitDocsQuery {
+    componentMetadata(displayName: { eq: "Split" }) {
+      ...ComponentDocs
+    }
+  }
+`;
+
+export default SplitDocs;


### PR DESCRIPTION
affects: @patternfly/react-core, @patternfly/react-docs

**What**:
Create new layout Split which allows horizontal alignment of items.
<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to docs**:
https://5b4f4db5fdd72a01b2df0c18--zen-swanson-2d3350.netlify.com/layouts/split/

**Additional issues**:
ISSUES CLOSED: #476
