### PR TITLE
fix(subcomponents): change how/where subcomponents are set on the component

### DIFF
--- a/packages/patternfly-react/src/common/helpers.js
+++ b/packages/patternfly-react/src/common/helpers.js
@@ -60,6 +60,10 @@ export const findChild = (children, validator) => {
 export const propsChanged = (propNames, oldProps, newProps) =>
   propNames.some(propName => oldProps[propName] !== newProps[propName]);
 
+/** Returns true if the component has the desired displayName value */
+export const hasDisplayName = (component, displayName) =>
+  component && component.type && component.type.displayName === displayName;
+
 /** Returns an object with the same keys as the given one, but all null values. */
 export const nullValues = obj => selectKeys(obj, Object.keys(obj), () => null);
 

--- a/packages/patternfly-react/src/components/AboutModal/AboutModal.js
+++ b/packages/patternfly-react/src/components/AboutModal/AboutModal.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 
 import { Modal } from '../../index';
 
+import AboutModalVersions from './AboutModalVersions';
+import AboutModalVersionItem from './AboutModalVersionItem';
+
 /**
  * AboutModal Component for PatternFly
  */
@@ -65,5 +68,8 @@ AboutModal.defaultProps = {
   altLogo: '',
   trademarkText: ''
 };
+
+AboutModal.Versions = AboutModalVersions;
+AboutModal.VersionItem = AboutModalVersionItem;
 
 export default AboutModal;

--- a/packages/patternfly-react/src/components/AboutModal/AboutModal.js
+++ b/packages/patternfly-react/src/components/AboutModal/AboutModal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Modal } from '../../index';
+import { Modal } from '../Modal';
 
 import AboutModalVersions from './AboutModalVersions';
 import AboutModalVersionItem from './AboutModalVersionItem';

--- a/packages/patternfly-react/src/components/AboutModal/index.js
+++ b/packages/patternfly-react/src/components/AboutModal/index.js
@@ -2,7 +2,4 @@ import AboutModal from './AboutModal';
 import AboutModalVersions from './AboutModalVersions';
 import AboutModalVersionItem from './AboutModalVersionItem';
 
-AboutModal.Versions = AboutModalVersions;
-AboutModal.VersionItem = AboutModalVersionItem;
-
 export { AboutModal, AboutModalVersions, AboutModalVersionItem };

--- a/packages/patternfly-react/src/components/ApplicationLauncher/ApplicationLauncher.js
+++ b/packages/patternfly-react/src/components/ApplicationLauncher/ApplicationLauncher.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import ApplicationLauncherToggle from './ApplicationLauncherToggle';
 import { Dropdown } from '../Dropdown';
 import { noop } from '../../common/helpers';
