### PR TITLE
chore(storybook): add resolve alias for patternfly-react to target src

### DIFF
--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -50,5 +50,13 @@ module.exports = (baseConfig, env, defaultConfig) => {
     }
   );
 
+  defaultConfig.resolve.alias = {
+    ...defaultConfig.resolve.alias,
+    'patternfly-react': path.resolve(
+      __dirname,
+      '../packages/patternfly-react/src'
+    )
+  };
+
   return defaultConfig;
 };


### PR DESCRIPTION
Target src within storybook to remove the requirement to build patternfly-react before running
storybook.
