### PR TITLE
Force react-core release for missing modal typings

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Modal/Backdrop.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/Backdrop.d.ts
@@ -1,4 +1,4 @@
-import {SFC, HTMLProps, ReactNode} from 'react';
+import { SFC, HTMLProps, ReactNode } from 'react';
 
 export interface BackdropProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;

--- a/packages/patternfly-4/react-core/src/components/Modal/Modal.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/Modal.d.ts
@@ -1,4 +1,4 @@
-import {SFC, HTMLProps, ReactNode} from 'react';
+import { SFC, HTMLProps, ReactNode } from 'react';
 
 export interface ModalProps extends HTMLProps<HTMLDivElement> {
   actions?: any,

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBox.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBox.d.ts
@@ -1,4 +1,4 @@
-import {SFC, HTMLProps, ReactNode} from 'react';
+import { SFC, HTMLProps, ReactNode } from 'react';
 
 export interface ModalBoxProps extends HTMLProps<HTMLDivElement> {
   children: ReactNode;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxBody.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxBody.d.ts
@@ -1,4 +1,4 @@
-import {SFC, HTMLProps, ReactNode} from 'react';
+import { SFC, HTMLProps, ReactNode } from 'react';
 
 export interface ModalBoxBodyProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxCloseButton.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxCloseButton.d.ts
@@ -1,4 +1,4 @@
-import {SFC, HTMLProps, ReactNode} from 'react';
+import { SFC, HTMLProps } from 'react';
 
 export interface ModalBoxCloseButtonProps extends HTMLProps<HTMLDivElement> {
   className?: string;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxFooter.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxFooter.d.ts
@@ -1,4 +1,4 @@
-import {SFC, HTMLProps, ReactNode} from 'react';
+import { SFC, HTMLProps, ReactNode } from 'react';
 
 export interface ModalBoxFooterProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxHeader.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxHeader.d.ts
@@ -1,4 +1,4 @@
-import {SFC, HTMLProps, ReactNode} from 'react';
+import { SFC, HTMLProps, ReactNode } from 'react';
 
 export interface ModalBoxHeaderProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.d.ts
@@ -1,4 +1,4 @@
-import {SFC, HTMLProps, ReactNode} from 'react';
+import { SFC, HTMLProps, ReactNode } from 'react';
 
 export interface ModalContentProps extends HTMLProps<HTMLDivElement> {
   children: ReactNode;


### PR DESCRIPTION
affects: @patternfly/react-core

Force react-core release for missing modal typings #586.

Previous commit did not contain proper `affects` tag. Used `yarn commit` to ensure commit message contains is formatted correctly.
