### PR TITLE
feat(MoreInformation): introduce the MoreInformation compoment

### DIFF
--- a/packages/patternfly-3/patternfly-react/less/more-information.less
+++ b/packages/patternfly-3/patternfly-react/less/more-information.less
@@ -1,0 +1,3 @@
+.pf-more-info > div:first-child {
+  text-align: center;
+}

--- a/packages/patternfly-3/patternfly-react/less/patternfly-react.less
+++ b/packages/patternfly-3/patternfly-react/less/patternfly-react.less
@@ -11,3 +11,4 @@
 @import 'type-ahead-select';
 @import 'verticalnavdivider';
 @import 'treeview';
+@import 'more-information';

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_more-information.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_more-information.scss
@@ -1,0 +1,3 @@
+.pf-more-info > div:first-child {
+  text-align: center;
+}

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_patternfly-react.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_patternfly-react.scss
@@ -11,3 +11,4 @@
 @import 'type-ahead-select';
 @import 'verticalnavdivider';
 @import 'treeview';
+@import 'more-information';

--- a/packages/patternfly-3/patternfly-react/src/components/MoreInformation/MoreInformation.js
+++ b/packages/patternfly-3/patternfly-react/src/components/MoreInformation/MoreInformation.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Button } from '../Button';
+
+class MoreInformation extends React.Component {
+  state = { expanded: false };
+
+  onClick = () => {
+    this.setState(prevState => ({ expanded: !prevState.expanded }));
+  };
+
+  render() {
+    return (
+      <div className="pf-more-info">
+        <div>
+          <Button bsStyle="link" onClick={this.onClick}>
+            {this.state.expanded ? <span className="fa fa-angle-down" /> : <span className="fa fa-angle-right" />}
+            &nbsp; {this.props.textMoreInfo}
+          </Button>
+        </div>
+        {this.state.expanded && this.props.children}
+      </div>
+    );
+  }
+}
+
+MoreInformation.propTypes = {
+  children: PropTypes.any.isRequired,
+
+  textMoreInfo: PropTypes.string
+};
+
+MoreInformation.defaultProps = {
+  textMoreInfo: 'More Information'
+};
+
+export default MoreInformation;

--- a/packages/patternfly-3/patternfly-react/src/components/MoreInformation/MoreInformation.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/MoreInformation/MoreInformation.stories.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { defaultTemplate } from 'storybook/decorators/storyTemplates';
+import { storybookPackageName, STORYBOOK_CATEGORY } from 'storybook/constants/siteConstants';
+import { MoreInformation } from './index';
+import { name } from '../../../package.json';
+
+const stories = storiesOf(`${storybookPackageName(name)}/${STORYBOOK_CATEGORY.WIDGETS}/MoreInformation`, module);
+stories.addDecorator(
+  defaultTemplate({
+    title: 'MoreInformation'
+  })
+);
+
+const MoreInformationContent = () => (
+  <center>Well done! The component takes 100% width by default and centers the link above.</center>
+);
+
+stories.add(
+  'MoreInformation',
+  withInfo(`This is the MoreInformation component.`)(() => (
+    <MoreInformation>
+      <MoreInformationContent />
+    </MoreInformation>
+  ))
+);

--- a/packages/patternfly-3/patternfly-react/src/components/MoreInformation/MoreInformation.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/MoreInformation/MoreInformation.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import MoreInformation from './MoreInformation';
+
+test('MoreInformation with content', () => {
+  const view = mount(
+    <MoreInformation>
+      <div id="content">My text</div>
+    </MoreInformation>
+  );
+
+  expect(view.find('#content')).toHaveLength(0);
+  expect(view.find('span.fa-angle-right')).toHaveLength(1);
+  expect(view.find('span.fa-angle-down')).toHaveLength(0);
+
+  const button = view.find('.btn-link');
+  expect(button).toHaveLength(1);
+  button.simulate('click');
+  expect(view.find('#content')).toHaveLength(1);
+  expect(view.find('span.fa-angle-right')).toHaveLength(0);
+  expect(view.find('span.fa-angle-down')).toHaveLength(1);
+  button.simulate('click');
+  expect(view.find('#content')).toHaveLength(0);
+  expect(view.find('span.fa-angle-right')).toHaveLength(1);
+  expect(view.find('span.fa-angle-down')).toHaveLength(0);
+});
+
+test('localized MoreInformation', () => {
+  const view = shallow(
+    <MoreInformation textMoreInfo="Additional Information">
+      <div id="content">My text</div>
+    </MoreInformation>
+  );
+
+  expect(view).toMatchSnapshot();
+});

--- a/packages/patternfly-3/patternfly-react/src/components/MoreInformation/__snapshots__/MoreInformation.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/MoreInformation/__snapshots__/MoreInformation.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`localized MoreInformation 1`] = `
+<div
+  className="pf-more-info"
+>
+  <div>
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
+      bsStyle="link"
+      disabled={false}
+      onClick={[Function]}
+    >
+      <span
+        className="fa fa-angle-right"
+      />
+        
+      Additional Information
+    </Button>
+  </div>
+</div>
+`;

--- a/packages/patternfly-3/patternfly-react/src/components/MoreInformation/index.js
+++ b/packages/patternfly-3/patternfly-react/src/components/MoreInformation/index.js
@@ -1,0 +1,1 @@
+export { default as MoreInformation } from './MoreInformation';

--- a/packages/patternfly-3/patternfly-react/src/index.js
+++ b/packages/patternfly-3/patternfly-react/src/index.js
@@ -47,3 +47,4 @@ export * from './components/UtilizationBar';
 export * from './components/Wizard';
 export * from './components/VerticalNav';
 export { patternfly, layout } from './common/patternfly';
+export * from './components/MoreInformation';


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->
**What**:  introduce the MoreInformation compoment

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**: https://mareklibra.github.io/patternfly-react/

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

**Additional information**:
The component consists of "More Information" link preceded with the fa-angle-right icon.
On click, inner components with additional text are rendered. The preceding icon is changed
to the fa-angle-down.
Subsequent mouse click collapses the content again.

The component is used either for texts exceeding size of tooltips or if the additional
information is expected to be copied and pasted.
