### PR TITLE
fix(wizard pattern): passes extra props from WizardPattern to underlying Wizard

### DIFF
--- a/packages/patternfly-react/src/components/Wizard/Patterns/WizardPattern.js
+++ b/packages/patternfly-react/src/components/Wizard/Patterns/WizardPattern.js
@@ -28,7 +28,8 @@ const WizardPattern = ({
   loading,
   nextButtonRef,
   bodyHeader,
-  children
+  children,
+  ...props
 }) => {
   const onFirstStep = activeStepIndex === 0;
   const onFinalStep = activeStepIndex === steps.length - 1;
@@ -100,7 +101,7 @@ const WizardPattern = ({
     getNextStep().preventEnter;
 
   return (
-    <Wizard show={show} onHide={onHideClick} onExited={onExited}>
+    <Wizard show={show} onHide={onHideClick} onExited={onExited} {...props}>
       <Wizard.Header onClose={onHideClick} title={title} />
       <Wizard.Body>
         {bodyHeader}

--- a/packages/patternfly-react/src/components/Wizard/Wizard.test.js
+++ b/packages/patternfly-react/src/components/Wizard/Wizard.test.js
@@ -286,7 +286,7 @@ const testWizardPattern = props => {
       onHide={onHide}
       onExited={onExited}
       title="Wizard Pattern Example"
-      shouldDisableNextStep={false}
+      nextStepDisabled={false}
       steps={[
         { title: 'General', render: () => <p>General</p> },
         { title: 'Step Two', render: () => <p>Step Two</p> },


### PR DESCRIPTION
fix(wizard pattern): passes extra props from WizardPattern to underlying Wizard

affects: patternfly-react

ISSUES CLOSED: #519

**What**:  
WizardPattern was not passing extra props down to wizard.  Passing them down gives the developer the ability to control the underlying Modal with props such as `backdrop="static"`

**Link to Storybook**:  
[Storybook@WizardPattern](https://cfchase.github.io/patternfly-react/?knob-Active%20Step%20Index=0&selectedKind=patternfly-react%2FCommunication%2FWizard%2FPatterns&selectedStory=Stateless%20WizardPattern%20Example&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)
