### PR TITLE
feat(vertical-tabs): add sub-tab support, with restricted mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "storybook:openurl": "node ./storybook/openBrowser.js",
     "storybook:run": "start-storybook -c storybook -p 6006",
     "storybook": "yarn storybook:run",
-    "stylelint": "stylelint --fix 'packages/**/sass/**/*.scss'",
+    "stylelint": "stylelint --fix 'packages/**/sass/**/*.scss' !**/dist/**/*.scss",
     "test": "yarn lint && jest",
     "test:current": "jest --watch",
     "test:watch": "jest --watchAll",

--- a/packages/patternfly-3/patternfly-react-extensions/less/vertical-tabs.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/vertical-tabs.less
@@ -1,16 +1,14 @@
 .vertical-tabs-pf {
-  background: transparent;
   padding: 0;
   list-style: none;
 }
 
 .vertical-tabs-pf-tab {
-  color: @vertical-tab-pf-color;
   margin-top: 4px;
   position: relative;
 
   .btn.btn-link {
-    color: initial;
+    color: @vertical-tab-pf-color;
     font-size: 13px;
     padding-left: 15px;
 
@@ -23,16 +21,14 @@
   }
 
   &.active {
-    .btn.btn-link {
+    > .btn.btn-link {
       color: @vertical-tab-pf-active-color;
 
       &::before {
         background: @vertical-tab-pf-active-color;
-        content: " ";
-        height: 100%;
+        content: "\00a0"; // &nbsp;
         left: 0;
         position: absolute;
-        top: 0;
         width: 3px;
       }
     }
@@ -40,5 +36,41 @@
 
   &:first-of-type {
     margin-top: 0;
+  }
+
+  > .vertical-tabs-pf {
+    > .vertical-tabs-pf-tab {
+      position: initial;
+      padding-left: 15px;
+    }
+  }
+}
+
+.vertical-tabs-pf.restrict-tabs {
+  .vertical-tabs-pf-tab {
+    display: none;
+
+    /* Show any active tab, tab that has an active descendant, or is force shown */
+    &.active,
+    &.active-descendant,
+    &.shown {
+      display: block;
+    }
+  }
+
+  /* Show siblings of the active tab */
+  &.active-tab {
+    > .vertical-tabs-pf-tab {
+      display: block;
+    }
+  }
+
+  /* Show the direct children of an active tab */
+  .vertical-tabs-pf-tab.active {
+    > .vertical-tabs-pf {
+      > .vertical-tabs-pf-tab {
+        display: block;
+      }
+    }
   }
 }

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_vertical-tabs.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_vertical-tabs.scss
@@ -1,11 +1,9 @@
 .vertical-tabs-pf {
-  background: transparent;
   padding: 0;
   list-style: none;
 }
 
 .vertical-tabs-pf-tab {
-  color: inherit;
   margin-top: 4px;
   position: relative;
 
@@ -23,16 +21,14 @@
   }
 
   &.active {
-    .btn.btn-link {
+    > .btn.btn-link {
       color: $vertical-tab-pf-active-color;
 
       &::before {
         background: $vertical-tab-pf-active-color;
-        content: " ";
-        height: 100%;
+        content: "\00a0"; // &nbsp;
         left: 0;
         position: absolute;
-        top: 0;
         width: 3px;
       }
     }
@@ -40,5 +36,41 @@
 
   &:first-of-type {
     margin-top: 0;
+  }
+
+  > .vertical-tabs-pf {
+    > .vertical-tabs-pf-tab {
+      position: initial;
+      padding-left: 15px;
+    }
+  }
+}
+
+.vertical-tabs-pf.restrict-tabs {
+  .vertical-tabs-pf-tab {
+    display: none;
+
+    /* Show any active tab, tab that has an active descendant, or is force shown */
+    &.active,
+    &.active-descendant,
+    &.shown {
+      display: block;
+    }
+  }
+
+  /* Show siblings of the active tab */
+  &.active-tab {
+    > .vertical-tabs-pf-tab {
+      display: block;
+    }
+  }
+
+  /* Show the direct children of an active tab */
+  .vertical-tabs-pf-tab.active {
+    > .vertical-tabs-pf {
+      > .vertical-tabs-pf-tab {
+        display: block;
+      }
+    }
   }
 }

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabs.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabs.js
@@ -6,8 +6,8 @@ import VerticalTabsTab from './VerticalTabsTab';
 /**
  * VerticalTabs Component for PatternFly
  */
-const VerticalTabs = ({ children, className, ...props }) => {
-  const classes = classNames('vertical-tabs-pf', className);
+const VerticalTabs = ({ children, className, restrictTabs, activeTab, ...props }) => {
+  const classes = classNames('vertical-tabs-pf', { 'restrict-tabs': restrictTabs, 'active-tab': activeTab }, className);
   return (
     <ul className={classes} {...props}>
       {children}
@@ -19,11 +19,17 @@ VerticalTabs.propTypes = {
   /** Children nodes */
   children: PropTypes.node,
   /** Additional css classes */
-  className: PropTypes.string
+  className: PropTypes.string,
+  /** Flag to restrict shown tabs to active tabs, their parents, their siblings, and direct children */
+  restrictTabs: PropTypes.bool,
+  /** Flag if a direct child is active (only used in restrictTabs mode) */
+  activeTab: PropTypes.bool
 };
 VerticalTabs.defaultProps = {
   children: null,
-  className: ''
+  className: '',
+  restrictTabs: false,
+  activeTab: false
 };
 
 VerticalTabs.Tab = VerticalTabsTab;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabs.stories.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabs.stories.js
@@ -1,21 +1,33 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info/dist/index';
-import { defaultTemplate } from 'storybook/decorators/storyTemplates';
+import { inlineTemplate } from 'storybook/decorators/storyTemplates';
 import { storybookPackageName, STORYBOOK_CATEGORY } from 'storybook/constants/siteConstants';
 import { VerticalTabs, VerticalTabsTab } from './index';
 import { MockVerticalTabsExample, MockVerticalTabsExampleSource } from './_mocks_/mockVerticalTabsExample';
 
 import { name } from '../../../package.json';
+import { boolean, withKnobs } from '@storybook/addon-knobs';
 
 const stories = storiesOf(`${storybookPackageName(name)}/${STORYBOOK_CATEGORY.WIDGETS}/Vertical Tabs`, module);
 
-stories.addDecorator(
-  defaultTemplate({
-    title: 'Vertical Tabs'
-  })
+const description = (
+  <div>
+    Vertical tabs can be used in a restricted mode by setting the <b>restrictTabs</b> flag on the <i>VerticalTabs</i>{' '}
+    component. This is useful when trying to restrict the vertical space used by the <i>VerticalTabs</i> component.
+    <br />
+    <br />
+    When not in restricted mode, all tabs are shown. In restricted mode, only the active tab along with the path
+    (parents) siblings of the active tab, and first level of children for the active tab are shown.
+    <br />
+    <br />
+    The application is responsible for setting the <b>activeTab</b> property (meaning a direct child is active) on the
+    <i>VerticalTab</i> as well as the <b>active</b> (this tab is active) and <b>hasActiveDescendant</b> (a child of this
+    tab is active) properties on the <i>VerticalTab.Tab</i>. Setting the <b>shown</b> property on a
+    <i>VerticalTab.Tab</i> will always show the tab if its parent tab is shown.
+  </div>
 );
-
+stories.addDecorator(withKnobs);
 stories.add(
   'Vertical Tabs',
   withInfo({
@@ -28,5 +40,13 @@ stories.add(
         <pre>{MockVerticalTabsExampleSource}</pre>
       </div>
     )
-  })(() => <MockVerticalTabsExample />)
+  })(() => {
+    const restrictTabs = boolean('Restrict Tabs', false);
+    const story = <MockVerticalTabsExample restrictTabs={restrictTabs} />;
+    return inlineTemplate({
+      title: 'Vertical Tabs',
+      description,
+      story
+    });
+  })
 );

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabs.test.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabs.test.js
@@ -2,12 +2,67 @@ import React from 'react';
 import { mount } from 'enzyme';
 import VerticalTabs from './VerticalTabs';
 
-test('Vertical Tabs renders properly', () => {
+test('Vertical Tabs renders tabs properly', () => {
   const component = mount(
-    <VerticalTabs id="vertical-tabs" className="test-class">
-      <VerticalTabs.Tab id="one" title="Tab One" active />
-      <VerticalTabs.Tab id="two" title="Tab Two" className="test-tab-class" />
-      <VerticalTabs.Tab id="three" title="Tab Three" />
+    <VerticalTabs id="vertical-tabs" className="test-vertical-tabs">
+      <VerticalTabs.Tab id="all" className="test-vertical-tabs-tab" title="All" />
+      <VerticalTabs.Tab id="one" title="Tab One">
+        <VerticalTabs.Tab key="one-one" id="one-one" title="Tab One-One">
+          <VerticalTabs.Tab key="one-one-one" id="one-one-one" title="Tab One-One-One" active />
+          <VerticalTabs.Tab key="one-one-two" id="one-one-two" title="Tab One-One-Two" active={false} />
+          <VerticalTabs.Tab key="one-one-three" id="one-one-three" title="Tab One-One-Three" />
+        </VerticalTabs.Tab>
+        <VerticalTabs.Tab key="one-two" id="one-two" title="Tab One-Two" />
+        <VerticalTabs.Tab key="one-three" id="one-three" title="Tab One-Three" />
+      </VerticalTabs.Tab>
+      <VerticalTabs.Tab id="two" title="Tab Two" className="test-tab-class">
+        <VerticalTabs.Tab key="one-one-one" id="two-one" title="Tab Two-One" />
+        <VerticalTabs.Tab key="one-one-two" id="two-two" title="Tab Two-Two" />
+        <VerticalTabs.Tab key="one-one-three" id="two-three" title="Tab Two-Three" />
+      </VerticalTabs.Tab>
+      <VerticalTabs.Tab id="three" title="Tab Three">
+        <VerticalTabs.Tab key="three-one" id="three-one" title="Tab Three-One" />
+        <VerticalTabs.Tab key="three-two" id="three-two" title="Tab Three-Two" />
+      </VerticalTabs.Tab>
+      <VerticalTabs.Tab id="four" title="Tab Four" />
+      <VerticalTabs.Tab id="five" title="Tab Five" />
+      <VerticalTabs.Tab id="six" title="Tab Six" />
+      <VerticalTabs.Tab id="seven" title="Tab Seven" />
+    </VerticalTabs>
+  );
+  expect(component.render()).toMatchSnapshot();
+});
+
+test('Vertical Tabs renders restricted tabs properly', () => {
+  const component = mount(
+    <VerticalTabs id="vertical-tabs" className="test-vertical-tabs" restrictTabs>
+      <VerticalTabs.Tab id="all" className="test-vertical-tabs-tab" title="All" shown />
+      <VerticalTabs.Tab id="one" title="Tab One" hasActiveDescendant>
+        <VerticalTabs restrictTabs>
+          <VerticalTabs.Tab key="one-one" id="one-one" title="Tab One-One">
+            <VerticalTabs restrictTabs activeTab>
+              <VerticalTabs.Tab key="one-one-one" id="one-one-one" title="Tab One-One-One" active />
+              <VerticalTabs.Tab key="one-one-two" id="one-one-two" title="Tab One-One-Two" active={false} />
+              <VerticalTabs.Tab key="one-one-three" id="one-one-three" title="Tab One-One-Three" />
+            </VerticalTabs>
+          </VerticalTabs.Tab>
+          <VerticalTabs.Tab key="one-two" id="one-two" title="Tab One-Two" />
+          <VerticalTabs.Tab key="one-three" id="one-three" title="Tab One-Three" />
+        </VerticalTabs>
+      </VerticalTabs.Tab>
+      <VerticalTabs.Tab id="two" title="Tab Two" className="test-tab-class">
+        <VerticalTabs restrictTabs activeTab>
+          <VerticalTabs.Tab key="one-one-one" id="two-one" title="Tab Two-One" active />
+          <VerticalTabs.Tab key="one-one-two" id="two-two" title="Tab Two-Two" active={false} />
+          <VerticalTabs.Tab key="one-one-three" id="two-three" title="Tab Two-Three" />
+        </VerticalTabs>
+      </VerticalTabs.Tab>
+      <VerticalTabs.Tab id="three" title="Tab Three">
+        <VerticalTabs restrictTabs>
+          <VerticalTabs.Tab key="three-one" id="three-one" title="Tab Three-One" />
+          <VerticalTabs.Tab key="three-two" id="three-two" title="Tab Three-Two" />
+        </VerticalTabs>
+      </VerticalTabs.Tab>
       <VerticalTabs.Tab id="four" title="Tab Four" />
       <VerticalTabs.Tab id="five" title="Tab Five" />
       <VerticalTabs.Tab id="six" title="Tab Six" />

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabsTab.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabsTab.js
@@ -3,33 +3,47 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Button, noop } from 'patternfly-react';
 
-const VerticalTabsTab = ({ className, title, active, onActivate, ...props }) => {
-  const classes = classNames('vertical-tabs-pf-tab', { active }, className);
+const VerticalTabsTab = ({ children, className, title, active, hasActiveDescendant, shown, onActivate, ...props }) => {
+  const classes = classNames(
+    'vertical-tabs-pf-tab',
+    { active, 'active-descendant': hasActiveDescendant, shown },
+    className
+  );
 
   return (
-    <li className={classes}>
-      <Button bsStyle="link" {...props} onClick={onActivate}>
+    <li className={classes} {...props}>
+      <Button bsStyle="link" onClick={onActivate}>
         {title}
       </Button>
+      {children}
     </li>
   );
 };
 
 VerticalTabsTab.propTypes = {
+  /** Child tab nodes (VerticalTabsTab's) */
+  children: PropTypes.node,
   /** Additional css classes */
   className: PropTypes.string,
   /** Title for the tab */
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /** Flag if this is the active tab */
   active: PropTypes.bool,
+  /** Flag if a descendant tab is active (used only in restrictTabs mode) */
+  hasActiveDescendant: PropTypes.bool,
+  /** Flag to force show the tab (if parent tab is shown, used only in restrictTabs mode) */
+  shown: PropTypes.bool,
   /** Callback function when the tab is activated */
   onActivate: PropTypes.func
 };
 
 VerticalTabsTab.defaultProps = {
+  children: null,
   className: '',
   title: null,
   active: false,
+  hasActiveDescendant: false,
+  shown: false,
   onActivate: noop
 };
 

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/__snapshots__/VerticalTabs.test.js.snap
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/__snapshots__/VerticalTabs.test.js.snap
@@ -1,49 +1,197 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Vertical Tabs renders properly 1`] = `
+exports[`Vertical Tabs renders restricted tabs properly 1`] = `
 <ul
-  class="vertical-tabs-pf test-class"
+  class="vertical-tabs-pf restrict-tabs test-vertical-tabs"
   id="vertical-tabs"
 >
   <li
-    class="vertical-tabs-pf-tab active"
+    class="vertical-tabs-pf-tab shown test-vertical-tabs-tab"
+    id="all"
   >
     <button
       class="btn btn-link"
-      id="one"
+      type="button"
+    >
+      All
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab active-descendant"
+    id="one"
+  >
+    <button
+      class="btn btn-link"
       type="button"
     >
       Tab One
     </button>
+    <ul
+      class="vertical-tabs-pf restrict-tabs"
+    >
+      <li
+        class="vertical-tabs-pf-tab"
+        id="one-one"
+      >
+        <button
+          class="btn btn-link"
+          type="button"
+        >
+          Tab One-One
+        </button>
+        <ul
+          class="vertical-tabs-pf restrict-tabs active-tab"
+        >
+          <li
+            class="vertical-tabs-pf-tab active"
+            id="one-one-one"
+          >
+            <button
+              class="btn btn-link"
+              type="button"
+            >
+              Tab One-One-One
+            </button>
+          </li>
+          <li
+            class="vertical-tabs-pf-tab"
+            id="one-one-two"
+          >
+            <button
+              class="btn btn-link"
+              type="button"
+            >
+              Tab One-One-Two
+            </button>
+          </li>
+          <li
+            class="vertical-tabs-pf-tab"
+            id="one-one-three"
+          >
+            <button
+              class="btn btn-link"
+              type="button"
+            >
+              Tab One-One-Three
+            </button>
+          </li>
+        </ul>
+      </li>
+      <li
+        class="vertical-tabs-pf-tab"
+        id="one-two"
+      >
+        <button
+          class="btn btn-link"
+          type="button"
+        >
+          Tab One-Two
+        </button>
+      </li>
+      <li
+        class="vertical-tabs-pf-tab"
+        id="one-three"
+      >
+        <button
+          class="btn btn-link"
+          type="button"
+        >
+          Tab One-Three
+        </button>
+      </li>
+    </ul>
   </li>
   <li
     class="vertical-tabs-pf-tab test-tab-class"
+    id="two"
   >
     <button
       class="btn btn-link"
-      id="two"
       type="button"
     >
       Tab Two
     </button>
+    <ul
+      class="vertical-tabs-pf restrict-tabs active-tab"
+    >
+      <li
+        class="vertical-tabs-pf-tab active"
+        id="two-one"
+      >
+        <button
+          class="btn btn-link"
+          type="button"
+        >
+          Tab Two-One
+        </button>
+      </li>
+      <li
+        class="vertical-tabs-pf-tab"
+        id="two-two"
+      >
+        <button
+          class="btn btn-link"
+          type="button"
+        >
+          Tab Two-Two
+        </button>
+      </li>
+      <li
+        class="vertical-tabs-pf-tab"
+        id="two-three"
+      >
+        <button
+          class="btn btn-link"
+          type="button"
+        >
+          Tab Two-Three
+        </button>
+      </li>
+    </ul>
   </li>
   <li
     class="vertical-tabs-pf-tab"
+    id="three"
   >
     <button
       class="btn btn-link"
-      id="three"
       type="button"
     >
       Tab Three
     </button>
+    <ul
+      class="vertical-tabs-pf restrict-tabs"
+    >
+      <li
+        class="vertical-tabs-pf-tab"
+        id="three-one"
+      >
+        <button
+          class="btn btn-link"
+          type="button"
+        >
+          Tab Three-One
+        </button>
+      </li>
+      <li
+        class="vertical-tabs-pf-tab"
+        id="three-two"
+      >
+        <button
+          class="btn btn-link"
+          type="button"
+        >
+          Tab Three-Two
+        </button>
+      </li>
+    </ul>
   </li>
   <li
     class="vertical-tabs-pf-tab"
+    id="four"
   >
     <button
       class="btn btn-link"
-      id="four"
       type="button"
     >
       Tab Four
@@ -51,10 +199,10 @@ exports[`Vertical Tabs renders properly 1`] = `
   </li>
   <li
     class="vertical-tabs-pf-tab"
+    id="five"
   >
     <button
       class="btn btn-link"
-      id="five"
       type="button"
     >
       Tab Five
@@ -62,10 +210,10 @@ exports[`Vertical Tabs renders properly 1`] = `
   </li>
   <li
     class="vertical-tabs-pf-tab"
+    id="six"
   >
     <button
       class="btn btn-link"
-      id="six"
       type="button"
     >
       Tab Six
@@ -73,10 +221,227 @@ exports[`Vertical Tabs renders properly 1`] = `
   </li>
   <li
     class="vertical-tabs-pf-tab"
+    id="seven"
   >
     <button
       class="btn btn-link"
-      id="seven"
+      type="button"
+    >
+      Tab Seven
+    </button>
+  </li>
+</ul>
+`;
+
+exports[`Vertical Tabs renders tabs properly 1`] = `
+<ul
+  class="vertical-tabs-pf test-vertical-tabs"
+  id="vertical-tabs"
+>
+  <li
+    class="vertical-tabs-pf-tab test-vertical-tabs-tab"
+    id="all"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      All
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="one"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab One
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="one-one"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab One-One
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab active"
+    id="one-one-one"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab One-One-One
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="one-one-two"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab One-One-Two
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="one-one-three"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab One-One-Three
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="one-two"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab One-Two
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="one-three"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab One-Three
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab test-tab-class"
+    id="two"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab Two
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="two-one"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab Two-One
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="two-two"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab Two-Two
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="two-three"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab Two-Three
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="three"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab Three
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="three-one"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab Three-One
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="three-two"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab Three-Two
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="four"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab Four
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="five"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab Five
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="six"
+  >
+    <button
+      class="btn btn-link"
+      type="button"
+    >
+      Tab Six
+    </button>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="seven"
+  >
+    <button
+      class="btn btn-link"
       type="button"
     >
       Tab Seven

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/_mocks_/mockVerticalTabsExample.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/_mocks_/mockVerticalTabsExample.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import VerticalTabs from '../VerticalTabs';
 
 class MockVerticalTabsExample extends React.Component {
   state = {
-    activeTabId: 'one'
+    activeTabId: 'all'
   };
 
   onActivateTab = id => {
@@ -11,22 +12,137 @@ class MockVerticalTabsExample extends React.Component {
   };
 
   render() {
+    const { restrictTabs } = this.props;
     const { activeTabId } = this.state;
 
+    const showAll = activeTabId === 'all';
+    const isTopLevelActive =
+      showAll ||
+      activeTabId === 'one' ||
+      activeTabId === 'two' ||
+      activeTabId === 'three' ||
+      activeTabId === 'four' ||
+      activeTabId === 'five' ||
+      activeTabId === 'six' ||
+      activeTabId === 'seven';
+
     return (
-      <VerticalTabs id="vertical-tabs">
+      <VerticalTabs id="vertical-tabs" restrictTabs={restrictTabs} activeTab={isTopLevelActive}>
+        <VerticalTabs.Tab id="all" title="All" onActivate={() => this.onActivateTab('all')} active={showAll} shown />
         <VerticalTabs.Tab
           id="one"
           title="Tab One"
           onActivate={() => this.onActivateTab('one')}
           active={activeTabId === 'one'}
-        />
+          hasActiveDescendant={activeTabId.startsWith('one')}
+        >
+          <VerticalTabs
+            restrictTabs={restrictTabs}
+            activeTab={activeTabId === 'one-one' || activeTabId === 'one-two' || activeTabId === 'one-three'}
+          >
+            <VerticalTabs.Tab
+              id="one-one"
+              title="Tab One-One"
+              onActivate={() => this.onActivateTab('one-one')}
+              active={activeTabId === 'one-one'}
+              hasActiveDescendant={activeTabId.startsWith('one-one')}
+            >
+              <VerticalTabs
+                restrictTabs={restrictTabs}
+                activeTab={
+                  activeTabId === 'one-one-one' || activeTabId === 'one-one-two' || activeTabId === 'one-one-three'
+                }
+              >
+                <VerticalTabs.Tab
+                  id="one-one-one"
+                  title="Tab One-One-One"
+                  onActivate={() => this.onActivateTab('one-one-one')}
+                  active={activeTabId === 'one-one-one'}
+                />
+                <VerticalTabs.Tab
+                  id="one-one-two"
+                  title="Tab One-One-Two"
+                  onActivate={() => this.onActivateTab('one-one-two')}
+                  active={activeTabId === 'one-one-two'}
+                />
+                <VerticalTabs.Tab
+                  id="one-one-three"
+                  title="Tab One-One-Three"
+                  onActivate={() => this.onActivateTab('one-one-three')}
+                  active={activeTabId === 'one-one-three'}
+                />
+              </VerticalTabs>
+            </VerticalTabs.Tab>
+            <VerticalTabs.Tab
+              id="one-two"
+              title="Tab One-Two"
+              onActivate={() => this.onActivateTab('one-two')}
+              active={activeTabId === 'one-two'}
+              hasActiveDescendant={activeTabId.startsWith('one-two')}
+            >
+              <VerticalTabs
+                restrictTabs={restrictTabs}
+                activeTab={
+                  activeTabId === 'one-two-one' || activeTabId === 'one-two-two' || activeTabId === 'one-two-three'
+                }
+              >
+                <VerticalTabs.Tab
+                  id="one-two-one"
+                  title="Tab One-Two-One"
+                  onActivate={() => this.onActivateTab('one-two-one')}
+                  active={activeTabId === 'one-two-one'}
+                />
+                <VerticalTabs.Tab
+                  id="one-two-two"
+                  title="Tab One-Two-Two"
+                  onActivate={() => this.onActivateTab('one-two-two')}
+                  active={activeTabId === 'one-two-two'}
+                />
+                <VerticalTabs.Tab
+                  id="one-two-three"
+                  title="Tab One-Two-Three"
+                  onActivate={() => this.onActivateTab('one-two-three')}
+                  active={activeTabId === 'one-two-three'}
+                />
+              </VerticalTabs>
+            </VerticalTabs.Tab>
+            <VerticalTabs.Tab
+              id="one-three"
+              title="Tab One-Three"
+              onActivate={() => this.onActivateTab('one-three')}
+              active={activeTabId === 'one-three'}
+              hasActiveDescendant={activeTabId.startsWith('one-three')}
+            />
+          </VerticalTabs>
+        </VerticalTabs.Tab>
         <VerticalTabs.Tab
           id="two"
           title="Tab Two"
           onActivate={() => this.onActivateTab('two')}
           active={activeTabId === 'two'}
-        />
+          hasActiveDescendant={activeTabId.startsWith('two')}
+        >
+          <VerticalTabs restrictTabs={restrictTabs} activeTab={activeTabId.startsWith('two')}>
+            <VerticalTabs.Tab
+              id="two-one"
+              title="Tab Two-One"
+              onActivate={() => this.onActivateTab('two-one')}
+              active={activeTabId === 'two-one'}
+            />
+            <VerticalTabs.Tab
+              id="two-two"
+              title="Tab Two-Two"
+              onActivate={() => this.onActivateTab('two-two')}
+              active={activeTabId === 'two-two'}
+            />
+            <VerticalTabs.Tab
+              id="two-three"
+              title="Tab Two-Three"
+              onActivate={() => this.onActivateTab('two-three')}
+              active={activeTabId === 'two-three'}
+            />
+          </VerticalTabs>
+        </VerticalTabs.Tab>
         <VerticalTabs.Tab
           id="three"
           title="Tab Three"
@@ -61,15 +177,25 @@ class MockVerticalTabsExample extends React.Component {
     );
   }
 }
+
+MockVerticalTabsExample.propTypes = {
+  restrictTabs: PropTypes.bool
+};
+
+MockVerticalTabsExample.defaultProps = {
+  restrictTabs: false
+};
+
 export { MockVerticalTabsExample };
 
 export const MockVerticalTabsExampleSource = `
 import React from 'react';
+import PropTypes from 'prop-types';
 import VerticalTabs from '../VerticalTabs';
 
 class MockVerticalTabsExample extends React.Component {
   state = {
-    activeTabId: 'one'
+    activeTabId: 'all'
   };
 
   onActivateTab = id => {
@@ -77,22 +203,137 @@ class MockVerticalTabsExample extends React.Component {
   };
 
   render() {
+    const { restrictTabs } = this.props;
     const { activeTabId } = this.state;
 
+    const showAll = activeTabId === 'all';
+    const isTopLevelActive =
+      showAll ||
+      activeTabId === 'one' ||
+      activeTabId === 'two' ||
+      activeTabId === 'three' ||
+      activeTabId === 'four' ||
+      activeTabId === 'five' ||
+      activeTabId === 'six' ||
+      activeTabId === 'seven';
+
     return (
-      <VerticalTabs id="vertical-tabs">
+      <VerticalTabs id="vertical-tabs" restrictTabs={restrictTabs} activeTab={isTopLevelActive}>
+        <VerticalTabs.Tab id="all" title="All" onActivate={() => this.onActivateTab('all')} active={showAll} shown />
         <VerticalTabs.Tab
           id="one"
           title="Tab One"
           onActivate={() => this.onActivateTab('one')}
           active={activeTabId === 'one'}
-        />
+          hasActiveDescendant={activeTabId.startsWith('one')}
+        >
+          <VerticalTabs
+            restrictTabs={restrictTabs}
+            activeTab={activeTabId === 'one-one' || activeTabId === 'one-two' || activeTabId === 'one-three'}
+          >
+            <VerticalTabs.Tab
+              id="one-one"
+              title="Tab One-One"
+              onActivate={() => this.onActivateTab('one-one')}
+              active={activeTabId === 'one-one'}
+              hasActiveDescendant={activeTabId.startsWith('one-one')}
+            >
+              <VerticalTabs
+                restrictTabs={restrictTabs}
+                activeTab={
+                  activeTabId === 'one-one-one' || activeTabId === 'one-one-two' || activeTabId === 'one-one-three'
+                }
+              >
+                <VerticalTabs.Tab
+                  id="one-one-one"
+                  title="Tab One-One-One"
+                  onActivate={() => this.onActivateTab('one-one-one')}
+                  active={activeTabId === 'one-one-one'}
+                />
+                <VerticalTabs.Tab
+                  id="one-one-two"
+                  title="Tab One-One-Two"
+                  onActivate={() => this.onActivateTab('one-one-two')}
+                  active={activeTabId === 'one-one-two'}
+                />
+                <VerticalTabs.Tab
+                  id="one-one-three"
+                  title="Tab One-One-Three"
+                  onActivate={() => this.onActivateTab('one-one-three')}
+                  active={activeTabId === 'one-one-three'}
+                />
+              </VerticalTabs>
+            </VerticalTabs.Tab>
+            <VerticalTabs.Tab
+              id="one-two"
+              title="Tab One-Two"
+              onActivate={() => this.onActivateTab('one-two')}
+              active={activeTabId === 'one-two'}
+              hasActiveDescendant={activeTabId.startsWith('one-two')}
+            >
+              <VerticalTabs
+                restrictTabs={restrictTabs}
+                activeTab={
+                  activeTabId === 'one-two-one' || activeTabId === 'one-two-two' || activeTabId === 'one-two-three'
+                }
+              >
+                <VerticalTabs.Tab
+                  id="one-two-one"
+                  title="Tab One-Two-One"
+                  onActivate={() => this.onActivateTab('one-two-one')}
+                  active={activeTabId === 'one-two-one'}
+                />
+                <VerticalTabs.Tab
+                  id="one-two-two"
+                  title="Tab One-Two-Two"
+                  onActivate={() => this.onActivateTab('one-two-two')}
+                  active={activeTabId === 'one-two-two'}
+                />
+                <VerticalTabs.Tab
+                  id="one-two-three"
+                  title="Tab One-Two-Three"
+                  onActivate={() => this.onActivateTab('one-two-three')}
+                  active={activeTabId === 'one-two-three'}
+                />
+              </VerticalTabs>
+            </VerticalTabs.Tab>
+            <VerticalTabs.Tab
+              id="one-three"
+              title="Tab One-Three"
+              onActivate={() => this.onActivateTab('one-three')}
+              active={activeTabId === 'one-three'}
+              hasActiveDescendant={activeTabId.startsWith('one-three')}
+            />
+          </VerticalTabs>
+        </VerticalTabs.Tab>
         <VerticalTabs.Tab
           id="two"
           title="Tab Two"
           onActivate={() => this.onActivateTab('two')}
           active={activeTabId === 'two'}
-        />
+          hasActiveDescendant={activeTabId.startsWith('two')}
+        >
+          <VerticalTabs restrictTabs={restrictTabs} activeTab={activeTabId.startsWith('two')}>
+            <VerticalTabs.Tab
+              id="two-one"
+              title="Tab Two-One"
+              onActivate={() => this.onActivateTab('two-one')}
+              active={activeTabId === 'two-one'}
+            />
+            <VerticalTabs.Tab
+              id="two-two"
+              title="Tab Two-Two"
+              onActivate={() => this.onActivateTab('two-two')}
+              active={activeTabId === 'two-two'}
+            />
+            <VerticalTabs.Tab
+              id="two-three"
+              title="Tab Two-Three"
+              onActivate={() => this.onActivateTab('two-three')}
+              active={activeTabId === 'two-three'}
+            />
+          </VerticalTabs>
+        </VerticalTabs.Tab>
         <VerticalTabs.Tab
           id="three"
           title="Tab Three"
@@ -127,5 +368,14 @@ class MockVerticalTabsExample extends React.Component {
     );
   }
 }
+
+MockVerticalTabsExample.propTypes = {
+  restrictTabs: PropTypes.bool
+};
+
+MockVerticalTabsExample.defaultProps = {
+  restrictTabs: false
+};
+
 export { MockVerticalTabsExample };
 `;


### PR DESCRIPTION
affects: patternfly-react-extensions

This adds the necessary properties and css for using sub-tabs in the VerticalTabs component.
Restricted mode resticts the tabs being shown to the active tab along with its parents, sibilings,
and direct sub tabs.


**Link to Storybook**:
https://rawgit.com/jeff-phillips-18/patternfly-react/vertical-tabs-storybook/index.html?selectedKind=patternfly-react-extensions%2FWidgets%2FVertical%20Tabs&selectedStory=Vertical%20Tabs&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs

@tlwu2013 @serenamarie125 
