### PR TITLE
docs(Storybook): add Table In Modal With Inline Edit Row story to reproduce button position bug

### DIFF
--- a/packages/patternfly-react/src/components/Modal/__mocks__/mockModalManager.js
+++ b/packages/patternfly-react/src/components/Modal/__mocks__/mockModalManager.js
@@ -1,8 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Button } from '../../Button';
 import { Modal } from '../index';
 
 export class MockModalManager extends React.Component {
+  propTypes = {
+    children: PropTypes.node
+  };
+
   constructor() {
     super();
     this.state = { showModal: false };
@@ -16,6 +21,36 @@ export class MockModalManager extends React.Component {
     this.setState({ showModal: true });
   }
   render() {
+    const { children } = this.props;
+    const defaultBody = (
+      <form className="form-horizontal">
+        <div className="form-group">
+          <label className="col-sm-3 control-label" htmlFor="textInput">
+            Field One
+          </label>
+          <div className="col-sm-9">
+            <input type="text" id="textInput" className="form-control" />
+          </div>
+        </div>
+        <div className="form-group">
+          <label className="col-sm-3 control-label" htmlFor="textInput2">
+            Field Two
+          </label>
+          <div className="col-sm-9">
+            <input type="text" id="textInput2" className="form-control" />
+          </div>
+        </div>
+        <div className="form-group">
+          <label className="col-sm-3 control-label" htmlFor="textInput3">
+            Field Three
+          </label>
+          <div className="col-sm-9">
+            <input type="text" id="textInput3" className="form-control" />
+          </div>
+        </div>
+      </form>
+    );
+
     return (
       <div>
         <Button bsStyle="primary" bsSize="large" onClick={this.open}>
@@ -27,34 +62,7 @@ export class MockModalManager extends React.Component {
             <Modal.CloseButton onClick={this.close} />
             <Modal.Title>Modal Overlay Title</Modal.Title>
           </Modal.Header>
-          <Modal.Body>
-            <form className="form-horizontal">
-              <div className="form-group">
-                <label className="col-sm-3 control-label" htmlFor="textInput">
-                  Field One
-                </label>
-                <div className="col-sm-9">
-                  <input type="text" id="textInput" className="form-control" />
-                </div>
-              </div>
-              <div className="form-group">
-                <label className="col-sm-3 control-label" htmlFor="textInput2">
-                  Field Two
-                </label>
-                <div className="col-sm-9">
-                  <input type="text" id="textInput2" className="form-control" />
-                </div>
-              </div>
-              <div className="form-group">
-                <label className="col-sm-3 control-label" htmlFor="textInput3">
-                  Field Three
-                </label>
-                <div className="col-sm-9">
-                  <input type="text" id="textInput3" className="form-control" />
-                </div>
-              </div>
-            </form>
-          </Modal.Body>
+          <Modal.Body>{children || defaultBody}</Modal.Body>
           <Modal.Footer>
             <Button bsStyle="default" className="btn-cancel" onClick={this.close}>
               Cancel

--- a/packages/patternfly-react/src/components/Table/Stories/InlineEditRowInModalTableStory.js
+++ b/packages/patternfly-react/src/components/Table/Stories/InlineEditRowInModalTableStory.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { withInfo } from '@storybook/addon-info';
+import { MockInlineEditRowTable } from '../__mocks__/mockInlineEditRowTable';
+import { MockModalManager } from '../../Modal/__mocks__/mockModalManager';
+import {
+  actionHeaderCellFormatter,
+  customHeaderFormattersDefinition,
+  sortableHeaderCellFormatter,
+  tableCellFormatter,
+  Table
+} from '../index';
+import { inlineTemplate } from 'storybook/decorators/storyTemplates';
+import { DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
+import { reactabularDescription } from './tableStoryDescriptions';
+
+/**
+ * Inline Edit Row Table stories
+ */
+const inlineEditRowInModalTableStory = stories => {
+  stories.add(
+    'Table in Modal With Inline Edit Row',
+    withInfo({
+      source: false,
+      propTablesExclude: [MockInlineEditRowTable, MockModalManager],
+      propTables: [
+        Table.Cell,
+        Table.Heading,
+        Table.PfProvider,
+        actionHeaderCellFormatter,
+        customHeaderFormattersDefinition,
+        sortableHeaderCellFormatter,
+        tableCellFormatter
+      ]
+    })(() => {
+      const story = (
+        <MockModalManager>
+          <MockInlineEditRowTable />
+        </MockModalManager>
+      );
+      return inlineTemplate({
+        title: 'Table in Modal With Inline Edit Row',
+        documentationLink: DOCUMENTATION_URL.PATTERNFLY_ORG_INLINE_EDIT,
+        story,
+        description: reactabularDescription
+      });
+    })
+  );
+};
+
+export default inlineEditRowInModalTableStory;

--- a/packages/patternfly-react/src/components/Table/Stories/index.js
+++ b/packages/patternfly-react/src/components/Table/Stories/index.js
@@ -4,5 +4,6 @@ export { default as clientSortableTable } from './ClientSortableTableStory';
 export { default as clientPaginationTable } from './ClientPaginationTableStory';
 export { default as serverPaginationTable } from './ServerPaginationTableStory';
 export { default as inlineEditRowTable } from './InlineEditRowTableStory';
+export { default as inlineEditRowInModalTable } from './InlineEditRowInModalTableStory';
 export { default as inlineEditColumnTable } from './InlineEditColumnTableStory';
 export { default as inlineEditCellTable } from './InlineEditCellTableStory';

--- a/packages/patternfly-react/src/components/Table/Table.stories.js
+++ b/packages/patternfly-react/src/components/Table/Table.stories.js
@@ -8,6 +8,7 @@ import {
   patternflyTable,
   serverPaginationTable,
   inlineEditRowTable,
+  inlineEditRowInModalTable,
   inlineEditColumnTable,
   inlineEditCellTable
 } from './Stories';
@@ -26,5 +27,6 @@ clientSortableTable(stories);
 clientPaginationTable(stories);
 serverPaginationTable(stories);
 inlineEditRowTable(stories);
+inlineEditRowInModalTable(stories);
 inlineEditColumnTable(stories);
 inlineEditCellTable(stories);


### PR DESCRIPTION
affects: patternfly-react

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:

This adds a new story called "Table in Modal With Inline Edit Row", which is just the "Table with Inline Edit Row" story inside the Modal example story.

This exposes a bug with the positioning of the confirm/cancel buttons after clicking the edit button on a row. The buttons appear to be positioned with JS, relative to the window, rather than relative to the modal, the table or the row.

With a large window:

![screenshot 2018-08-15 10 50 32](https://user-images.githubusercontent.com/811963/44158595-0cc1fd80-a083-11e8-8702-5323f047a965.png)

With a small window:

![screenshot 2018-08-15 11 59 23](https://user-images.githubusercontent.com/811963/44158615-1c414680-a083-11e8-834d-08d147cc8e9a.png)


This PR should be merged just to add the story, and then a separate PR should be used to fix the bug..


<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:

http://localhost:6006/?knob-Show%20Help=true&knob-Field%20Level%20Help%20Content=Please%20specify%20Country%20code%20%3Cbr%3E%20%3Ca%20target%3D%27_blank%27%20href%3D%27https%3A%2F%2Fcountrycode.org%2F%27%3EClick%20here%20for%20a%20list%20of%20Country%20codes%3C%2Fa%3E&knob-Close%20Popover=true&knob-Show%20Modal=true&selectedKind=patternfly-react%2FContent%20Views%2FTable%20View&selectedStory=Table%20in%20Modal%20With%20Inline%20Edit%20Row&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

This story showcases the bug reported in #535.

<!-- feel free to add additional comments -->