### PR TITLE
Small wizard pattern component fixes

### DIFF
--- a/packages/patternfly-react/src/components/Wizard/Patterns/StatefulWizardPattern.js
+++ b/packages/patternfly-react/src/components/Wizard/Patterns/StatefulWizardPattern.js
@@ -52,7 +52,7 @@ class StatefulWizardPattern extends React.Component {
 }
 
 StatefulWizardPattern.propTypes = {
-  ...excludeKeys(WizardPattern.propTypes, ['activeStepIndex', 'nextStepDisabled']),
+  ...excludeKeys(WizardPattern.propTypes, ['nextStepDisabled']),
   steps: PropTypes.arrayOf(
     PropTypes.shape({
       ...wizardStepShape,
@@ -69,5 +69,7 @@ StatefulWizardPattern.defaultProps = {
   shouldDisableNextStep: noop,
   shouldPreventStepChange: noop
 };
+
+StatefulWizardPattern.displayName = 'StatefulWizardPattern';
 
 export default StatefulWizardPattern;

--- a/packages/patternfly-react/src/components/Wizard/Patterns/WizardPattern.js
+++ b/packages/patternfly-react/src/components/Wizard/Patterns/WizardPattern.js
@@ -5,7 +5,7 @@ import WizardPatternBody from './WizardPatternBody';
 import { wizardStepShape } from './WizardPatternConstants';
 
 /**
- * WizardPattern - the Wizard Pattern Body component.
+ * WizardPattern - the Wizard Pattern component.
  */
 const WizardPattern = ({
   steps,


### PR DESCRIPTION
- don't exclude `activeStepIndex` from `StatefulWizardPattern.propTypes` since this prop is still supported through `getDerivedStateFromProps`
- ensure explicit `displayName`