### PR TITLE
chore(lerna-changelog): set the next version attribute appropriately

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,7 +9,7 @@
   "changelog": {
     "repo": "patternfly/patternfly-react",
     "cacheDir": ".changelog",
-    "nextVersion": "Unreleased",
+    "nextVersion": "Change Log",
     "labels": {
       "breaking change :boom:": ":boom: Breaking Change",
       "enhancement :rocket:": ":rocket: New Feature",


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Since `lerna-changelog` runs prior to `lerna publish` when generating CHANGELOG but is included w/ the [lerna publish commit](https://github.com/patternfly/patternfly-react/commit/4e2e70d51412809b30a49a26a8c4bf4cb3efa562), the log title reads `Unreleased` b/c lerna-changelog is not aware of the pending release. This was the simplest way to hook lerna-changelog w/ the current version of lerna used in this project. For this reason, we can simply change the title to something more relevant, such as "Change Log".

In the future versions of Lerna, we may be able to hook directly into the "versions" command, but setting this to something more appropriate for now.

https://github.com/lerna/lerna-changelog/issues/46

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
