### PR TITLE
feat(table-grid): add Row and Cell selection support to TableGrid

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/table-grid.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/table-grid.less
@@ -18,7 +18,9 @@
   }
 
   .table-grid-pf-head {
+    color: @color-pf-black-600;
     font-size: 12px;
+    font-weight: 300;
     padding: 10px 0;
   }
 
@@ -28,7 +30,9 @@
     text-transform: uppercase;
 
     .btn.btn-link {
-      color: initial;
+      color: @color-pf-black-600;
+      font-size: 12px;
+      font-weight: 300;
       overflow-x: hidden;
       padding: 0;
       text-overflow: ellipsis;
@@ -57,6 +61,46 @@
     .table-grid-pf-head,
     .table-grid-pf-body .row {
       border-bottom: solid 1px #eee;
+    }
+  }
+
+  &.cell-select {
+    .table-grid-pf-body {
+      .row {
+        padding: 0;
+      }
+
+      .table-grid-pf-col {
+        cursor: pointer;
+        display: inline-block;
+        padding-top: 10px;
+        padding-bottom: 10px;
+        width: 100%;
+
+        &.active {
+          background-color: @list-view-active-bg;
+        }
+
+        &:hover {
+          background-color: @list-view-hover-bg;
+        }
+      }
+    }
+  }
+
+  &.row-select {
+    .table-grid-pf-body {
+      .row {
+        cursor: pointer;
+
+        &.active {
+          background-color: @list-view-active-bg;
+        }
+
+        &:hover {
+          background-color: @list-view-hover-bg;
+        }
+      }
     }
   }
 }

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_table-grid.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_table-grid.scss
@@ -18,7 +18,9 @@
   }
 
   .table-grid-pf-head {
+    color: $color-pf-black-600;
     font-size: 12px;
+    font-weight: 300;
     padding: 10px 0;
   }
 
@@ -28,7 +30,9 @@
     text-transform: uppercase;
 
     .btn.btn-link {
-      color: initial;
+      color: $color-pf-black-600;
+      font-size: 12px;
+      font-weight: 300;
       overflow-x: hidden;
       padding: 0;
       text-overflow: ellipsis;
@@ -57,6 +61,46 @@
     .table-grid-pf-head,
     .table-grid-pf-body .row {
       border-bottom: solid 1px #eee;
+    }
+  }
+
+  &.cell-select {
+    .table-grid-pf-body {
+      .row {
+        padding: 0;
+      }
+
+      .table-grid-pf-col {
+        cursor: pointer;
+        display: inline-block;
+        padding-top: 10px;
+        padding-bottom: 10px;
+        width: 100%;
+
+        &.active {
+          background-color: $list-view-active-bg;
+        }
+
+        &:hover {
+          background-color: $list-view-hover-bg;
+        }
+      }
+    }
+  }
+
+  &.row-select {
+    .table-grid-pf-body {
+      .row {
+        cursor: pointer;
+
+        &.active {
+          background-color: $list-view-active-bg;
+        }
+
+        &:hover {
+          background-color: $list-view-hover-bg;
+        }
+      }
     }
   }
 }

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/TableGrid.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/TableGrid.js
@@ -5,13 +5,18 @@ import TableGridHead from './TableGridHead';
 import TableGridColumnHeader from './TableGridColumnHeader';
 import TableGridBody from './TableGridBody';
 import TableGridRow from './TableGridRow';
+import TableGridCol from './TableGridCol';
 
 /**
  * TableGrid Component for PatternFly
  */
 
