### PR TITLE
docs(Dropdown): fix component imports in Dropdown examples

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/examples/DirectionUpDropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/examples/DirectionUpDropdown.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownDirection } from '../../../../dist/js';
+import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownDirection } from '@patternfly/react-core';
 
 export default class ExampleDropdown extends Component {
   static title = 'Dropdown - direction up';

--- a/packages/patternfly-4/react-core/src/components/Dropdown/examples/KebabDropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/examples/KebabDropdown.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Dropdown, KebabToggle, DropdownItem, DropdownSeparator } from '../../../../dist/js';
+import { Dropdown, KebabToggle, DropdownItem, DropdownSeparator } from '@patternfly/react-core';
 
 export default class ExampleDropdown extends Component {
   static title = 'Kebab';

--- a/packages/patternfly-4/react-core/src/components/Dropdown/examples/PositionRightDropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/examples/PositionRightDropdown.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownPosition } from '../../../../dist/js';
+import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownPosition } from '@patternfly/react-core';
 
 export default class ExampleDropdown extends Component {
   static title = 'Dropdown - position right';

--- a/packages/patternfly-4/react-core/src/components/Dropdown/examples/SimpleDropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/examples/SimpleDropdown.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator } from '../../../../dist/js';
+import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator } from '@patternfly/react-core';
 
 export default class ExampleDropdown extends Component {
   static title = 'Simple dropdown';


### PR DESCRIPTION
affects: @patternfly/react-core

PF4-React workspace Dropdown examples will now hot reload changes made to the Dropdown components

ISSUES CLOSED: #609

**What**:  Fix import statements in Dropdown examples