### PR TITLE
feat(components): Add "copy to clipboard" to "Forms and Controls"

### DIFF
--- a/packages/patternfly-3/patternfly-react/less/copytoclipboard.less
+++ b/packages/patternfly-3/patternfly-react/less/copytoclipboard.less
@@ -1,0 +1,12 @@
+.copytoclipboard-pf-button {
+  height: 24px;
+  width: 24px;
+}
+
+.copytoclipboard-pf-textbox {
+  width: 24px;
+}
+
+.copytoclipboard-pf-block {
+  padding: 4px;
+}

--- a/packages/patternfly-3/patternfly-react/package.json
+++ b/packages/patternfly-3/patternfly-react/package.json
@@ -27,6 +27,7 @@
     "bootstrap-slider-without-jquery": "^10.0.0",
     "breakjs": "^1.0.0",
     "classnames": "^2.2.5",
+    "copy-to-clipboard": "^3.0.8",
     "css-element-queries": "^1.0.1",
     "lodash": "^4.17.11",
     "patternfly": "^3.58.0",

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_copytoclipboard.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_copytoclipboard.scss
@@ -1,0 +1,12 @@
+.copytoclipboard-pf-button {
+  height: 24px;
+  width: 24px;
+}
+
+.copytoclipboard-pf-textbox {
+  width: 24px;
+}
+
+.copytoclipboard-pf-block {
+  padding: 4px;
+}

--- a/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/BlockBar.js
+++ b/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/BlockBar.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Panel } from 'react-bootstrap';
+import { Form, Icon, Button } from '../../index';
+import { noop } from '../../common/helpers';
+
+const BlockBar = ({ children, toggleBlock, show, text }) => (
+  <Form.FormGroup>
+    <Form.InputGroup>
+      <Form.InputGroup.Button>
+        <Button
+          style={{ height: '24px', width: '24px' }}
+          className="copytoclipboard-pf-button"
+          onClick={toggleBlock}
+          aria-label={show ? 'collapse text block' : 'expand text block'}
+        >
+          <Icon type="fa" name={show ? 'angle-down' : 'angle-right'} />
+        </Button>
+      </Form.InputGroup.Button>
+      {children}
+    </Form.InputGroup>
+    {show && (
+      <Form.FormGroup>
+        <Form.InputGroup>
+          <Panel>
+            <Panel.Body style={{ padding: '4px' }} className="copytoclipboard-pf-block">
+              {text}
+            </Panel.Body>
+          </Panel>
+        </Form.InputGroup>
+      </Form.FormGroup>
+    )}
+  </Form.FormGroup>
+);
+
+BlockBar.propTypes = {
+  /** Content to render inside the block bar */
+  children: PropTypes.node.isRequired,
+  /** Text to render inside the block panel */
+  text: PropTypes.string.isRequired,
+  /** Toggle block panel function */
+  toggleBlock: PropTypes.func,
+  /** Flag to determine whether to show the block panel */
+  show: PropTypes.bool
+};
+
+BlockBar.defaultProps = {
+  toggleBlock: noop,
+  show: false
+};
+
+export default BlockBar;

--- a/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/CopyButton.js
+++ b/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/CopyButton.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Form, Icon, Button, OverlayTrigger, Tooltip } from '../../index';
+import { noop } from '../../common/helpers';
+
+const CopyButton = ({ onCopy, copied, tooltipText, id }) => {
+  const tooltip = <Tooltip id={`tooltip-copy-to-clipboard-${id}`}>{tooltipText}</Tooltip>;
+  return (
+    <Form.InputGroup.Button>
+      <OverlayTrigger placement="top" overlay={tooltip}>
+        <Button
+          style={{ width: '24px', height: '24px' }}
+          className="copytoclipboard-pf-button"
+          onClick={onCopy}
+          aria-label={`${id} copy to clipboard button`}
+        >
+          <Icon type="fa" name={copied ? 'check' : 'paste'} />
+        </Button>
+      </OverlayTrigger>
+    </Form.InputGroup.Button>
+  );
+};
+
+CopyButton.propTypes = {
+  /** Short aria description of the copy to clipboard text */
+  id: PropTypes.string.isRequired,
+  /** Function that is triggered on copy */
+  onCopy: PropTypes.func,
+  /** Text message to display in tooltip */
+  tooltipText: PropTypes.string,
+  /** Flag to determine whether text was copied */
+  copied: PropTypes.bool
+};
+
+CopyButton.defaultProps = {
+  onCopy: noop,
+  copied: false,
+  tooltipText: 'Copy to clipboard'
+};
+
+export default CopyButton;

