### PR TITLE
PF4 Modal: Add missing modal typings

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Modal/Backdrop.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/Backdrop.d.ts
@@ -1,0 +1,10 @@
+import {SFC, HTMLProps, ReactNode} from 'react';
+
+export interface BackdropProps extends HTMLProps<HTMLDivElement> {
+  children?: ReactNode;
+  className?: string;
+}
+
+declare const Backdrop: SFC<BackdropProps>;
+
+export default Backdrop;

--- a/packages/patternfly-4/react-core/src/components/Modal/Modal.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/Modal.d.ts
@@ -1,0 +1,16 @@
+import {SFC, HTMLProps, ReactNode} from 'react';
+
+export interface ModalProps extends HTMLProps<HTMLDivElement> {
+  actions?: any,
+  children: ReactNode;
+  className?: string;
+  hideTitle?: boolean;
+  isLarge?: boolean;
+  isOpen?: boolean;
+  onClose?: Function;
+  title: string;
+}
+
+declare const Modal: SFC<ModalProps>;
+
+export default Modal;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBox.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBox.d.ts
@@ -1,0 +1,13 @@
+import {SFC, HTMLProps, ReactNode} from 'react';
+
+export interface ModalBoxProps extends HTMLProps<HTMLDivElement> {
+  children: ReactNode;
+  className?: string;
+  id: string;
+  isLarge?: boolean;
+  title: string;
+}
+
+declare const ModalBox: SFC<ModalBoxProps>;
+
+export default ModalBox;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxBody.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxBody.d.ts
@@ -1,0 +1,11 @@
+import {SFC, HTMLProps, ReactNode} from 'react';
+
+export interface ModalBoxBodyProps extends HTMLProps<HTMLDivElement> {
+  children?: ReactNode;
+  className?: string;
+  id?: string;
+}
+
+declare const ModalBoxBody: SFC<ModalBoxBodyProps>;
+
+export default ModalBoxBody;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxCloseButton.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxCloseButton.d.ts
@@ -1,0 +1,10 @@
+import {SFC, HTMLProps, ReactNode} from 'react';
+
+export interface ModalBoxCloseButtonProps extends HTMLProps<HTMLDivElement> {
+  className?: string;
+  onClose?: Function;
+}
+
+declare const ModalBoxCloseButton: SFC<ModalBoxCloseButtonProps>;
+
+export default ModalBoxCloseButton;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxFooter.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxFooter.d.ts
@@ -1,0 +1,10 @@
+import {SFC, HTMLProps, ReactNode} from 'react';
+
+export interface ModalBoxFooterProps extends HTMLProps<HTMLDivElement> {
+  children?: ReactNode;
+  className?: string;
+}
+
+declare const ModalBoxFooter: SFC<ModalBoxFooterProps>;
+
+export default ModalBoxFooter;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxHeader.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxHeader.d.ts
@@ -1,0 +1,10 @@
+import {SFC, HTMLProps, ReactNode} from 'react';
+
+export interface ModalBoxHeaderProps extends HTMLProps<HTMLDivElement> {
+  children?: ReactNode;
+  className?: string;
+}
+
+declare const ModalBoxHeader: SFC<ModalBoxHeaderProps>;
+
+export default ModalBoxHeader;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.d.ts
@@ -1,0 +1,17 @@
+import {SFC, HTMLProps, ReactNode} from 'react';
+
+export interface ModalContentProps extends HTMLProps<HTMLDivElement> {
+  children: ReactNode;
+  className?: string;
+  id: string;
+  isLarge?: boolean;
+  isOpen?: boolean;
+  hideTitle?: boolean;
+  actions?: any,
+  onClose?: Function;
+  title: string;
+}
+
+declare const ModalContent: SFC<ModalContentProps>;
+
+export default ModalContent;

--- a/packages/patternfly-4/react-core/src/components/Modal/index.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/index.d.ts
@@ -1,0 +1,8 @@
+export { default as Backdrop, BackdropProps } from './Backdrop';
+export { default as Modal, ModalProps } from './Modal';
+export { default as ModalBox, ModalBoxProps } from './ModalBox';
+export { default as ModalBoxBody, ModalBoxBodyProps } from './ModalBoxBody';
+export { default as ModalBoxCloseButton, ModalBoxCloseButtonProps } from './ModalBoxCloseButton';
+export { default as ModalBoxFooter, ModalBoxFooterProps } from './ModalBoxFooter';
+export { default as ModalBoxHeader, ModalBoxHeaderProps } from './ModalBoxHeader';
+export { default as ModalContent, ModalContentProps } from './ModalContent';

--- a/packages/patternfly-4/react-core/src/components/Modal/index.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/index.js
@@ -1,1 +1,8 @@
+export { default as Backdrop } from './Backdrop';
 export { default as Modal } from './Modal';
+export { default as ModalBox } from './ModalBox';
+export { default as ModalBoxBody } from './ModalBoxBody';
+export { default as ModalBoxCloseButton } from './ModalBoxCloseButton';
+export { default as ModalBoxFooter } from './ModalBoxFooter';
+export { default as ModalBoxHeader } from './ModalBoxHeader';
+export { default as ModalContent } from './ModalContent';

--- a/packages/patternfly-4/react-core/src/components/index.d.ts
+++ b/packages/patternfly-4/react-core/src/components/index.d.ts
@@ -3,6 +3,7 @@ export * from './Badge';
 export * from './Button';
 export * from './Card';
 export * from './Checkbox';
+export * from './Modal';
 export * from './Radio';
 export * from './Title';
 export * from './Alert';


### PR DESCRIPTION
Add missing modal typings to PF4.

Fixes: https://github.com/patternfly/patternfly-react/issues/581