+import ApplicationLauncherToggle from './ApplicationLauncherToggle';
+import ApplicationLauncherItem from './ApplicationLauncherItem';
 
 const ApplicationLauncher = ({
   open,
@@ -59,5 +60,8 @@ ApplicationLauncher.defaultProps = {
   grid: false,
   open: false
 };
+
+ApplicationLauncher.Toggle = ApplicationLauncherToggle;
+ApplicationLauncher.Item = ApplicationLauncherItem;
 
 export default ApplicationLauncher;

--- a/packages/patternfly-react/src/components/ApplicationLauncher/index.js
+++ b/packages/patternfly-react/src/components/ApplicationLauncher/index.js
@@ -1,8 +1,5 @@
-import ApplicationLauncherToggle from './ApplicationLauncherToggle';
 import ApplicationLauncher from './ApplicationLauncher';
+import ApplicationLauncherToggle from './ApplicationLauncherToggle';
 import ApplicationLauncherItem from './ApplicationLauncherItem';
-
-ApplicationLauncher.Toggle = ApplicationLauncherToggle;
-ApplicationLauncher.Item = ApplicationLauncherItem;
 
 export { ApplicationLauncher, ApplicationLauncherItem, ApplicationLauncherToggle };

--- a/packages/patternfly-react/src/components/Cards/Card.js
+++ b/packages/patternfly-react/src/components/Cards/Card.js
@@ -2,6 +2,14 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import CardTitle from './CardTitle';
+import CardBody from './CardBody';
+import CardHeading from './CardHeading';
+import CardFooter from './CardFooter';
+import CardLink from './CardLink';
+import CardDropdownButton from './CardDropdownButton';
+import CardHeightMatching from './CardHeightMatching';
+
 /**
  * Card Component for PatternFly React
  */
@@ -49,5 +57,13 @@ Card.defaultProps = {
   matchHeight: false,
   cardRef: null
 };
+
+Card.Title = CardTitle;
+Card.Body = CardBody;
+Card.Heading = CardHeading;
+Card.Footer = CardFooter;
+Card.Link = CardLink;
+Card.DropdownButton = CardDropdownButton;
+Card.HeightMatching = CardHeightMatching;
 
 export default Card;

--- a/packages/patternfly-react/src/components/Cards/CardGrid.js
+++ b/packages/patternfly-react/src/components/Cards/CardGrid.js
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import CardHeightMatching from './CardHeightMatching';
-import { Grid } from '../Grid/index';
+import { Grid, Row, Col, Clearfix } from '../Grid';
 
 const CardGrid = ({ matchHeight, children, className, ...props }) => {
   const classes = classNames('container-cards-pf', className);
@@ -34,4 +34,9 @@ CardGrid.defaultProps = {
   className: '',
   matchHeight: false
 };
+
+CardGrid.Row = Row;
+CardGrid.Col = Col;
+CardGrid.Clearfix = Clearfix;
+
 export default CardGrid;

--- a/packages/patternfly-react/src/components/Cards/index.js
+++ b/packages/patternfly-react/src/components/Cards/index.js
@@ -17,21 +17,6 @@ import {
   UtilizationCardDetailsLine2
 } from './UtilizationTrendCard';
 
-import { default as Row } from '../Grid/Row';
-import { default as Col } from '../Grid/Col';
-import { default as Clearfix } from '../Grid/Clearfix';
-
-Card.Title = CardTitle;
-Card.Body = CardBody;
-Card.Heading = CardHeading;
-Card.Footer = CardFooter;
-Card.Link = CardLink;
-Card.DropdownButton = CardDropdownButton;
-Card.HeightMatching = CardHeightMatching;
-CardGrid.Row = Row;
-CardGrid.Col = Col;
-CardGrid.Clearfix = Clearfix;
-
 export {
   Card,
   CardTitle,

--- a/packages/patternfly-react/src/components/Chart/BulletChart/BulletChart.js
+++ b/packages/patternfly-react/src/components/Chart/BulletChart/BulletChart.js
@@ -291,4 +291,13 @@ BulletChart.defaultProps = {
 BulletChart.DEFAULT_PRIMARY_COLORS = defaultPrimaryColors;
 BulletChart.DEFAULT_EXTENDED_COLORS = defaultExtendedColors;
 
+BulletChart.Title = BulletChartTitle;
+BulletChart.Value = BulletChartValue;
+BulletChart.Range = BulletChartRange;
+BulletChart.Axis = BulletChartAxis;
+BulletChart.AxisTic = BulletChartAxisTic;
+BulletChart.Legend = BulletChartLegend;
+BulletChart.LegendItem = BulletChartLegendItem;
+BulletChart.Threshold = BulletChartThreshold;
+
 export default BulletChart;

--- a/packages/patternfly-react/src/components/Chart/BulletChart/index.js
+++ b/packages/patternfly-react/src/components/Chart/BulletChart/index.js
@@ -8,15 +8,6 @@ import BulletChartLegend from './BulletChartLegend';
 import BulletChartLegendItem from './BulletChartLegendItem';
 import BulletChartThreshold from './BulletChartThreshold';
 
-BulletChart.Title = BulletChartTitle;
-BulletChart.Value = BulletChartValue;
-BulletChart.Range = BulletChartRange;
-BulletChart.Axis = BulletChartAxis;
-BulletChart.AxisTic = BulletChartAxisTic;
-BulletChart.Legend = BulletChartLegend;
-BulletChart.LegendItem = BulletChartLegendItem;
-BulletChart.Threshold = BulletChartThreshold;
-
 export {
   BulletChart,
   BulletChartTitle,

--- a/packages/patternfly-react/src/components/EmptyState/EmptyState.js
+++ b/packages/patternfly-react/src/components/EmptyState/EmptyState.js
@@ -2,6 +2,12 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import EmptyStateIcon from './EmptyStateIcon';
+import EmptyStateTitle from './EmptyStateTitle';
+import EmptyStateInfo from './EmptyStateInfo';
+import EmptyStateHelp from './EmptyStateHelp';
+import EmptyStateAction from './EmptyStateAction';
+
 /**
  * Empty State Component for Patternfly React
  */
@@ -23,4 +29,11 @@ EmptyState.propTypes = {
 EmptyState.defaultProps = {
   className: ''
 };
+
+EmptyState.Title = EmptyStateTitle;
+EmptyState.Icon = EmptyStateIcon;
+EmptyState.Info = EmptyStateInfo;
+EmptyState.Help = EmptyStateHelp;
+EmptyState.Action = EmptyStateAction;
+
 export default EmptyState;

--- a/packages/patternfly-react/src/components/EmptyState/index.js
+++ b/packages/patternfly-react/src/components/EmptyState/index.js
@@ -5,10 +5,4 @@ import EmptyStateInfo from './EmptyStateInfo';
 import EmptyStateHelp from './EmptyStateHelp';
 import EmptyStateAction from './EmptyStateAction';
 
-EmptyState.Title = EmptyStateTitle;
-EmptyState.Icon = EmptyStateIcon;
-EmptyState.Info = EmptyStateInfo;
-EmptyState.Help = EmptyStateHelp;
-EmptyState.Action = EmptyStateAction;
-
 export { EmptyState, EmptyStateIcon, EmptyStateTitle, EmptyStateInfo, EmptyStateHelp, EmptyStateAction };

--- a/packages/patternfly-react/src/components/Filter/Filter.js
+++ b/packages/patternfly-react/src/components/Filter/Filter.js
@@ -13,7 +13,7 @@ import FilterItem from './FilterItem';
 
 // Disabled eslint due to `isDescendantOfToolbar` being a context property we don't want passed by consumers
 // eslint-disable-next-line react/prop-types
-const FilterContext = ({ children, className, isDescendantOfToolbar, ...props }) => {
+const ContextualFilter = ({ children, className, isDescendantOfToolbar, ...props }) => {
   const classes = classNames(
     {
       'filter-pf form-group': true,
@@ -31,19 +31,19 @@ const FilterContext = ({ children, className, isDescendantOfToolbar, ...props })
   );
 };
 
-FilterContext.propTypes = {
+ContextualFilter.propTypes = {
   /** Children nodes */
   children: PropTypes.node,
   /** Additional css classes */
   className: PropTypes.string
 };
 
-FilterContext.defaultProps = {
+ContextualFilter.defaultProps = {
   children: null,
   className: ''
 };
 
-const Filter = getContext(toolbarContextTypes)(FilterContext);
+const Filter = getContext(toolbarContextTypes)(ContextualFilter);
 
 Filter.TypeSelector = FilterTypeSelector;
 Filter.ValueSelector = FilterValueSelector;

--- a/packages/patternfly-react/src/components/Filter/Filter.js
+++ b/packages/patternfly-react/src/components/Filter/Filter.js
@@ -3,10 +3,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { getContext } from 'recompose';
 import { toolbarContextTypes } from '../Toolbar/ToolbarConstants';
+import FilterTypeSelector from './FilterTypeSelector';
+import FilterValueSelector from './FilterValueSelector';
+import FilterCategorySelector from './FilterCategorySelector';
+import FilterCategoryValueSelector from './FilterCategoryValueSelector';
+import FilterActiveLabel from './FilterActiveLabel';
+import FilterList from './FilterList';
+import FilterItem from './FilterItem';
 
 // Disabled eslint due to `isDescendantOfToolbar` being a context property we don't want passed by consumers
 // eslint-disable-next-line react/prop-types
-const Filter = ({ children, className, isDescendantOfToolbar, ...props }) => {
+const FilterContext = ({ children, className, isDescendantOfToolbar, ...props }) => {
   const classes = classNames(
     {
       'filter-pf form-group': true,
@@ -24,15 +31,26 @@ const Filter = ({ children, className, isDescendantOfToolbar, ...props }) => {
   );
 };
 
-Filter.propTypes = {
+FilterContext.propTypes = {
   /** Children nodes */
   children: PropTypes.node,
   /** Additional css classes */
   className: PropTypes.string
 };
 
-Filter.defaultProps = {
+FilterContext.defaultProps = {
   children: null,
   className: ''
 };
-export default getContext(toolbarContextTypes)(Filter);
+
+const Filter = getContext(toolbarContextTypes)(FilterContext);
+
+Filter.TypeSelector = FilterTypeSelector;
+Filter.ValueSelector = FilterValueSelector;
+Filter.CategorySelector = FilterCategorySelector;
+Filter.CategoryValueSelector = FilterCategoryValueSelector;
+Filter.ActiveLabel = FilterActiveLabel;
+Filter.List = FilterList;
+Filter.Item = FilterItem;
+
+export default Filter;

--- a/packages/patternfly-react/src/components/Filter/index.js
+++ b/packages/patternfly-react/src/components/Filter/index.js
@@ -7,14 +7,6 @@ import FilterActiveLabel from './FilterActiveLabel';
 import FilterList from './FilterList';
 import FilterItem from './FilterItem';
 
-Filter.TypeSelector = FilterTypeSelector;
-Filter.ValueSelector = FilterValueSelector;
-Filter.CategorySelector = FilterCategorySelector;
-Filter.CategoryValueSelector = FilterCategoryValueSelector;
-Filter.ActiveLabel = FilterActiveLabel;
-Filter.List = FilterList;
-Filter.Item = FilterItem;
-
 export {
   Filter,
   FilterTypeSelector,

--- a/packages/patternfly-react/src/components/Form/Form.js
+++ b/packages/patternfly-react/src/components/Form/Form.js
@@ -1,3 +1,18 @@
 import { Form } from 'react-bootstrap';
+import { default as Checkbox } from './Checkbox';
+import { default as ControlLabel } from './ControlLabel';
+import { default as FormControl } from './FormControl';
+import { default as FormGroup } from './FormGroup';
+import { default as HelpBlock } from './HelpBlock';
+import { default as InputGroup } from './InputGroup';
+import { default as Radio } from './Radio';
+
+Form.Checkbox = Checkbox;
+Form.ControlLabel = ControlLabel;
+Form.FormControl = FormControl;
+Form.FormGroup = FormGroup;
+Form.HelpBlock = HelpBlock;
+Form.InputGroup = InputGroup;
+Form.Radio = Radio;
 
 export default Form;

--- a/packages/patternfly-react/src/components/Form/index.js
+++ b/packages/patternfly-react/src/components/Form/index.js
@@ -7,12 +7,4 @@ import { default as HelpBlock } from './HelpBlock';
 import { default as InputGroup } from './InputGroup';
 import { default as Radio } from './Radio';
 
-Form.Checkbox = Checkbox;
-Form.ControlLabel = ControlLabel;
-Form.FormControl = FormControl;
-Form.FormGroup = FormGroup;
-Form.HelpBlock = HelpBlock;
-Form.InputGroup = InputGroup;
-Form.Radio = Radio;
-
 export { Checkbox, ControlLabel, Form, FormControl, FormGroup, HelpBlock, InputGroup, Radio };

--- a/packages/patternfly-react/src/components/Grid/Grid.js
+++ b/packages/patternfly-react/src/components/Grid/Grid.js
@@ -1,3 +1,10 @@
 import { Grid } from 'react-bootstrap';
+import { default as Row } from './Row';
+import { default as Col } from './Col';
+import { default as Clearfix } from './Clearfix';
+
+Grid.Row = Row;
+Grid.Col = Col;
+Grid.Clearfix = Clearfix;
 
 export default Grid;

--- a/packages/patternfly-react/src/components/Grid/index.js
+++ b/packages/patternfly-react/src/components/Grid/index.js
@@ -3,8 +3,4 @@ import { default as Row } from './Row';
 import { default as Col } from './Col';
 import { default as Clearfix } from './Clearfix';
 
-Grid.Row = Row;
-Grid.Col = Col;
-Grid.Clearfix = Clearfix;
-
 export { Grid, Row, Col, Clearfix };

--- a/packages/patternfly-react/src/components/InfoTip/InfoTip.js
+++ b/packages/patternfly-react/src/components/InfoTip/InfoTip.js
@@ -2,6 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown } from '../Dropdown';
 import { KEY_CODES } from '../../common/helpers';
+import { default as InfoTipToggle } from './InfoTipToggle';
+import { default as InfoTipMenu } from './InfoTipMenu';
+import { default as InfoTipMenuFooter } from './InfoTipMenuFooter';
+import { default as InfoTipMenuItemIcon } from './InfoTipMenuItemIcon';
 
 class InfoTip extends React.Component {
   state = { open: false, footerFocused: false };
@@ -78,5 +82,10 @@ InfoTip.propTypes = {
   children: PropTypes.node.isRequired,
   id: PropTypes.string.isRequired
 };
+
+InfoTip.Toggle = InfoTipToggle;
+InfoTip.Menu = InfoTipMenu;
+InfoTip.MenuItemIcon = InfoTipMenuItemIcon;
+InfoTip.MenuFooter = InfoTipMenuFooter;
 
 export default InfoTip;

--- a/packages/patternfly-react/src/components/InfoTip/index.js
+++ b/packages/patternfly-react/src/components/InfoTip/index.js
@@ -4,9 +4,4 @@ import { default as InfoTipMenu } from './InfoTipMenu';
 import { default as InfoTipMenuFooter } from './InfoTipMenuFooter';
 import { default as InfoTipMenuItemIcon } from './InfoTipMenuItemIcon';
 
-InfoTip.Toggle = InfoTipToggle;
-InfoTip.Menu = InfoTipMenu;
-InfoTip.MenuItemIcon = InfoTipMenuItemIcon;
-InfoTip.MenuFooter = InfoTipMenuFooter;
-
 export { InfoTip, InfoTipToggle, InfoTipMenu, InfoTipMenuItemIcon, InfoTipMenuFooter };

--- a/packages/patternfly-react/src/components/InlineEdit/CancelButton.js
+++ b/packages/patternfly-react/src/components/InlineEdit/CancelButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, Icon } from '../../index';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
 
 const CancelButton = props => (
   <Button {...props}>

--- a/packages/patternfly-react/src/components/InlineEdit/ConfirmButton.js
+++ b/packages/patternfly-react/src/components/InlineEdit/ConfirmButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Button, Icon } from '../../index';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
 
 const ConfirmButton = props => (
   <Button {...props}>

--- a/packages/patternfly-react/src/components/ListView/ListView.js
+++ b/packages/patternfly-react/src/components/ListView/ListView.js
@@ -1,6 +1,23 @@
 import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import ListViewActions from './ListViewActions';
+import ListViewAdditionalInfo from './ListViewAdditionalInfo';
+import ListViewBody from './ListViewBody';
+import ListViewCheckbox from './ListViewCheckbox';
+import ListViewDescription from './ListViewDescription';
+import ListViewDescriptionHeading from './ListViewDescriptionHeading';
+import ListViewDescriptionText from './ListViewDescriptionText';
+import ListViewExpand from './ListViewExpand';
+import ListViewGroupItem from './ListViewGroupItem';
+import ListViewGroupItemContainer from './ListViewGroupItemContainer';
+import ListViewGroupItemHeader from './ListViewGroupItemHeader';
+import ListViewIcon from './ListViewIcon';
+import ListViewInfoItem from './ListViewInfoItem';
+import ListViewItem from './ListViewItem';
+import ListViewLeft from './ListViewLeft';
+import ListViewMainInfo from './ListViewMainInfo';
+import ListViewRow from './ListViewRow';
 
 /**
  * Components in this module are used as building blocks for ListViewItem and
@@ -73,5 +90,23 @@ ListView.defaultProps = {
   className: '',
   children: null
 };
+
+ListView.Actions = ListViewActions;
+ListView.AdditionalInfo = ListViewAdditionalInfo;
+ListView.Body = ListViewBody;
+ListView.Checkbox = ListViewCheckbox;
+ListView.Description = ListViewDescription;
+ListView.DescriptionHeading = ListViewDescriptionHeading;
+ListView.DescriptionText = ListViewDescriptionText;
+ListView.Expand = ListViewExpand;
+ListView.GroupItem = ListViewGroupItem;
+ListView.GroupItemContainer = ListViewGroupItemContainer;
+ListView.GroupItemHeader = ListViewGroupItemHeader;
+ListView.Icon = ListViewIcon;
+ListView.InfoItem = ListViewInfoItem;
+ListView.Item = ListViewItem;
+ListView.Left = ListViewLeft;
+ListView.MainInfo = ListViewMainInfo;
+ListView.Row = ListViewRow;
 
 export default ListView;

--- a/packages/patternfly-react/src/components/ListView/index.js
+++ b/packages/patternfly-react/src/components/ListView/index.js
@@ -17,24 +17,6 @@ import ListViewLeft from './ListViewLeft';
 import ListViewMainInfo from './ListViewMainInfo';
 import ListViewRow from './ListViewRow';
 
-ListView.Actions = ListViewActions;
-ListView.AdditionalInfo = ListViewAdditionalInfo;
-ListView.Body = ListViewBody;
-ListView.Checkbox = ListViewCheckbox;
-ListView.Description = ListViewDescription;
-ListView.DescriptionHeading = ListViewDescriptionHeading;
-ListView.DescriptionText = ListViewDescriptionText;
-ListView.Expand = ListViewExpand;
-ListView.GroupItem = ListViewGroupItem;
-ListView.GroupItemContainer = ListViewGroupItemContainer;
-ListView.GroupItemHeader = ListViewGroupItemHeader;
-ListView.Icon = ListViewIcon;
-ListView.InfoItem = ListViewInfoItem;
-ListView.Item = ListViewItem;
-ListView.Left = ListViewLeft;
-ListView.MainInfo = ListViewMainInfo;
-ListView.Row = ListViewRow;
-
 export {
   ListView,
   ListViewActions,

--- a/packages/patternfly-react/src/components/Masthead/Masthead.js
+++ b/packages/patternfly-react/src/components/Masthead/Masthead.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { noop } from '../../common/helpers';
+import MastheadCollapse from './MastheadCollapse';
+import MastheadDropdown from './MastheadDropdown';
 
 /**
  * Masthead
@@ -98,5 +100,8 @@ Masthead.defaultProps = {
   middleContent: null,
   children: null
 };
+
+Masthead.Collapse = MastheadCollapse;
+Masthead.Dropdown = MastheadDropdown;
 
 export default Masthead;

--- a/packages/patternfly-react/src/components/Masthead/index.js
+++ b/packages/patternfly-react/src/components/Masthead/index.js
@@ -2,7 +2,4 @@ import Masthead from './Masthead';
 import MastheadCollapse from './MastheadCollapse';
 import MastheadDropdown from './MastheadDropdown';
 
-Masthead.Collapse = MastheadCollapse;
-Masthead.Dropdown = MastheadDropdown;
-
 export { Masthead, MastheadCollapse, MastheadDropdown };

--- a/packages/patternfly-react/src/components/MessageDialog/MessageDialog.js
+++ b/packages/patternfly-react/src/components/MessageDialog/MessageDialog.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { noop } from '../../common/helpers';
-import { Modal, Button } from '../../index';
+import { Modal } from '../Modal';
+import { Button } from '../Button';
 
 const MessageDialog = ({
   show,

--- a/packages/patternfly-react/src/components/Modal/Modal.js
+++ b/packages/patternfly-react/src/components/Modal/Modal.js
@@ -1,5 +1,6 @@
 import { Modal as BsModal } from 'react-bootstrap';
 import CustomModalDialog from './InnerComponents/CustomModalDialog';
+import ModalCloseButton from './ModalCloseButton';
 
 /**
  * Modal Component for Patternfly React
@@ -14,5 +15,7 @@ Modal.defaultProps = {
   ...BsModal.defaultProps,
   dialogComponentClass: CustomModalDialog
 };
+
+Modal.CloseButton = ModalCloseButton;
 
 export default Modal;

--- a/packages/patternfly-react/src/components/Modal/ModalCloseButton.js
+++ b/packages/patternfly-react/src/components/Modal/ModalCloseButton.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon } from '../../index';
+import { Icon } from '../Icon';
 
 const ModalCloseButton = ({ className, closeText, ...props }) => (
   <button className={classNames(`close`, className)} {...props}>

--- a/packages/patternfly-react/src/components/Modal/index.js
+++ b/packages/patternfly-react/src/components/Modal/index.js
@@ -1,6 +1,4 @@
 import Modal from './Modal';
 import ModalCloseButton from './ModalCloseButton';
 
-Modal.CloseButton = ModalCloseButton;
-
 export { Modal, ModalCloseButton };

--- a/packages/patternfly-react/src/components/Notification/Notification.js
+++ b/packages/patternfly-react/src/components/Notification/Notification.js
@@ -2,6 +2,11 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Spinner from '../Spinner/Spinner';
+import NotificationContent from './NotificationContent';
+import NotificationInfo from './NotificationInfo';
+import NotificationMessage from './NotificationMessage';
+import NotificationInfoRight from './NotificationInfoRight';
+import NotificationInfoLeft from './NotificationInfoLeft';
 
 const Notification = ({ type, children, seen, className, ...props }) => {
   const classes = classNames(
@@ -37,5 +42,11 @@ Notification.defaultProps = {
   seen: false,
   type: 'notification'
 };
+
+Notification.Content = NotificationContent;
+Notification.Info = NotificationInfo;
+Notification.InfoRight = NotificationInfoRight;
+Notification.InfoLeft = NotificationInfoLeft;
+Notification.Message = NotificationMessage;
 
 export default Notification;

--- a/packages/patternfly-react/src/components/Notification/index.js
+++ b/packages/patternfly-react/src/components/Notification/index.js
@@ -5,10 +5,11 @@ import NotificationMessage from './NotificationMessage';
 import NotificationInfoRight from './NotificationInfoRight';
 import NotificationInfoLeft from './NotificationInfoLeft';
 
-Notification.Content = NotificationContent;
-Notification.Info = NotificationInfo;
-Notification.InfoRight = NotificationInfoRight;
-Notification.InfoLeft = NotificationInfoLeft;
-Notification.Message = NotificationMessage;
-
-export { Notification };
+export {
+  Notification,
+  NotificationContent,
+  NotificationInfo,
+  NotificationMessage,
+  NotificationInfoRight,
+  NotificationInfoLeft
+};

--- a/packages/patternfly-react/src/components/Pagination/PaginationRow.js
+++ b/packages/patternfly-react/src/components/Pagination/PaginationRow.js
@@ -11,6 +11,7 @@ import { PAGINATION_VIEW_TYPES, PAGINATION_VIEW } from './PaginationConstants';
 import { Form, FormControl, FormGroup, ControlLabel } from '../Form';
 import { DropdownButton } from '../Button';
 import { MenuItem } from '../MenuItem';
+import PaginationRowArrowIcon from './PaginationRowArrowIcon';
 
 /**
  * PaginationRow component for Patternfly React
@@ -178,4 +179,14 @@ PaginationRow.defaultProps = {
   onLastPage: noop,
   dropdownButtonId: 'pagination-row-dropdown'
 };
+
+PaginationRow.AmountOfPages = PaginationRowAmountOfPages;
+PaginationRow.ArrowIcon = PaginationRowArrowIcon;
+PaginationRow.Back = PaginationRowBack;
+PaginationRow.ButtonGroup = PaginationRowButtonGroup;
+PaginationRow.Forward = PaginationRowForward;
+PaginationRow.Items = PaginationRowItems;
+PaginationRow.PAGINATION_VIEW = PAGINATION_VIEW;
+PaginationRow.PAGINATION_VIEW_TYPES = PAGINATION_VIEW_TYPES;
+
 export default PaginationRow;

--- a/packages/patternfly-react/src/components/Pagination/index.js
+++ b/packages/patternfly-react/src/components/Pagination/index.js
@@ -10,15 +10,6 @@ import PaginationRowButtonGroup from './PaginationRowButtonGroup';
 import PaginationRowForward from './PaginationRowForward';
 import PaginationRowItems from './PaginationRowItems';
 
-PaginationRow.AmountOfPages = PaginationRowAmountOfPages;
-PaginationRow.ArrowIcon = PaginationRowArrowIcon;
-PaginationRow.Back = PaginationRowBack;
-PaginationRow.ButtonGroup = PaginationRowButtonGroup;
-PaginationRow.Forward = PaginationRowForward;
-PaginationRow.Items = PaginationRowItems;
-PaginationRow.PAGINATION_VIEW = PAGINATION_VIEW;
-PaginationRow.PAGINATION_VIEW_TYPES = PAGINATION_VIEW_TYPES;
-
 export {
   paginate,
   Pager,

--- a/packages/patternfly-react/src/components/Slider/DropdownMenu.js
+++ b/packages/patternfly-react/src/components/Slider/DropdownMenu.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Dropdown, MenuItem } from '../../index';
+import { Dropdown } from '../Dropdown';
+import { MenuItem } from '../MenuItem';
 
 const DropdownMenu = props => {
   const { dropup, dropdownList, onFormatChange, title } = props;

--- a/packages/patternfly-react/src/components/Slider/Slider.js
+++ b/packages/patternfly-react/src/components/Slider/Slider.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import BootstrapSlider from './BootstrapSlider';
-import { Icon, ControlLabel, FormControl } from '../../index';
+import { Icon } from '../Icon';
+import { ControlLabel, FormControl } from '../Form';
 import Boundaries from './Boundaries';
 import DropdownMenu from './DropdownMenu';
 

--- a/packages/patternfly-react/src/components/Sort/Sort.js
+++ b/packages/patternfly-react/src/components/Sort/Sort.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import SortTypeSelector from './SortTypeSelector';
+import SortDirectionSelector from './SortDirectionSelector';
 
 /**
  * Sort Component for PatternFly React
@@ -25,5 +27,8 @@ Sort.defaultProps = {
   children: null,
   className: ''
 };
+
+Sort.TypeSelector = SortTypeSelector;
+Sort.DirectionSelector = SortDirectionSelector;
 
 export default Sort;

--- a/packages/patternfly-react/src/components/Sort/SortDirectionSelector.js
+++ b/packages/patternfly-react/src/components/Sort/SortDirectionSelector.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Icon } from '../../index';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
 
 const SortDirectionSelector = ({ className, isNumeric, isAscending, ...props }) => {
   let directionName;

--- a/packages/patternfly-react/src/components/Sort/index.js
+++ b/packages/patternfly-react/src/components/Sort/index.js
@@ -2,7 +2,4 @@ import Sort from './Sort';
 import SortTypeSelector from './SortTypeSelector';
 import SortDirectionSelector from './SortDirectionSelector';
 
-Sort.TypeSelector = SortTypeSelector;
-Sort.DirectionSelector = SortDirectionSelector;
-
 export { Sort, SortTypeSelector, SortDirectionSelector };

--- a/packages/patternfly-react/src/components/Table/Table.js
+++ b/packages/patternfly-react/src/components/Table/Table.js
@@ -1,1 +1,55 @@
-export * as Table from 'reactabular-table';
+import * as Table from 'reactabular-table';
+
+import actionHeaderCellFormatter from './Formatters/actionHeaderCellFormatter';
+import customHeaderFormattersDefinition from './Formatters/customHeaderFormattersDefinition';
+import selectionCellFormatter from './Formatters/selectionCellFormatter';
+import selectionHeaderCellFormatter from './Formatters/selectionHeaderCellFormatter';
+import sortableHeaderCellFormatter from './Formatters/sortableHeaderCellFormatter';
+import tableCellFormatter from './Formatters/tableCellFormatter';
+import inlineEditFormatterFactory from './Formatters/inlineEditFormatterFactory';
+
+import {
+  defaultSortingOrder,
+  TABLE_ALIGN,
+  TABLE_ALIGNMENT_TYPES,
+  TABLE_SORT_DIRECTION,
+  TABLE_SORT_DIRECTIONS
+} from './TableConstants';
+import TableActions from './TableActions';
+import TableButton from './TableButton';
+import TableCell from './TableCell';
+import TableCheckbox from './TableCheckbox';
+import TableDropdownKebab from './TableDropdownKebab';
+import TableHeading from './TableHeading';
+import TableInlineEditRow from './TableInlineEditRow';
+import TableInlineEditHeaderRow from './TableInlineEditHeaderRow';
+import TablePfProvider from './TablePfProvider';
+import TableSelectionCell from './TableSelectionCell';
+import TableSelectionHeading from './TableSelectionHeading';
+
+Table.actionHeaderCellFormatter = actionHeaderCellFormatter;
+Table.customHeaderFormattersDefinition = customHeaderFormattersDefinition;
+Table.defaultSortingOrder = defaultSortingOrder;
+Table.selectionCellFormatter = selectionCellFormatter;
+Table.selectionHeaderCellFormatter = selectionHeaderCellFormatter;
+Table.sortableHeaderCellFormatter = sortableHeaderCellFormatter;
+Table.tableCellFormatter = tableCellFormatter;
+Table.inlineEditFormatterFactory = inlineEditFormatterFactory;
+
+Table.Actions = TableActions;
+Table.Button = TableButton;
+Table.Cell = TableCell;
+Table.Checkbox = TableCheckbox;
+Table.DropdownKebab = TableDropdownKebab;
+Table.Heading = TableHeading;
+Table.PfProvider = TablePfProvider;
+Table.InlineEditRow = TableInlineEditRow;
+Table.TableInlineEditHeaderRow = TableInlineEditHeaderRow;
+Table.SelectionCell = TableSelectionCell;
+Table.SelectionHeading = TableSelectionHeading;
+Table.TABLE_ALIGN = TABLE_ALIGN;
+Table.TABLE_ALIGNMENT_TYPES = TABLE_ALIGNMENT_TYPES;
+Table.TABLE_SORT_DIRECTION = TABLE_SORT_DIRECTION;
+Table.TABLE_SORT_DIRECTIONS = TABLE_SORT_DIRECTIONS;
+
+export { Table };

--- a/packages/patternfly-react/src/components/Table/index.js
+++ b/packages/patternfly-react/src/components/Table/index.js
@@ -26,31 +26,6 @@ import TablePfProvider from './TablePfProvider';
 import TableSelectionCell from './TableSelectionCell';
 import TableSelectionHeading from './TableSelectionHeading';
 
-Table.actionHeaderCellFormatter = actionHeaderCellFormatter;
-Table.customHeaderFormattersDefinition = customHeaderFormattersDefinition;
-Table.defaultSortingOrder = defaultSortingOrder;
-Table.selectionCellFormatter = selectionCellFormatter;
-Table.selectionHeaderCellFormatter = selectionHeaderCellFormatter;
-Table.sortableHeaderCellFormatter = sortableHeaderCellFormatter;
-Table.tableCellFormatter = tableCellFormatter;
-Table.inlineEditFormatterFactory = inlineEditFormatterFactory;
-
-Table.Actions = TableActions;
-Table.Button = TableButton;
-Table.Cell = TableCell;
-Table.Checkbox = TableCheckbox;
-Table.DropdownKebab = TableDropdownKebab;
-Table.Heading = TableHeading;
-Table.PfProvider = TablePfProvider;
-Table.InlineEditRow = TableInlineEditRow;
-Table.TableInlineEditHeaderRow = TableInlineEditHeaderRow;
-Table.SelectionCell = TableSelectionCell;
-Table.SelectionHeading = TableSelectionHeading;
-Table.TABLE_ALIGN = TABLE_ALIGN;
-Table.TABLE_ALIGNMENT_TYPES = TABLE_ALIGNMENT_TYPES;
-Table.TABLE_SORT_DIRECTION = TABLE_SORT_DIRECTION;
-Table.TABLE_SORT_DIRECTIONS = TABLE_SORT_DIRECTIONS;
-
 export {
   actionHeaderCellFormatter,
   customHeaderFormattersDefinition,

--- a/packages/patternfly-react/src/components/ToastNotification/ToastNotificationList.js
+++ b/packages/patternfly-react/src/components/ToastNotification/ToastNotificationList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { noop } from '../../common/helpers';
+import { noop, hasDisplayName } from '../../common/helpers';
 import TimedToastNotification from './TimedToastNotification';
 
 /**
@@ -35,7 +35,7 @@ class ToastNotificationList extends React.Component {
   renderChildren() {
     const { paused } = this.state;
     return React.Children.map(this.props.children, child => {
-      if (child && child.type && child.type.displayName === TimedToastNotification.displayName) {
+      if (hasDisplayName(child, TimedToastNotification.displayName)) {
         /**
          * If any of the notifications are hovered, pause
          * all child notifications from dismissing

--- a/packages/patternfly-react/src/components/ToastNotification/ToastNotificationList.js
+++ b/packages/patternfly-react/src/components/ToastNotification/ToastNotificationList.js
@@ -35,7 +35,7 @@ class ToastNotificationList extends React.Component {
   renderChildren() {
     const { paused } = this.state;
     return React.Children.map(this.props.children, child => {
-      if (child && child.type.displayName === TimedToastNotification.displayName) {
+      if (child && child.type && child.type.displayName === TimedToastNotification.displayName) {
         /**
          * If any of the notifications are hovered, pause
          * all child notifications from dismissing

--- a/packages/patternfly-react/src/components/Toolbar/Toolbar.js
+++ b/packages/patternfly-react/src/components/Toolbar/Toolbar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withContext } from 'recompose';
+import { hasDisplayName, filterChildren } from '../../common/helpers';
 import { Grid } from '../Grid';
 import ToolbarResults from './ToolbarResults';
 import ToolbarRightContent from './ToolbarRightContent';
@@ -9,14 +10,9 @@ import ToolbarViewSelector from './ToolbarViewSelector';
 
 import { toolbarContextTypes, getToolbarContext, ToolbarContextProvider } from './ToolbarConstants';
 
-const ToolbarContext = ({ children, className, ...props }) => {
-  const childrenArray = children && React.Children.count(children) > 0 && React.Children.toArray(children);
-
-  const toolbarChildren =
-    childrenArray &&
-    childrenArray.filter(child => !child.type || child.type.displayName !== ToolbarResults.displayName);
-  const resultsChildren =
-    childrenArray && childrenArray.filter(child => child.type && child.type.displayName === ToolbarResults.displayName);
+const ContextualToolbar = ({ children, className, ...props }) => {
+  const toolbarChildren = filterChildren(children, child => !hasDisplayName(child, ToolbarResults.displayName));
+  const resultsChildren = filterChildren(children, child => hasDisplayName(child, ToolbarResults.displayName));
 
   return (
     <ToolbarContextProvider isDescendantOfToolbar>
@@ -32,19 +28,19 @@ const ToolbarContext = ({ children, className, ...props }) => {
   );
 };
 
-ToolbarContext.propTypes = {
+ContextualToolbar.propTypes = {
   /** Children nodes */
   children: PropTypes.node,
   /** Additional css classes */
   className: PropTypes.string
 };
 
-ToolbarContext.defaultProps = {
+ContextualToolbar.defaultProps = {
   children: null,
   className: ''
 };
 
-const Toolbar = withContext(toolbarContextTypes, getToolbarContext)(ToolbarContext);
+const Toolbar = withContext(toolbarContextTypes, getToolbarContext)(ContextualToolbar);
 
 Toolbar.Results = ToolbarResults;
 Toolbar.RightContent = ToolbarRightContent;

--- a/packages/patternfly-react/src/components/Toolbar/Toolbar.js
+++ b/packages/patternfly-react/src/components/Toolbar/Toolbar.js
@@ -1,17 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withContext } from 'recompose';
-import { Grid, ToolbarResults } from '../../index';
+import { Grid } from '../Grid';
+import ToolbarResults from './ToolbarResults';
+import ToolbarRightContent from './ToolbarRightContent';
+import ToolbarFind from './ToolbarFind';
+import ToolbarViewSelector from './ToolbarViewSelector';
 
 import { toolbarContextTypes, getToolbarContext, ToolbarContextProvider } from './ToolbarConstants';
 
-const Toolbar = ({ children, className, ...props }) => {
+const ToolbarContext = ({ children, className, ...props }) => {
   const childrenArray = children && React.Children.count(children) > 0 && React.Children.toArray(children);
 
   const toolbarChildren =
-    childrenArray && childrenArray.filter(child => child.type.displayName !== ToolbarResults.displayName);
+    childrenArray &&
+    childrenArray.filter(child => !child.type || child.type.displayName !== ToolbarResults.displayName);
   const resultsChildren =
-    childrenArray && childrenArray.filter(child => child.type.displayName === ToolbarResults.displayName);
+    childrenArray && childrenArray.filter(child => child.type && child.type.displayName === ToolbarResults.displayName);
 
   return (
     <ToolbarContextProvider isDescendantOfToolbar>
@@ -27,16 +32,23 @@ const Toolbar = ({ children, className, ...props }) => {
   );
 };
 
-Toolbar.propTypes = {
+ToolbarContext.propTypes = {
   /** Children nodes */
   children: PropTypes.node,
   /** Additional css classes */
   className: PropTypes.string
 };
 
-Toolbar.defaultProps = {
+ToolbarContext.defaultProps = {
   children: null,
   className: ''
 };
 
-export default withContext(toolbarContextTypes, getToolbarContext)(Toolbar);
+const Toolbar = withContext(toolbarContextTypes, getToolbarContext)(ToolbarContext);
+
+Toolbar.Results = ToolbarResults;
+Toolbar.RightContent = ToolbarRightContent;
+Toolbar.Find = ToolbarFind;
+Toolbar.ViewSelector = ToolbarViewSelector;
+
+export default Toolbar;

--- a/packages/patternfly-react/src/components/Toolbar/ToolbarFind.js
+++ b/packages/patternfly-react/src/components/Toolbar/ToolbarFind.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Button, Icon, FormControl } from '../../index';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import { FormControl } from '../Form';
 import { noop } from '../../common/helpers';
 
 class ToolbarFind extends React.Component {

--- a/packages/patternfly-react/src/components/Toolbar/ToolbarResults.js
+++ b/packages/patternfly-react/src/components/Toolbar/ToolbarResults.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from '../../index';
+import { Row, Col } from '../Grid';
 
 const ToolbarResults = ({ children, className, ...props }) => {
   const classes = classNames('toolbar-pf-results', className);

--- a/packages/patternfly-react/src/components/Toolbar/index.js
+++ b/packages/patternfly-react/src/components/Toolbar/index.js
@@ -4,9 +4,4 @@ import ToolbarRightContent from './ToolbarRightContent';
 import ToolbarFind from './ToolbarFind';
 import ToolbarViewSelector from './ToolbarViewSelector';
 
-Toolbar.Results = ToolbarResults;
-Toolbar.RightContent = ToolbarRightContent;
-Toolbar.Find = ToolbarFind;
-Toolbar.ViewSelector = ToolbarViewSelector;
-
 export { Toolbar, ToolbarResults, ToolbarRightContent, ToolbarFind, ToolbarViewSelector };

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNav.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNav.js
@@ -18,6 +18,10 @@ import {
 } from './VerticalNavConstants';
 import VerticalNavSecondaryItem from './VerticalNavSecondaryItem';
 import VerticalNavTertiaryItem from './VerticalNavTertiaryItem';
+import VerticalNavBrand from './VerticalNavBrand';
+import VerticalNavIconBar from './VerticalNavIconBar';
+import VerticalNavBadge from './VerticalNavBadge';
+import VerticalNavDividerItem from './VerticalNavDividerItem';
 
 /**
  * VerticalNav - The Vertical Navigation pattern
@@ -255,7 +259,10 @@ class BaseVerticalNav extends React.Component {
     // Nav items may be passed either as nested VerticalNavItem children, or as nested items in a prop.
     // The items prop will take priority, if present, and must be an array of item objects (not React components).
     // If the items prop is not present, items must be expressed as VerticalNavItem children instead.
-    const itemsFromChildren = filterChildren(children, child => child.type.displayName === VerticalNavItem.displayName);
+    const itemsFromChildren = filterChildren(
+      children,
+      child => child.type && child.type.displayName === VerticalNavItem.displayName
+    );
     const itemsFromProps =
       items &&
       items.length > 0 &&
@@ -299,7 +306,7 @@ class BaseVerticalNav extends React.Component {
 
     const mastheadElem = masthead || (
       <nav className={classNames('navbar navbar-pf-vertical')}>
-        {findChild(children, child => child.type.displayName === VerticalNavMasthead.displayName)}
+        {findChild(children, child => child.type && child.type.displayName === VerticalNavMasthead.displayName)}
       </nav>
     );
 
@@ -504,5 +511,14 @@ VerticalNav.displayName = 'VerticalNav';
 
 VerticalNav.NoPersist = NoPersist;
 VerticalNav.WithPersist = WithPersist;
+
+VerticalNav.Masthead = VerticalNavMasthead;
+VerticalNav.Item = VerticalNavItem;
+VerticalNav.SecondaryItem = VerticalNavSecondaryItem;
+VerticalNav.TertiaryItem = VerticalNavTertiaryItem;
+VerticalNav.Brand = VerticalNavBrand;
+VerticalNav.IconBar = VerticalNavIconBar;
+VerticalNav.Badge = VerticalNavBadge;
+VerticalNav.Divider = VerticalNavDividerItem;
 
 export default VerticalNav;

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNav.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNav.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { ListGroup } from '../ListGroup';
 import VerticalNavItem from './VerticalNavItem';
 import VerticalNavMasthead from './VerticalNavMasthead';
-import { filterChildren, findChild, noop, propsChanged } from '../../common/helpers';
+import { filterChildren, findChild, hasDisplayName, noop, propsChanged } from '../../common/helpers';
 import Timer from '../../common/Timer';
 import controlled from '../../common/controlled';
 import { layout } from '../../common/patternfly';
@@ -259,10 +259,7 @@ class BaseVerticalNav extends React.Component {
     // Nav items may be passed either as nested VerticalNavItem children, or as nested items in a prop.
     // The items prop will take priority, if present, and must be an array of item objects (not React components).
     // If the items prop is not present, items must be expressed as VerticalNavItem children instead.
-    const itemsFromChildren = filterChildren(
-      children,
-      child => child.type && child.type.displayName === VerticalNavItem.displayName
-    );
+    const itemsFromChildren = filterChildren(children, child => hasDisplayName(child, VerticalNavItem.displayName));
     const itemsFromProps =
       items &&
       items.length > 0 &&
@@ -306,7 +303,7 @@ class BaseVerticalNav extends React.Component {
 
     const mastheadElem = masthead || (
       <nav className={classNames('navbar navbar-pf-vertical')}>
-        {findChild(children, child => child.type && child.type.displayName === VerticalNavMasthead.displayName)}
+        {findChild(children, child => hasDisplayName(child, VerticalNavMasthead.displayName))}
       </nav>
     );
 

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNavBadge.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNavBadge.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { OverlayTrigger, Tooltip } from '../../index';
+import { OverlayTrigger } from '../OverlayTrigger';
+import { Tooltip } from '../Tooltip';
 
 const VerticalNavBadge = props => {
   const { badgeClass, iconClass, tooltip, count } = props;

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNavConstants.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNavConstants.js
@@ -144,7 +144,11 @@ correctDepth.defaultProps = {
 };
 
 const isNavItem = node =>
-  node.type.displayName && node.type.displayName.includes('VerticalNav') && node.type.displayName.includes('Item');
+  node &&
+  node.type &&
+  node.type.displayName &&
+  node.type.displayName.includes('VerticalNav') &&
+  node.type.displayName.includes('Item');
 
 const getItemProps = props => {
   const itemChildren = filterChildren(props.children, isNavItem);

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
@@ -232,7 +232,7 @@ class BaseVerticalNavItemHelper extends React.Component {
     }
 
     const childBadgeComponents =
-      filterChildren(children, child => child.type.displayName === VerticalNavBadge.displayName) ||
+      filterChildren(children, child => child.type && child.type.displayName === VerticalNavBadge.displayName) ||
       (badges &&
         badges.length > 0 &&
         badges.map(badge => {

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
@@ -6,7 +6,7 @@ import { ListGroup, ListGroupItem } from '../ListGroup';
 import { OverlayTrigger } from '../OverlayTrigger';
 import { Tooltip } from '../Tooltip';
 import VerticalNavBadge from './VerticalNavBadge';
-import { filterChildren } from '../../common/helpers';
+import { filterChildren, hasDisplayName } from '../../common/helpers';
 import VerticalNavDividerItem from './VerticalNavDividerItem';
 import {
   NavContextProvider,
@@ -232,7 +232,7 @@ class BaseVerticalNavItemHelper extends React.Component {
     }
 
     const childBadgeComponents =
-      filterChildren(children, child => child.type && child.type.displayName === VerticalNavBadge.displayName) ||
+      filterChildren(children, child => hasDisplayName(child, VerticalNavBadge.displayName)) ||
       (badges &&
         badges.length > 0 &&
         badges.map(badge => {

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNavMasthead.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNavMasthead.js
@@ -4,7 +4,7 @@ import { getContext } from 'recompose';
 import { Navbar } from 'react-bootstrap';
 import VerticalNavBrand from './VerticalNavBrand';
 import { navContextTypes } from './VerticalNavConstants';
-import { noop } from '../../common/helpers';
+import { noop, hasDisplayName, filterChildren } from '../../common/helpers';
 
 /**
  * VerticalNavMasthead - the first child of a VerticalNav component
@@ -12,13 +12,8 @@ import { noop } from '../../common/helpers';
 const BaseVerticalNavMasthead = props => {
   const { children, href, iconImg, titleImg, title } = props;
 
-  const childrenArray = children && React.Children.count(children) > 0 && React.Children.toArray(children);
-  const brandChildren =
-    childrenArray &&
-    childrenArray.filter(child => child.type && child.type.displayName === VerticalNavBrand.displayName);
-  const otherChildren =
-    childrenArray &&
-    childrenArray.filter(child => !child.type || child.type.displayName !== VerticalNavBrand.displayName);
+  const brandChildren = filterChildren(children, child => hasDisplayName(child, VerticalNavBrand.displayName));
+  const otherChildren = filterChildren(children, child => !hasDisplayName(child, VerticalNavBrand.displayName));
 
   return (
     <React.Fragment>

--- a/packages/patternfly-react/src/components/VerticalNav/VerticalNavMasthead.js
+++ b/packages/patternfly-react/src/components/VerticalNav/VerticalNavMasthead.js
@@ -14,9 +14,11 @@ const BaseVerticalNavMasthead = props => {
 
   const childrenArray = children && React.Children.count(children) > 0 && React.Children.toArray(children);
   const brandChildren =
-    childrenArray && childrenArray.filter(child => child.type.displayName === VerticalNavBrand.displayName);
+    childrenArray &&
+    childrenArray.filter(child => child.type && child.type.displayName === VerticalNavBrand.displayName);
   const otherChildren =
-    childrenArray && childrenArray.filter(child => child.type.displayName !== VerticalNavBrand.displayName);
+    childrenArray &&
+    childrenArray.filter(child => !child.type || child.type.displayName !== VerticalNavBrand.displayName);
 
   return (
     <React.Fragment>

--- a/packages/patternfly-react/src/components/VerticalNav/index.js
+++ b/packages/patternfly-react/src/components/VerticalNav/index.js
@@ -8,15 +8,6 @@ import VerticalNavIconBar from './VerticalNavIconBar';
 import VerticalNavBadge from './VerticalNavBadge';
 import VerticalNavDividerItem from './VerticalNavDividerItem';
 
-VerticalNav.Masthead = VerticalNavMasthead;
-VerticalNav.Item = VerticalNavItem;
-VerticalNav.SecondaryItem = VerticalNavSecondaryItem;
-VerticalNav.TertiaryItem = VerticalNavTertiaryItem;
-VerticalNav.Brand = VerticalNavBrand;
-VerticalNav.IconBar = VerticalNavIconBar;
-VerticalNav.Badge = VerticalNavBadge;
-VerticalNav.Divider = VerticalNavDividerItem;
-
 export {
   VerticalNav,
   VerticalNavMasthead,

--- a/packages/patternfly-react/src/components/Wizard/Wizard.js
+++ b/packages/patternfly-react/src/components/Wizard/Wizard.js
@@ -1,6 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop, Modal } from '../../index';
+import WizardBody from './WizardBody';
+import WizardContents from './WizardContents';
+import WizardFooter from './WizardFooter';
+import WizardHeader from './WizardHeader';
+import WizardMain from './WizardMain';
+import WizardReviewContent from './WizardReviewContent';
+import WizardReviewItem from './WizardReviewItem';
+import WizardReviewStep from './WizardReviewStep';
+import WizardReviewSteps from './WizardReviewSteps';
+import WizardReviewSubStep from './WizardReviewSubStep';
+import WizardReviewSubSteps from './WizardReviewSubSteps';
+import WizardRow from './WizardRow';
+import WizardSidebar from './WizardSidebar';
+import WizardSidebarGroup from './WizardSidebarGroup';
+import WizardSidebarGroupItem from './WizardSidebarGroupItem';
+import WizardStep from './WizardStep';
+import WizardSteps from './WizardSteps';
+import WizardSubStep from './WizardSubStep';
+
+import WizardPattern from './Patterns/WizardPattern';
+import WizardPatternBody from './Patterns/WizardPatternBody';
+import StatefulWizardPattern from './Patterns/StatefulWizardPattern';
 
 /**
  * Wizard - main Wizard component.
@@ -38,4 +60,28 @@ Wizard.defaultProps = {
   onClose: noop,
   onExited: noop
 };
+
+Wizard.Body = WizardBody;
+Wizard.Contents = WizardContents;
+Wizard.Footer = WizardFooter;
+Wizard.Header = WizardHeader;
+Wizard.Main = WizardMain;
+Wizard.ReviewContent = WizardReviewContent;
+Wizard.ReviewItem = WizardReviewItem;
+Wizard.ReviewStep = WizardReviewStep;
+Wizard.ReviewSteps = WizardReviewSteps;
+Wizard.ReviewSubStep = WizardReviewSubStep;
+Wizard.ReviewSubSteps = WizardReviewSubSteps;
+Wizard.Row = WizardRow;
+Wizard.Sidebar = WizardSidebar;
+Wizard.SidebarGroup = WizardSidebarGroup;
+Wizard.SidebarGroupItem = WizardSidebarGroupItem;
+Wizard.Step = WizardStep;
+Wizard.Steps = WizardSteps;
+Wizard.SubStep = WizardSubStep;
+
+Wizard.Pattern = WizardPattern;
+Wizard.Pattern.Body = WizardPatternBody;
+Wizard.Pattern.Stateful = StatefulWizardPattern;
+
 export default Wizard;

--- a/packages/patternfly-react/src/components/Wizard/Wizard.js
+++ b/packages/patternfly-react/src/components/Wizard/Wizard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { noop, Modal } from '../../index';
+import { noop } from '../../common/helpers';
+import { Modal } from '../Modal';
 import WizardBody from './WizardBody';
 import WizardContents from './WizardContents';
 import WizardFooter from './WizardFooter';

--- a/packages/patternfly-react/src/components/Wizard/WizardBody.js
+++ b/packages/patternfly-react/src/components/Wizard/WizardBody.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Modal } from '../../index';
+import { Modal } from '../Modal';
 
 /**
  * WizardBody component for Patternfly React

--- a/packages/patternfly-react/src/components/Wizard/WizardFooter.js
+++ b/packages/patternfly-react/src/components/Wizard/WizardFooter.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Modal } from '../../index';
+import { Modal } from '../Modal';
 
 /**
  * WizardFooter component for Patternfly React

--- a/packages/patternfly-react/src/components/Wizard/WizardHeader.js
+++ b/packages/patternfly-react/src/components/Wizard/WizardHeader.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Modal, Icon } from '../../index';
+import { Icon } from '../Icon';
+import { Modal } from '../Modal';
 
 /**
  * WizardHeader component for Patternfly React

--- a/packages/patternfly-react/src/components/Wizard/index.js
+++ b/packages/patternfly-react/src/components/Wizard/index.js
@@ -22,29 +22,6 @@ import WizardPattern from './Patterns/WizardPattern';
 import WizardPatternBody from './Patterns/WizardPatternBody';
 import StatefulWizardPattern from './Patterns/StatefulWizardPattern';
 
-Wizard.Body = WizardBody;
-Wizard.Contents = WizardContents;
-Wizard.Footer = WizardFooter;
-Wizard.Header = WizardHeader;
-Wizard.Main = WizardMain;
-Wizard.ReviewContent = WizardReviewContent;
-Wizard.ReviewItem = WizardReviewItem;
-Wizard.ReviewStep = WizardReviewStep;
-Wizard.ReviewSteps = WizardReviewSteps;
-Wizard.ReviewSubStep = WizardReviewSubStep;
-Wizard.ReviewSubSteps = WizardReviewSubSteps;
-Wizard.Row = WizardRow;
-Wizard.Sidebar = WizardSidebar;
-Wizard.SidebarGroup = WizardSidebarGroup;
-Wizard.SidebarGroupItem = WizardSidebarGroupItem;
-Wizard.Step = WizardStep;
-Wizard.Steps = WizardSteps;
-Wizard.SubStep = WizardSubStep;
-
-Wizard.Pattern = WizardPattern;
-Wizard.Pattern.Body = WizardPatternBody;
-Wizard.Pattern.Stateful = StatefulWizardPattern;
-
 export {
   Wizard,
   WizardBody,

--- a/packages/react-console/src/VncConsole/__snapshots__/VncConsole.test.js.snap
+++ b/packages/react-console/src/VncConsole/__snapshots__/VncConsole.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`placeholder render test 1`] = `
-<withContext(Toolbar)
+<withContext(ToolbarContext)
   className="vnc-console"
 >
   <ToolbarResults
@@ -14,5 +14,5 @@ exports[`placeholder render test 1`] = `
     </div>
     <div />
   </ToolbarResults>
-</withContext(Toolbar)>
+</withContext(ToolbarContext)>
 `;

--- a/packages/react-console/src/VncConsole/__snapshots__/VncConsole.test.js.snap
+++ b/packages/react-console/src/VncConsole/__snapshots__/VncConsole.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`placeholder render test 1`] = `
-<withContext(ToolbarContext)
+<withContext(ContextualToolbar)
   className="vnc-console"
 >
   <ToolbarResults
@@ -14,5 +14,5 @@ exports[`placeholder render test 1`] = `
     </div>
     <div />
   </ToolbarResults>
-</withContext(ToolbarContext)>
+</withContext(ContextualToolbar)>
 `;


### PR DESCRIPTION
affects: patternfly-react

There are some issues with production builds when pulling in patternfly-react:

- Some of the subcomponents are not being found
- There are some checks in pf-react components that look for `child.type.displayName` when in production builds the `child.type` is not set on all components. 
- Some pf-react components import other components from the overall index file which pulls in all of pf-react if an application uses that component

This PR:

- Sets component's subcomponents in the component file rather than in index.js
- Imports other components from their component rather than from the overall index file.
- Checks for a `child.type` before checking `child.type.displayName`

