### PR TITLE
feat(bugfix-icon_import): when importing icons their name has to haveicon suffix in them

### DIFF
--- a/packages/react-icons/build/generateIcons.js
+++ b/packages/react-icons/build/generateIcons.js
@@ -18,7 +18,7 @@ function getFontAwesomeIcon(name) {
   const faIconDef = require(`@fortawesome/free-solid-svg-icons/${faIconName}`); // eslint-disable-line
 
   return {
-    id: name,
+    id: `${name}-icon`,
     name: pascalCase(`${name}-icon`),
     width: faIconDef.width,
     height: faIconDef.height,


### PR DESCRIPTION
affects: @patternfly/react-icons

Looks like our babel config is trying to load wrong icons when outside `development`.

When using component with icon it tries to import from file `icons/${iconName}-icon` however these files does not exist. Either create files with `-icon` suffix in them or change `importPath`. The option with adding `-icon` suffix to each file seems easier and faster.

https://5b5091ecb31274118e4ae653--zen-swanson-2d3350.netlify.com/styles/icons

This bug couldn't be caught when running tests and with react docs because these are using `development` flag, we might turn it off when running tests.