### PR TITLE
fix(react-core): remove Variant Reference in Split and Stack barrel files

### DIFF
--- a/packages/react-core/src/layouts/Split/index.js
+++ b/packages/react-core/src/layouts/Split/index.js
@@ -1,2 +1,2 @@
 export { default as Split } from './Split';
-export { default as SplitItem, SplitItemVariant } from './SplitItem';
+export { default as SplitItem } from './SplitItem';

--- a/packages/react-core/src/layouts/Stack/index.js
+++ b/packages/react-core/src/layouts/Stack/index.js
@@ -1,2 +1,2 @@
 export { default as Stack } from './Stack';
-export { default as StackItem, StackItemVariant } from './StackItem';
+export { default as StackItem } from './StackItem';


### PR DESCRIPTION

affects: @patternfly/react-core

StackVariant and SplitVariant were removed. Removed old references to them.
