### PR TITLE
ListView: add expanded prop to ListViewItem

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/ListView/ListView.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ListView/ListView.stories.js
@@ -61,6 +61,7 @@ stories.add(
           heading={title}
           description={description}
           stacked={boolean('Stacked', false)}
+          expanded={boolean('Expanded', false)}
           hideCloseIcon={boolean('Hide close icon', false)}
         >
           <Row>
@@ -133,6 +134,7 @@ stories.add(
           </div>
         }
         stacked={boolean('Stacked', false)}
+        expanded={boolean('Expanded', false)}
       >
         Expanded Content
       </ListView.Item>
@@ -160,6 +162,7 @@ stories.add(
           </span>
         }
         stacked={boolean('Stacked', false)}
+        expanded={boolean('Expanded', false)}
       />
       <ListView.Item
         key="item3"
@@ -181,6 +184,7 @@ stories.add(
           </ListView.InfoItem>
         ]}
         stacked={boolean('Stacked', false)}
+        expanded={boolean('Expanded', false)}
       />
       <ListView.Item
         key="item4"
@@ -193,6 +197,7 @@ stories.add(
           </ListView.InfoItem>
         ]}
         stacked={boolean('Stacked', false)}
+        expanded={boolean('Expanded', false)}
       />
       <ListView.Item
         key="item5"
@@ -214,6 +219,7 @@ stories.add(
           </ListView.InfoItem>
         ]}
         stacked={boolean('Stacked', false)}
+        expanded={boolean('Expanded', false)}
       />
     </ListView>
   ))

--- a/packages/patternfly-3/patternfly-react/src/components/ListView/ListViewItem.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ListView/ListViewItem.js
@@ -15,7 +15,12 @@ import ListViewRow from './ListViewRow';
  * renders ListViewGroupItemHeader and ListViewGroupItemContainer
  */
 class ListViewItem extends React.Component {
-  state = { expanded: false };
+  constructor(props) {
+    super(props);
+
+    this.state = { expanded: props.expanded };
+  }
+
   toggleExpanded = () => {
     const { onExpand, onExpandClose } = this.props;
     if (this.state.expanded) {
@@ -105,6 +110,8 @@ ListViewItem.propTypes = {
   children: PropTypes.node,
   /** Display the ListViewItem stacked or not */
   stacked: PropTypes.bool,
+  /** Display the ListViewItem expanded or not */
+  expanded: PropTypes.bool,
   /** Function triggered when expandable content is expanded */
   onExpand: PropTypes.func,
   /** Function triggered when expandable content is closed */
@@ -144,6 +151,7 @@ ListViewItem.defaultProps = {
   onExpand: noop,
   onExpandClose: noop,
   onCloseCompoundExpand: noop,
-  stacked: false
+  stacked: false,
+  expanded: false
 };
 export default ListViewItem;


### PR DESCRIPTION
It would be nice, if the user can set expanded state of a ListViewItem
if needed. This patch adds initiating the initial expanded state from props.

**What**:
Read the initial state of ListViewItem expanded status from props, in case the user wants to show some items expanded.

**Link to Storybook**:
https://thrix.github.io/patternfly-react/?selectedKind=patternfly-react%2FContent%20Views%2FList%20View