### PR TITLE
feat(react-core/Alignment): Add PF4 Alignment Layout

### DIFF
--- a/packages/react-core/src/layouts/Alignment/Alignment.d.ts
+++ b/packages/react-core/src/layouts/Alignment/Alignment.d.ts
@@ -1,0 +1,9 @@
+import { HTMLProps, SFC, ReactType } from 'react';
+
+export interface AlignmentProps extends HTMLProps<HTMLDivElement> {
+  component?: ReactType<AlignmentProps>;
+}
+
+declare const Alignment: SFC<AlignmentProps>;
+
+export default Alignment;

--- a/packages/react-core/src/layouts/Alignment/Alignment.js
+++ b/packages/react-core/src/layouts/Alignment/Alignment.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { css, getModifier } from '@patternfly/react-styles';
+import styles from '@patternfly/patternfly-next/layouts/Alignment/styles.css';
+import PropTypes from 'prop-types';
+import { componentShape } from '../../internal/componentShape';
+
+const AlignVariant = {
+  left: 'left',
+  right: 'right',
+  center: 'center'
+};
+
+const propTypes = {
+  children: PropTypes.any,
+  className: PropTypes.string,
+  component: componentShape,
+  align: PropTypes.oneOf(Object.keys(AlignVariant))
+};
+
+const defaultProps = {
+  children: null,
+  className: '',
+  component: 'div',
+  align: AlignVariant.left
+};
+
+const Alignment = ({
+  children,
+  className,
+  align,
+  component: Component,
+  ...props
+}) => (
+  <Component
+    className={css(styles.alignment, className, getModifier(styles, align))}
+    {...props}
+  >
+    {children}
+  </Component>
+);
+
+Alignment.propTypes = propTypes;
+Alignment.defaultProps = defaultProps;
+
+export default Alignment;

--- a/packages/react-core/src/layouts/Alignment/Alignment.test.js
+++ b/packages/react-core/src/layouts/Alignment/Alignment.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import Alignment from './Alignment';
+import { shallow } from 'enzyme';
+
+test('allows passing in a string as the component', () => {
+  const component = 'div';
+  const view = shallow(<Alignment component={component} />);
+  expect(view.type()).toBe(component);
+});
+
+test('allows passing in a React Component as the component', () => {
+  const Component = () => null;
+  const view = shallow(<Alignment component={Component} />);
+  expect(view.type()).toBe(Component);
+});
+
+test('right alignment', () => {
+  const view = shallow(<Alignment align="right" />);
+  expect(view).toMatchSnapshot();
+});
+
+test('left alignment', () => {
+  const view = shallow(<Alignment align="left" />);
+  expect(view).toMatchSnapshot();
+});
+
+test('center alignment', () => {
+  const view = shallow(<Alignment align="center" />);
+  expect(view).toMatchSnapshot();
+});

--- a/packages/react-core/src/layouts/Alignment/__snapshots__/Alignment.test.js.snap
+++ b/packages/react-core/src/layouts/Alignment/__snapshots__/Alignment.test.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`center alignment 1`] = `
+.pf-l-alignment.pf-m-center {
+  display: block;
+  padding: 0px;
+  margin: 0px;
+  text-align: center;
+}
+
+<div
+  className="pf-l-alignment pf-m-center"
+/>
+`;
+
+exports[`left alignment 1`] = `
+.pf-l-alignment.pf-m-left {
+  display: block;
+  padding: 0px;
+  margin: 0px;
+  text-align: left;
+}
+
+<div
+  className="pf-l-alignment pf-m-left"
+/>
+`;
+
+exports[`right alignment 1`] = `
+.pf-l-alignment.pf-m-right {
+  display: block;
+  padding: 0px;
+  margin: 0px;
+  text-align: right;
+}
+
+<div
+  className="pf-l-alignment pf-m-right"
+/>
+`;

--- a/packages/react-core/src/layouts/Alignment/index.d.ts
+++ b/packages/react-core/src/layouts/Alignment/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Alignment, AlignmentProps } from './Alignment';

--- a/packages/react-core/src/layouts/Alignment/index.js
+++ b/packages/react-core/src/layouts/Alignment/index.js
@@ -1,0 +1,1 @@
+export { default as Alignment } from './Alignment';

--- a/packages/react-core/src/layouts/index.d.ts
+++ b/packages/react-core/src/layouts/index.d.ts
@@ -2,3 +2,4 @@ export * from './Bullseye';
 export * from './Gallery';
 export * from './Grid';
 export * from './Level';
+export * from './Alignment';

--- a/packages/react-core/src/layouts/index.js
+++ b/packages/react-core/src/layouts/index.js
@@ -2,3 +2,4 @@ export * from './Bullseye';
 export * from './Gallery';
 export * from './Grid';
 export * from './Level';
+export * from './Alignment';

--- a/packages/react-docs/src/pages/layouts/alignment.js
+++ b/packages/react-docs/src/pages/layouts/alignment.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import ComponentDocs from '../../components/componentDocs';
+import PropTypes from 'prop-types';
+import { Alignment } from '@patternfly/react-core';
+import Example from '../../components/example';
+
+const propTypes = {
+  data: PropTypes.any.isRequired
+};
+
+const AlignmentDocs = ({ data }) => (
+  <ComponentDocs data={data}>
+    <Example title="Left">
+      <Alignment align="left">
+        <div>content</div>
+      </Alignment>
+    </Example>
+    <Example title="Center">
+      <Alignment align="center">
+        <div>content</div>
+      </Alignment>
+    </Example>
+    <Example title="Right">
+      <Alignment align="right">
+        <div>content</div>
+      </Alignment>
+    </Example>
+  </ComponentDocs>
+);
+
+AlignmentDocs.propTypes = propTypes;
+
+export const query = graphql`
+  query AlignmentDocsQuery {
+    componentMetadata(displayName: { eq: "Alignment" }) {
+      ...ComponentDocs
+    }
+  }
+`;
+
+export default AlignmentDocs;


### PR DESCRIPTION
**Affects**: @patternfly/react-core, @patternfly/react-docs

**What**: Introducing the PF4 Alignment Layout

ISSUES CLOSED:  https://github.com/patternfly/patternfly-react/issues/445

@dmiller9911 I tried to add the typescript files...being that I'm unfamiliar, please let me know if I'm missing anything. 