### PR TITLE
fix(Alert): Use the correct css class name for screen readers

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Alert/Alert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/Alert.js
@@ -51,7 +51,7 @@ const Alert = ({
 }) => {
   const readerTitle = (
     <React.Fragment>
-      <span className={css(accessibleStyles.srOnly)}>{capitalize(AlertVariant[variant])}: </span>
+      <span className={css(accessibleStyles.uSrOnly)}>{capitalize(AlertVariant[variant])}: </span>
       {title}
     </React.Fragment>
   );


### PR DESCRIPTION
**What**:

It looks like the "Danger" prefix was shown because the wrong class name was not set correctly.
Instead of ".pf-u-sr-only" the class name was an empty string and the reason for that
is because of a "typo": `accessibleStyles.srOnly` instead of `accessibleStyles.uSrOnly` .

![screenshot-2018-10-4 koku ui](https://user-images.githubusercontent.com/2453279/46494669-144c8a00-c81c-11e8-8a9c-2f729f455957.png)


**Additional issues**:
closes #601 