### PR TITLE
fix(pf-4): checkboxProps to be consistent with Checkbox.propTypes

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.d.ts
@@ -3,9 +3,9 @@ import { Omit } from '../../typeUtils';
 
 export interface CheckboxProps
   extends Omit<HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled'> {
-  isDisabled: boolean;
-  isValid: boolean;
-  onChange(checked: boolean, event: FormEvent<HTMLInputElement>): void;
+  isDisabled?: boolean;
+  isValid?: boolean;
+  onChange?(checked: boolean, event: FormEvent<HTMLInputElement>): void;
 }
 
 declare const Checkbox: React.SFC<CheckboxProps>;


### PR DESCRIPTION
affects: patternfly4-react-lerna-root, @patternfly/react-core

**What**:

Typescripts gives me error messages about not specifying `isDisabled`, `isValid` and `onChange?` although it's specified in the docs that they're not mandatory.

This commit is supposed to fix this problem.