### PR TITLE
fix(catalog-tile): allow icons to be used in the tile image area

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
@@ -26,6 +26,7 @@
 }
 
 .catalog-tile-pf-icon {
+  font-size: 40px;
   height: 40px;
   max-width: 80px;
   min-width: 40px;
@@ -37,7 +38,7 @@
   justify-content: flex-end;
 
   .catalog-tile-pf-badge {
-    font-size: (@font-size-base + 1);
+    font-size: 16px;
     padding-left: 5px;
 
     > .fa,

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
@@ -26,6 +26,7 @@
 }
 
 .catalog-tile-pf-icon {
+  font-size: 40px;
   height: 40px;
   max-width: 80px;
   min-width: 40px;
@@ -37,7 +38,7 @@
   justify-content: flex-end;
 
   .catalog-tile-pf-badge {
-    font-size: ($font-size-base + 1);
+    font-size: 16px;
     padding-left: 5px;
 
     > .fa,

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.js
@@ -10,6 +10,7 @@ const CatalogTile = ({
   className,
   featured,
   iconImg,
+  iconClass,
   badges,
   title,
   vendor,
@@ -53,6 +54,7 @@ const CatalogTile = ({
     <div id={id} className={classes} {...props}>
       <div className="catalog-tile-pf-header">
         {iconImg && <img className="catalog-tile-pf-icon" src={iconImg} alt="" />}
+        {iconClass && <span className={`catalog-tile-pf-icon ${iconClass}`} />}
         {renderBadges()}
       </div>
       <div className="catalog-tile-pf-body">
@@ -73,6 +75,8 @@ CatalogTile.propTypes = {
   featured: PropTypes.bool,
   /** URL of an image for the item's icon */
   iconImg: PropTypes.string,
+  /** Class for the image when an icon is to be used (exclusive from iconImg) */
+  iconClass: PropTypes.string,
   /** Array of badges */
   badges: PropTypes.arrayOf(PropTypes.node),
   /** Tile for the catalog item */
@@ -92,6 +96,7 @@ CatalogTile.defaultProps = {
   className: '',
   featured: false,
   iconImg: null,
+  iconClass: null,
   badges: [],
   vendor: null,
   description: null,

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.stories.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.stories.js
@@ -59,6 +59,17 @@ stories.add(
         description="The open source web server that powers 400 million websites."
       />
       <CatalogTile
+        iconClass="fa fa-codepen"
+        badges={[
+          <CatalogTileBadge id="approved">
+            <Icon type="pf" name="ok" />
+          </CatalogTileBadge>
+        ]}
+        title="CodePen"
+        vendor="provided by CodePen"
+        description="An online community for testing and showcasing user-created HTML, CSS and JavaScript code snippets."
+      />
+      <CatalogTile
         iconImg={pfBrand}
         badges={[
           <CatalogTileBadge title="Certified" id="certified">

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.test.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.test.js
@@ -72,6 +72,18 @@ test('CatalogTile renders properly', () => {
         }
       />
       <CatalogTile
+        id="test-iconClass"
+        iconClass="fa fa-codepen"
+        badges={[
+          <CatalogTile.Badge title="USDA Approved" id="approved">
+            <Icon type="pf" name="ok" />
+          </CatalogTile.Badge>
+        ]}
+        title="CodePen"
+        vendor="provided by CodePen"
+        description="An online community for testing and showcasing user-created HTML, CSS and JavaScript code snippets."
+      />
+      <CatalogTile
         id="test-custom-truncation"
         featured
         iconImg={pfBrand}

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTileBadge.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTileBadge.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Icon, OverlayTrigger, Tooltip } from 'patternfly-react';
+import { OverlayTrigger, Tooltip } from 'patternfly-react';
 
 const CatalogTileBadge = ({ children, className, id, title, ...props }) => {
   const classes = classNames('catalog-tile-pf-badge', className);
@@ -20,7 +20,11 @@ const CatalogTileBadge = ({ children, className, id, title, ...props }) => {
     );
   }
 
-  return <Icon className={classes} {...props} />;
+  return (
+    <span className={classes} {...props}>
+      {children}
+    </span>
+  );
 };
 
 CatalogTileBadge.propTypes = {

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/__snapshots__/CatalogTile.test.js.snap
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/__snapshots__/CatalogTile.test.js.snap
@@ -34,9 +34,13 @@ exports[`CatalogTile renders properly 1`] = `
         </span>
         <span>
           <span
-            aria-hidden="true"
-            class="fa fa-undefined catalog-tile-pf-badge"
-          />
+            class="catalog-tile-pf-badge"
+          >
+            <span
+              aria-hidden="true"
+              class="fa fa-cog"
+            />
+          </span>
         </span>
       </div>
     </div>
@@ -192,6 +196,56 @@ exports[`CatalogTile renders properly 1`] = `
         <span>
           This is a very long description that should be truncated after 112 characters. 112 is the default but can be ...
         </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="catalog-tile-pf"
+    id="test-iconClass"
+  >
+    <div
+      class="catalog-tile-pf-header"
+    >
+      <span
+        class="catalog-tile-pf-icon fa fa-codepen"
+      />
+      <div
+        class="catalog-tile-pf-badge-container"
+      >
+        <span>
+          <span
+            class="catalog-tile-pf-badge"
+          >
+            <span
+              aria-hidden="true"
+              class="pficon pficon-ok"
+            />
+            <span
+              class="sr-only"
+            >
+              USDA Approved
+            </span>
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      class="catalog-tile-pf-body"
+    >
+      <div
+        class="catalog-tile-pf-title"
+      >
+        CodePen
+      </div>
+      <div
+        class="catalog-tile-pf-subtitle"
+      >
+        provided by CodePen
+      </div>
+      <div
+        class="catalog-tile-pf-description"
+      >
+        An online community for testing and showcasing user-created HTML, CSS and JavaScript code snippets.
       </div>
     </div>
   </div>


### PR DESCRIPTION
affects: patternfly-react-extensions

ISSUES CLOSED: #618

**Link to Storybook**:
https://rawgit.com/jeff-phillips-18/patternfly-react/catalog-tile-storybook/index.html?&selectedKind=patternfly-react-extensions%2FCatalog%20Components%2FCatalog%20Tile&selectedStory=Catalog%20Tile&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs
