### PR TITLE
fix(child types): update checking for child types to use the displayName field

### DIFF
--- a/packages/patternfly-react/src/components/ToastNotification/TimedToastNotification.js
+++ b/packages/patternfly-react/src/components/ToastNotification/TimedToastNotification.js
@@ -87,4 +87,6 @@ TimedToastNotification.TOAST_NOTIFICATION_TYPES = [
   ...ToastNotification.TOAST_NOTIFICATION_TYPES
 ];
 
+TimedToastNotification.displayName = 'TimedToastNotification';
+
 export default TimedToastNotification;

--- a/packages/patternfly-react/src/components/ToastNotification/ToastNotificationList.js
+++ b/packages/patternfly-react/src/components/ToastNotification/ToastNotificationList.js
@@ -35,7 +35,10 @@ class ToastNotificationList extends React.Component {
   renderChildren() {
     const { paused } = this.state;
     return React.Children.map(this.props.children, child => {
-      if (child && child.type === TimedToastNotification) {
+      if (
+        child &&
+        child.type.displayName === TimedToastNotification.displayName
+      ) {
         /**
          * If any of the notifications are hovered, pause
          * all child notifications from dismissing

--- a/packages/patternfly-react/src/components/Toolbar/Toolbar.js
+++ b/packages/patternfly-react/src/components/Toolbar/Toolbar.js
@@ -17,10 +17,14 @@ const Toolbar = ({ children, className, ...props }) => {
 
   const toolbarChildren =
     childrenArray &&
-    childrenArray.filter(child => child.type !== ToolbarResults);
+    childrenArray.filter(
+      child => child.type.displayName !== ToolbarResults.displayName
+    );
   const resultsChildren =
     childrenArray &&
-    childrenArray.filter(child => child.type === ToolbarResults);
+    childrenArray.filter(
+      child => child.type.displayName === ToolbarResults.displayName
+    );
 
   return (
     <ToolbarContextProvider isDescendantOfToolbar>

--- a/packages/patternfly-react/src/components/Toolbar/ToolbarResults.js
+++ b/packages/patternfly-react/src/components/Toolbar/ToolbarResults.js
@@ -27,4 +27,6 @@ ToolbarResults.defaultProps = {
   className: ''
 };
 
+ToolbarResults.displayName = 'ToolbarResults';
+
 export default ToolbarResults;

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNav.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNav.js
@@ -305,7 +305,7 @@ class BaseVerticalNav extends React.Component {
     // If the items prop is not present, items must be expressed as VerticalNavItem children instead.
     const itemsFromChildren = filterChildren(
       children,
-      child => child.type === VerticalNavItem
+      child => child.type.displayName === VerticalNavItem.displayName
     );
     const itemsFromProps =
       items &&
@@ -356,7 +356,10 @@ class BaseVerticalNav extends React.Component {
 
     const mastheadElem = masthead || (
       <nav className={classNames('navbar navbar-pf-vertical')}>
-        {findChild(children, child => child.type === VerticalNavMasthead)}
+        {findChild(
+          children,
+          child => child.type.displayName === VerticalNavMasthead.displayName
+        )}
       </nav>
     );
 

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
@@ -250,7 +250,10 @@ class BaseVerticalNavItemHelper extends React.Component {
     }
 
     const childBadgeComponents =
-      filterChildren(children, child => child.type === VerticalNavBadge) ||
+      filterChildren(
+        children,
+        child => child.type.displayName === VerticalNavBadge.displayName
+      ) ||
       (badges &&
         badges.length > 0 &&
         badges.map(badge => {

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNavMasthead.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNavMasthead.js
@@ -18,10 +18,14 @@ const BaseVerticalNavMasthead = props => {
     React.Children.toArray(children);
   const brandChildren =
     childrenArray &&
-    childrenArray.filter(child => child.type === VerticalNavBrand);
+    childrenArray.filter(
+      child => child.type.displayName === VerticalNavBrand.displayName
+    );
   const otherChildren =
     childrenArray &&
-    childrenArray.filter(child => child.type !== VerticalNavBrand);
+    childrenArray.filter(
+      child => child.type.displayName !== VerticalNavBrand.displayName
+    );
 
   return (
     <React.Fragment>


### PR DESCRIPTION
affects: patternfly-react

The '===' comparision of types does not always produce a positive result.
Though the child is specified as the correct type, the comparison fails.
Checking the displayName will always produce the desired result.

There is no visual changes created by this PR.