### PR TITLE
test(test URL): add test URL to jest config so we don't get errors with localStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,8 @@
     "roots": [
       "<rootDir>/packages",
       "<rootDir>/scripts"
-    ]
+    ],
+    "testURL": "http://localhost"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
After cleaning all packages and installing them, tests will break because jsdom requires testUrl to
be set in jest config

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:

Not needed

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
https://github.com/jsdom/jsdom/issues/2304

<!-- feel free to add additional comments -->