### PR TITLE
fix(warnings): fix warnings and compound-label.less

### DIFF
--- a/packages/patternfly-3/patternfly-react/less/compound-label.less
+++ b/packages/patternfly-3/patternfly-react/less/compound-label.less
@@ -1,8 +1,8 @@
 .compound-label-pf {
-  background-color: $color-pf-blue-500;
+  background-color: @color-pf-blue-500;
   padding-left: 15px;
   padding-right: 15px;
-  color: $color-pf-white;
+  color: @color-pf-white;
   margin-left: 5px;
   margin-right: 10px;
   font-size: 14px;
@@ -34,5 +34,5 @@
 }
 
 .compound-label-inner-color-pf {
-  background-color: $color-pf-blue-400;
+  background-color: @color-pf-blue-400;
 }

--- a/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/HorizontalNavMenuItem.js
+++ b/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/HorizontalNavMenuItem.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { Dropdown, ListGroup, ListGroupItem } from '../../index';
 
 const HorizontalNavMenuItem = props => {
-  const { children, onItemClick, title, active, dropdown, submenu, dropup, pullLeft } = props;
+  const { children, onItemClick, title, active, dropdown, submenu, dropup, pullLeft, ...otherProps } = props;
 
   const dropdownClasses = classNames({
     'dropdown-submenu': submenu,
@@ -12,15 +12,14 @@ const HorizontalNavMenuItem = props => {
   });
 
   return dropdown ? (
-    <Dropdown componentClass="li" className={dropdownClasses}>
-      <a bsRole="toggle">
+    <Dropdown componentClass="li" className={dropdownClasses} {...otherProps}>
+      <Dropdown.Toggle useAnchor noCaret={submenu}>
         {title}
-        {!submenu && <span className="caret" />}
-      </a>
+      </Dropdown.Toggle>
       <Dropdown.Menu className={dropup ? 'dropup' : ''}>{children}</Dropdown.Menu>
     </Dropdown>
   ) : (
-    <ListGroupItem listItem bsClass="" active={active}>
+    <ListGroupItem listItem bsClass="" active={active} {...otherProps}>
       <a href="#" onClick={onItemClick}>
         {title}
       </a>

--- a/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/__mocks__/dropdownLevel.js
+++ b/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/__mocks__/dropdownLevel.js
@@ -4,7 +4,7 @@ import { MenuItem } from '../../../index';
 
 export const dropdownLevel = (
   <HorizontalNavMenu>
-    <HorizontalNavMenuItem title="Dropdown" dropdown>
+    <HorizontalNavMenuItem id="dropdown" title="Dropdown" dropdown>
       <MenuItem>Link</MenuItem>
       <MenuItem>Another link</MenuItem>
       <MenuItem divider />
@@ -12,14 +12,14 @@ export const dropdownLevel = (
       <MenuItem divider />
       <MenuItem>One more separated link</MenuItem>
     </HorizontalNavMenuItem>
-    <HorizontalNavMenuItem title="Dropdown with Submenu" dropdown>
+    <HorizontalNavMenuItem id="dropdown-with-submenu" title="Dropdown with Submenu" dropdown>
       <MenuItem>Link</MenuItem>
       <MenuItem>Another link</MenuItem>
       <MenuItem divider />
       <MenuItem>Separated link</MenuItem>
       <MenuItem divider />
       <MenuItem>One more separated link</MenuItem>
-      <HorizontalNavMenuItem title="More options" dropdown submenu>
+      <HorizontalNavMenuItem id="more-options" title="More options" dropdown submenu>
         <MenuItem>Link</MenuItem>
         <MenuItem>Another link</MenuItem>
         <MenuItem divider />
@@ -28,14 +28,14 @@ export const dropdownLevel = (
         <MenuItem>One more separated link</MenuItem>
       </HorizontalNavMenuItem>
     </HorizontalNavMenuItem>
-    <HorizontalNavMenuItem title="Dropdown with Dropup Submenu" dropdown dropup>
+    <HorizontalNavMenuItem id="dropup-submenu" title="Dropdown with Dropup Submenu" dropdown dropup>
       <MenuItem>Link</MenuItem>
       <MenuItem>Another link</MenuItem>
       <MenuItem divider />
       <MenuItem>Separated link</MenuItem>
       <MenuItem divider />
       <MenuItem>One more separated link</MenuItem>
-      <HorizontalNavMenuItem title="More options" dropdown submenu>
+      <HorizontalNavMenuItem id="more-options" title="More options" dropdown submenu>
         <MenuItem>Link</MenuItem>
         <MenuItem>Another link</MenuItem>
         <MenuItem divider />
@@ -44,14 +44,14 @@ export const dropdownLevel = (
         <MenuItem>One more separated link</MenuItem>
       </HorizontalNavMenuItem>
     </HorizontalNavMenuItem>
-    <HorizontalNavMenuItem title="Dropdown with Pull-left Submenu" dropdown>
+    <HorizontalNavMenuItem id="pull-left" title="Dropdown with Pull-left Submenu" dropdown>
       <MenuItem>Link</MenuItem>
       <MenuItem>Another link</MenuItem>
       <MenuItem divider />
       <MenuItem>Separated link</MenuItem>
       <MenuItem divider />
       <MenuItem>One more separated link</MenuItem>
-      <HorizontalNavMenuItem title="More options" dropdown submenu pullLeft>
+      <HorizontalNavMenuItem id="left-more-options" title="More options" dropdown submenu pullLeft>
         <MenuItem>Link</MenuItem>
         <MenuItem>Another link</MenuItem>
         <MenuItem divider />
@@ -60,6 +60,6 @@ export const dropdownLevel = (
         <MenuItem>One more separated link</MenuItem>
       </HorizontalNavMenuItem>
     </HorizontalNavMenuItem>
-    <HorizontalNavMenuItem title="No Dropdown" />
+    <HorizontalNavMenuItem id="no-dropdown" title="No Dropdown" />
   </HorizontalNavMenu>
 );

--- a/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/__mocks__/singleLevel.js
+++ b/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/__mocks__/singleLevel.js
@@ -3,8 +3,8 @@ import { HorizontalNavMenu, HorizontalNavMenuItem } from '../index';
 
 export const singleLevel = (
   <HorizontalNavMenu>
-    <HorizontalNavMenuItem title="First Link" />
-    <HorizontalNavMenuItem title="Another Link" />
-    <HorizontalNavMenuItem title="And Another" />
+    <HorizontalNavMenuItem id="first" title="First Link" />
+    <HorizontalNavMenuItem id="another" title="Another Link" />
+    <HorizontalNavMenuItem id="and-another" title="And Another" />
   </HorizontalNavMenu>
 );

--- a/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/__mocks__/twoLevel.js
+++ b/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/__mocks__/twoLevel.js
@@ -3,18 +3,18 @@ import { HorizontalNavMenu, HorizontalNavMenuItem } from '../index';
 
 export const twoLevel = (
   <HorizontalNavMenu twoLevels>
-    <HorizontalNavMenuItem title="First Link" />
-    <HorizontalNavMenuItem title="Another Link" active>
-      <HorizontalNavMenuItem title="Link" />
-      <HorizontalNavMenuItem title="Another Link" active />
-      <HorizontalNavMenuItem title="Something Else Here" />
-      <HorizontalNavMenuItem title="Remembering to keep" />
-      <HorizontalNavMenuItem title="It between five and seven" />
-      <HorizontalNavMenuItem title="More options" />
+    <HorizontalNavMenuItem id="first" title="First Link" />
+    <HorizontalNavMenuItem id="another" title="Another Link" active>
+      <HorizontalNavMenuItem id="link" title="Link" />
+      <HorizontalNavMenuItem id="another-link" title="Another Link" active />
+      <HorizontalNavMenuItem id="something-else" title="Something Else Here" />
+      <HorizontalNavMenuItem id="remember" title="Remembering to keep" />
+      <HorizontalNavMenuItem id="between-5-7" title="It between five and seven" />
+      <HorizontalNavMenuItem id="more" title="More options" />
     </HorizontalNavMenuItem>
-    <HorizontalNavMenuItem title="And Another" />
-    <HorizontalNavMenuItem title="As a General Rule" />
-    <HorizontalNavMenuItem title="Five to Seven Links" />
-    <HorizontalNavMenuItem title="Is Good" />
+    <HorizontalNavMenuItem id="and-another" title="And Another" />
+    <HorizontalNavMenuItem id="general-rule" title="As a General Rule" />
+    <HorizontalNavMenuItem id="five-to-seven" title="Five to Seven Links" />
+    <HorizontalNavMenuItem id="is-good" title="Is Good" />
   </HorizontalNavMenu>
 );

--- a/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/__snapshots__/HorizontalNav.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/__snapshots__/HorizontalNav.test.js.snap
@@ -140,15 +140,20 @@ exports[`HorizontalNav renders properly with dropdown Levels 1`] = `
         class="dropdown"
       >
         <a
-          bsclass="dropdown-toggle"
-          bsrole="toggle"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="dropdown-toggle"
+          href="#"
+          id="dropdown"
+          role="button"
         >
-          Dropdown
+          Dropdown 
           <span
             class="caret"
           />
         </a>
         <ul
+          aria-labelledby="dropdown"
           class="dropdown-menu"
           role="menu"
         >
@@ -214,15 +219,20 @@ exports[`HorizontalNav renders properly with dropdown Levels 1`] = `
         class="dropdown"
       >
         <a
-          bsclass="dropdown-toggle"
-          bsrole="toggle"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="dropdown-toggle"
+          href="#"
+          id="dropdown-with-submenu"
+          role="button"
         >
-          Dropdown with Submenu
+          Dropdown with Submenu 
           <span
             class="caret"
           />
         </a>
         <ul
+          aria-labelledby="dropdown-with-submenu"
           class="dropdown-menu"
           role="menu"
         >
@@ -286,12 +296,17 @@ exports[`HorizontalNav renders properly with dropdown Levels 1`] = `
             class="dropdown-submenu dropdown"
           >
             <a
-              bsclass="dropdown-toggle"
-              bsrole="toggle"
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="dropdown-toggle"
+              href="#"
+              id="more-options"
+              role="button"
             >
               More options
             </a>
             <ul
+              aria-labelledby="more-options"
               class="dropdown-menu"
               role="menu"
             >
@@ -359,15 +374,20 @@ exports[`HorizontalNav renders properly with dropdown Levels 1`] = `
         class="dropdown"
       >
         <a
-          bsclass="dropdown-toggle"
-          bsrole="toggle"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="dropdown-toggle"
+          href="#"
+          id="dropup-submenu"
+          role="button"
         >
-          Dropdown with Dropup Submenu
+          Dropdown with Dropup Submenu 
           <span
             class="caret"
           />
         </a>
         <ul
+          aria-labelledby="dropup-submenu"
           class="dropup dropdown-menu"
           role="menu"
         >
@@ -431,12 +451,17 @@ exports[`HorizontalNav renders properly with dropdown Levels 1`] = `
             class="dropdown-submenu dropdown"
           >
             <a
-              bsclass="dropdown-toggle"
-              bsrole="toggle"
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="dropdown-toggle"
+              href="#"
+              id="more-options"
+              role="button"
             >
               More options
             </a>
             <ul
+              aria-labelledby="more-options"
               class="dropdown-menu"
               role="menu"
             >
@@ -504,15 +529,20 @@ exports[`HorizontalNav renders properly with dropdown Levels 1`] = `
         class="dropdown"
       >
         <a
-          bsclass="dropdown-toggle"
-          bsrole="toggle"
+          aria-expanded="false"
+          aria-haspopup="true"
+          class="dropdown-toggle"
+          href="#"
+          id="pull-left"
+          role="button"
         >
-          Dropdown with Pull-left Submenu
+          Dropdown with Pull-left Submenu 
           <span
             class="caret"
           />
         </a>
         <ul
+          aria-labelledby="pull-left"
           class="dropdown-menu"
           role="menu"
         >
@@ -576,12 +606,17 @@ exports[`HorizontalNav renders properly with dropdown Levels 1`] = `
             class="dropdown-submenu pull-left dropdown"
           >
             <a
-              bsclass="dropdown-toggle"
-              bsrole="toggle"
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="dropdown-toggle"
+              href="#"
+              id="left-more-options"
+              role="button"
             >
               More options
             </a>
             <ul
+              aria-labelledby="left-more-options"
               class="dropdown-menu"
               role="menu"
             >
@@ -647,6 +682,7 @@ exports[`HorizontalNav renders properly with dropdown Levels 1`] = `
       </li>
       <li
         class=""
+        id="no-dropdown"
       >
         <a
           href="#"
@@ -797,6 +833,7 @@ exports[`HorizontalNav renders properly with singleLevel 1`] = `
     >
       <li
         class=""
+        id="first"
       >
         <a
           href="#"
@@ -806,6 +843,7 @@ exports[`HorizontalNav renders properly with singleLevel 1`] = `
       </li>
       <li
         class=""
+        id="another"
       >
         <a
           href="#"
@@ -815,6 +853,7 @@ exports[`HorizontalNav renders properly with singleLevel 1`] = `
       </li>
       <li
         class=""
+        id="and-another"
       >
         <a
           href="#"
@@ -965,6 +1004,7 @@ exports[`HorizontalNav renders properly with two Levels 1`] = `
     >
       <li
         class=""
+        id="first"
       >
         <a
           href="#"
@@ -974,6 +1014,7 @@ exports[`HorizontalNav renders properly with two Levels 1`] = `
       </li>
       <li
         class=" active"
+        id="another"
       >
         <a
           href="#"
@@ -985,6 +1026,7 @@ exports[`HorizontalNav renders properly with two Levels 1`] = `
         >
           <li
             class=""
+            id="link"
           >
             <a
               href="#"
@@ -994,6 +1036,7 @@ exports[`HorizontalNav renders properly with two Levels 1`] = `
           </li>
           <li
             class=" active"
+            id="another-link"
           >
             <a
               href="#"
@@ -1003,6 +1046,7 @@ exports[`HorizontalNav renders properly with two Levels 1`] = `
           </li>
           <li
             class=""
+            id="something-else"
           >
             <a
               href="#"
@@ -1012,6 +1056,7 @@ exports[`HorizontalNav renders properly with two Levels 1`] = `
           </li>
           <li
             class=""
+            id="remember"
           >
             <a
               href="#"
@@ -1021,6 +1066,7 @@ exports[`HorizontalNav renders properly with two Levels 1`] = `
           </li>
           <li
             class=""
+            id="between-5-7"
           >
             <a
               href="#"
@@ -1030,6 +1076,7 @@ exports[`HorizontalNav renders properly with two Levels 1`] = `
           </li>
           <li
             class=""
+            id="more"
           >
             <a
               href="#"
@@ -1041,6 +1088,7 @@ exports[`HorizontalNav renders properly with two Levels 1`] = `
       </li>
       <li
         class=""
+        id="and-another"
       >
         <a
           href="#"
@@ -1050,6 +1098,7 @@ exports[`HorizontalNav renders properly with two Levels 1`] = `
       </li>
       <li
         class=""
+        id="general-rule"
       >
         <a
           href="#"
@@ -1059,6 +1108,7 @@ exports[`HorizontalNav renders properly with two Levels 1`] = `
       </li>
       <li
         class=""
+        id="five-to-seven"
       >
         <a
           href="#"
@@ -1068,6 +1118,7 @@ exports[`HorizontalNav renders properly with two Levels 1`] = `
       </li>
       <li
         class=""
+        id="is-good"
       >
         <a
           href="#"

--- a/packages/patternfly-3/patternfly-react/src/components/Wizard/Patterns/StatefulWizardPattern.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Wizard/Patterns/StatefulWizardPattern.js
@@ -53,7 +53,7 @@ class StatefulWizardPattern extends React.Component {
 }
 
 StatefulWizardPattern.propTypes = {
-  ...excludeKeys(WizardPattern.propTypes, ['nextStepDisabled', 'previousStepDisabled']),
+  ...excludeKeys(WizardPattern.propTypes, ['activeStepIndex', 'nextStepDisabled', 'previousStepDisabled']),
   steps: PropTypes.arrayOf(
     PropTypes.shape({
       ...wizardStepShape,


### PR DESCRIPTION
affects: patternfly-react

Fixes warnings in HorizontalNav by using Dropdown.Toggle with useAnchor
Fix StatefulWizardPattern to not require activeStepIndex
Fix compilation errors in compound-label.less

ISSUES CLOSED: #575, #572

