### PR TITLE
fix(catalog tile): remove the default tooltip for description text

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { OverlayTrigger, Tooltip } from 'patternfly-react';
 
 import CatalogTileBadge from './CatalogTileBadge';
 
@@ -26,11 +25,11 @@ const CatalogTile = ({
       return text;
     }
 
-    const tooltip = <Tooltip id={`${id || Date.now()}_tooltip`}>{text}</Tooltip>;
     return (
-      <OverlayTrigger overlay={tooltip} placement="top">
-        <span>{`${text.substring(0, max - 3)}...`}</span>
-      </OverlayTrigger>
+      <React.Fragment>
+        {text.substring(0, max - 3)}
+        &hellip;
+      </React.Fragment>
     );
   };
 

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/__snapshots__/CatalogTile.test.js.snap
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/__snapshots__/CatalogTile.test.js.snap
@@ -193,9 +193,7 @@ exports[`CatalogTile renders properly 1`] = `
       <div
         class="catalog-tile-pf-description"
       >
-        <span>
-          This is a very long description that should be truncated after 112 characters. 112 is the default but can be ...
-        </span>
+        This is a very long description that should be truncated after 112 characters. 112 is the default but can be …
       </div>
     </div>
   </div>


### PR DESCRIPTION
affects: patternfly-react-extensions

ISSUES CLOSED: #637

**Link to Storybook**:
https://rawgit.com/jeff-phillips-18/patternfly-react/fixes-storybook/index.html?selectedKind=patternfly-react-extensions%2FCatalog%20Components%2FCatalog%20Tile&selectedStory=Catalog%20Tile&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs
