### PR TITLE
fix(docs): fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import { Alert } from 'patternfly-react'
 
 ## Using patterfly-react Sass files
 
-As an alernative to consuming the `patternfly-react.css` file (found in `dist/css`), you can build patternfly-react styles into your css by including the Sass partials from `dist/sass`. The partial `_patternfly-react.scss` will pull in all the partials required for the patternfly-react components. When using the patternfly-react Sass files, you **MUST** include bootstrap and patternfly variables and mixins. An example of the required imports can be found in [patternfly-react.scss](./packages/patternfly-react/sass/patternfly-react.scss).
+As an alernative to consuming the `patternfly-react.css` file (found in `dist/css`), you can build patternfly-react styles into your css by including the Sass partials from `dist/sass`. The partial `_patternfly-react.scss` will pull in all the partials required for the patternfly-react components. When using the patternfly-react Sass files, you **MUST** include bootstrap and patternfly variables and mixins. An example of the required imports can be found in [patternfly-react.scss](./packages/patternfly-3/patternfly-react/sass/patternfly-react.scss).
 
 ## Node Environment
 


### PR DESCRIPTION
This PR makes a small fix to the link for patternfly-react.scss. It was previously point to.. nowhere. Now it takes users to a place where they may have a better chance at getting help from:

update path to patternfly-react.scss

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
https://github.com/seanforyou23/patternfly-react/tree/readme-typo

