### PR TITLE
refactor: use keycode from src/common/helpers.js in LoginPage

### DIFF
--- a/packages/patternfly-react/src/common/helpers.js
+++ b/packages/patternfly-react/src/common/helpers.js
@@ -65,9 +65,19 @@ export const nullValues = obj => selectKeys(obj, Object.keys(obj), () => null);
 
 export const noop = Function.prototype;
 
-export const KEY_CODES = { TAB_KEY: 9, ENTER_KEY: 13, ESCAPE_KEY: 27 };
+export const KEY_CODES = {
+  TAB_KEY: 9,
+  ENTER_KEY: 13,
+  ESCAPE_KEY: 27,
+  SHIFT: 16,
+  A: 65,
+  Z: 90,
+  NUMPAD: { 0: 97 },
+  F11: 122
+};
 export const KEYS = {
   ENTER: 'Enter',
+  CAPSLOCK: 'CapsLock',
   SPACE: ' ',
   ARROW_LEFT: 'ArrowLeft',
   ARROW_RIGHT: 'ArrowRight',

--- a/packages/patternfly-react/src/components/LoginPage/LoginPage.test.js
+++ b/packages/patternfly-react/src/components/LoginPage/LoginPage.test.js
@@ -4,6 +4,7 @@ import { DropdownButton } from 'react-bootstrap';
 import englishMessages from './mocks/messages.en';
 import frenchMessages from './mocks/messages.fr';
 import { LoginPage, LoginCardWithValidation } from './index';
+import { KEY_CODES } from '../../common/helpers';
 
 const { Input, ForgotPassword, SignUp } = LoginPage.Card;
 const { FooterLinks } = LoginPage;
@@ -118,7 +119,7 @@ test('Toggle Caps lock warning in password field by the events: focus, blur and 
   const component = mount(<LoginPage {...createProps()} />);
   const passwordElement = component.find('input[type="password"]').at(0);
 
-  passwordElement.simulate('focus').simulate('keypress', { keyCode: 80, shiftKey: false });
+  passwordElement.simulate('focus').simulate('keypress', { keyCode: KEY_CODES.A, shiftKey: false });
 
   expect(
     component
@@ -134,7 +135,7 @@ test('Toggle Caps lock warning in password field by the events: focus, blur and 
       .props().showWarning
   ).toEqual(true);
 
-  passwordElement.simulate('blur').simulate('keypress', { keyCode: 80, shiftKey: false });
+  passwordElement.simulate('blur').simulate('keypress', { keyCode: KEY_CODES.A, shiftKey: false });
 
   expect(
     component
@@ -143,7 +144,7 @@ test('Toggle Caps lock warning in password field by the events: focus, blur and 
       .props().showWarning
   ).toEqual(false);
 
-  passwordElement.simulate('keypress', { keyCode: 80, shiftKey: false }).simulate('focus');
+  passwordElement.simulate('keypress', { keyCode: KEY_CODES.A, shiftKey: false }).simulate('focus');
 
   expect(
     component

--- a/packages/patternfly-react/src/components/LoginPage/components/LoginCardComponents/LoginCardWithValidation.js
+++ b/packages/patternfly-react/src/components/LoginPage/components/LoginCardComponents/LoginCardWithValidation.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import LoginCardInput from './LoginCardInput';
+import { KEY_CODES, KEYS } from '../../../../common/helpers';
 
 class LoginCardWithValidation extends React.Component {
   state = {
@@ -186,7 +187,7 @@ class LoginCardWithValidation extends React.Component {
     if (!this.state.passwordField.value) {
       return;
     }
-    e.key === 'CapsLock' &&
+    e.key === KEYS.CAPSLOCK &&
       this.setState({
         isCapsLock: !this.state.isCapsLock
       });
@@ -194,8 +195,10 @@ class LoginCardWithValidation extends React.Component {
 
   handleCapsLock = e => {
     const keyCode = e.keyCode ? e.keyCode : e.which;
-    const shiftKey = e.shiftKey ? e.shiftKey : keyCode === 16;
-    const isCapsLock = (keyCode >= 65 && keyCode <= 90 && !shiftKey) || (keyCode >= 97 && keyCode <= 122 && shiftKey);
+    const shiftKey = e.shiftKey ? e.shiftKey : keyCode === KEY_CODES.SHIFT;
+    const isCapsLock =
+      (keyCode >= KEY_CODES.A && keyCode <= KEY_CODES.Z && !shiftKey) ||
+      (keyCode >= KEY_CODES.NUMPAD['0'] && keyCode <= KEY_CODES.F11 && shiftKey);
     this.setState({
       isCapsLock
     });


### PR DESCRIPTION
affects: patternfly-react

ISSUES CLOSED: #530

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Use KEYS and KEYCODE from src/common/helpers.js at handleCapsLock and toggleCapsLock in LoginPage

