### PR TITLE
feat(modeless-overlay): add the ModelessOverlay component

### DIFF
--- a/packages/patternfly-3/patternfly-react/less/modeless-overlay.less
+++ b/packages/patternfly-3/patternfly-react/less/modeless-overlay.less
@@ -1,0 +1,20 @@
+.modal.modeless-pf {
+  left: initial;
+
+  &.shown {
+    display: block;
+  }
+
+  .modal-dialog {
+    margin: @navbar-pf-height 0 0 10px;
+
+    .modal-content {
+      height: ~'calc(100vh - @{navbar-pf-height})';
+    }
+  }
+
+  &.fade:not(.in) .modal-dialog {
+    -webkit-transform: translate3d(-75%, 0, 0);
+    transform: translate3d(75%, 0, 0);
+  }
+}

--- a/packages/patternfly-3/patternfly-react/less/patternfly-react.less
+++ b/packages/patternfly-3/patternfly-react/less/patternfly-react.less
@@ -5,6 +5,7 @@
 @import 'utilization-bar';
 @import 'breadcrumb';
 @import 'label-remove';
+@import 'modeless-overlay';
 @import 'notificationdrawer';
 @import 'inline-edit';
 @import 'field-level-help';

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_modeless-overlay.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_modeless-overlay.scss
@@ -1,0 +1,20 @@
+.modal.modeless-pf {
+  left: initial;
+
+  &.shown {
+    display: block;
+  }
+
+  .modal-dialog {
+    margin: $navbar-pf-height 0 0 10px;
+
+    .modal-content {
+      height: calc(100vh - #{$navbar-pf-height});
+    }
+  }
+
+  &.fade:not(.in) .modal-dialog {
+    -webkit-transform: translate3d(-75%, 0, 0);
+    transform: translate3d(75%, 0, 0);
+  }
+}

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_patternfly-react.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_patternfly-react.scss
@@ -5,6 +5,7 @@
 @import 'utilization-bar';
 @import 'breadcrumb';
 @import 'label-remove';
+@import 'modeless-overlay';
 @import 'notificationdrawer';
 @import 'inline-edit';
 @import 'field-level-help';

--- a/packages/patternfly-3/patternfly-react/src/components/Modal/Modal.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/Modal.stories.js
@@ -8,7 +8,10 @@ import { MockModalManager, basicExampleSource } from './__mocks__/mockModalManag
 import { Modal } from '../../index';
 import { name } from '../../../package.json';
 
-const stories = storiesOf(`${storybookPackageName(name)}/${STORYBOOK_CATEGORY.WIDGETS}/Modal Overlay`, module);
+const stories = storiesOf(
+  `${storybookPackageName(name)}/${STORYBOOK_CATEGORY.FORMS_AND_CONTROLS}/Modal Overlay`,
+  module
+);
 
 stories.add(
   'Modal',

--- a/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/ModelessOverlay.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/ModelessOverlay.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import Timer from '../../common/Timer';
+import { excludeKeys } from '../../common/helpers';
+
+class ModelessOverlay extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { isIn: false };
+    this.inTimer = new Timer(null, 150);
+  }
+
+  componentWillUnmount() {
+    this.inTimer.clearTimer();
+  }
+
+  updateForTransitions = () => {
+    this.setState({ isIn: this.props.show });
+  };
+
+  render() {
+    const { children, className, bsSize, show, ...otherProps } = this.props;
+    const { isIn } = this.state;
+
+    const classes = classNames('modal modeless-pf fade', { shown: show || isIn, in: show && isIn }, className);
+
+    if (isIn !== show) {
+      this.inTimer.startTimer(() => this.updateForTransitions(), show ? 0 : 150);
+    }
+
+    const dialogClasses = classNames('modal-dialog', {
+      'modal-sm': bsSize === 'sm' || bsSize === 'small',
+      'modal-lg': bsSize === 'lg' || bsSize === 'large'
+    });
+    return (
+      <div role="dialog" tabIndex={-1} className={classes} {...excludeKeys(otherProps, ['show'])}>
+        <div className={dialogClasses}>
+          <div className="modal-content">{children}</div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ModelessOverlay.propTypes = {
+  /** Children */
+  children: PropTypes.node,
+  /** Additional css classes */
+  className: PropTypes.string,
+  /** When true, the dialog is shown */
+  show: PropTypes.bool,
+  /** Component size variations (effects dialog width). */
+  bsSize: PropTypes.oneOf(['lg', 'large', 'sm', 'small', 'default'])
+};
+
+ModelessOverlay.defaultProps = {
+  children: null,
+  className: '',
+  show: false,
+  bsSize: 'default'
+};
+
+export default ModelessOverlay;

--- a/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/ModelessOverlay.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/ModelessOverlay.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Button } from '../Button';
+import { Modal } from '../Modal';
+import { ModelessOverlay } from './index';
+
+test('ModelessOverlay renders properly', () => {
+  const component = mount(
+    <ModelessOverlay id="test-modeless-overlay-id" className="test-modeless-overlay-class">
+      <Modal.Header>
+        <Modal.CloseButton />
+        <Modal.Title>Modal Overlay Title</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>test body text</Modal.Body>
+      <Modal.Footer>
+        <Button bsStyle="default" className="btn-cancel">
+          Cancel
+        </Button>
+        <Button bsStyle="primary">Save</Button>
+      </Modal.Footer>
+    </ModelessOverlay>
+  );
+  expect(component.render()).toMatchSnapshot();
+});
+
+test('ModelessOverlay renders properly when setting size', () => {
+  const component = mount(
+    <ModelessOverlay id="test-modeless-overlay-id" className="test-modeless-overlay-class" bsSize="sm">
+      <Modal.Header>
+        <Modal.CloseButton />
+        <Modal.Title>Modal Overlay Title</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>test body text</Modal.Body>
+      <Modal.Footer>
+        <Button bsStyle="default" className="btn-cancel">
+          Cancel
+        </Button>
+        <Button bsStyle="primary">Save</Button>
+      </Modal.Footer>
+    </ModelessOverlay>
+  );
+  expect(component.render()).toMatchSnapshot();
+});

--- a/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/ModlessOverlay.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/ModlessOverlay.stories.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { inlineTemplate } from 'storybook/decorators/storyTemplates';
+import { storybookPackageName, DOCUMENTATION_URL, STORYBOOK_CATEGORY } from 'storybook/constants/siteConstants';
+import { select, withKnobs } from '@storybook/addon-knobs';
+
+import { MockModelessManager, basicExampleSource } from './__mocks__/mockModelessManager';
+import { name } from '../../../package.json';
+
+import ModelessOverlay from './ModelessOverlay';
+
+const stories = storiesOf(
+  `${storybookPackageName(name)}/${STORYBOOK_CATEGORY.FORMS_AND_CONTROLS}/Modeless Overlay`,
+  module
+);
+
+stories.addDecorator(withKnobs);
+
+stories.add(
+  'Modeless Overlay',
+  withInfo({
+    source: false,
+    propTables: [ModelessOverlay],
+    propTablesExclude: [MockModelessManager],
+    text: (
+      <div>
+        <h1>Story Source</h1>
+        <pre>{basicExampleSource}</pre>
+      </div>
+    )
+  })(() => {
+    const size = select('Size', { default: 'Default', sm: 'Small', lg: 'Large' }, 'default');
+    const story = <MockModelessManager size={size} />;
+    return inlineTemplate({
+      title: 'Modeless Overlay',
+      documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_FORMS}modeless-overlay/`,
+      description:
+        'Built off the Bootstrap Modal classes, the modeless overlay is a non-modal version of the Bootstrap Modal',
+      story
+    });
+  })
+);

--- a/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/__mocks__/mockModelessManager.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/__mocks__/mockModelessManager.js
@@ -1,0 +1,169 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '../../Button';
+import { Modal } from '../../Modal';
+import { ModelessOverlay } from '../index';
+
+export class MockModelessManager extends React.Component {
+  constructor() {
+    super();
+    this.state = { showOverlay: false };
+  }
+  close = () => {
+    this.setState({ showOverlay: false });
+  };
+  toggleOpen = () => {
+    this.setState({ showOverlay: !this.state.showOverlay });
+  };
+  render() {
+    const { children, size } = this.props;
+    const defaultBody = (
+      <form className="form-horizontal">
+        <div className="form-group">
+          <label className="col-sm-3 control-label" htmlFor="textInput">
+            Field One
+          </label>
+          <div className="col-sm-9">
+            <input type="text" id="textInput" className="form-control" />
+          </div>
+        </div>
+        <div className="form-group">
+          <label className="col-sm-3 control-label" htmlFor="textInput2">
+            Field Two
+          </label>
+          <div className="col-sm-9">
+            <input type="text" id="textInput2" className="form-control" />
+          </div>
+        </div>
+        <div className="form-group">
+          <label className="col-sm-3 control-label" htmlFor="textInput3">
+            Field Three
+          </label>
+          <div className="col-sm-9">
+            <input type="text" id="textInput3" className="form-control" />
+          </div>
+        </div>
+      </form>
+    );
+
+    return (
+      <div>
+        <Button bsStyle="primary" bsSize="large" onClick={this.toggleOpen}>
+          {this.state.showOverlay ? 'Close Modeless Overlay' : 'Open Modeless Overlay'}
+        </Button>
+
+        <ModelessOverlay show={this.state.showOverlay} bsSize={size !== 'default' ? size : null}>
+          <Modal.Header>
+            <Modal.CloseButton onClick={this.close} />
+            <Modal.Title>Modal Overlay Title</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>{children || defaultBody}</Modal.Body>
+          <Modal.Footer>
+            <Button bsStyle="default" className="btn-cancel" onClick={this.close}>
+              Cancel
+            </Button>
+            <Button bsStyle="primary" onClick={this.close}>
+              Save
+            </Button>
+          </Modal.Footer>
+        </ModelessOverlay>
+      </div>
+    );
+  }
+}
+
+MockModelessManager.propTypes = {
+  children: PropTypes.node,
+  size: PropTypes.string
+};
+
+MockModelessManager.defaultProps = {
+  children: null,
+  size: 'default'
+};
+
+export const basicExampleSource = `
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '../../Button';
+import { Modal } from '../../Modal';
+import { ModelessOverlay } from '../index';
+
+export class MockModelessManager extends React.Component {
+  constructor() {
+    super();
+    this.state = { showOverlay: false };
+  }
+  close = () => {
+    this.setState({ showOverlay: false });
+  };
+  toggleOpen = () => {
+    this.setState({ showOverlay: !this.state.showOverlay });
+  };
+  render() {
+    const { children, size } = this.props;
+    const defaultBody = (
+      <form className="form-horizontal">
+        <div className="form-group">
+          <label className="col-sm-3 control-label" htmlFor="textInput">
+            Field One
+          </label>
+          <div className="col-sm-9">
+            <input type="text" id="textInput" className="form-control" />
+          </div>
+        </div>
+        <div className="form-group">
+          <label className="col-sm-3 control-label" htmlFor="textInput2">
+            Field Two
+          </label>
+          <div className="col-sm-9">
+            <input type="text" id="textInput2" className="form-control" />
+          </div>
+        </div>
+        <div className="form-group">
+          <label className="col-sm-3 control-label" htmlFor="textInput3">
+            Field Three
+          </label>
+          <div className="col-sm-9">
+            <input type="text" id="textInput3" className="form-control" />
+          </div>
+        </div>
+      </form>
+    );
+
+    return (
+      <div>
+        <Button bsStyle="primary" bsSize="large" onClick={this.toggleOpen}>
+          {this.state.showOverlay ? 'Close Modeless Overlay' : 'Open Modeless Overlay'}
+        </Button>
+
+        <ModelessOverlay show={this.state.showOverlay} bsSize={size !== 'default' ? size : null}>
+          <Modal.Header>
+            <Modal.CloseButton onClick={this.close} />
+            <Modal.Title>Modal Overlay Title</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>{children || defaultBody}</Modal.Body>
+          <Modal.Footer>
+            <Button bsStyle="default" className="btn-cancel" onClick={this.close}>
+              Cancel
+            </Button>
+            <Button bsStyle="primary" onClick={this.close}>
+              Save
+            </Button>
+          </Modal.Footer>
+        </ModelessOverlay>
+      </div>
+    );
+  }
+}
+
+MockModelessManager.propTypes = {
+  children: PropTypes.node,
+  size: PropTypes.string
+};
+
+MockModelessManager.defaultProps = {
+  children: null,
+  size: 'default'
+};
+`;

--- a/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/__snapshots__/ModelessOverlay.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/__snapshots__/ModelessOverlay.test.js.snap
@@ -1,0 +1,125 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModelessOverlay renders properly 1`] = `
+<div
+  class="modal modeless-pf fade test-modeless-overlay-class"
+  id="test-modeless-overlay-id"
+  role="dialog"
+  tabindex="-1"
+>
+  <div
+    class="modal-dialog"
+  >
+    <div
+      class="modal-content"
+    >
+      <div
+        class="modal-header"
+      >
+        <button
+          class="close"
+        >
+          <span
+            aria-hidden="true"
+            class="pficon pficon-close"
+            title="Close"
+          />
+          <span
+            class="sr-only"
+          >
+            Close
+          </span>
+        </button>
+        <h4
+          class="modal-title"
+        >
+          Modal Overlay Title
+        </h4>
+      </div>
+      <div
+        class="modal-body"
+      >
+        test body text
+      </div>
+      <div
+        class="modal-footer"
+      >
+        <button
+          class="btn-cancel btn btn-default"
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          class="btn btn-primary"
+          type="button"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ModelessOverlay renders properly when setting size 1`] = `
+<div
+  class="modal modeless-pf fade test-modeless-overlay-class"
+  id="test-modeless-overlay-id"
+  role="dialog"
+  tabindex="-1"
+>
+  <div
+    class="modal-dialog modal-sm"
+  >
+    <div
+      class="modal-content"
+    >
+      <div
+        class="modal-header"
+      >
+        <button
+          class="close"
+        >
+          <span
+            aria-hidden="true"
+            class="pficon pficon-close"
+            title="Close"
+          />
+          <span
+            class="sr-only"
+          >
+            Close
+          </span>
+        </button>
+        <h4
+          class="modal-title"
+        >
+          Modal Overlay Title
+        </h4>
+      </div>
+      <div
+        class="modal-body"
+      >
+        test body text
+      </div>
+      <div
+        class="modal-footer"
+      >
+        <button
+          class="btn-cancel btn btn-default"
+          type="button"
+        >
+          Cancel
+        </button>
+        <button
+          class="btn btn-primary"
+          type="button"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/index.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/index.js
@@ -1,0 +1,3 @@
+import ModelessOverlay from './ModelessOverlay';
+
+export { ModelessOverlay };

--- a/packages/patternfly-3/patternfly-react/src/index.js
+++ b/packages/patternfly-3/patternfly-react/src/index.js
@@ -26,6 +26,7 @@ export * from './components/Masthead';
 export * from './components/MenuItem';
 export * from './components/MessageDialog';
 export * from './components/Modal';
+export * from './components/ModelessOverlay';
 export * from './components/Nav';
 export * from './components/Navbar';
 export * from './components/Notification';


### PR DESCRIPTION
affects: patternfly-react

**What**:
Built off the Bootstrap Modal classes, the modeless overlay is a non-modal version of the Bootstrap Modal

**Patternfly Design**
https://www.patternfly.org/pattern-library/forms-and-controls/modeless-overlay/#design

**Link to Storybook**:
https://rawgit.com/jeff-phillips-18/patternfly-react/modeless-overlay-storybook/index.html?selectedKind=patternfly-react%2FForms%20and%20Controls%2FModeless%20Overlay&selectedStory=Modeless%20Overlay&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs

@serenamarie125 