### PR TITLE
fix(Default gridSpan): when using Grid Item by default it should span over 1 column

### DIFF
--- a/packages/react-core/src/layouts/Grid/GridItem.js
+++ b/packages/react-core/src/layouts/Grid/GridItem.js
@@ -37,7 +37,7 @@ const propTypes = {
 const defaultProps = {
   children: null,
   className: '',
-  span: null,
+  span: 1,
   rowSpan: null,
   offset: null,
   sm: null,


### PR DESCRIPTION

affects: @patternfly/react-core

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
When consumers are using GridItem they shouldn't be forced to set ColSpan but it should default to 1.
