### PR TITLE
feat(Properties Side Panel): adds the PropertiesSidePanel component

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/patternfly-react-extensions.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/patternfly-react-extensions.less
@@ -2,5 +2,6 @@
 @import 'catalog-item';
 @import 'catalog-tile';
 @import 'filter-side-panel';
+@import 'properties-side-panel';
 @import 'table-grid';
 @import 'vertical-tabs';

--- a/packages/patternfly-3/patternfly-react-extensions/less/properties-side-panel.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/properties-side-panel.less
@@ -1,0 +1,25 @@
+.properties-side-panel-pf {
+  width: 165px;
+}
+
+.properties-side-panel-pf-property {
+  margin-top: 20px;
+
+  &:first-of-type {
+    margin-top: 0;
+  }
+}
+
+.properties-side-panel-pf-property-label {
+  color: @color-pf-black-600;
+  font-weight: 300;
+  font-size: 12px;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.properties-side-panel-pf-property-value {
+  font-size: 14px;
+  margin-top: 5px;
+  word-break: break-word;
+}

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_patternfly-react-extensions.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_patternfly-react-extensions.scss
@@ -5,5 +5,6 @@
 @import 'catalog-item';
 @import 'catalog-tile';
 @import 'filter-side-panel';
+@import 'properties-side-panel';
 @import 'table-grid';
 @import 'vertical-tabs';

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_properties-side-panel.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_properties-side-panel.scss
@@ -1,0 +1,25 @@
+.properties-side-panel-pf {
+  width: 165px;
+}
+
+.properties-side-panel-pf-property {
+  margin-top: 20px;
+
+  &:first-of-type {
+    margin-top: 0;
+  }
+}
+
+.properties-side-panel-pf-property-label {
+  color: $color-pf-black-600;
+  font-weight: 300;
+  font-size: 12px;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.properties-side-panel-pf-property-value {
+  font-size: 14px;
+  margin-top: 5px;
+  word-break: break-word;
+}

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/PropertiesSidePanel/PropertiesSIdePanel.test.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/PropertiesSidePanel/PropertiesSIdePanel.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Icon } from 'patternfly-react';
+import { PropertiesSidePanel, PropertyItem } from './index';
+
+test('PropertyItem renders properly', () => {
+  const component = mount(
+    <PropertyItem label="Operator Version" value="0.9.8 (latest)" className="test-property-item-class" />
+  );
+  expect(component.render()).toMatchSnapshot();
+});
+
+test('PropertiesSidePanel renders properly', () => {
+  const component = mount(
+    <PropertiesSidePanel className="test-properties-side-panel-class">
+      <PropertyItem label="Operator Version" value="0.9.8 (latest)" className="test-property-item-class" />
+      <PropertyItem
+        label="Certified Level"
+        value={
+          <span>
+            <Icon type="pf" name="ok" /> Certified
+          </span>
+        }
+      />
+      <PropertyItem label="Provider" value="Red Hat, Inc" />
+      <PropertyItem label="Health Index" value="A" />
+      <PropertyItem
+        label="Repository"
+        value={
+          <a href="https://quay.io/repository/redhat/prometheus-operator">
+            https://quay.io/repository/redhat/prometheus-operator
+          </a>
+        }
+      />
+      <PropertyItem
+        label="Container Image"
+        value={
+          <a href="#">
+            0.22.2 <Icon type="fa" name="external-link" />
+          </a>
+        }
+      />
+      <PropertyItem
+        label="Created At"
+        value={
+          <span>
+            <Icon type="fa" name="globe" /> Aug 23, 1:58pm
+          </span>
+        }
+      />
+      <PropertyItem label="Support" value={<a href="#">Red Hat</a>} />
+    </PropertiesSidePanel>
+  );
+  expect(component.render()).toMatchSnapshot();
+});

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/PropertiesSidePanel/PropertiesSidePanel.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/PropertiesSidePanel/PropertiesSidePanel.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import PropertyItem from './PropertyItem';
+
+const PropertiesSidePanel = ({ children, className, ...otherProps }) => {
+  const classes = classNames('properties-side-panel-pf', className);
+
+  return (
+    <div className={classes} {...otherProps}>
+      {children}
+    </div>
+  );
+};
+
+PropertiesSidePanel.propTypes = {
+  /** Children, should be PropertyItem items plus any action buttons, etc */
+  children: PropTypes.node,
+  /** Additional css classes */
+  className: PropTypes.string
+};
+
+PropertiesSidePanel.defaultProps = {
+  children: null,
+  className: ''
+};
+
+PropertiesSidePanel.Property = PropertyItem;
+
+export default PropertiesSidePanel;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/PropertiesSidePanel/PropertyItem.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/PropertiesSidePanel/PropertyItem.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+const PropertyItem = ({ className, label, value, ...otherProps }) => {
+  const classes = classNames('properties-side-panel-pf-property', className);
+
+  return (
+    <div className={classes} {...otherProps}>
+      <h5 className="properties-side-panel-pf-property-label">{label}</h5>
+      <div className="properties-side-panel-pf-property-value">{value}</div>
+    </div>
+  );
+};
+
+PropertyItem.propTypes = {
+  /** Additional css classes */
+  className: PropTypes.string,
+  /** Label for the property */
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  /** Value of the property */
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
+};
+
+PropertyItem.defaultProps = {
+  className: '',
+  value: null
+};
+
+export default PropertyItem;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/PropertiesSidePanel/PropertySidePanel.stories.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/PropertiesSidePanel/PropertySidePanel.stories.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info/dist/index';
+import { defaultTemplate } from 'storybook/decorators/storyTemplates';
+import { storybookPackageName, STORYBOOK_CATEGORY } from 'storybook/constants/siteConstants';
+import { name } from '../../../package.json';
+import { Icon } from 'patternfly-react';
+
+import { PropertiesSidePanel, PropertyItem } from './index';
+
+const stories = storiesOf(
+  `${storybookPackageName(name)}/${STORYBOOK_CATEGORY.FORMS_AND_CONTROLS}/Properties Side Panel`,
+  module
+);
+
+stories.addDecorator(
+  defaultTemplate({
+    title: 'Properties Side Panel',
+    description:
+      'This is a sidebar component used to show the properties of an item. ' +
+      'Note: the 15px padding and border styling are not part of the PropertiesSidePanel.'
+  })
+);
+
+stories.add(
+  'PropertiesSidePanel',
+  withInfo()(() => (
+    <div style={{ display: 'inline-block', padding: '15px', border: '1px solid grey' }}>
+      <PropertiesSidePanel>
+        <PropertyItem label="Operator Version" value="0.9.8 (latest)" />
+        <PropertyItem
+          label="Certified Level"
+          value={
+            <span>
+              <Icon type="pf" name="ok" /> Certified
+            </span>
+          }
+        />
+        <PropertyItem label="Provider" value="Red Hat, Inc" />
+        <PropertyItem label="Health Index" value="A" />
+        <PropertyItem
+          label="Repository"
+          value={
+            <a href="https://quay.io/repository/redhat/prometheus-operator">
+              https://quay.io/repository/redhat/prometheus-operator
+            </a>
+          }
+        />
+        <PropertyItem
+          label="Container Image"
+          value={
+            <a href="#">
+              0.22.2 <Icon type="fa" name="external-link" />
+            </a>
+          }
+        />
+        <PropertyItem
+          label="Created At"
+          value={
+            <span>
+              <Icon type="fa" name="globe" /> Aug 23, 1:58pm
+            </span>
+          }
+        />
+        <PropertyItem label="Support" value={<a href="#">Red Hat</a>} />
+      </PropertiesSidePanel>
+    </div>
+  ))
+);

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/PropertiesSidePanel/__snapshots__/PropertiesSIdePanel.test.js.snap
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/PropertiesSidePanel/__snapshots__/PropertiesSIdePanel.test.js.snap
@@ -1,0 +1,165 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PropertiesSidePanel renders properly 1`] = `
+<div
+  class="properties-side-panel-pf test-properties-side-panel-class"
+>
+  <div
+    class="properties-side-panel-pf-property test-property-item-class"
+  >
+    <h5
+      class="properties-side-panel-pf-property-label"
+    >
+      Operator Version
+    </h5>
+    <div
+      class="properties-side-panel-pf-property-value"
+    >
+      0.9.8 (latest)
+    </div>
+  </div>
+  <div
+    class="properties-side-panel-pf-property"
+  >
+    <h5
+      class="properties-side-panel-pf-property-label"
+    >
+      Certified Level
+    </h5>
+    <div
+      class="properties-side-panel-pf-property-value"
+    >
+      <span>
+        <span
+          aria-hidden="true"
+          class="pficon pficon-ok"
+        />
+         Certified
+      </span>
+    </div>
+  </div>
+  <div
+    class="properties-side-panel-pf-property"
+  >
+    <h5
+      class="properties-side-panel-pf-property-label"
+    >
+      Provider
+    </h5>
+    <div
+      class="properties-side-panel-pf-property-value"
+    >
+      Red Hat, Inc
+    </div>
+  </div>
+  <div
+    class="properties-side-panel-pf-property"
+  >
+    <h5
+      class="properties-side-panel-pf-property-label"
+    >
+      Health Index
+    </h5>
+    <div
+      class="properties-side-panel-pf-property-value"
+    >
+      A
+    </div>
+  </div>
+  <div
+    class="properties-side-panel-pf-property"
+  >
+    <h5
+      class="properties-side-panel-pf-property-label"
+    >
+      Repository
+    </h5>
+    <div
+      class="properties-side-panel-pf-property-value"
+    >
+      <a
+        href="https://quay.io/repository/redhat/prometheus-operator"
+      >
+        https://quay.io/repository/redhat/prometheus-operator
+      </a>
+    </div>
+  </div>
+  <div
+    class="properties-side-panel-pf-property"
+  >
+    <h5
+      class="properties-side-panel-pf-property-label"
+    >
+      Container Image
+    </h5>
+    <div
+      class="properties-side-panel-pf-property-value"
+    >
+      <a
+        href="#"
+      >
+        0.22.2 
+        <span
+          aria-hidden="true"
+          class="fa fa-external-link"
+        />
+      </a>
+    </div>
+  </div>
+  <div
+    class="properties-side-panel-pf-property"
+  >
+    <h5
+      class="properties-side-panel-pf-property-label"
+    >
+      Created At
+    </h5>
+    <div
+      class="properties-side-panel-pf-property-value"
+    >
+      <span>
+        <span
+          aria-hidden="true"
+          class="fa fa-globe"
+        />
+         Aug 23, 1:58pm
+      </span>
+    </div>
+  </div>
+  <div
+    class="properties-side-panel-pf-property"
+  >
+    <h5
+      class="properties-side-panel-pf-property-label"
+    >
+      Support
+    </h5>
+    <div
+      class="properties-side-panel-pf-property-value"
+    >
+      <a
+        href="#"
+      >
+        Red Hat
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`PropertyItem renders properly 1`] = `
+<div
+  class="properties-side-panel-pf-property test-property-item-class"
+>
+  <h5
+    class="properties-side-panel-pf-property-label"
+  >
+    Operator Version
+  </h5>
+  <div
+    class="properties-side-panel-pf-property-value"
+  >
+    0.9.8 (latest)
+  </div>
+</div>
+`;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/PropertiesSidePanel/index.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/PropertiesSidePanel/index.js
@@ -1,0 +1,4 @@
+import PropertiesSidePanel from './PropertiesSidePanel';
+import PropertyItem from './PropertyItem';
+
+export { PropertiesSidePanel, PropertyItem };

--- a/packages/patternfly-3/patternfly-react-extensions/src/index.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/index.js
@@ -2,5 +2,6 @@ export * from './components/CatalogItemHeader';
 export * from './components/CatalogTile';
 export * from './components/CatalogTileView';
 export * from './components/FilterSidePanel';
+export * from './components/PropertiesSidePanel';
 export * from './components/TableGrid';
 export * from './components/VerticalTabs';


### PR DESCRIPTION
affects: patternfly-react-extensions

**What**:
Adds the PropertiesSidePanel and PropertyItem component to patternfly-react-extensions

**Link to Storybook**:
https://rawgit.com/jeff-phillips-18/patternfly-react/properties-sidebar-storybook/index.html?selectedKind=patternfly-react-extensions%2FForms%20and%20Controls%2FProperties%20Side%20Panel&selectedStory=PropertiesSidePanel&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs

@serenamarie125 @tlwu2013 