### PR TITLE
Force react-styles release

### DIFF
--- a/packages/patternfly-4/react-styles/src/index.d.ts
+++ b/packages/patternfly-4/react-styles/src/index.d.ts
@@ -7,3 +7,4 @@ export {
   getInsertedStyles,
   getClassName
 } from './utils';
+


### PR DESCRIPTION
Force react-styles release for #593.

Used `yarn commit` to ensure commit message contains an `affects` tag.