### PR TITLE
Fix #431 : Add href paths to VerticalNav menuItems

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/VerticalNav/VerticalNav.js
+++ b/packages/patternfly-3/patternfly-react/src/components/VerticalNav/VerticalNav.js
@@ -269,6 +269,7 @@ class BaseVerticalNav extends React.Component {
             primaryItem.subItems.map(secondaryItem => (
               <VerticalNavSecondaryItem
                 isDivider={secondaryItem.isDivider}
+                preventHref={secondaryItem.preventHref}
                 item={secondaryItem}
                 key={`secondary_${secondaryItem.title}`}
               >

--- a/packages/patternfly-3/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
+++ b/packages/patternfly-3/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
@@ -82,18 +82,19 @@ class BaseVerticalNavItemHelper extends React.Component {
 
   onItemClick = event => {
     const { primary, secondary, tertiary } = this.getContextNavItems();
-    const { isMobile, updateNavOnItemClick, idPath } = this.props;
-    const { href, onClick } = this.navItem();
-    event.preventDefault();
+    const { isMobile, preventHref, updateNavOnItemClick, idPath } = this.props;
+    const { onClick } = this.navItem();
+
+    if (preventHref && !!onClick) {
+      event.preventDefault();
+    }
+
     updateNavOnItemClick(primary, secondary, tertiary, this.idPath(), idPath); // Clears all mobile selections
     if (isMobile) {
       this.onMobileSelection(primary, secondary, tertiary); // Applies new mobile selection here
     }
     this.setActive();
     onClick && onClick(primary, secondary, tertiary);
-    if (href) {
-      window.location = href; // Note: This should become router-aware later on.
-    }
   };
 
   onItemHover = () => {
@@ -266,7 +267,7 @@ class BaseVerticalNavItemHelper extends React.Component {
         // NOTE onItemBlur takes a boolean, we want to prevent it being passed a truthy event.
         onMouseLeave={e => this.onItemBlur(false)}
       >
-        <a href="#" onClick={this.onItemClick}>
+        <a href={href || '#'} onClick={this.onItemClick}>
           {depth === 'primary' &&
             icon &&
             (!isMobile && navCollapsed ? (
@@ -323,14 +324,17 @@ BaseVerticalNavItemHelper.propTypes = {
   children: PropTypes.node,
   title: PropTypes.string,
   /** Divider bool */
-  isDivider: PropTypes.bool
+  isDivider: PropTypes.bool,
+  /** should Prevent Href */
+  preventHref: PropTypes.bool
 };
 
 BaseVerticalNavItemHelper.defaultProps = {
   item: {},
   children: null,
   title: '',
-  isDivider: false
+  isDivider: false,
+  preventHref: true
 };
 
 const VerticalNavItemHelper = getContext(navContextTypes)(BaseVerticalNavItemHelper);

--- a/packages/patternfly-3/patternfly-react/src/components/VerticalNav/__mocks__/mockNavItems.js
+++ b/packages/patternfly-3/patternfly-react/src/components/VerticalNav/__mocks__/mockNavItems.js
@@ -102,7 +102,8 @@ export const mockNavItems = [
       },
       {
         title: 'Item 3-B (external link)',
-        href: 'http://www.patternfly.org'
+        href: 'http://www.patternfly.org',
+        preventHref: false
       },
       {
         title: 'Item 3-C',


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:
Fix #431 
This will help Turbolinks in Foreman/Angular in Katello to better handle navigations in their own products. The default behaviour is to still prevent the default behaviour of the `href` if an `onItemClicked` function is provided. We want an option to not prevent it.

**Storybook**:
[Link to Storybook](https://rawgit.com/gilad215/patternfly-react/verticalnav-href-storybook/index.html?knob-Max%20Shown=5&knob-Leeway=2&selectedKind=patternfly-react%2FNavigation%2FVertical%20Navigation&selectedStory=Items%20as%20Objects&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)

Try `Ipsum -> Item 3-B` for demonstration

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->

<!-- Are there any upstream issues or separate issues you need to reference? -->


<!-- feel free to add additional comments -->