### PR TITLE
fix(Pagination) - buttons are clickable when disabled

### DIFF
--- a/packages/patternfly-3/patternfly-react/less/pagination.less
+++ b/packages/patternfly-3/patternfly-react/less/pagination.less
@@ -1,0 +1,5 @@
+.pagination > li.disabled {
+  a {
+    pointer-events: none;
+  }
+}

--- a/packages/patternfly-3/patternfly-react/less/patternfly-react.less
+++ b/packages/patternfly-3/patternfly-react/less/patternfly-react.less
@@ -12,3 +12,4 @@
 @import 'type-ahead-select';
 @import 'verticalnavdivider';
 @import 'treeview';
+@import 'pagination';

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_pagination.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_pagination.scss
@@ -1,0 +1,5 @@
+.pagination > li.disabled {
+  a {
+    pointer-events: none;
+  }
+}

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_patternfly-react.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_patternfly-react.scss
@@ -12,3 +12,4 @@
 @import 'type-ahead-select';
 @import 'verticalnavdivider';
 @import 'treeview';
+@import 'pagination';


### PR DESCRIPTION
Fix pagination buttons being clickable when disabled

fix #704

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

[Storybook](https://rawgit.com/glekner/patternfly-react/fix/pagination-storybook/index.html?knob-Page=1&knob-firstPage=First%20Page&knob-Total%20items=75&knob-of=of&knob-currentPage=Current%20Page&knob-perPage=per%20page&knob-nextPage=Next%20Page&knob-View%20Type%3A=list&knob-lastPage=Last%20Page&knob-previousPage=Previous%20Page&selectedKind=patternfly-react%2FWidgets%2FPagination&selectedStory=Pagination%20row%20w%2F%20state%20manager&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs)

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
