### PR TITLE
fix(VerticalTabs): set tab text to wrap when necessary

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/vertical-tabs.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/vertical-tabs.less
@@ -7,21 +7,35 @@
   margin-top: 4px;
   position: relative;
 
-  .btn.btn-link {
+  > a {
     color: @vertical-tab-pf-color;
+    display: inline-block;
     font-size: 13px;
     padding-left: 15px;
+    vertical-align: top;
+    width: 100%;
+    word-break: break-word;
 
     &:hover,
     &:focus {
       color: @vertical-tab-pf-active-color;
-      outline: 0;
       text-decoration: none;
+    }
+
+    &.no-wrap {
+      overflow-x: hidden;
+      white-space: nowrap;
+    }
+
+    &.truncate {
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 
   &.active {
-    > .btn.btn-link {
+    > a {
       color: @vertical-tab-pf-active-color;
 
       &::before {

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_vertical-tabs.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_vertical-tabs.scss
@@ -7,21 +7,35 @@
   margin-top: 4px;
   position: relative;
 
-  .btn.btn-link {
+  > a {
     color: $vertical-tab-pf-color;
+    display: inline-block;
     font-size: 13px;
     padding-left: 15px;
+    vertical-align: top;
+    width: 100%;
+    word-break: break-word;
 
     &:hover,
     &:focus {
       color: $vertical-tab-pf-active-color;
-      outline: 0;
       text-decoration: none;
+    }
+
+    &.no-wrap {
+      overflow-x: hidden;
+      white-space: nowrap;
+    }
+
+    &.truncate {
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 
   &.active {
-    > .btn.btn-link {
+    > a {
       color: $vertical-tab-pf-active-color;
 
       &::before {

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabs.stories.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabs.stories.js
@@ -7,7 +7,7 @@ import { VerticalTabs, VerticalTabsTab } from './index';
 import { MockVerticalTabsExample, MockVerticalTabsExampleSource } from './_mocks_/mockVerticalTabsExample';
 
 import { name } from '../../../package.json';
-import { boolean, withKnobs } from '@storybook/addon-knobs';
+import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 
 const stories = storiesOf(`${storybookPackageName(name)}/${STORYBOOK_CATEGORY.WIDGETS}/Vertical Tabs`, module);
 
@@ -25,6 +25,9 @@ const description = (
     <i>VerticalTab</i> as well as the <b>active</b> (this tab is active) and <b>hasActiveDescendant</b> (a child of this
     tab is active) properties on the <i>VerticalTab.Tab</i>. Setting the <b>shown</b> property on a
     <i>VerticalTab.Tab</i> will always show the tab if its parent tab is shown.
+    <br />
+    <br />
+    Note: the width and border styling is not part of the VerticalTabs component.
   </div>
 );
 stories.addDecorator(withKnobs);
@@ -42,7 +45,12 @@ stories.add(
     )
   })(() => {
     const restrictTabs = boolean('Restrict Tabs', false);
-    const story = <MockVerticalTabsExample restrictTabs={restrictTabs} />;
+    const wrapStyle = select('Wrap Style', { wrap: 'Word - Default', truncate: 'Truncate', nowrap: 'No Wrap' }, 'wrap');
+    const story = (
+      <div style={{ width: '195px', border: '1px solid grey' }}>
+        <MockVerticalTabsExample restrictTabs={restrictTabs} wrapStyle={wrapStyle} />
+      </div>
+    );
     return inlineTemplate({
       title: 'Vertical Tabs',
       description,

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabs.test.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabs.test.js
@@ -79,3 +79,26 @@ test('Vertical Tabs renders restricted tabs properly', () => {
   );
   expect(component.render()).toMatchSnapshot();
 });
+
+test('Vertical Tabs Tab onActivate is called correctly', () => {
+  const onActivateMock = jest.fn();
+
+  const component = mount(<VerticalTabs.Tab id="text-click" title="Click Me" onActivate={onActivateMock} />);
+  component.find('#text-click > a').simulate('click');
+
+  expect(component.render()).toMatchSnapshot();
+  expect(onActivateMock).toBeCalled();
+});
+
+test('Vertical Tabs Tab wrap styling is set correctly', () => {
+  const component = mount(
+    <div>
+      <VerticalTabs.Tab id="default-wrap" title="Default Wrap" />
+      <VerticalTabs.Tab id="word-wrap" title="Word Wrap" wrapStyle="wrap" />
+      <VerticalTabs.Tab id="truncate" title="Truncate" wrapStyle="truncate" />
+      <VerticalTabs.Tab id="no-wrap" title="No Wrap" wrapStyle="nowrap" />
+    </div>
+  );
+
+  expect(component.render()).toMatchSnapshot();
+});

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabsTab.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/VerticalTabsTab.js
@@ -1,20 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Button, noop } from 'patternfly-react';
 
-const VerticalTabsTab = ({ children, className, title, active, hasActiveDescendant, shown, onActivate, ...props }) => {
+const VerticalTabsTab = ({
+  children,
+  className,
+  title,
+  wrapStyle,
+  active,
+  hasActiveDescendant,
+  shown,
+  onActivate,
+  ...props
+}) => {
   const classes = classNames(
     'vertical-tabs-pf-tab',
     { active, 'active-descendant': hasActiveDescendant, shown },
     className
   );
 
+  const linkClasses = classNames({
+    'no-wrap': wrapStyle === 'nowrap',
+    truncate: wrapStyle === 'truncate'
+  });
+
+  const handleActivate = e => {
+    e.preventDefault();
+    if (onActivate) {
+      onActivate();
+    }
+  };
+
   return (
     <li className={classes} {...props}>
-      <Button bsStyle="link" onClick={onActivate}>
+      <a className={linkClasses} onClick={e => handleActivate(e)} href="#">
         {title}
-      </Button>
+      </a>
       {children}
     </li>
   );
@@ -27,6 +48,8 @@ VerticalTabsTab.propTypes = {
   className: PropTypes.string,
   /** Title for the tab */
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /** Title wrap style */
+  wrapStyle: PropTypes.oneOf(['wrap', 'truncate', 'nowrap']),
   /** Flag if this is the active tab */
   active: PropTypes.bool,
   /** Flag if a descendant tab is active (used only in restrictTabs mode) */
@@ -41,10 +64,11 @@ VerticalTabsTab.defaultProps = {
   children: null,
   className: '',
   title: null,
+  wrapStyle: 'wrap',
   active: false,
   hasActiveDescendant: false,
   shown: false,
-  onActivate: noop
+  onActivate: null
 };
 
 export default VerticalTabsTab;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/__snapshots__/VerticalTabs.test.js.snap
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/__snapshots__/VerticalTabs.test.js.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Vertical Tabs Tab onActivate is called correctly 1`] = `
+<li
+  class="vertical-tabs-pf-tab"
+  id="text-click"
+>
+  <a
+    class=""
+    href="#"
+  >
+    Click Me
+  </a>
+</li>
+`;
+
+exports[`Vertical Tabs Tab wrap styling is set correctly 1`] = `
+<div>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="default-wrap"
+  >
+    <a
+      class=""
+      href="#"
+    >
+      Default Wrap
+    </a>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="word-wrap"
+  >
+    <a
+      class=""
+      href="#"
+    >
+      Word Wrap
+    </a>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="truncate"
+  >
+    <a
+      class="truncate"
+      href="#"
+    >
+      Truncate
+    </a>
+  </li>
+  <li
+    class="vertical-tabs-pf-tab"
+    id="no-wrap"
+  >
+    <a
+      class="no-wrap"
+      href="#"
+    >
+      No Wrap
+    </a>
+  </li>
+</div>
+`;
+
 exports[`Vertical Tabs renders restricted tabs properly 1`] = `
 <ul
   class="vertical-tabs-pf restrict-tabs test-vertical-tabs"
@@ -9,23 +72,23 @@ exports[`Vertical Tabs renders restricted tabs properly 1`] = `
     class="vertical-tabs-pf-tab shown test-vertical-tabs-tab"
     id="all"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       All
-    </button>
+    </a>
   </li>
   <li
     class="vertical-tabs-pf-tab active-descendant"
     id="one"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab One
-    </button>
+    </a>
     <ul
       class="vertical-tabs-pf restrict-tabs"
     >
@@ -33,12 +96,12 @@ exports[`Vertical Tabs renders restricted tabs properly 1`] = `
         class="vertical-tabs-pf-tab"
         id="one-one"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab One-One
-        </button>
+        </a>
         <ul
           class="vertical-tabs-pf restrict-tabs active-tab"
         >
@@ -46,34 +109,34 @@ exports[`Vertical Tabs renders restricted tabs properly 1`] = `
             class="vertical-tabs-pf-tab active"
             id="one-one-one"
           >
-            <button
-              class="btn btn-link"
-              type="button"
+            <a
+              class=""
+              href="#"
             >
               Tab One-One-One
-            </button>
+            </a>
           </li>
           <li
             class="vertical-tabs-pf-tab"
             id="one-one-two"
           >
-            <button
-              class="btn btn-link"
-              type="button"
+            <a
+              class=""
+              href="#"
             >
               Tab One-One-Two
-            </button>
+            </a>
           </li>
           <li
             class="vertical-tabs-pf-tab"
             id="one-one-three"
           >
-            <button
-              class="btn btn-link"
-              type="button"
+            <a
+              class=""
+              href="#"
             >
               Tab One-One-Three
-            </button>
+            </a>
           </li>
         </ul>
       </li>
@@ -81,23 +144,23 @@ exports[`Vertical Tabs renders restricted tabs properly 1`] = `
         class="vertical-tabs-pf-tab"
         id="one-two"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab One-Two
-        </button>
+        </a>
       </li>
       <li
         class="vertical-tabs-pf-tab"
         id="one-three"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab One-Three
-        </button>
+        </a>
       </li>
     </ul>
   </li>
@@ -105,12 +168,12 @@ exports[`Vertical Tabs renders restricted tabs properly 1`] = `
     class="vertical-tabs-pf-tab test-tab-class"
     id="two"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab Two
-    </button>
+    </a>
     <ul
       class="vertical-tabs-pf restrict-tabs active-tab"
     >
@@ -118,34 +181,34 @@ exports[`Vertical Tabs renders restricted tabs properly 1`] = `
         class="vertical-tabs-pf-tab active"
         id="two-one"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab Two-One
-        </button>
+        </a>
       </li>
       <li
         class="vertical-tabs-pf-tab"
         id="two-two"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab Two-Two
-        </button>
+        </a>
       </li>
       <li
         class="vertical-tabs-pf-tab"
         id="two-three"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab Two-Three
-        </button>
+        </a>
       </li>
     </ul>
   </li>
@@ -153,12 +216,12 @@ exports[`Vertical Tabs renders restricted tabs properly 1`] = `
     class="vertical-tabs-pf-tab"
     id="three"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab Three
-    </button>
+    </a>
     <ul
       class="vertical-tabs-pf restrict-tabs"
     >
@@ -166,23 +229,23 @@ exports[`Vertical Tabs renders restricted tabs properly 1`] = `
         class="vertical-tabs-pf-tab"
         id="three-one"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab Three-One
-        </button>
+        </a>
       </li>
       <li
         class="vertical-tabs-pf-tab"
         id="three-two"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab Three-Two
-        </button>
+        </a>
       </li>
     </ul>
   </li>
@@ -190,45 +253,45 @@ exports[`Vertical Tabs renders restricted tabs properly 1`] = `
     class="vertical-tabs-pf-tab"
     id="four"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab Four
-    </button>
+    </a>
   </li>
   <li
     class="vertical-tabs-pf-tab"
     id="five"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab Five
-    </button>
+    </a>
   </li>
   <li
     class="vertical-tabs-pf-tab"
     id="six"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab Six
-    </button>
+    </a>
   </li>
   <li
     class="vertical-tabs-pf-tab"
     id="seven"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab Seven
-    </button>
+    </a>
   </li>
 </ul>
 `;
@@ -242,23 +305,23 @@ exports[`Vertical Tabs renders tabs properly 1`] = `
     class="vertical-tabs-pf-tab test-vertical-tabs-tab"
     id="all"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       All
-    </button>
+    </a>
   </li>
   <li
     class="vertical-tabs-pf-tab"
     id="one"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab One
-    </button>
+    </a>
     <ul
       class="vertical-tabs-pf"
     >
@@ -266,12 +329,12 @@ exports[`Vertical Tabs renders tabs properly 1`] = `
         class="vertical-tabs-pf-tab"
         id="one-one"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab One-One
-        </button>
+        </a>
         <ul
           class="vertical-tabs-pf active-tab"
         >
@@ -279,34 +342,34 @@ exports[`Vertical Tabs renders tabs properly 1`] = `
             class="vertical-tabs-pf-tab active"
             id="one-one-one"
           >
-            <button
-              class="btn btn-link"
-              type="button"
+            <a
+              class=""
+              href="#"
             >
               Tab One-One-One
-            </button>
+            </a>
           </li>
           <li
             class="vertical-tabs-pf-tab"
             id="one-one-two"
           >
-            <button
-              class="btn btn-link"
-              type="button"
+            <a
+              class=""
+              href="#"
             >
               Tab One-One-Two
-            </button>
+            </a>
           </li>
           <li
             class="vertical-tabs-pf-tab"
             id="one-one-three"
           >
-            <button
-              class="btn btn-link"
-              type="button"
+            <a
+              class=""
+              href="#"
             >
               Tab One-One-Three
-            </button>
+            </a>
           </li>
         </ul>
       </li>
@@ -314,23 +377,23 @@ exports[`Vertical Tabs renders tabs properly 1`] = `
         class="vertical-tabs-pf-tab"
         id="one-two"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab One-Two
-        </button>
+        </a>
       </li>
       <li
         class="vertical-tabs-pf-tab"
         id="one-three"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab One-Three
-        </button>
+        </a>
       </li>
     </ul>
   </li>
@@ -338,12 +401,12 @@ exports[`Vertical Tabs renders tabs properly 1`] = `
     class="vertical-tabs-pf-tab test-tab-class"
     id="two"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab Two
-    </button>
+    </a>
     <ul
       class="vertical-tabs-pf"
     >
@@ -351,34 +414,34 @@ exports[`Vertical Tabs renders tabs properly 1`] = `
         class="vertical-tabs-pf-tab"
         id="two-one"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab Two-One
-        </button>
+        </a>
       </li>
       <li
         class="vertical-tabs-pf-tab"
         id="two-two"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab Two-Two
-        </button>
+        </a>
       </li>
       <li
         class="vertical-tabs-pf-tab"
         id="two-three"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab Two-Three
-        </button>
+        </a>
       </li>
     </ul>
   </li>
@@ -386,12 +449,12 @@ exports[`Vertical Tabs renders tabs properly 1`] = `
     class="vertical-tabs-pf-tab"
     id="three"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab Three
-    </button>
+    </a>
     <ul
       class="vertical-tabs-pf"
     >
@@ -399,23 +462,23 @@ exports[`Vertical Tabs renders tabs properly 1`] = `
         class="vertical-tabs-pf-tab"
         id="three-one"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab Three-One
-        </button>
+        </a>
       </li>
       <li
         class="vertical-tabs-pf-tab"
         id="three-two"
       >
-        <button
-          class="btn btn-link"
-          type="button"
+        <a
+          class=""
+          href="#"
         >
           Tab Three-Two
-        </button>
+        </a>
       </li>
     </ul>
   </li>
@@ -423,45 +486,45 @@ exports[`Vertical Tabs renders tabs properly 1`] = `
     class="vertical-tabs-pf-tab"
     id="four"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab Four
-    </button>
+    </a>
   </li>
   <li
     class="vertical-tabs-pf-tab"
     id="five"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab Five
-    </button>
+    </a>
   </li>
   <li
     class="vertical-tabs-pf-tab"
     id="six"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab Six
-    </button>
+    </a>
   </li>
   <li
     class="vertical-tabs-pf-tab"
     id="seven"
   >
-    <button
-      class="btn btn-link"
-      type="button"
+    <a
+      class=""
+      href="#"
     >
       Tab Seven
-    </button>
+    </a>
   </li>
 </ul>
 `;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/_mocks_/mockVerticalTabsExample.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/VerticalTabs/_mocks_/mockVerticalTabsExample.js
@@ -12,178 +12,73 @@ class MockVerticalTabsExample extends React.Component {
   };
 
   render() {
-    const { restrictTabs } = this.props;
+    const { restrictTabs, wrapStyle } = this.props;
     const { activeTabId } = this.state;
 
-    const showAll = activeTabId === 'all';
-    const isTopLevelActive =
-      showAll ||
-      activeTabId === 'one' ||
-      activeTabId === 'two' ||
-      activeTabId === 'three' ||
-      activeTabId === 'four' ||
-      activeTabId === 'five' ||
-      activeTabId === 'six' ||
-      activeTabId === 'seven';
+    const topLevelIds = ['all', 'one', 'two', 'three', 'four', 'five', 'six', 'seven'];
+
+    const renderTab = (id, title, children, props) => {
+      const childIds = React.Children.map(children, child => child.props.id);
+
+      return (
+        <VerticalTabs.Tab
+          id={id}
+          key={id}
+          title={title}
+          wrapStyle={wrapStyle}
+          onActivate={() => this.onActivateTab(id)}
+          active={activeTabId === id}
+          hasActiveDescendant={activeTabId.startsWith(id)}
+          {...props}
+        >
+          {children && (
+            <VerticalTabs restrictTabs={restrictTabs} activeTab={childIds.includes(activeTabId)}>
+              {children}
+            </VerticalTabs>
+          )}
+        </VerticalTabs.Tab>
+      );
+    };
 
     return (
-      <VerticalTabs id="vertical-tabs" restrictTabs={restrictTabs} activeTab={isTopLevelActive}>
-        <VerticalTabs.Tab id="all" title="All" onActivate={() => this.onActivateTab('all')} active={showAll} shown />
-        <VerticalTabs.Tab
-          id="one"
-          title="Tab One"
-          onActivate={() => this.onActivateTab('one')}
-          active={activeTabId === 'one'}
-          hasActiveDescendant={activeTabId.startsWith('one')}
-        >
-          <VerticalTabs
-            restrictTabs={restrictTabs}
-            activeTab={activeTabId === 'one-one' || activeTabId === 'one-two' || activeTabId === 'one-three'}
-          >
-            <VerticalTabs.Tab
-              id="one-one"
-              title="Tab One-One"
-              onActivate={() => this.onActivateTab('one-one')}
-              active={activeTabId === 'one-one'}
-              hasActiveDescendant={activeTabId.startsWith('one-one')}
-            >
-              <VerticalTabs
-                restrictTabs={restrictTabs}
-                activeTab={
-                  activeTabId === 'one-one-one' || activeTabId === 'one-one-two' || activeTabId === 'one-one-three'
-                }
-              >
-                <VerticalTabs.Tab
-                  id="one-one-one"
-                  title="Tab One-One-One"
-                  onActivate={() => this.onActivateTab('one-one-one')}
-                  active={activeTabId === 'one-one-one'}
-                />
-                <VerticalTabs.Tab
-                  id="one-one-two"
-                  title="Tab One-One-Two"
-                  onActivate={() => this.onActivateTab('one-one-two')}
-                  active={activeTabId === 'one-one-two'}
-                />
-                <VerticalTabs.Tab
-                  id="one-one-three"
-                  title="Tab One-One-Three"
-                  onActivate={() => this.onActivateTab('one-one-three')}
-                  active={activeTabId === 'one-one-three'}
-                />
-              </VerticalTabs>
-            </VerticalTabs.Tab>
-            <VerticalTabs.Tab
-              id="one-two"
-              title="Tab One-Two"
-              onActivate={() => this.onActivateTab('one-two')}
-              active={activeTabId === 'one-two'}
-              hasActiveDescendant={activeTabId.startsWith('one-two')}
-            >
-              <VerticalTabs
-                restrictTabs={restrictTabs}
-                activeTab={
-                  activeTabId === 'one-two-one' || activeTabId === 'one-two-two' || activeTabId === 'one-two-three'
-                }
-              >
-                <VerticalTabs.Tab
-                  id="one-two-one"
-                  title="Tab One-Two-One"
-                  onActivate={() => this.onActivateTab('one-two-one')}
-                  active={activeTabId === 'one-two-one'}
-                />
-                <VerticalTabs.Tab
-                  id="one-two-two"
-                  title="Tab One-Two-Two"
-                  onActivate={() => this.onActivateTab('one-two-two')}
-                  active={activeTabId === 'one-two-two'}
-                />
-                <VerticalTabs.Tab
-                  id="one-two-three"
-                  title="Tab One-Two-Three"
-                  onActivate={() => this.onActivateTab('one-two-three')}
-                  active={activeTabId === 'one-two-three'}
-                />
-              </VerticalTabs>
-            </VerticalTabs.Tab>
-            <VerticalTabs.Tab
-              id="one-three"
-              title="Tab One-Three"
-              onActivate={() => this.onActivateTab('one-three')}
-              active={activeTabId === 'one-three'}
-              hasActiveDescendant={activeTabId.startsWith('one-three')}
-            />
-          </VerticalTabs>
-        </VerticalTabs.Tab>
-        <VerticalTabs.Tab
-          id="two"
-          title="Tab Two"
-          onActivate={() => this.onActivateTab('two')}
-          active={activeTabId === 'two'}
-          hasActiveDescendant={activeTabId.startsWith('two')}
-        >
-          <VerticalTabs restrictTabs={restrictTabs} activeTab={activeTabId.startsWith('two')}>
-            <VerticalTabs.Tab
-              id="two-one"
-              title="Tab Two-One"
-              onActivate={() => this.onActivateTab('two-one')}
-              active={activeTabId === 'two-one'}
-            />
-            <VerticalTabs.Tab
-              id="two-two"
-              title="Tab Two-Two"
-              onActivate={() => this.onActivateTab('two-two')}
-              active={activeTabId === 'two-two'}
-            />
-            <VerticalTabs.Tab
-              id="two-three"
-              title="Tab Two-Three"
-              onActivate={() => this.onActivateTab('two-three')}
-              active={activeTabId === 'two-three'}
-            />
-          </VerticalTabs>
-        </VerticalTabs.Tab>
-        <VerticalTabs.Tab
-          id="three"
-          title="Tab Three"
-          onActivate={() => this.onActivateTab('three')}
-          active={activeTabId === 'three'}
-        />
-        <VerticalTabs.Tab
-          id="four"
-          title="Tab Four"
-          onActivate={() => this.onActivateTab('four')}
-          active={activeTabId === 'four'}
-        />
-        <VerticalTabs.Tab
-          id="five"
-          title="Tab Five"
-          onActivate={() => this.onActivateTab('five')}
-          active={activeTabId === 'five'}
-        />
-        <VerticalTabs.Tab
-          id="six"
-          title="Tab Six"
-          onActivate={() => this.onActivateTab('six')}
-          active={activeTabId === 'six'}
-        />
-        <VerticalTabs.Tab
-          id="seven"
-          title="Tab Seven"
-          onActivate={() => this.onActivateTab('seven')}
-          active={activeTabId === 'seven'}
-        />
+      <VerticalTabs id="vertical-tabs" restrictTabs={restrictTabs} activeTab={topLevelIds.includes(activeTabId)}>
+        {renderTab('all', 'All', null, { shown: true })}
+        {renderTab('one', 'Tab One', [
+          renderTab('one-one', 'Tab One-One', [
+            renderTab('one-one-one', 'Tab One-One-One'),
+            renderTab('one-one-two', 'Tab One-One-Two'),
+            renderTab('one-one-three', 'Tab One-One-Three')
+          ]),
+          renderTab('one-two', 'Tab One-Two', [
+            renderTab('one-two-one', 'Tab One-Two-One'),
+            renderTab('one-two-two', 'Tab One-Two-Two'),
+            renderTab('one-two-three', 'Tab One-Two-Three')
+          ]),
+          renderTab('one-three', 'Tab One-Thee')
+        ])}
+        {renderTab('two', 'Tab Two', [
+          renderTab('two-one', 'Tab Two-One'),
+          renderTab('two-two', 'Tab Two-Two'),
+          renderTab('two-three', 'Tab Two-Three')
+        ])}
+        {renderTab('three', 'Tab Three - Donec id elit non mi porta gravida at eget metus')}
+        {renderTab('four', 'Tab Four')}
+        {renderTab('five', 'Tab Five')}
+        {renderTab('six', 'Tab Six')}
+        {renderTab('seven', 'Tab Seven')}
       </VerticalTabs>
     );
   }
 }
 
 MockVerticalTabsExample.propTypes = {
-  restrictTabs: PropTypes.bool
+  restrictTabs: PropTypes.bool,
+  wrapStyle: PropTypes.oneOf(['wrap', 'truncate', 'nowrap'])
 };
 
 MockVerticalTabsExample.defaultProps = {
-  restrictTabs: false
+  restrictTabs: false,
+  wrapStyle: 'word'
 };
 
 export { MockVerticalTabsExample };
@@ -203,178 +98,73 @@ class MockVerticalTabsExample extends React.Component {
   };
 
   render() {
-    const { restrictTabs } = this.props;
+    const { restrictTabs, wrapStyle } = this.props;
     const { activeTabId } = this.state;
 
-    const showAll = activeTabId === 'all';
-    const isTopLevelActive =
-      showAll ||
-      activeTabId === 'one' ||
-      activeTabId === 'two' ||
-      activeTabId === 'three' ||
-      activeTabId === 'four' ||
-      activeTabId === 'five' ||
-      activeTabId === 'six' ||
-      activeTabId === 'seven';
+    const topLevelIds = ['all', 'one', 'two', 'three', 'four', 'five', 'six', 'seven'];
+
+    const renderTab = (id, title, children, props) => {
+      const childIds = React.Children.map(children, child => child.props.id);
+
+      return (
+        <VerticalTabs.Tab
+          id={id}
+          key={id}
+          title={title}
+          wrapStyle={wrapStyle}
+          onActivate={() => this.onActivateTab(id)}
+          active={activeTabId === id}
+          hasActiveDescendant={activeTabId.startsWith(id)}
+          {...props}
+        >
+          {children && (
+            <VerticalTabs restrictTabs={restrictTabs} activeTab={childIds.includes(activeTabId)}>
+              {children}
+            </VerticalTabs>
+          )}
+        </VerticalTabs.Tab>
+      );
+    };
 
     return (
-      <VerticalTabs id="vertical-tabs" restrictTabs={restrictTabs} activeTab={isTopLevelActive}>
-        <VerticalTabs.Tab id="all" title="All" onActivate={() => this.onActivateTab('all')} active={showAll} shown />
-        <VerticalTabs.Tab
-          id="one"
-          title="Tab One"
-          onActivate={() => this.onActivateTab('one')}
-          active={activeTabId === 'one'}
-          hasActiveDescendant={activeTabId.startsWith('one')}
-        >
-          <VerticalTabs
-            restrictTabs={restrictTabs}
-            activeTab={activeTabId === 'one-one' || activeTabId === 'one-two' || activeTabId === 'one-three'}
-          >
-            <VerticalTabs.Tab
-              id="one-one"
-              title="Tab One-One"
-              onActivate={() => this.onActivateTab('one-one')}
-              active={activeTabId === 'one-one'}
-              hasActiveDescendant={activeTabId.startsWith('one-one')}
-            >
-              <VerticalTabs
-                restrictTabs={restrictTabs}
-                activeTab={
-                  activeTabId === 'one-one-one' || activeTabId === 'one-one-two' || activeTabId === 'one-one-three'
-                }
-              >
-                <VerticalTabs.Tab
-                  id="one-one-one"
-                  title="Tab One-One-One"
-                  onActivate={() => this.onActivateTab('one-one-one')}
-                  active={activeTabId === 'one-one-one'}
-                />
-                <VerticalTabs.Tab
-                  id="one-one-two"
-                  title="Tab One-One-Two"
-                  onActivate={() => this.onActivateTab('one-one-two')}
-                  active={activeTabId === 'one-one-two'}
-                />
-                <VerticalTabs.Tab
-                  id="one-one-three"
-                  title="Tab One-One-Three"
-                  onActivate={() => this.onActivateTab('one-one-three')}
-                  active={activeTabId === 'one-one-three'}
-                />
-              </VerticalTabs>
-            </VerticalTabs.Tab>
-            <VerticalTabs.Tab
-              id="one-two"
-              title="Tab One-Two"
-              onActivate={() => this.onActivateTab('one-two')}
-              active={activeTabId === 'one-two'}
-              hasActiveDescendant={activeTabId.startsWith('one-two')}
-            >
-              <VerticalTabs
-                restrictTabs={restrictTabs}
-                activeTab={
-                  activeTabId === 'one-two-one' || activeTabId === 'one-two-two' || activeTabId === 'one-two-three'
-                }
-              >
-                <VerticalTabs.Tab
-                  id="one-two-one"
-                  title="Tab One-Two-One"
-                  onActivate={() => this.onActivateTab('one-two-one')}
-                  active={activeTabId === 'one-two-one'}
-                />
-                <VerticalTabs.Tab
-                  id="one-two-two"
-                  title="Tab One-Two-Two"
-                  onActivate={() => this.onActivateTab('one-two-two')}
-                  active={activeTabId === 'one-two-two'}
-                />
-                <VerticalTabs.Tab
-                  id="one-two-three"
-                  title="Tab One-Two-Three"
-                  onActivate={() => this.onActivateTab('one-two-three')}
-                  active={activeTabId === 'one-two-three'}
-                />
-              </VerticalTabs>
-            </VerticalTabs.Tab>
-            <VerticalTabs.Tab
-              id="one-three"
-              title="Tab One-Three"
-              onActivate={() => this.onActivateTab('one-three')}
-              active={activeTabId === 'one-three'}
-              hasActiveDescendant={activeTabId.startsWith('one-three')}
-            />
-          </VerticalTabs>
-        </VerticalTabs.Tab>
-        <VerticalTabs.Tab
-          id="two"
-          title="Tab Two"
-          onActivate={() => this.onActivateTab('two')}
-          active={activeTabId === 'two'}
-          hasActiveDescendant={activeTabId.startsWith('two')}
-        >
-          <VerticalTabs restrictTabs={restrictTabs} activeTab={activeTabId.startsWith('two')}>
-            <VerticalTabs.Tab
-              id="two-one"
-              title="Tab Two-One"
-              onActivate={() => this.onActivateTab('two-one')}
-              active={activeTabId === 'two-one'}
-            />
-            <VerticalTabs.Tab
-              id="two-two"
-              title="Tab Two-Two"
-              onActivate={() => this.onActivateTab('two-two')}
-              active={activeTabId === 'two-two'}
-            />
-            <VerticalTabs.Tab
-              id="two-three"
-              title="Tab Two-Three"
-              onActivate={() => this.onActivateTab('two-three')}
-              active={activeTabId === 'two-three'}
-            />
-          </VerticalTabs>
-        </VerticalTabs.Tab>
-        <VerticalTabs.Tab
-          id="three"
-          title="Tab Three"
-          onActivate={() => this.onActivateTab('three')}
-          active={activeTabId === 'three'}
-        />
-        <VerticalTabs.Tab
-          id="four"
-          title="Tab Four"
-          onActivate={() => this.onActivateTab('four')}
-          active={activeTabId === 'four'}
-        />
-        <VerticalTabs.Tab
-          id="five"
-          title="Tab Five"
-          onActivate={() => this.onActivateTab('five')}
-          active={activeTabId === 'five'}
-        />
-        <VerticalTabs.Tab
-          id="six"
-          title="Tab Six"
-          onActivate={() => this.onActivateTab('six')}
-          active={activeTabId === 'six'}
-        />
-        <VerticalTabs.Tab
-          id="seven"
-          title="Tab Seven"
-          onActivate={() => this.onActivateTab('seven')}
-          active={activeTabId === 'seven'}
-        />
+      <VerticalTabs id="vertical-tabs" restrictTabs={restrictTabs} activeTab={topLevelIds.includes(activeTabId)}>
+        {renderTab('all', 'All', null, { shown: true })}
+        {renderTab('one', 'Tab One', [
+          renderTab('one-one', 'Tab One-One', [
+            renderTab('one-one-one', 'Tab One-One-One'),
+            renderTab('one-one-two', 'Tab One-One-Two'),
+            renderTab('one-one-three', 'Tab One-One-Three')
+          ]),
+          renderTab('one-two', 'Tab One-Two', [
+            renderTab('one-two-one', 'Tab One-Two-One'),
+            renderTab('one-two-two', 'Tab One-Two-Two'),
+            renderTab('one-two-three', 'Tab One-Two-Three')
+          ]),
+          renderTab('one-three', 'Tab One-Thee')
+        ])}
+        {renderTab('two', 'Tab Two', [
+          renderTab('two-one', 'Tab Two-One'),
+          renderTab('two-two', 'Tab Two-Two'),
+          renderTab('two-three', 'Tab Two-Three')
+        ])}
+        {renderTab('three', 'Tab Three - Donec id elit non mi porta gravida at eget metus')}
+        {renderTab('four', 'Tab Four')}
+        {renderTab('five', 'Tab Five')}
+        {renderTab('six', 'Tab Six')}
+        {renderTab('seven', 'Tab Seven')}
       </VerticalTabs>
     );
   }
 }
 
 MockVerticalTabsExample.propTypes = {
-  restrictTabs: PropTypes.bool
+  restrictTabs: PropTypes.bool,
+  wrapStyle: PropTypes.oneOf(['wrap', 'truncate', 'nowrap'])
 };
 
 MockVerticalTabsExample.defaultProps = {
-  restrictTabs: false
+  restrictTabs: false,
+  wrapStyle: 'word'
 };
 
 export { MockVerticalTabsExample };


### PR DESCRIPTION
affects: patternfly3-react-lerna-root, patternfly-react-extensions

Changed the tab from a button to an anchor and set the width to be 100% of the li and to wrap on
long text.

ISSUES CLOSED: #663

**Link to Storybook**:
https://rawgit.com/jeff-phillips-18/patternfly-react/vertical-tabs-storybook/index.html?selectedKind=patternfly-react-extensions%2FWidgets%2FVertical%20Tabs&selectedStory=Vertical%20Tabs
