### PR TITLE
feat(index.js): export the layout helper so consumers can use layout.is('mobile')

### DIFF
--- a/packages/patternfly-react/src/index.js
+++ b/packages/patternfly-react/src/index.js
@@ -46,4 +46,4 @@ export * from './components/TypeAheadSelect';
 export * from './components/UtilizationBar';
 export * from './components/Wizard';
 export * from './components/VerticalNav';
-export { patternfly } from './common/patternfly';
+export { patternfly, layout } from './common/patternfly';


### PR DESCRIPTION
affects: patternfly-react

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:

This layout helper is used internally for the default stateful behavior of VerticalNav.
It would be useful to expose for consumers who want to override parts of that state.


<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**:

Not relevant (no changes will be apparent in Storybook)

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

@priley86 , this is necessary for part of the fix I was writing for https://github.com/patternfly/patternfly-react-demo-app/pull/36 (https://github.com/patternfly/patternfly-react/issues/525). In order to lift `showMobileNav` state out, I want to use `layout.is('mobile')` and `layout.addChangeListener()` in the demo app, without having to pull in BreakJS directly.

<!-- feel free to add additional comments -->