--- a/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/CopyTextBox.js
+++ b/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/CopyTextBox.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Form } from '../..';
+import { noop } from '../../common/helpers';
+
+const CopyTextBox = ({ innerRef, children, id }) => (
+  <Form.FormControl
+    inputRef={innerRef}
+    aria-label={id}
+    bsClass="form-control text-overflow-pf"
+    type="text"
+    value={children}
+    onChange={noop}
+    className="copytoclipboard-pf-textbox"
+    style={{ height: '24px' }}
+  />
+);
+
+CopyTextBox.propTypes = {
+  /** Reference to the input box for selecting text */
+  innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.instanceOf(Element) })]),
+  /** Short aria description of the copy to clipboard text */
+  id: PropTypes.string.isRequired,
+  /** Text to display inside the input form */
+  children: PropTypes.string.isRequired
+};
+
+CopyTextBox.defaultProps = {
+  innerRef: null
+};
+
+export default React.forwardRef(({ children, ...props }, ref) => (
+  <CopyTextBox innerRef={ref} {...props}>
+    {children}
+  </CopyTextBox>
+));

--- a/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/CopyToClipboard.js
+++ b/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/CopyToClipboard.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import CopyTextBox from './CopyTextBox';
+import CopyButton from './CopyButton';
+import BlockBar from './BlockBar';
+import { clipboardCopy } from './copy';
+import { Form } from '../../index';
+import Timer from '../../common/Timer';
+
+class CopyToClipboard extends React.Component {
+  constructor(props) {
+    super(props);
+    this.inputRef = React.createRef();
+    this.timer = new Timer();
+    this.state = {
+      copied: false,
+      show: false
+    };
+  }
+
+  render() {
+    const { delay, children, id, copyText, copiedText, block, onCopy } = this.props;
+    const { copied, show } = this.state;
+
+    const toggleBlock = () => {
+      this.setState({ show: !show });
+    };
+    const copyFunc = () => {
+      onCopy(this.inputRef.current) &&
+        this.setState({ copied: true }, () => {
+          this.timer.startTimer(() => this.setState({ copied: false }), delay);
+        });
+    };
+    const copyChilds = [
+      <CopyTextBox key={`copy-text-box-${id}`} ref={this.inputRef} id={id}>
+        {children}
+      </CopyTextBox>,
+      <CopyButton
+        key={`copy-button-${id}`}
+        onCopy={copyFunc}
+        copied={copied}
+        tooltipText={copied ? copiedText : copyText}
+        id={id}
+      />
+    ];
+    return block ? (
+      <BlockBar toggleBlock={toggleBlock} show={show} text={children}>
+        {copyChilds}
+      </BlockBar>
+    ) : (
+      <Form.InputGroup>{copyChilds}</Form.InputGroup>
+    );
+  }
+}
+
+CopyToClipboard.propTypes = {
+  /** Content to render inside the block bar */
+  children: PropTypes.node.isRequired,
+  /** Description of copied data */
+  id: PropTypes.string.isRequired,
+  /** Milliseconds to reset after copying */
+  delay: PropTypes.number,
+  /** Tooltip text displayed */
+  copyText: PropTypes.string,
+  /** Tooltip text displayed when copied */
+  copiedText: PropTypes.string,
+  /** Flag to render as block bar */
+  block: PropTypes.bool,
+  /** Copy function */
+  onCopy: PropTypes.func
+};
+
+CopyToClipboard.defaultProps = {
+  delay: 2000,
+  copyText: 'Copy to clipboard',
+  copiedText: 'Copied',
+  block: false,
+  onCopy: clipboardCopy
+};
+
+export default CopyToClipboard;

--- a/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/CopyToClipboard.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/CopyToClipboard.stories.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs } from '@storybook/addon-knobs';
+// import { withInfo } from '@storybook/addon-info';
+import { defaultTemplate } from 'storybook/decorators/storyTemplates';
+import { storybookPackageName, DOCUMENTATION_URL, STORYBOOK_CATEGORY } from 'storybook/constants/siteConstants';
+import { name } from '../../../package.json';
+import { CopyToClipboard } from './index';
+
+const CopyToClipboardStories = storiesOf(
+  `${storybookPackageName(name)}/${STORYBOOK_CATEGORY.FORMS_AND_CONTROLS}/Copy To Clipboard`,
+  module
+);
+
+const lorem = `Lorem ipsum dolor sit amet,
+consectetur adipiscing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+commodo consequat. Duis aute irure dolor in reprehenderit
+in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident,
+sunt in culpa qui officia deserunt mollit anim id est laborum.
+`;
+
+CopyToClipboardStories.addDecorator(withKnobs);
+CopyToClipboardStories.addDecorator(
+  defaultTemplate({
+    title: 'Copy to clipboard',
+    documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_FORMS}copy-to-clipboard`
+  })
+);
+
+CopyToClipboardStories.addWithInfo('Copy to clipboard', () => (
+  <CopyToClipboard delay={2000} copyText="Copy to clipboard" copiedText="Copied!" id="copy to clipboard example">
+    {lorem.slice(0, 10)}
+  </CopyToClipboard>
+));
+
+CopyToClipboardStories.addWithInfo('Copy to clipboard block bar', () => (
+  <CopyToClipboard block delay={2000} copyText="Copy to clipboard" copiedText="Copied!" id="copy to clipboard example">
+    {lorem}
+  </CopyToClipboard>
+));
+
+/*
+CopyToClipboardStories.addWithInfo('Copy to clipboard block bar', () => (
+  <div style={{ width: '50%' }}>
+    <CopyToClipboardBlockBar
+      isShown={boolean('show', false)}
+      isCopied={boolean('copied', false)}
+      onCopy={action('text was copied')}
+      onClick={action('show item')}
+      copiedText={text('tooltip text on copy', 'Copied!')}
+      copyText={text('tooltip text before copy', 'Copy to clipboard')}
+      id="inline copy to clipboard bar example"
+      ref={() => {}}
+    >
+      {text('value', lorem)}
+    </CopyToClipboardBlockBar>
+  </div>
+));
+
+CopyToClipboardStories.add(
+  'Copy to clipboard container',
+  withInfo({
+    propTablesExclude: [Form.FormGroup]
+  })(() => (
+    <div style={{ width: '40%' }}>
+      <Form.FormGroup>
+        <CopyToClipboard id="copy to clipboard example" delay={number('delay', 2000)} block={boolean('block mode', false)}>
+          {lorem}
+        </CopyToClipboard>
+      </Form.FormGroup>
+    </div>
+  ))
+);
+*/

--- a/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/CopyToClipboard.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/CopyToClipboard.test.js
@@ -1,0 +1,152 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import CopyTextBox from './CopyTextBox';
+import CopyButton from './CopyButton';
+import CopyToClipboard from './CopyToClipboard';
+
+test('copy to clipboard copy text box', () => {
+  const view = mount(<CopyTextBox id="test">This is my text</CopyTextBox>);
+  expect(view.find('input')).toHaveLength(1);
+  expect(view.find('input').props().value).toBe('This is my text');
+  expect(view.find('input').props()['aria-label']).toBe('test');
+});
+
+test('copy to clipboard copy button', () => {
+  const view = mount(<CopyButton id="test" />);
+  expect(view.find('button')).toHaveLength(1);
+  expect(view.find('button').props()['aria-label']).toBe('test copy to clipboard button');
+  expect(
+    view
+      .find('button')
+      .find('span')
+      .props().className
+  ).toBe('fa fa-paste');
+});
+
+test('copy to clipboard copied button', () => {
+  const view = mount(<CopyButton copied id="test" />);
+  expect(view.find('button')).toHaveLength(1);
+  expect(view.find('button').props()['aria-label']).toBe('test copy to clipboard button');
+  expect(
+    view
+      .find('button')
+      .find('span')
+      .props().className
+  ).toBe('fa fa-check');
+});
+
+test('copy to clipboard copy button click', () => {
+  const oncopy = jest.fn();
+  const view = mount(<CopyButton id="test" onCopy={oncopy} />);
+  expect(oncopy).not.toBeCalled();
+  view.find('button').simulate('click');
+  expect(oncopy).toBeCalled();
+});
+
+test('copy to clipboard reset delay', () => {
+  const getIcon = view =>
+    view
+      .find('button')
+      .find('span')
+      .props().className;
+  jest.useFakeTimers();
+  const oncopy = jest.fn(() => true);
+  const view = mount(
+    <CopyToClipboard onCopy={oncopy} delay={300} id="inline-test">
+      text
+    </CopyToClipboard>
+  );
+  expect(getIcon(view)).toBe('fa fa-paste');
+  view.find('button').simulate('click');
+  jest.advanceTimersByTime(299);
+  view.update();
+  expect(getIcon(view)).toBe('fa fa-check');
+  jest.advanceTimersByTime(300);
+  view.update();
+  expect(getIcon(view)).toBe('fa fa-paste');
+});
+
+test('inline copy to clipboard', () => {
+  const view = mount(<CopyToClipboard id="inline-test">This is my inline copy to clipboard</CopyToClipboard>);
+  expect(view.find('button')).toHaveLength(1);
+  expect(view.find('button').props()['aria-label']).toBe('inline-test copy to clipboard button');
+  expect(view.find('input')).toHaveLength(1);
+  expect(view.find('input').props().value).toBe('This is my inline copy to clipboard');
+  expect(view.find('input').props()['aria-label']).toBe('inline-test');
+});
+
+test('block copy to clipboard bar', () => {
+  const view = mount(
+    <CopyToClipboard block id="block-test">
+      This is my inline copy to clipboard
+    </CopyToClipboard>
+  );
+  expect(view.find('button')).toHaveLength(2);
+  expect(
+    view
+      .find('button')
+      .at(0)
+      .props()['aria-label']
+  ).toBe('expand text block');
+  expect(
+    view
+      .find('button')
+      .at(1)
+      .props()['aria-label']
+  ).toBe('block-test copy to clipboard button');
+  expect(
+    view
+      .find('button')
+      .at(0)
+      .find('span')
+      .props().className
+  ).toBe('fa fa-angle-right');
+  expect(view.find('div.panel-body')).toHaveLength(0);
+});
+
+test('block copy to clipboard bar expand', () => {
+  const view = mount(
+    <CopyToClipboard block id="block-test">
+      This is my inline copy to clipboard
+    </CopyToClipboard>
+  );
+  expect(view.find('button')).toHaveLength(2);
+  view
+    .find('button')
+    .at(0)
+    .simulate('click');
+  view.update();
+  expect(
+    view
+      .find('button')
+      .at(0)
+      .props()['aria-label']
+  ).toBe('collapse text block');
+  expect(
+    view
+      .find('button')
+      .at(0)
+      .find('span')
+      .props().className
+  ).toBe('fa fa-angle-down');
+  expect(view.find('div.panel-body')).toHaveLength(1);
+  view
+    .find('button')
+    .at(0)
+    .simulate('click');
+  view.update();
+  expect(
+    view
+      .find('button')
+      .at(0)
+      .props()['aria-label']
+  ).toBe('expand text block');
+  expect(
+    view
+      .find('button')
+      .at(0)
+      .find('span')
+      .props().className
+  ).toBe('fa fa-angle-right');
+  expect(view.find('div.panel-body')).toHaveLength(0);
+});

--- a/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/copy.js
+++ b/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/copy.js
@@ -1,0 +1,10 @@
+export const clipboardCopy = inputNode => {
+  if (!inputNode) {
+    return false;
+  }
+  inputNode.select();
+  const copiedSuccessfully = document.execCommand('copy');
+  inputNode.blur();
+  // if execCommand copy is not supported or disabled return false
+  return copiedSuccessfully;
+};

--- a/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/copy.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/copy.test.js
@@ -1,0 +1,18 @@
+import { clipboardCopy } from './copy';
+
+test('passing null does nothing', () => {
+  const spyFunc = jest.fn(() => true);
+  // Object.defineProperty(global.document, 'execCommand', { value: spyFunc });
+  expect(clipboardCopy(null)).toBe(false);
+  expect(spyFunc).not.toBeCalled();
+});
+
+test('passing input node copies its text', () => {
+  const spyFunc = jest.fn(() => true);
+  const inputNode = { select: jest.fn(), blur: jest.fn() };
+  Object.defineProperty(global.document, 'execCommand', { value: spyFunc });
+  expect(clipboardCopy(inputNode)).toBe(true);
+  expect(spyFunc).toBeCalled();
+  expect(inputNode.select).toBeCalled();
+  expect(inputNode.blur).toBeCalled();
+});

--- a/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/index.js
+++ b/packages/patternfly-3/patternfly-react/src/components/CopyToClipboard/index.js
@@ -1,0 +1,1 @@
+export { default as CopyToClipboard } from './CopyToClipboard';


### PR DESCRIPTION
affects: patternfly3-react-lerna-root, patternfly-react

**What**:
Add the `copy to clipboard` component to patternfly-3

**Link to Storybook**:
storybook can be found [here](https://rawgit.com/boaz1337/patternfly-react/copytoclipboard-storybook/index.html?selectedKind=patternfly-react%2FForms%20and%20Controls%2FCopy%20To%20Clipboard&selectedStory=Copy%20to%20clipboard%20container&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)