-const TableGrid = ({ children, className, bordered, ...props }) => {
-  const classes = classNames('table-grid-pf', { bordered }, className);
+const TableGrid = ({ children, className, bordered, selectType, ...props }) => {
+  const classes = classNames(
+    'table-grid-pf',
+    { bordered, 'row-select': selectType === 'row', 'cell-select': selectType === 'cell' },
+    className
+  );
   return (
     <div className={classes} {...props}>
       {children}
@@ -25,17 +30,21 @@ TableGrid.propTypes = {
   /** Additional css classes */
   className: PropTypes.string,
   /** Flag to use a bordered grid */
-  bordered: PropTypes.bool
+  bordered: PropTypes.bool,
+  /** Type of selection for the grid */
+  selectType: PropTypes.oneOf(['row', 'cell', 'none'])
 };
 TableGrid.defaultProps = {
   children: null,
   className: '',
-  bordered: true
+  bordered: true,
+  selectType: 'none'
 };
 
 TableGrid.Head = TableGridHead;
 TableGrid.ColumnHeader = TableGridColumnHeader;
 TableGrid.Body = TableGridBody;
 TableGrid.Row = TableGridRow;
+TableGrid.Col = TableGridCol;
 
 export default TableGrid;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/TableGrid.stories.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/TableGrid.stories.js
@@ -5,19 +5,27 @@ import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { storybookPackageName, STORYBOOK_CATEGORY } from 'storybook/constants/siteConstants';
 import { MockTableGridExample, MockTableGridExampleSource } from './_mocks_/mockTableGridExample';
 
-import { TableGrid, TableGridHead, TableGridColumnHeader, TableGridBody, TableGridRow } from './index';
+import { TableGrid, TableGridHead, TableGridColumnHeader, TableGridBody, TableGridRow, TableGridCol } from './index';
 
 import { name } from '../../../package.json';
-import { boolean, withKnobs } from '@storybook/addon-knobs';
+import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 
 const stories = storiesOf(`${storybookPackageName(name)}/${STORYBOOK_CATEGORY.CONTENT_VIEWS}/TableGrid`, module);
 
 stories.addDecorator(
   defaultTemplate({
     title: 'Table Grid',
-    description:
-      'The TableGrid is based on the Bootstrap Grid Layout. The TableGridColumnHeaders should have the same ' +
-      'bootstrap col classes as the children of the TableGridRow component in order to maintain equal widths.'
+    description: (
+      <div>
+        The TableGrid is based on the Bootstrap Grid Layout. The <b>TableGrid.ColumnHeaders</b> should have the same
+        bootstrap column classes as the children of the <b>TableGrid.Row</b> component in order to maintain equal
+        widths.
+        <br />
+        <br />
+        When using <i>cell</i> selection, the <b>TableGrid.Col</b> component should be used in place of the
+        <b> Grid.Col</b> component for correct selection styling.
+      </div>
+    )
   })
 );
 
@@ -26,7 +34,7 @@ stories.add(
   'TableGrid',
   withInfo({
     source: false,
-    propTables: [TableGrid, TableGridHead, TableGridColumnHeader, TableGridBody, TableGridRow],
+    propTables: [TableGrid, TableGridHead, TableGridColumnHeader, TableGridBody, TableGridRow, TableGridCol],
     propTablesExclude: [MockTableGridExample],
     text: (
       <div>
@@ -36,6 +44,8 @@ stories.add(
     )
   })(() => {
     const bordered = boolean('Bordered', true);
-    return <MockTableGridExample bordered={bordered} />;
+    const selectType = select('Selection Type', { none: 'None', row: 'Row', cell: 'Cell' }, 'none');
+
+    return <MockTableGridExample bordered={bordered} selectType={selectType} />;
   })
 );

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/TableGrid.test.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/TableGrid.test.js
@@ -54,3 +54,119 @@ test('TableGrid renders properly', () => {
   );
   expect(component.render()).toMatchSnapshot();
 });
+
+test('TableGrid with Row select renders properly', () => {
+  const component = mount(
+    <TableGrid id="table-grid" selectType="row">
+      <TableGrid.Head>
+        <TableGrid.ColumnHeader id="title" sortable isSorted isAscending className="test-class">
+          Column 1
+        </TableGrid.ColumnHeader>
+        <TableGrid.ColumnHeader>Column 2</TableGrid.ColumnHeader>
+        <TableGrid.ColumnHeader sortable={false} isSorted={false} isAscending={false} onSortToggle={noop} />
+        <TableGrid.ColumnHeader sortable={false} isSorted={false} isAscending={false} onSortToggle={noop}>
+          <div>
+            <span>test 1</span>
+            <span>and two</span>
+          </div>
+        </TableGrid.ColumnHeader>
+      </TableGrid.Head>
+      <TableGrid.Body id="test-grid-body" className="test-grid-body">
+        <TableGrid.Row id="test-grid-row" className="test-grid-row">
+          <Grid.Col id="test-col-1" className="test-col1">
+            item 1 column 1
+          </Grid.Col>
+          <Grid.Col id="test-col-2" className="test-col2">
+            item 1 column 2
+          </Grid.Col>
+          <Grid.Col id="test-col-3" className="test-col3">
+            item 1 column 3
+          </Grid.Col>
+          <Grid.Col id="test-col-4" className="test-col4">
+            item 1 column 4
+          </Grid.Col>
+        </TableGrid.Row>
+        <TableGrid.Row id="test-grid-row-2-selected" selected>
+          <Grid.Col id="test-row-2-col-1">item 2 column 1</Grid.Col>
+          <Grid.Col id="two-children" className="test-col2">
+            <span>item 1</span>
+            <span>column 2</span>
+          </Grid.Col>
+          <Grid.Col id="icon-name" className="test-col3">
+            <Icon type="pf" name="error-circle-o" />
+            Danger
+          </Grid.Col>
+          <Grid.Col id="test-col-4" className="test-col4">
+            item 2 column 4
+          </Grid.Col>
+        </TableGrid.Row>
+        <TableGrid.Row id="test-grid-row-3" selected={false}>
+          <Grid.Col id="test-row-3-col-1">item 3 column 1</Grid.Col>
+          <Grid.Col id="two-children" className="test-col3">
+            <span>item 3</span>
+            <span>column 2</span>
+          </Grid.Col>
+          <Grid.Col id="icon-name" className="test-col3">
+            <Icon type="pf" name="error-circle-o" />
+            Danger
+          </Grid.Col>
+          <Grid.Col id="test-col-4" className="test-col4">
+            item 3 column 4
+          </Grid.Col>
+        </TableGrid.Row>
+      </TableGrid.Body>
+    </TableGrid>
+  );
+  expect(component.render()).toMatchSnapshot();
+});
+
+test('TableGrid with Cell select renders properly', () => {
+  const component = mount(
+    <TableGrid id="table-grid" selectType="cell">
+      <TableGrid.Head>
+        <TableGrid.ColumnHeader id="title" sortable isSorted isAscending className="test-class">
+          Column 1
+        </TableGrid.ColumnHeader>
+        <TableGrid.ColumnHeader>Column 2</TableGrid.ColumnHeader>
+        <TableGrid.ColumnHeader sortable={false} isSorted={false} isAscending={false} onSortToggle={noop} />
+        <TableGrid.ColumnHeader sortable={false} isSorted={false} isAscending={false} onSortToggle={noop}>
+          <div>
+            <span>test 1</span>
+            <span>and two</span>
+          </div>
+        </TableGrid.ColumnHeader>
+      </TableGrid.Head>
+      <TableGrid.Body id="test-grid-body" className="test-grid-body">
+        <TableGrid.Row id="test-grid-row" className="test-grid-row">
+          <TableGrid.Col id="test-col-1" className="test-col1">
+            item 1 column 1
+          </TableGrid.Col>
+          <TableGrid.Col id="test-col-2" className="test-col2" selected>
+            item 1 column 2
+          </TableGrid.Col>
+          <TableGrid.Col id="test-col-3" className="test-col3" selected={false}>
+            item 1 column 3
+          </TableGrid.Col>
+          <TableGrid.Col id="test-col-4" className="test-col4">
+            item 1 column 4
+          </TableGrid.Col>
+        </TableGrid.Row>
+        <TableGrid.Row id="test-grid-row-2-selected">
+          <TableGrid.Col id="test-row-2-col-1">item 2 column 1</TableGrid.Col>
+          <TableGrid.Col id="two-children" className="test-col2">
+            <span>item 1</span>
+            <span>column 2</span>
+          </TableGrid.Col>
+          <TableGrid.Col id="icon-name" className="test-col3">
+            <Icon type="pf" name="error-circle-o" />
+            Danger
+          </TableGrid.Col>
+          <TableGrid.Col id="test-col-4" className="test-col4">
+            item 2 column 4
+          </TableGrid.Col>
+        </TableGrid.Row>
+      </TableGrid.Body>
+    </TableGrid>
+  );
+  expect(component.render()).toMatchSnapshot();
+});

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/TableGridCol.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/TableGridCol.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { Grid } from 'patternfly-react';
+
+/**
+ * TableGridCol Component for PatternFly
+ */
+
+const TableGridCol = ({ children, selected, ...props }) => {
+  const classes = classNames('table-grid-pf-col', { active: selected });
+  return (
+    <Grid.Col {...props}>
+      <span className={classes}>{children}</span>
+    </Grid.Col>
+  );
+};
+
+TableGridCol.propTypes = {
+  /** Children nodes */
+  children: PropTypes.node,
+  /** Flag if the cell is selected */
+  selected: PropTypes.bool
+};
+
+TableGridCol.defaultProps = {
+  children: null,
+  selected: false
+};
+
+export default TableGridCol;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/TableGridRow.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/TableGridRow.js
@@ -7,8 +7,8 @@ import { Grid } from 'patternfly-react';
  * TableGridRow Component for PatternFly
  */
 
-const TableGridRow = ({ children, className, ...props }) => {
-  const classes = classNames('table-grid-pf-row', className);
+const TableGridRow = ({ children, className, selected, ...props }) => {
+  const classes = classNames('table-grid-pf-row', { active: selected }, className);
   return (
     <Grid.Row className={classes} {...props}>
       {children}
@@ -20,11 +20,15 @@ TableGridRow.propTypes = {
   /** Children nodes */
   children: PropTypes.node,
   /** Additional css classes */
-  className: PropTypes.string
+  className: PropTypes.string,
+  /** Flag if the row is selected */
+  selected: PropTypes.bool
 };
+
 TableGridRow.defaultProps = {
   children: null,
-  className: ''
+  className: '',
+  selected: false
 };
 
 export default TableGridRow;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/__snapshots__/TableGrid.test.js.snap
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/__snapshots__/TableGrid.test.js.snap
@@ -118,3 +118,311 @@ exports[`TableGrid renders properly 1`] = `
   </div>
 </div>
 `;
+
+exports[`TableGrid with Cell select renders properly 1`] = `
+<div
+  class="table-grid-pf bordered cell-select"
+  id="table-grid"
+>
+  <div
+    class="table-grid-pf-head row"
+  >
+    <div
+      class="table-grid-pf-column-header text-nowrap active-sort test-class "
+      id="title"
+    >
+      <button
+        class="btn btn-link"
+        type="button"
+      >
+        Column 1
+        <span
+          aria-hidden="true"
+          class="pficon pficon-sort-common-asc table-grid-pf-header-sort-arrow"
+        />
+      </button>
+    </div>
+    <div
+      class="table-grid-pf-column-header text-nowrap "
+    >
+      Column 2
+    </div>
+    <div
+      class="table-grid-pf-column-header text-nowrap descending "
+    />
+    <div
+      class="table-grid-pf-column-header text-nowrap descending "
+    >
+      <div>
+        <span>
+          test 1
+        </span>
+        <span>
+          and two
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="table-grid-pf-body test-grid-body"
+    id="test-grid-body"
+  >
+    <div
+      class="table-grid-pf-row test-grid-row row"
+      id="test-grid-row"
+    >
+      <div
+        class="test-col1 "
+        id="test-col-1"
+      >
+        <span
+          class="table-grid-pf-col"
+        >
+          item 1 column 1
+        </span>
+      </div>
+      <div
+        class="test-col2 "
+        id="test-col-2"
+      >
+        <span
+          class="table-grid-pf-col active"
+        >
+          item 1 column 2
+        </span>
+      </div>
+      <div
+        class="test-col3 "
+        id="test-col-3"
+      >
+        <span
+          class="table-grid-pf-col"
+        >
+          item 1 column 3
+        </span>
+      </div>
+      <div
+        class="test-col4 "
+        id="test-col-4"
+      >
+        <span
+          class="table-grid-pf-col"
+        >
+          item 1 column 4
+        </span>
+      </div>
+    </div>
+    <div
+      class="table-grid-pf-row row"
+      id="test-grid-row-2-selected"
+    >
+      <div
+        class=""
+        id="test-row-2-col-1"
+      >
+        <span
+          class="table-grid-pf-col"
+        >
+          item 2 column 1
+        </span>
+      </div>
+      <div
+        class="test-col2 "
+        id="two-children"
+      >
+        <span
+          class="table-grid-pf-col"
+        >
+          <span>
+            item 1
+          </span>
+          <span>
+            column 2
+          </span>
+        </span>
+      </div>
+      <div
+        class="test-col3 "
+        id="icon-name"
+      >
+        <span
+          class="table-grid-pf-col"
+        >
+          <span
+            aria-hidden="true"
+            class="pficon pficon-error-circle-o"
+          />
+          Danger
+        </span>
+      </div>
+      <div
+        class="test-col4 "
+        id="test-col-4"
+      >
+        <span
+          class="table-grid-pf-col"
+        >
+          item 2 column 4
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TableGrid with Row select renders properly 1`] = `
+<div
+  class="table-grid-pf bordered row-select"
+  id="table-grid"
+>
+  <div
+    class="table-grid-pf-head row"
+  >
+    <div
+      class="table-grid-pf-column-header text-nowrap active-sort test-class "
+      id="title"
+    >
+      <button
+        class="btn btn-link"
+        type="button"
+      >
+        Column 1
+        <span
+          aria-hidden="true"
+          class="pficon pficon-sort-common-asc table-grid-pf-header-sort-arrow"
+        />
+      </button>
+    </div>
+    <div
+      class="table-grid-pf-column-header text-nowrap "
+    >
+      Column 2
+    </div>
+    <div
+      class="table-grid-pf-column-header text-nowrap descending "
+    />
+    <div
+      class="table-grid-pf-column-header text-nowrap descending "
+    >
+      <div>
+        <span>
+          test 1
+        </span>
+        <span>
+          and two
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="table-grid-pf-body test-grid-body"
+    id="test-grid-body"
+  >
+    <div
+      class="table-grid-pf-row test-grid-row row"
+      id="test-grid-row"
+    >
+      <div
+        class="test-col1 "
+        id="test-col-1"
+      >
+        item 1 column 1
+      </div>
+      <div
+        class="test-col2 "
+        id="test-col-2"
+      >
+        item 1 column 2
+      </div>
+      <div
+        class="test-col3 "
+        id="test-col-3"
+      >
+        item 1 column 3
+      </div>
+      <div
+        class="test-col4 "
+        id="test-col-4"
+      >
+        item 1 column 4
+      </div>
+    </div>
+    <div
+      class="table-grid-pf-row active row"
+      id="test-grid-row-2-selected"
+    >
+      <div
+        class=""
+        id="test-row-2-col-1"
+      >
+        item 2 column 1
+      </div>
+      <div
+        class="test-col2 "
+        id="two-children"
+      >
+        <span>
+          item 1
+        </span>
+        <span>
+          column 2
+        </span>
+      </div>
+      <div
+        class="test-col3 "
+        id="icon-name"
+      >
+        <span
+          aria-hidden="true"
+          class="pficon pficon-error-circle-o"
+        />
+        Danger
+      </div>
+      <div
+        class="test-col4 "
+        id="test-col-4"
+      >
+        item 2 column 4
+      </div>
+    </div>
+    <div
+      class="table-grid-pf-row row"
+      id="test-grid-row-3"
+    >
+      <div
+        class=""
+        id="test-row-3-col-1"
+      >
+        item 3 column 1
+      </div>
+      <div
+        class="test-col3 "
+        id="two-children"
+      >
+        <span>
+          item 3
+        </span>
+        <span>
+          column 2
+        </span>
+      </div>
+      <div
+        class="test-col3 "
+        id="icon-name"
+      >
+        <span
+          aria-hidden="true"
+          class="pficon pficon-error-circle-o"
+        />
+        Danger
+      </div>
+      <div
+        class="test-col4 "
+        id="test-col-4"
+      >
+        item 3 column 4
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/_mocks_/mockTableGridExample.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/_mocks_/mockTableGridExample.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import TableGrid from '../TableGrid';
-import { Grid, OverlayTrigger, Tooltip } from 'patternfly-react';
+import { OverlayTrigger, Tooltip } from 'patternfly-react';
 import { mockItems } from './mockItems';
 
 const titleColSizes = {
@@ -24,7 +24,9 @@ class MockTableGridExample extends React.Component {
   state = {
     sortField: 'title',
     isAscending: true,
-    items: mockItems
+    items: mockItems,
+    selectedItem: null,
+    selectedField: null
   };
 
   onSortToggle = id => {
@@ -55,20 +57,57 @@ class MockTableGridExample extends React.Component {
     this.setState({ items, sortField: id, isAscending: updateAscending });
   };
 
-  renderItemRow = (item, index) => (
-    <TableGrid.Row key={index}>
-      <Grid.Col {...titleColSizes}>{item.title}</Grid.Col>
-      <Grid.Col {...descrColSizes}>{item.description}</Grid.Col>
-      <Grid.Col {...countColSizes}>{item.hosts}</Grid.Col>
-      <Grid.Col {...countColSizes}>{item.clusters}</Grid.Col>
-    </TableGrid.Row>
-  );
+  onSelect = (item, field) => {
+    this.setState({ selectedItem: item, selectedField: field });
+  };
+
+  renderItemRow = (item, index) => {
+    const { selectType } = this.props;
+    const { selectedItem, selectedField } = this.state;
+    const selected = selectedItem === item;
+    return (
+      <TableGrid.Row
+        key={index}
+        onClick={() => selectType === 'row' && this.onSelect(item)}
+        selected={selectType === 'row' && selected}
+      >
+        <TableGrid.Col
+          {...titleColSizes}
+          onClick={() => selectType === 'cell' && this.onSelect(item, 'title')}
+          selected={selectType === 'cell' && selected && selectedField === 'title'}
+        >
+          {item.title}
+        </TableGrid.Col>
+        <TableGrid.Col
+          {...descrColSizes}
+          onClick={() => selectType === 'cell' && this.onSelect(item, 'description')}
+          selected={selectType === 'cell' && selected && selectedField === 'description'}
+        >
+          {item.description}
+        </TableGrid.Col>
+        <TableGrid.Col
+          {...countColSizes}
+          onClick={() => selectType === 'cell' && this.onSelect(item, 'hosts')}
+          selected={selectType === 'cell' && selected && selectedField === 'hosts'}
+        >
+          {item.hosts}
+        </TableGrid.Col>
+        <TableGrid.Col
+          {...countColSizes}
+          onClick={() => selectType === 'cell' && this.onSelect(item, 'clusters')}
+          selected={selectType === 'cell' && selected && selectedField === 'clusters'}
+        >
+          {item.clusters}
+        </TableGrid.Col>
+      </TableGrid.Row>
+    );
+  };
 
   render() {
     const { items, sortField, isAscending } = this.state;
-    const { bordered } = this.props;
+    const { bordered, selectType } = this.props;
     return (
-      <TableGrid id="table-grid" bordered={bordered}>
+      <TableGrid id="table-grid" bordered={bordered} selectType={selectType}>
         <TableGrid.Head>
           <TableGrid.ColumnHeader
             id="title"
@@ -121,11 +160,13 @@ class MockTableGridExample extends React.Component {
 }
 
 MockTableGridExample.propTypes = {
-  bordered: PropTypes.bool
+  bordered: PropTypes.bool,
+  selectType: PropTypes.oneOf(['row', 'cell', 'none'])
 };
 
 MockTableGridExample.defaultProps = {
-  bordered: false
+  bordered: false,
+  selectType: 'none'
 };
 
 export { MockTableGridExample };
@@ -134,7 +175,7 @@ export const MockTableGridExampleSource = `
 import React from 'react';
 import PropTypes from 'prop-types';
 import TableGrid from '../TableGrid';
-import { Grid, OverlayTrigger, Tooltip } from 'patternfly-react';
+import { OverlayTrigger, Tooltip } from 'patternfly-react';
 import { mockItems } from './mockItems';
 
 const titleColSizes = {
@@ -157,7 +198,9 @@ class MockTableGridExample extends React.Component {
   state = {
     sortField: 'title',
     isAscending: true,
-    items: mockItems
+    items: mockItems,
+    selectedItem: null,
+    selectedField: null
   };
 
   onSortToggle = id => {
@@ -188,20 +231,57 @@ class MockTableGridExample extends React.Component {
     this.setState({ items, sortField: id, isAscending: updateAscending });
   };
 
-  renderItemRow = (item, index) => (
-    <TableGrid.Row key={index}>
-      <Grid.Col {...titleColSizes}>{item.title}</Grid.Col>
-      <Grid.Col {...descrColSizes}>{item.description}</Grid.Col>
-      <Grid.Col {...countColSizes}>{item.hosts}</Grid.Col>
-      <Grid.Col {...countColSizes}>{item.clusters}</Grid.Col>
-    </TableGrid.Row>
-  );
+  onSelect = (item, field) => {
+    this.setState({ selectedItem: item, selectedField: field });
+  };
+
+  renderItemRow = (item, index) => {
+    const { selectType } = this.props;
+    const { selectedItem, selectedField } = this.state;
+    const selected = selectedItem === item;
+    return (
+      <TableGrid.Row
+        key={index}
+        onClick={() => selectType === 'row' && this.onSelect(item)}
+        selected={selectType === 'row' && selected}
+      >
+        <TableGrid.Col
+          {...titleColSizes}
+          onClick={() => selectType === 'cell' && this.onSelect(item, 'title')}
+          selected={selectType === 'cell' && selected && selectedField === 'title'}
+        >
+          {item.title}
+        </TableGrid.Col>
+        <TableGrid.Col
+          {...descrColSizes}
+          onClick={() => selectType === 'cell' && this.onSelect(item, 'description')}
+          selected={selectType === 'cell' && selected && selectedField === 'description'}
+        >
+          {item.description}
+        </TableGrid.Col>
+        <TableGrid.Col
+          {...countColSizes}
+          onClick={() => selectType === 'cell' && this.onSelect(item, 'hosts')}
+          selected={selectType === 'cell' && selected && selectedField === 'hosts'}
+        >
+          {item.hosts}
+        </TableGrid.Col>
+        <TableGrid.Col
+          {...countColSizes}
+          onClick={() => selectType === 'cell' && this.onSelect(item, 'clusters')}
+          selected={selectType === 'cell' && selected && selectedField === 'clusters'}
+        >
+          {item.clusters}
+        </TableGrid.Col>
+      </TableGrid.Row>
+    );
+  };
 
   render() {
     const { items, sortField, isAscending } = this.state;
-    const { bordered } = this.props;
+    const { bordered, selectType } = this.props;
     return (
-      <TableGrid id="table-grid" bordered={bordered}>
+      <TableGrid id="table-grid" bordered={bordered} selectType={selectType}>
         <TableGrid.Head>
           <TableGrid.ColumnHeader
             id="title"
@@ -254,11 +334,13 @@ class MockTableGridExample extends React.Component {
 }
 
 MockTableGridExample.propTypes = {
-  bordered: PropTypes.bool
+  bordered: PropTypes.bool,
+  selectType: PropTypes.oneOf(['row', 'cell', 'none'])
 };
 
 MockTableGridExample.defaultProps = {
-  bordered: false
+  bordered: false,
+  selectType: 'none'
 };
 
 export { MockTableGridExample };

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/index.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/index.js
@@ -3,5 +3,6 @@ import TableGridHead from './TableGridHead';
 import TableGridColumnHeader from './TableGridColumnHeader';
 import TableGridBody from './TableGridBody';
 import TableGridRow from './TableGridRow';
+import TableGridCol from './TableGridCol';
 
-export { TableGrid, TableGridHead, TableGridColumnHeader, TableGridBody, TableGridRow };
+export { TableGrid, TableGridHead, TableGridColumnHeader, TableGridBody, TableGridRow, TableGridCol };


### PR DESCRIPTION
affects: patternfly3-react-lerna-root, patternfly-react-extensions

Updates styles for TableGrid's header to be inline with properties sidebar.

ISSUES CLOSED: #656 #652

**What**:
Adds support for Row and Cell selection to the TableGrid component in patternfly-react-extensions. This also updates the header style to be inline with the PropertiesSidePanel per UX feedback.

**Link to Storybook**:
https://rawgit.com/jeff-phillips-18/patternfly-react/fixes-storybook/index.html?selectedKind=patternfly-react-extensions%2FContent%20Views%2FTableGrid&selectedStory=TableGrid

@serenamarie125 @tlwu2013 
