### PR TITLE
fix(stylesheet): restore css export

### DIFF
--- a/packages/patternfly-4/react-styles/src/index.d.ts
+++ b/packages/patternfly-4/react-styles/src/index.d.ts
@@ -1,4 +1,4 @@
-export { StyleSheet, StyleSheetStatic, StyleSheetValueStatic } from './StyleSheet';
+export { css, StyleSheet, StyleSheetStatic, StyleSheetValueStatic } from './StyleSheet';
 export {
   isValidStyleDeclaration,
   StyleDeclarationStatic,


### PR DESCRIPTION
This restores the css function export from Stylesheet. This already exists in index.js, but is missing from index.d.ts

Fixes: https://github.com/patternfly/patternfly-react/issues/584
