### PR TITLE
feat(ExpandCollapse): introduce ExpandCollapse component

### DIFF
--- a/packages/patternfly-3/patternfly-react/less/expand-collapse.less
+++ b/packages/patternfly-3/patternfly-react/less/expand-collapse.less
@@ -1,15 +1,27 @@
 .expand-collapse-pf {
-  .expand-collapse-pf-left {
-    text-align: left;
-  }
-
-  .expand-collapse-pf-center {
-    text-align: center;
+  .expand-collapse-pf-link-container {
+    display: flex;
   }
 
   .btn.btn-link {
     &:focus {
       outline: none;
+    }
+    .fa,
+    .pficon {
+      color: initial;
+      font-size: 14px;
+      margin-right: 5px;
+      width: 10px;
+    }
+  }
+
+  .expand-collapse-pf-separator {
+    flex: 1;
+    height: 1px;
+    margin-top: 12px;
+    &.bordered {
+      border-top: 1px solid @color-pf-black-300;
     }
   }
 }

--- a/packages/patternfly-3/patternfly-react/less/expand-collapse.less
+++ b/packages/patternfly-3/patternfly-react/less/expand-collapse.less
@@ -1,0 +1,15 @@
+.expand-collapse-pf {
+  .expand-collapse-pf-left {
+    text-align: left;
+  }
+
+  .expand-collapse-pf-center {
+    text-align: center;
+  }
+
+  .btn.btn-link {
+    &:focus {
+      outline: none;
+    }
+  }
+}

--- a/packages/patternfly-3/patternfly-react/less/patternfly-react.less
+++ b/packages/patternfly-3/patternfly-react/less/patternfly-react.less
@@ -13,3 +13,5 @@
 @import 'verticalnavdivider';
 @import 'treeview';
 @import 'pagination';
+@import 'expand-collapse';
+

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_expand-collapse.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_expand-collapse.scss
@@ -1,0 +1,15 @@
+.expand-collapse-pf {
+  .expand-collapse-pf-left {
+    text-align: left;
+  }
+
+  .expand-collapse-pf-center {
+    text-align: center;
+  }
+
+  .btn.btn-link {
+    &:focus {
+      outline: none;
+    }
+  }
+}

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_expand-collapse.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_expand-collapse.scss
@@ -1,15 +1,27 @@
 .expand-collapse-pf {
-  .expand-collapse-pf-left {
-    text-align: left;
-  }
-
-  .expand-collapse-pf-center {
-    text-align: center;
+  .expand-collapse-pf-link-container {
+    display: flex;
   }
 
   .btn.btn-link {
     &:focus {
       outline: none;
+    }
+    .fa,
+    .pficon {
+      color: initial;
+      font-size: 14px;
+      margin-right: 5px;
+      width: 10px;
+    }
+  }
+
+  .expand-collapse-pf-separator {
+    flex: 1;
+    height: 1px;
+    margin-top: 12px;
+    &.bordered {
+      border-top: 1px solid $color-pf-black-300;
     }
   }
 }

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_patternfly-react.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_patternfly-react.scss
@@ -13,3 +13,5 @@
 @import 'verticalnavdivider';
 @import 'treeview';
 @import 'pagination';
+@import 'expand-collapse';
+

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.js
@@ -8,7 +8,17 @@ import { Icon } from '../Icon';
 import { ALIGN_LEFT, ALIGN_CENTER, ALIGN_TYPES } from './constants';
 
 class ExpandCollapse extends React.Component {
-  state = { expanded: false };
+  state = { expanded: false, mirroredExpanded: false };
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (prevState.mirroredExpanded !== nextProps.expanded) {
+      return {
+        expanded: nextProps.expanded,
+        mirroredExpanded: nextProps.expanded
+      };
+    }
+    return null;
+  }
 
   onClick = () => {
     this.setState(prevState => ({ expanded: !prevState.expanded }));

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { Button } from '../Button';
+import { Icon } from '../Icon';
 
 import { ALIGN_LEFT, ALIGN_CENTER, ALIGN_TYPES } from './constants';
 
@@ -14,20 +15,20 @@ class ExpandCollapse extends React.Component {
   };
 
   render() {
-    const { children, textCollapsed, textExpanded, align, className } = this.props;
+    const { children, textCollapsed, textExpanded, align, className, bordered } = this.props;
+    const { expanded } = this.state;
 
-    const alignClass = classNames({
-      'expand-collapse-pf-left': align === ALIGN_LEFT,
-      'expand-collapse-pf-center': align === ALIGN_CENTER
-    });
+    const separatorClass = classNames('expand-collapse-pf-separator', { bordered });
 
     return (
-      <div className={classNames(['expand-collapse-pf', className])}>
-        <div className={alignClass}>
-          {this.state.expanded ? <span className="fa fa-angle-down" /> : <span className="fa fa-angle-right" />}
+      <div className={classNames('expand-collapse-pf', className)}>
+        <div className="expand-collapse-pf-link-container">
+          {align === ALIGN_CENTER && <span className={separatorClass} />}
           <Button bsStyle="link" onClick={this.onClick}>
-            {this.state.expanded ? textExpanded : textCollapsed}
+            <Icon type="fa" name={expanded ? 'angle-down' : 'angle-right'} />
+            {expanded ? textExpanded : textCollapsed}
           </Button>
+          <span className={separatorClass} />
         </div>
         {this.state.expanded && children}
       </div>
@@ -37,18 +38,24 @@ class ExpandCollapse extends React.Component {
 
 ExpandCollapse.propTypes = {
   children: PropTypes.any.isRequired,
-
-  className: PropTypes.string /** Top-level custom class */,
-  textCollapsed: PropTypes.string /** Text for the link in collapsed state */,
-  textExpanded: PropTypes.string /** Text for the link in expanded state */,
-  align: PropTypes.oneOf(ALIGN_TYPES) /** Align the link to the left or center. Default: left. */
+  /** Top-level custom class */
+  className: PropTypes.string,
+  /** Text for the link in collapsed state */
+  textCollapsed: PropTypes.string,
+  /** Text for the link in expanded state */
+  textExpanded: PropTypes.string,
+  /** Align the link to the left or center. Default: left. */
+  align: PropTypes.oneOf(ALIGN_TYPES),
+  /** Flag to show a separation border line */
+  bordered: PropTypes.bool
 };
 
 ExpandCollapse.defaultProps = {
   className: '',
   textCollapsed: 'Show Advanced Options',
   textExpanded: 'Hide Advanced Options',
-  align: ALIGN_LEFT
+  align: ALIGN_LEFT,
+  bordered: true
 };
 
 export default ExpandCollapse;

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import { Button } from '../Button';
+
+import { ALIGN_LEFT, ALIGN_CENTER, ALIGN_TYPES } from './constants';
+
+class ExpandCollapse extends React.Component {
+  state = { expanded: false };
+
+  onClick = () => {
+    this.setState(prevState => ({ expanded: !prevState.expanded }));
+  };
+
+  render() {
+    const { children, textCollapsed, textExpanded, align, className } = this.props;
+
+    const alignClass = classNames({
+      'expand-collapse-pf-left': align === ALIGN_LEFT,
+      'expand-collapse-pf-center': align === ALIGN_CENTER
+    });
+
+    return (
+      <div className={classNames(['expand-collapse-pf', className])}>
+        <div className={alignClass}>
+          {this.state.expanded ? <span className="fa fa-angle-down" /> : <span className="fa fa-angle-right" />}
+          <Button bsStyle="link" onClick={this.onClick}>
+            {this.state.expanded ? textExpanded : textCollapsed}
+          </Button>
+        </div>
+        {this.state.expanded && children}
+      </div>
+    );
+  }
+}
+
+ExpandCollapse.propTypes = {
+  children: PropTypes.any.isRequired,
+
+  className: PropTypes.string /** Top-level custom class */,
+  textCollapsed: PropTypes.string /** Text for the link in collapsed state */,
+  textExpanded: PropTypes.string /** Text for the link in expanded state */,
+  align: PropTypes.oneOf(ALIGN_TYPES) /** Align the link to the left or center. Default: left. */
+};
+
+ExpandCollapse.defaultProps = {
+  className: '',
+  textCollapsed: 'Show Advanced Options',
+  textExpanded: 'Hide Advanced Options',
+  align: ALIGN_LEFT
+};
+
+export default ExpandCollapse;

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.js
@@ -57,7 +57,9 @@ ExpandCollapse.propTypes = {
   /** Align the link to the left or center. Default: left. */
   align: PropTypes.oneOf(ALIGN_TYPES),
   /** Flag to show a separation border line */
-  bordered: PropTypes.bool
+  bordered: PropTypes.bool,
+  /** Flag to control expansion state */
+  expanded: PropTypes.bool // eslint-disable-line react/no-unused-prop-types
 };
 
 ExpandCollapse.defaultProps = {
@@ -65,7 +67,8 @@ ExpandCollapse.defaultProps = {
   textCollapsed: 'Show Advanced Options',
   textExpanded: 'Hide Advanced Options',
   align: ALIGN_LEFT,
-  bordered: true
+  bordered: true,
+  expanded: false
 };
 
 export default ExpandCollapse;

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.stories.js
@@ -30,6 +30,7 @@ stories.add(
         bordered={boolean('bordered', true)}
         textExpanded={text('textExpanded', 'Hide Advanced Options')}
         textCollapsed={text('textCollapsed', 'Show Advanced Options')}
+        expanded={boolean('expanded', false)}
       >
         <p>Well done! The component takes 100% width by default and aligns the link to the left or center.</p>
         <p>And other text comes here.</p>

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.stories.js
@@ -4,7 +4,7 @@ import { withInfo } from '@storybook/addon-info';
 import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { storybookPackageName, STORYBOOK_CATEGORY, DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
 import { name } from '../../../package.json';
-import { select, text, withKnobs } from '@storybook/addon-knobs';
+import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
 
 import { ExpandCollapse } from './index';
 import { ALIGN_TYPES } from './constants';
@@ -27,6 +27,7 @@ stories.add(
     <div style={{ width: '600px', border: '1px solid lightgray' }}>
       <ExpandCollapse
         align={select('align', ALIGN_TYPES)}
+        bordered={boolean('bordered', true)}
         textExpanded={text('textExpanded', 'Hide Advanced Options')}
         textCollapsed={text('textCollapsed', 'Show Advanced Options')}
       >

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.stories.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { defaultTemplate } from 'storybook/decorators/storyTemplates';
+import { storybookPackageName, STORYBOOK_CATEGORY, DOCUMENTATION_URL } from 'storybook/constants/siteConstants';
+import { name } from '../../../package.json';
+import { select, text, withKnobs } from '@storybook/addon-knobs';
+
+import { ExpandCollapse } from './index';
+import { ALIGN_TYPES } from './constants';
+
+const stories = storiesOf(
+  `${storybookPackageName(name)}/${STORYBOOK_CATEGORY.FORMS_AND_CONTROLS}/Expand Collapse`,
+  module
+);
+stories.addDecorator(withKnobs);
+stories.addDecorator(
+  defaultTemplate({
+    title: 'Expand Collapse',
+    documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_FORMS}expand-collapse-section/`
+  })
+);
+
+stories.add(
+  'ExpandCollapse',
+  withInfo(`This is the ExpandCollapse component.`)(() => (
+    <div style={{ width: '600px', border: '1px solid lightgray' }}>
+      <ExpandCollapse
+        align={select('align', ALIGN_TYPES)}
+        textExpanded={text('textExpanded', 'Hide Advanced Options')}
+        textCollapsed={text('textCollapsed', 'Show Advanced Options')}
+      >
+        <p>Well done! The component takes 100% width by default and aligns the link to the left or center.</p>
+        <p>And other text comes here.</p>
+      </ExpandCollapse>
+    </div>
+  ))
+);

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.test.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { mount, render } from 'enzyme';
+
+import ExpandCollapse from './ExpandCollapse';
+import { ALIGN_LEFT, ALIGN_CENTER } from './constants';
+
+test('ExpandCollapse with content', () => {
+  const view = mount(
+    <ExpandCollapse>
+      <div id="content">My text</div>
+    </ExpandCollapse>
+  );
+
+  expect(view.find('#content')).toHaveLength(0);
+  expect(view.find('span.fa-angle-right')).toHaveLength(1);
+  expect(view.find('span.fa-angle-down')).toHaveLength(0);
+  expect(view.find('.btn-link').text()).toEqual('Show Advanced Options');
+
+  const button = view.find('.btn-link');
+  expect(button).toHaveLength(1);
+  button.simulate('click');
+  expect(view.find('#content')).toHaveLength(1);
+  expect(view.find('span.fa-angle-right')).toHaveLength(0);
+  expect(view.find('span.fa-angle-down')).toHaveLength(1);
+  expect(view.find('.btn-link').text()).toEqual('Hide Advanced Options');
+  button.simulate('click');
+  expect(view.find('#content')).toHaveLength(0);
+  expect(view.find('span.fa-angle-right')).toHaveLength(1);
+  expect(view.find('span.fa-angle-down')).toHaveLength(0);
+  expect(view.find('.btn-link').text()).toEqual('Show Advanced Options');
+});
+
+test('localized ExpandCollapse', () => {
+  const view = mount(
+    <ExpandCollapse textCollapsed="Click to expand" textExpanded="Click to collapse">
+      <div id="content">My text</div>
+    </ExpandCollapse>
+  );
+  expect(view).toMatchSnapshot();
+  view.find('.btn-link').simulate('click');
+  expect(view).toMatchSnapshot();
+});
+
+test('aligned ExpandCollapse', () => {
+  const def = render(
+    <ExpandCollapse>
+      <div id="content">My text</div>
+    </ExpandCollapse>
+  );
+  expect(def.find('.expand-collapse-pf-left')).toHaveLength(1);
+  expect(def.find('.expand-collapse-pf-center')).toHaveLength(0);
+
+  const left = render(
+    <ExpandCollapse align={ALIGN_LEFT}>
+      <div id="content">My text</div>
+    </ExpandCollapse>
+  );
+  expect(left.find('.expand-collapse-pf-left')).toHaveLength(1);
+  expect(left.find('.expand-collapse-pf-center')).toHaveLength(0);
+
+  const center = render(
+    <ExpandCollapse align={ALIGN_CENTER}>
+      <div id="content">My text</div>
+    </ExpandCollapse>
+  );
+  expect(center.find('.expand-collapse-pf-left')).toHaveLength(0);
+  expect(center.find('.expand-collapse-pf-center')).toHaveLength(1);
+});

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.test.js
@@ -47,22 +47,51 @@ test('aligned ExpandCollapse', () => {
       <div id="content">My text</div>
     </ExpandCollapse>
   );
-  expect(def.find('.expand-collapse-pf-left')).toHaveLength(1);
-  expect(def.find('.expand-collapse-pf-center')).toHaveLength(0);
+  expect(def.find('.expand-collapse-pf-separator')).toHaveLength(1);
 
   const left = render(
     <ExpandCollapse align={ALIGN_LEFT}>
       <div id="content">My text</div>
     </ExpandCollapse>
   );
-  expect(left.find('.expand-collapse-pf-left')).toHaveLength(1);
-  expect(left.find('.expand-collapse-pf-center')).toHaveLength(0);
+  expect(left.find('.expand-collapse-pf-separator')).toHaveLength(1);
 
   const center = render(
     <ExpandCollapse align={ALIGN_CENTER}>
       <div id="content">My text</div>
     </ExpandCollapse>
   );
-  expect(center.find('.expand-collapse-pf-left')).toHaveLength(0);
-  expect(center.find('.expand-collapse-pf-center')).toHaveLength(1);
+  expect(center.find('.expand-collapse-pf-separator')).toHaveLength(2);
+});
+
+test('ExpandCollapse with separator', () => {
+  const def = render(
+    <ExpandCollapse>
+      <div id="content">My text</div>
+    </ExpandCollapse>
+  );
+  expect(def.find('.expand-collapse-pf-separator.bordered')).toHaveLength(1);
+
+  const noSep = render(
+    <ExpandCollapse bordered={false}>
+      <div id="content">My text</div>
+    </ExpandCollapse>
+  );
+  expect(noSep.find('.expand-collapse-pf-separator')).toHaveLength(1);
+  expect(noSep.find('.expand-collapse-pf-separator.bordered')).toHaveLength(0);
+
+  const center = render(
+    <ExpandCollapse align={ALIGN_CENTER}>
+      <div id="content">My text</div>
+    </ExpandCollapse>
+  );
+  expect(center.find('.expand-collapse-pf-separator.bordered')).toHaveLength(2);
+
+  const centerNoSep = render(
+    <ExpandCollapse align={ALIGN_CENTER} bordered={false}>
+      <div id="content">My text</div>
+    </ExpandCollapse>
+  );
+  expect(centerNoSep.find('.expand-collapse-pf-separator')).toHaveLength(2);
+  expect(centerNoSep.find('.expand-collapse-pf-separator.bordered')).toHaveLength(0);
 });

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.test.js
@@ -95,3 +95,16 @@ test('ExpandCollapse with separator', () => {
   expect(centerNoSep.find('.expand-collapse-pf-separator')).toHaveLength(2);
   expect(centerNoSep.find('.expand-collapse-pf-separator.bordered')).toHaveLength(0);
 });
+
+test('ExpandCollapse with explicit override prop', () => {
+  const view = mount(
+    <ExpandCollapse expanded>
+      <div id="content">My text</div>
+    </ExpandCollapse>
+  );
+
+  expect(view.find('#content')).toHaveLength(1);
+  expect(view.find('span.fa-angle-right')).toHaveLength(0);
+  expect(view.find('span.fa-angle-down')).toHaveLength(1);
+  expect(view.find('.btn-link').text()).toEqual('Hide Advanced Options');
+});

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/__snapshots__/ExpandCollapse.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/__snapshots__/ExpandCollapse.test.js.snap
@@ -3,6 +3,7 @@
 exports[`localized ExpandCollapse 1`] = `
 <ExpandCollapse
   align="left"
+  bordered={true}
   className=""
   textCollapsed="Click to expand"
   textExpanded="Click to collapse"
@@ -11,11 +12,8 @@ exports[`localized ExpandCollapse 1`] = `
     className="expand-collapse-pf"
   >
     <div
-      className="expand-collapse-pf-left"
+      className="expand-collapse-pf-link-container"
     >
-      <span
-        className="fa fa-angle-right"
-      />
       <Button
         active={false}
         block={false}
@@ -30,9 +28,25 @@ exports[`localized ExpandCollapse 1`] = `
           onClick={[Function]}
           type="button"
         >
+          <Icon
+            name="angle-right"
+            type="fa"
+          >
+            <FontAwesome
+              name="angle-right"
+            >
+              <span
+                aria-hidden={true}
+                className="fa fa-angle-right"
+              />
+            </FontAwesome>
+          </Icon>
           Click to expand
         </button>
       </Button>
+      <span
+        className="expand-collapse-pf-separator bordered"
+      />
     </div>
   </div>
 </ExpandCollapse>
@@ -41,6 +55,7 @@ exports[`localized ExpandCollapse 1`] = `
 exports[`localized ExpandCollapse 2`] = `
 <ExpandCollapse
   align="left"
+  bordered={true}
   className=""
   textCollapsed="Click to expand"
   textExpanded="Click to collapse"
@@ -49,11 +64,8 @@ exports[`localized ExpandCollapse 2`] = `
     className="expand-collapse-pf"
   >
     <div
-      className="expand-collapse-pf-left"
+      className="expand-collapse-pf-link-container"
     >
-      <span
-        className="fa fa-angle-down"
-      />
       <Button
         active={false}
         block={false}
@@ -68,9 +80,25 @@ exports[`localized ExpandCollapse 2`] = `
           onClick={[Function]}
           type="button"
         >
+          <Icon
+            name="angle-down"
+            type="fa"
+          >
+            <FontAwesome
+              name="angle-down"
+            >
+              <span
+                aria-hidden={true}
+                className="fa fa-angle-down"
+              />
+            </FontAwesome>
+          </Icon>
           Click to collapse
         </button>
       </Button>
+      <span
+        className="expand-collapse-pf-separator bordered"
+      />
     </div>
     <div
       id="content"

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/__snapshots__/ExpandCollapse.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/__snapshots__/ExpandCollapse.test.js.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`localized ExpandCollapse 1`] = `
+<ExpandCollapse
+  align="left"
+  className=""
+  textCollapsed="Click to expand"
+  textExpanded="Click to collapse"
+>
+  <div
+    className="expand-collapse-pf"
+  >
+    <div
+      className="expand-collapse-pf-left"
+    >
+      <span
+        className="fa fa-angle-right"
+      />
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="link"
+        disabled={false}
+        onClick={[Function]}
+      >
+        <button
+          className="btn btn-link"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Click to expand
+        </button>
+      </Button>
+    </div>
+  </div>
+</ExpandCollapse>
+`;
+
+exports[`localized ExpandCollapse 2`] = `
+<ExpandCollapse
+  align="left"
+  className=""
+  textCollapsed="Click to expand"
+  textExpanded="Click to collapse"
+>
+  <div
+    className="expand-collapse-pf"
+  >
+    <div
+      className="expand-collapse-pf-left"
+    >
+      <span
+        className="fa fa-angle-down"
+      />
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="link"
+        disabled={false}
+        onClick={[Function]}
+      >
+        <button
+          className="btn btn-link"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          Click to collapse
+        </button>
+      </Button>
+    </div>
+    <div
+      id="content"
+    >
+      My text
+    </div>
+  </div>
+</ExpandCollapse>
+`;

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/__snapshots__/ExpandCollapse.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/__snapshots__/ExpandCollapse.test.js.snap
@@ -5,6 +5,7 @@ exports[`localized ExpandCollapse 1`] = `
   align="left"
   bordered={true}
   className=""
+  expanded={false}
   textCollapsed="Click to expand"
   textExpanded="Click to collapse"
 >
@@ -57,6 +58,7 @@ exports[`localized ExpandCollapse 2`] = `
   align="left"
   bordered={true}
   className=""
+  expanded={false}
   textCollapsed="Click to expand"
   textExpanded="Click to collapse"
 >

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/constants.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/constants.js
@@ -1,0 +1,4 @@
+export const ALIGN_LEFT = 'left';
+export const ALIGN_CENTER = 'center';
+
+export const ALIGN_TYPES = [ALIGN_LEFT, ALIGN_CENTER];

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/index.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/index.js
@@ -1,0 +1,1 @@
+export { default as ExpandCollapse } from './ExpandCollapse';

--- a/packages/patternfly-3/patternfly-react/src/index.js
+++ b/packages/patternfly-3/patternfly-react/src/index.js
@@ -51,3 +51,4 @@ export * from './components/UtilizationBar';
 export * from './components/VerticalNav';
 export * from './components/Wizard';
 export { patternfly, layout } from './common/patternfly';
+export * from './components/ExpandCollapse';


### PR DESCRIPTION
<!-- What changes are being made? (What issue is being addressed here?) -->
**What**: introduce ExpandCollapse component

<!-- Please provide a link to your fork's Storybook. See README notes on how to do this. -->
**Link to Storybook**: [https://rawgit.com/mareklibra/patternfly-react/ExpandCollapse-sb4/index.html](https://rawgit.com/mareklibra/patternfly-react/ExpandCollapse-sb4/index.html?knob-bordered=true&knob-textExpanded=Hide%20Advanced%20Options&knob-textCollapsed=Show%20Advanced%20Options&selectedKind=patternfly-react%2FForms%20and%20Controls%2FExpand%20Collapse&selectedStory=ExpandCollapse&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:

**Additional info**:
Implementation for the Expand Collapse Section is provided.
[Patternfly.org Design](https://www.patternfly.org/pattern-library/forms-and-controls/expand-collapse-section/)

The component can be farther used for the "More Information" use-case,
where additional text/components are hidden unless the user clicks
on a link.

Such a per-request rendered content is used for texts exceeding scope of a tooltip or
when the user is expected to copy and paste part of the information.
