### PR TITLE
feat(modal): add class to allow Modal dialog to be placed on the right side

### DIFF
--- a/packages/patternfly-3/patternfly-react/less/modeless-overlay.less
+++ b/packages/patternfly-3/patternfly-react/less/modeless-overlay.less
@@ -1,9 +1,5 @@
-.modal.modeless-pf {
+.modal.right-side-modal-pf {
   left: initial;
-
-  &.shown {
-    display: block;
-  }
 
   .modal-dialog {
     margin: @navbar-pf-height 0 0 10px;
@@ -17,4 +13,8 @@
     -webkit-transform: translate3d(-75%, 0, 0);
     transform: translate3d(75%, 0, 0);
   }
+}
+
+.modal.modeless-pf.shown {
+  display: block;
 }

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_modeless-overlay.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_modeless-overlay.scss
@@ -1,9 +1,5 @@
-.modal.modeless-pf {
+.modal.right-side-modal-pf {
   left: initial;
-
-  &.shown {
-    display: block;
-  }
 
   .modal-dialog {
     margin: $navbar-pf-height 0 0 10px;
@@ -17,4 +13,8 @@
     -webkit-transform: translate3d(-75%, 0, 0);
     transform: translate3d(75%, 0, 0);
   }
+}
+
+.modal.modeless-pf.shown {
+  display: block;
 }

--- a/packages/patternfly-3/patternfly-react/src/components/Modal/Modal.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/Modal.stories.js
@@ -7,10 +7,19 @@ import { storybookPackageName, DOCUMENTATION_URL, STORYBOOK_CATEGORY } from 'sto
 import { MockModalManager, basicExampleSource } from './__mocks__/mockModalManager';
 import { Modal } from '../../index';
 import { name } from '../../../package.json';
+import { boolean, withKnobs } from '@storybook/addon-knobs';
 
 const stories = storiesOf(
   `${storybookPackageName(name)}/${STORYBOOK_CATEGORY.FORMS_AND_CONTROLS}/Modal Overlay`,
   module
+);
+
+stories.addDecorator(withKnobs);
+
+const description = (
+  <div>
+    Adding the class <b>right-side-modal-pf</b> will show the modal on the right side of the window.
+  </div>
 );
 
 stories.add(
@@ -26,11 +35,13 @@ stories.add(
       </div>
     )
   })(() => {
-    const story = <MockModalManager />;
+    const rightSide = boolean('Right Side', false);
+    const story = <MockModalManager rightSide={rightSide} />;
     return inlineTemplate({
       title: 'Modal Example',
       documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_FORMS}modal-overlay/`,
       reactBootstrapDocumentationLink: `${DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT}modal/`,
+      description,
       story
     });
   })

--- a/packages/patternfly-3/patternfly-react/src/components/Modal/__mocks__/mockModalManager.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/__mocks__/mockModalManager.js
@@ -5,7 +5,8 @@ import { Modal } from '../index';
 
 export class MockModalManager extends React.Component {
   propTypes = {
-    children: PropTypes.node
+    children: PropTypes.node,
+    rightSide: PropTypes.bool
   };
 
   constructor() {
@@ -21,7 +22,7 @@ export class MockModalManager extends React.Component {
     this.setState({ showModal: true });
   }
   render() {
-    const { children } = this.props;
+    const { children, rightSide } = this.props;
     const defaultBody = (
       <form className="form-horizontal">
         <div className="form-group">
@@ -57,7 +58,7 @@ export class MockModalManager extends React.Component {
           Launch Modal
         </Button>
 
-        <Modal show={this.state.showModal} onHide={this.close}>
+        <Modal show={this.state.showModal} onHide={this.close} className={rightSide ? 'right-side-modal-pf' : ''}>
           <Modal.Header>
             <Modal.CloseButton onClick={this.close} />
             <Modal.Title>Modal Overlay Title</Modal.Title>

--- a/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/ModelessOverlay.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/ModelessOverlay.js
@@ -23,7 +23,11 @@ class ModelessOverlay extends React.Component {
     const { children, className, bsSize, show, ...otherProps } = this.props;
     const { isIn } = this.state;
 
-    const classes = classNames('modal modeless-pf fade', { shown: show || isIn, in: show && isIn }, className);
+    const classes = classNames(
+      'modal modeless-pf fade right-side-modal-pf',
+      { shown: show || isIn, in: show && isIn },
+      className
+    );
 
     if (isIn !== show) {
       this.inTimer.startTimer(() => this.updateForTransitions(), show ? 0 : 150);

--- a/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/__snapshots__/ModelessOverlay.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/__snapshots__/ModelessOverlay.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ModelessOverlay renders properly 1`] = `
 <div
-  class="modal modeless-pf fade test-modeless-overlay-class"
+  class="modal modeless-pf fade right-side-modal-pf test-modeless-overlay-class"
   id="test-modeless-overlay-id"
   role="dialog"
   tabindex="-1"
@@ -64,7 +64,7 @@ exports[`ModelessOverlay renders properly 1`] = `
 
 exports[`ModelessOverlay renders properly when setting size 1`] = `
 <div
-  class="modal modeless-pf fade test-modeless-overlay-class"
+  class="modal modeless-pf fade right-side-modal-pf test-modeless-overlay-class"
   id="test-modeless-overlay-id"
   role="dialog"
   tabindex="-1"


### PR DESCRIPTION
affects: patternfly3-react-lerna-root, patternfly-react

**What**:
Add a class `right-side-modal-pf` to allow Modal dialog component to be placed on the right side, similar to the ModelessOverlay. Refactor the ModelessOverlay to use the same class.

**Link to Storybook**:
https://rawgit.com/jeff-phillips-18/patternfly-react/modal-storybook/index.html?selectedKind=patternfly-react%2FForms%20and%20Controls%2FModal%20Overlay&selectedStory=Modal&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs
