### PR TITLE
Password form control

### DIFF
--- a/packages/patternfly-react/src/components/Form/Form.test.js
+++ b/packages/patternfly-react/src/components/Form/Form.test.js
@@ -8,7 +8,8 @@ import {
   Form,
   Grid,
   MenuItem,
-  Modal
+  Modal,
+  Password
 } from '../../index';
 
 test('Inline Form renders properly', () => {
@@ -293,6 +294,13 @@ test('Supported controls render properly', () => {
   );
 
   expect(component.render()).toMatchSnapshot();
+});
+
+test('Password field behaves correctly', () => {
+  expect(() => mount(<Password value={null} />)).toThrowError(
+    'The `value` property is forbidden for password fields'
+  );
+  expect(mount(<Password />).render()).toMatchSnapshot();
 });
 
 test('Input Groups render properly', () => {

--- a/packages/patternfly-react/src/components/Form/Password.js
+++ b/packages/patternfly-react/src/components/Form/Password.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { default as FormControl } from './FormControl';
+
+function PasswordPropertyViolation(message) {
+  this.message = message;
+  this.name = 'PasswordPropertyViolation';
+}
+
+class Password extends React.Component {
+  constructor(props) {
+    if (props.value !== undefined) { // eslint-disable-line react/prop-types,prettier/prettier
+      throw new PasswordPropertyViolation(
+        'The `value` property is forbidden for password fields'
+      );
+    }
+    super(props);
+  }
+
+  render() {
+    return <FormControl type="password" {...this.props} />;
+  }
+}
+
+export { Password as default };

--- a/packages/patternfly-react/src/components/Form/Stories/SupportedControlsForm.js
+++ b/packages/patternfly-react/src/components/Form/Stories/SupportedControlsForm.js
@@ -26,9 +26,7 @@ export const SupportedControlsFormFields = [
     controlId: 'password',
     label: 'Password',
     help: 'Help text',
-    formControl: ({ validationState, ...props }) => (
-      <Form.FormControl type="password" {...props} />
-    )
+    formControl: ({ validationState, ...props }) => <Form.Password {...props} />
   },
   {
     controlId: 'file',

--- a/packages/patternfly-react/src/components/Form/__snapshots__/Form.test.js.snap
+++ b/packages/patternfly-react/src/components/Form/__snapshots__/Form.test.js.snap
@@ -412,6 +412,13 @@ exports[`Input Groups render properly 1`] = `
 
 exports[`Modal Form renders properly 1`] = `null`;
 
+exports[`Password field behaves correctly 1`] = `
+<input
+  class="form-control"
+  type="password"
+/>
+`;
+
 exports[`Supported controls render properly 1`] = `
 <form
   class=""

--- a/packages/patternfly-react/src/components/Form/index.js
+++ b/packages/patternfly-react/src/components/Form/index.js
@@ -5,6 +5,7 @@ import { default as FormControl } from './FormControl';
 import { default as FormGroup } from './FormGroup';
 import { default as HelpBlock } from './HelpBlock';
 import { default as InputGroup } from './InputGroup';
+import { default as Password } from './Password';
 import { default as Radio } from './Radio';
 
 Form.Checkbox = Checkbox;
@@ -14,6 +15,7 @@ Form.FormGroup = FormGroup;
 Form.HelpBlock = HelpBlock;
 Form.InputGroup = InputGroup;
 Form.Radio = Radio;
+Form.Password = Password;
 
 export {
   Checkbox,
@@ -23,5 +25,6 @@ export {
   FormGroup,
   HelpBlock,
   InputGroup,
+  Password,
   Radio
 };


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**: A thin wrapper around form control for Password inputs that disallows setting of the `value` property to prevent snooping via CSS (can provide more details if you want)

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**: https://shaded-enmity.github.io/patternfly-react/

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- feel free to add additional comments -->