### PR TITLE
refactor([react-core] Alert): replace custom srOnly styles with pf-core class

### DIFF
--- a/packages/react-core/src/components/Alert/Alert.js
+++ b/packages/react-core/src/components/Alert/Alert.js
@@ -1,25 +1,13 @@
 import React from 'react';
-import { StyleSheet, css, getModifier } from '@patternfly/react-styles';
+import { css, getModifier } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
 import styles from '@patternfly/patternfly-next/components/Alert/styles.css';
+import accessibleStyles from '@patternfly/patternfly-next/utilities/Accessibility/styles.css';
 
 import AlertIcon from './AlertIcon';
 import AlertBody from './AlertBody';
 import AlertAction from './AlertAction';
 import { capitalize } from '../../internal/util';
-
-const utils = StyleSheet.create({
-  srOnly: {
-    position: 'absolute',
-    width: '1px',
-    height: '1px',
-    padding: '0',
-    margin: '-1px',
-    overflow: 'hidden',
-    clip: 'rect(0,0,0,0)',
-    border: '0'
-  }
-});
 
 export const AlertVariant = {
   success: 'success',
@@ -56,7 +44,7 @@ const Alert = ({
 }) => {
   const readerTitle = (
     <React.Fragment>
-      <span className={css(utils.srOnly)}>
+      <span className={css(accessibleStyles.srOnly)}>
         {capitalize(AlertVariant[variant])}:{' '}
       </span>
       {title}

--- a/packages/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -6,6 +6,17 @@ exports[`Alert - danger Action 1`] = `
   padding: 1rem;
   font-size: 24px;
 }
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
+}
 .pf-c-alert__title {
   display: block;
   margin-top: 0.25rem;
@@ -69,7 +80,7 @@ exports[`Alert - danger Action 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Danger
             :
@@ -86,7 +97,7 @@ exports[`Alert - danger Action 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Danger
             :
@@ -114,6 +125,17 @@ exports[`Alert - danger Action and Title 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -178,7 +200,7 @@ exports[`Alert - danger Action and Title 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Danger
             :
@@ -195,7 +217,7 @@ exports[`Alert - danger Action and Title 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Danger
             :
@@ -224,6 +246,17 @@ exports[`Alert - danger Body 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -284,7 +317,7 @@ exports[`Alert - danger Body 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Danger
             :
@@ -301,7 +334,7 @@ exports[`Alert - danger Body 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Danger
             :
@@ -320,6 +353,17 @@ exports[`Alert - danger Custom aria label 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -385,7 +429,7 @@ exports[`Alert - danger Custom aria label 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Danger
             :
@@ -402,7 +446,7 @@ exports[`Alert - danger Custom aria label 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Danger
             :
@@ -431,6 +475,17 @@ exports[`Alert - danger Title 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -491,7 +546,7 @@ exports[`Alert - danger Title 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Danger
             :
@@ -508,7 +563,7 @@ exports[`Alert - danger Title 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Danger
             :
@@ -528,6 +583,17 @@ exports[`Alert - info Action 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -592,7 +658,7 @@ exports[`Alert - info Action 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Info
             :
@@ -609,7 +675,7 @@ exports[`Alert - info Action 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Info
             :
@@ -637,6 +703,17 @@ exports[`Alert - info Action and Title 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -701,7 +778,7 @@ exports[`Alert - info Action and Title 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Info
             :
@@ -718,7 +795,7 @@ exports[`Alert - info Action and Title 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Info
             :
@@ -747,6 +824,17 @@ exports[`Alert - info Body 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -807,7 +895,7 @@ exports[`Alert - info Body 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Info
             :
@@ -824,7 +912,7 @@ exports[`Alert - info Body 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Info
             :
@@ -843,6 +931,17 @@ exports[`Alert - info Custom aria label 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -908,7 +1007,7 @@ exports[`Alert - info Custom aria label 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Info
             :
@@ -925,7 +1024,7 @@ exports[`Alert - info Custom aria label 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Info
             :
@@ -954,6 +1053,17 @@ exports[`Alert - info Title 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -1014,7 +1124,7 @@ exports[`Alert - info Title 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Info
             :
@@ -1031,7 +1141,7 @@ exports[`Alert - info Title 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Info
             :
@@ -1051,6 +1161,17 @@ exports[`Alert - success Action 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -1115,7 +1236,7 @@ exports[`Alert - success Action 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Success
             :
@@ -1132,7 +1253,7 @@ exports[`Alert - success Action 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Success
             :
@@ -1160,6 +1281,17 @@ exports[`Alert - success Action and Title 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -1224,7 +1356,7 @@ exports[`Alert - success Action and Title 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Success
             :
@@ -1241,7 +1373,7 @@ exports[`Alert - success Action and Title 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Success
             :
@@ -1270,6 +1402,17 @@ exports[`Alert - success Body 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -1330,7 +1473,7 @@ exports[`Alert - success Body 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Success
             :
@@ -1347,7 +1490,7 @@ exports[`Alert - success Body 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Success
             :
@@ -1366,6 +1509,17 @@ exports[`Alert - success Custom aria label 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -1431,7 +1585,7 @@ exports[`Alert - success Custom aria label 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Success
             :
@@ -1448,7 +1602,7 @@ exports[`Alert - success Custom aria label 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Success
             :
@@ -1477,6 +1631,17 @@ exports[`Alert - success Title 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -1537,7 +1702,7 @@ exports[`Alert - success Title 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Success
             :
@@ -1554,7 +1719,7 @@ exports[`Alert - success Title 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Success
             :
@@ -1574,6 +1739,17 @@ exports[`Alert - warning Action 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -1638,7 +1814,7 @@ exports[`Alert - warning Action 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Warning
             :
@@ -1655,7 +1831,7 @@ exports[`Alert - warning Action 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Warning
             :
@@ -1683,6 +1859,17 @@ exports[`Alert - warning Action and Title 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -1747,7 +1934,7 @@ exports[`Alert - warning Action and Title 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Warning
             :
@@ -1764,7 +1951,7 @@ exports[`Alert - warning Action and Title 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Warning
             :
@@ -1793,6 +1980,17 @@ exports[`Alert - warning Body 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -1853,7 +2051,7 @@ exports[`Alert - warning Body 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Warning
             :
@@ -1870,7 +2068,7 @@ exports[`Alert - warning Body 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Warning
             :
@@ -1889,6 +2087,17 @@ exports[`Alert - warning Custom aria label 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -1954,7 +2163,7 @@ exports[`Alert - warning Custom aria label 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Warning
             :
@@ -1971,7 +2180,7 @@ exports[`Alert - warning Custom aria label 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Warning
             :
@@ -2000,6 +2209,17 @@ exports[`Alert - warning Title 1`] = `
   display: flex;
   padding: 1rem;
   font-size: 24px;
+}
+.pf-u-sr-only {
+  display: block;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0px;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
 }
 .pf-c-alert__title {
   display: block;
@@ -2060,7 +2280,7 @@ exports[`Alert - warning Title 1`] = `
       title={
         <UNDEFINED>
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Warning
             :
@@ -2077,7 +2297,7 @@ exports[`Alert - warning Title 1`] = `
           className="pf-c-alert__title"
         >
           <span
-            className="srOnly_in455u"
+            className="pf-u-sr-only"
           >
             Warning
             :

--- a/packages/react-docs/gatsby-node.js
+++ b/packages/react-docs/gatsby-node.js
@@ -3,7 +3,7 @@ const pascalCase = require('pascal-case');
 
 exports.modifyWebpackConfig = ({ config, stage }) => {
   const oldCSSLoader = config._loaders.css;
-  const pfStylesTest = /patternfly-next.*(components|layouts).*\.css$/;
+  const pfStylesTest = /patternfly-next.*(components|layouts|utilities).*\.css$/;
   config.removeLoader('css');
   if (
     oldCSSLoader.config.loaders &&

--- a/packages/react-styles/src/utils.js
+++ b/packages/react-styles/src/utils.js
@@ -34,7 +34,7 @@ export function getModifier(styleObj, modifier, defaultModifier) {
 }
 
 export function formatClassName(className) {
-  return camelcase(className.replace(/pf-((c|l|m|is|has)-)?/g, ''));
+  return camelcase(className.replace(/pf-((c|l|m|u|is|has)-)?/g, ''));
 }
 
 export function getCSSClasses(cssString) {


### PR DESCRIPTION
affects: @patternfly/react-core, @patternfly/react-docs, @patternfly/react-styles

ISSUES CLOSED: #467

**What**:
1.  ~Upgrades @patternfly/patternfly-next to make use of `pf-u-sr-only`~
2.  Removes custom `srOnly` CSS
3.  Make updates for `utilities` category

**Link to Storybook**:
