### PR TITLE
fix(VerticalTabs): restore vertical spacing between tabs

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/vertical-tabs.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/vertical-tabs.less
@@ -11,7 +11,7 @@
     color: @vertical-tab-pf-color;
     display: inline-block;
     font-size: 13px;
-    padding-left: 15px;
+    padding: 3px 6px 3px 15px;
     vertical-align: top;
     width: 100%;
     word-break: break-word;

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_vertical-tabs.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_vertical-tabs.scss
@@ -11,7 +11,7 @@
     color: $vertical-tab-pf-color;
     display: inline-block;
     font-size: 13px;
-    padding-left: 15px;
+    padding: 3px 6px 3px 15px;
     vertical-align: top;
     width: 100%;
     word-break: break-word;


### PR DESCRIPTION
affects: patternfly3-react-lerna-root, patternfly-react-extensions

Prior to #664, the vertical spacing between tabs was larger.  This PR restores it to what it was.

Fixes #687

![localhost_9000_catalog_ns_robb](https://user-images.githubusercontent.com/895728/46295080-3e285700-c565-11e8-93ee-31dbaff5eab5.png)
![localhost_9000_catalog_ns_robb 1](https://user-images.githubusercontent.com/895728/46295078-3e285700-c565-11e8-8780-01f35482cd6a.png)
![localhost_9000_catalog_ns_robb 2](https://user-images.githubusercontent.com/895728/46295079-3e285700-c565-11e8-8c2f-46d1734c77d0.png)

