### PR TITLE
Allow disabling back button in Wizard.Pattern. Fixes #527

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Wizard/Patterns/StatefulWizardPattern.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Wizard/Patterns/StatefulWizardPattern.js
@@ -36,13 +36,14 @@ class StatefulWizardPattern extends React.Component {
   };
 
   render() {
-    const { shouldDisableNextStep, ...otherProps } = this.props;
+    const { shouldDisableNextStep, shouldDisablePreviousStep, ...otherProps } = this.props;
     const { activeStepIndex } = this.state;
     // NOTE: the steps array is passed down with ...otherProps, including any shouldPreventEnter or shouldPreventExit functions inside it.
     // These functions are for StatefulWizardPattern only and should not be used in WizardPattern despite being passed down here.
     return (
       <WizardPattern
         nextStepDisabled={shouldDisableNextStep(activeStepIndex)}
+        previousStepDisabled={shouldDisablePreviousStep(activeStepIndex)}
         {...excludeKeys(otherProps, ['shouldPreventStepChange'])}
         activeStepIndex={activeStepIndex} // Value from state, as set by getDerivedStateFromProps
         onStepChanged={this.onStepChanged}
@@ -52,7 +53,7 @@ class StatefulWizardPattern extends React.Component {
 }
 
 StatefulWizardPattern.propTypes = {
-  ...excludeKeys(WizardPattern.propTypes, ['nextStepDisabled']),
+  ...excludeKeys(WizardPattern.propTypes, ['nextStepDisabled', 'previousStepDisabled']),
   steps: PropTypes.arrayOf(
     PropTypes.shape({
       ...wizardStepShape,
@@ -61,12 +62,14 @@ StatefulWizardPattern.propTypes = {
     })
   ),
   shouldDisableNextStep: PropTypes.func,
+  shouldDisablePreviousStep: PropTypes.func,
   shouldPreventStepChange: PropTypes.func
 };
 
 StatefulWizardPattern.defaultProps = {
-  ...excludeKeys(WizardPattern.defaultProps, ['activeStepIndex', 'nextStepDisabled']),
+  ...excludeKeys(WizardPattern.defaultProps, ['activeStepIndex', 'nextStepDisabled', 'previousStepDisabled']),
   shouldDisableNextStep: noop,
+  shouldDisablePreviousStep: noop,
   shouldPreventStepChange: noop
 };
 

--- a/packages/patternfly-3/patternfly-react/src/components/Wizard/Patterns/WizardPattern.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Wizard/Patterns/WizardPattern.js
@@ -14,6 +14,7 @@ const WizardPattern = ({
   onNext,
   onBack,
   nextStepDisabled,
+  previousStepDisabled,
   title,
   loadingTitle,
   loadingMessage,
@@ -76,14 +77,15 @@ const WizardPattern = ({
 
     const preventExitActive = activeStep.preventExit;
     const preventEnterTarget = targetStep.preventEnter || (stepBeforeTarget && stepBeforeTarget.isInvalid);
-    const nextStepClicked = newStepIndex === activeStepIndex + 1;
+    const nextStepClicked = newStepIndex > activeStepIndex;
 
-    return preventExitActive || preventEnterTarget || (nextStepClicked && nextStepDisabled);
+    return preventExitActive || preventEnterTarget || nextStepClicked ? nextStepDisabled : previousStepDisabled;
   };
 
   const activeStepStr = (activeStepIndex + 1).toString();
 
-  const prevStepUnreachable = onFirstStep || activeStep.preventExit || getPrevStep().preventEnter;
+  const prevStepUnreachable =
+    previousStepDisabled || onFirstStep || activeStep.preventExit || getPrevStep().preventEnter;
   // nextStepUnreachable is still true onFinalStep, because the Next button turns into a Close button
   const nextStepUnreachable =
     nextStepDisabled || activeStep.isInvalid || activeStep.preventExit || getNextStep().preventEnter;
@@ -152,6 +154,7 @@ WizardPattern.propTypes = {
   closeText: PropTypes.string,
   steps: PropTypes.arrayOf(PropTypes.shape(wizardStepShape)),
   nextStepDisabled: PropTypes.bool,
+  previousStepDisabled: PropTypes.bool,
   stepButtonsDisabled: PropTypes.bool,
   nextButtonRef: PropTypes.func,
   bodyHeader: PropTypes.node,
@@ -175,6 +178,7 @@ WizardPattern.defaultProps = {
   closeText: 'Close',
   steps: [],
   nextStepDisabled: false,
+  previousStepDisabled: false,
   stepButtonsDisabled: false,
   nextButtonRef: noop,
   bodyHeader: null,

--- a/packages/patternfly-3/patternfly-react/src/components/Wizard/Wizard.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Wizard/Wizard.test.js
@@ -312,6 +312,7 @@ const testStatefulWizardPattern = props => {
       onExited={onExited}
       title="Wizard Pattern Stateful Example"
       shouldDisableNextStep={() => false}
+      shouldDisablePreviousStep={() => false}
       shouldPreventStepChange={() => false}
       steps={[
         { title: 'General', render: () => <p>General</p> },
@@ -378,12 +379,49 @@ const testDisableNextStepWizard = props => {
   );
 };
 
+const testDisablePreviousStepWizard = props => {
+  const onHide = jest.fn();
+  const onExited = jest.fn();
+  const onStepChanged = jest.fn();
+  return (
+    <Wizard.Pattern.Stateful
+      show
+      onHide={onHide}
+      onExited={onExited}
+      onStepChanged={onStepChanged}
+      title="Wizard Disable Next Step"
+      shouldDisablePreviousStep={() => true}
+      steps={[
+        { title: '1', render: () => <p>1</p> },
+        { title: '2', render: () => <p className=".step2">2</p> },
+        { title: '3', render: () => <p>3</p> }
+      ]}
+      {...props}
+    />
+  );
+};
+
 test('Wizard Stateful with shouldDisableNextStep should disable next step', () => {
   const component = mount(testDisableNextStepWizard());
   expect(
     component
       .find('.wizard-pf-footer .btn')
       .at(2)
+      .getDOMNode().disabled
+  ).toBe(true);
+});
+
+test('Wizard Stateful with shouldDisablePreviousStep should disable previous step', () => {
+  const component = mount(testDisablePreviousStepWizard());
+  component
+    .find('.wizard-pf-footer .btn')
+    .at(2)
+    .simulate('click');
+  expect(component.exists('.step2')).toEqual(true);
+  expect(
+    component
+      .find('.wizard-pf-footer .btn')
+      .at(1)
       .getDOMNode().disabled
   ).toBe(true);
 });

--- a/packages/patternfly-3/patternfly-react/src/components/Wizard/__snapshots__/Wizard.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/Wizard/__snapshots__/Wizard.test.js.snap
@@ -109,6 +109,7 @@ exports[`Wizard Stateful Pattern renders properly: Wizard stateful pattern snaps
   onHide={[MockFunction]}
   onNext={[Function]}
   onStepChanged={[Function]}
+  previousStepDisabled={false}
   show={true}
   stepButtonsDisabled={false}
   steps={


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**: https://github.com/patternfly/patternfly-react/issues/527 and https://github.com/patternfly/patternfly-react/issues/526

Add new property previousStepDisabled to Wizard.Pattern which disables/enables back steps

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:


<!-- feel free to add additional comments -->