### PR TITLE
fix(TypeAheadSelect): expose inner components of "react-bootstrap-typeahead"

### DIFF
--- a/packages/patternfly-react/src/components/TypeAheadSelect/GithubMenuItem.js
+++ b/packages/patternfly-react/src/components/TypeAheadSelect/GithubMenuItem.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Highlighter } from 'react-bootstrap-typeahead';
+import { TypeAheadSelect } from './index';
 
 const GithubMenuItem = props => (
   <div key={props.option.id}>
@@ -10,7 +10,9 @@ const GithubMenuItem = props => (
       src={props.option.avatar_url}
       style={{ borderRadius: '10px', margin: '5px' }}
     />
-    <Highlighter search={props.text}>{props.option.login}</Highlighter>
+    <TypeAheadSelect.Highlighter search={props.text}>
+      {props.option.login}
+    </TypeAheadSelect.Highlighter>
   </div>
 );
 

--- a/packages/patternfly-react/src/components/TypeAheadSelect/TypeAheadSelect.js
+++ b/packages/patternfly-react/src/components/TypeAheadSelect/TypeAheadSelect.js
@@ -1,1 +1,22 @@
-export { Typeahead as TypeAheadSelect } from 'react-bootstrap-typeahead';
+import {
+  Typeahead as TypeAheadSelect,
+  Highlighter,
+  Menu,
+  MenuItem,
+  Token,
+  TypeaheadMenu,
+  asyncContainer,
+  menuItemContainer,
+  tokenContainer
+} from 'react-bootstrap-typeahead';
+
+TypeAheadSelect.Highlighter = Highlighter;
+TypeAheadSelect.Menu = Menu;
+TypeAheadSelect.MenuItem = MenuItem;
+TypeAheadSelect.Token = Token;
+TypeAheadSelect.TypeaheadMenu = TypeaheadMenu;
+TypeAheadSelect.asyncContainer = asyncContainer;
+TypeAheadSelect.menuItemContainer = menuItemContainer;
+TypeAheadSelect.tokenContainer = tokenContainer;
+
+export default TypeAheadSelect;

--- a/packages/patternfly-react/src/components/TypeAheadSelect/TypeAheadSelect.test.js
+++ b/packages/patternfly-react/src/components/TypeAheadSelect/TypeAheadSelect.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { TypeAheadSelect } from './TypeAheadSelect';
+import { TypeAheadSelect } from './index';
 
 test('TypeAheadSelect is working !!', () => {
   const component = shallow(

--- a/packages/patternfly-react/src/components/TypeAheadSelect/index.js
+++ b/packages/patternfly-react/src/components/TypeAheadSelect/index.js
@@ -1,4 +1,4 @@
-import { TypeAheadSelect } from './TypeAheadSelect';
+import TypeAheadSelect from './TypeAheadSelect';
 import AsyncTypeAheadSelect from './AsyncTypeAheadSelect';
 
 export { TypeAheadSelect, AsyncTypeAheadSelect };


### PR DESCRIPTION
Expose inner components for external use.

The components are:
  - Highlighter,
  - Menu,
  - MenuItem,
  - Token,
  - TypeaheadMenu,
  - asyncContainer,
  - menuItemContainer,
  - tokenContainer

affects: patternfly-react

ISSUES CLOSED: #483
