### PR TITLE
fix(backgroundImage): import images to override css paths

### DIFF
--- a/packages/patternfly-4/react-core/build/copyStyles.js
+++ b/packages/patternfly-4/react-core/build/copyStyles.js
@@ -33,6 +33,7 @@ ast.stylesheet.rules = ast.stylesheet.rules.filter(rule => {
   }
 });
 
+copySync(join(pfDir, 'assets/images'), join(stylesDir, 'assets/images'));
 copySync(join(pfDir, 'assets/fonts'), join(stylesDir, 'assets/fonts'), {
   filter(src) {
     return !ununsedFontFilesRegExt.test(src);

--- a/packages/patternfly-4/react-core/package.json
+++ b/packages/patternfly-4/react-core/package.json
@@ -46,7 +46,7 @@
     "@patternfly/react-tokens": "^1.0.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly-next": "1.0.55",
+    "@patternfly/patternfly-next": "1.0.57",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.d.ts
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.d.ts
@@ -1,7 +1,31 @@
 import { SFC, HTMLProps, ReactNode } from 'react';
+import { OneOf } from '../../typeUtils';
+
+export const BackgroundImageSrc: {
+  lg: 'lg',
+  md: 'md',
+  md2x: 'md2x',
+  sm: 'sm',
+  sm2x: 'sm2x',
+  xl: 'xl',
+  xs: 'xs',
+  xs2x: 'xs2x',
+  filter: 'filter'
+};
 
 export interface BackgroundImageProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
+  src: string | {
+    lg?: string;
+    md?: string;
+    md2x?: string;
+    sm?: string;
+    sm2x?: string;
+    xl?: string;
+    xs?: string;
+    xs2x?: string;
+    filter?: string;
+  };
 }
 
 declare const BackgroundImage: SFC<BackgroundImageProps>;

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.docs.js
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.docs.js
@@ -1,10 +1,13 @@
-import { BackgroundImage } from '@patternfly/react-core';
+import { BackgroundImage, BackgroundImageSrc } from '@patternfly/react-core';
 import SimpleBackgroundImage from './examples/SimpleBackgroundImage';
 
 export default {
   title: 'Background Image',
   components: {
     BackgroundImage
+  },
+  enumValues: {
+    'Object.values(BackgroundImageSrc)': Object.values(BackgroundImageSrc)
   },
   examples: [SimpleBackgroundImage],
   fullPageOnly: true

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.js
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.js
@@ -1,14 +1,66 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { css } from '@patternfly/react-styles';
+import { css, StyleSheet } from '@patternfly/react-styles';
 import styles from '@patternfly/patternfly-next/components/BackgroundImage/background-image.css';
+
+/* eslint-disable camelcase */
+import {
+  c_background_image_BackgroundImage_lg,
+  c_background_image_BackgroundImage_md,
+  c_background_image_BackgroundImage_md_2x,
+  c_background_image_BackgroundImage_sm,
+  c_background_image_BackgroundImage_sm_2x,
+  c_background_image_BackgroundImage_xl,
+  c_background_image_BackgroundImage_xs,
+  c_background_image_BackgroundImage_xs_2x,
+  c_background_image_Filter
+} from '@patternfly/react-tokens';
+
+export const BackgroundImageSrc = {
+  lg: 'lg',
+  md: 'md',
+  md2x: 'md2x',
+  sm: 'sm',
+  sm2x: 'sm2x',
+  xl: 'xl',
+  xs: 'xs',
+  xs2x: 'xs2x',
+  filter: 'filter'
+};
+
+const variableMap = {
+  [BackgroundImageSrc.lg]: c_background_image_BackgroundImage_lg.name,
+  [BackgroundImageSrc.md]: c_background_image_BackgroundImage_md.name,
+  [BackgroundImageSrc.md2x]: c_background_image_BackgroundImage_md_2x.name,
+  [BackgroundImageSrc.sm]: c_background_image_BackgroundImage_sm.name,
+  [BackgroundImageSrc.sm2x]: c_background_image_BackgroundImage_sm_2x.name,
+  [BackgroundImageSrc.xl]: c_background_image_BackgroundImage_xl.name,
+  [BackgroundImageSrc.xs]: c_background_image_BackgroundImage_xs.name,
+  [BackgroundImageSrc.xs2x]: c_background_image_BackgroundImage_xs_2x.name,
+  [BackgroundImageSrc.filter]: c_background_image_Filter.name
+};
 
 export const propTypes = {
   /** Content rendered inside the background */
   children: PropTypes.node,
   /** Additional classes added to the background. */
-  className: PropTypes.string
+  className: PropTypes.string,
+  /** Override image styles using a string or BackgroundImageSrc */
+  src: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({
+      lg: PropTypes.string,
+      md: PropTypes.string,
+      md2x: PropTypes.string,
+      sm: PropTypes.string,
+      sm2x: PropTypes.string,
+      xl: PropTypes.string,
+      xs: PropTypes.string,
+      xs2x: PropTypes.string,
+      filter: PropTypes.string
+    })
+  ]).isRequired
 };
 
 export const defaultProps = {
@@ -16,11 +68,34 @@ export const defaultProps = {
   className: ''
 };
 
-const BackgroundImage = ({ className, children, ...props }) => (
-  <div {...props} className={css(styles.backgroundImage, className)}>
-    {children}
-  </div>
-);
+const BackgroundImage = ({ className, children, src, ...props }) => {
+  // Default string value to handle all sizes
+  const variableOverrides =
+    typeof src === 'string'
+      ? Object.keys(BackgroundImageSrc).reduce(
+          (prev, size) => ({
+            ...prev,
+            [BackgroundImageSrc[size]]: src
+          }),
+          {}
+        )
+      : src;
+
+  const bgStyles = StyleSheet.create({
+    bgOverrides: `&.pf-c-background-image {
+      ${Object.keys(variableOverrides).reduce(
+        (prev, size) => `${prev.length ? prev : ''}${variableMap[size]}: url('${variableOverrides[size]}');`,
+        {}
+      )}
+    }`
+  });
+
+  return (
+    <div className={css(styles.backgroundImage, bgStyles.bgOverrides, className)} >
+      {children}
+    </div>
+  );
+};
 
 BackgroundImage.propTypes = propTypes;
 BackgroundImage.defaultProps = defaultProps;

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.test.js
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.test.js
@@ -1,10 +1,27 @@
-import BackgroundImage from './BackgroundImage';
+import BackgroundImage, { BackgroundImageSrc } from './BackgroundImage';
 import React from 'react';
 import { shallow } from 'enzyme';
 
+const images = {
+  [BackgroundImageSrc.lg]: '/assets/images/pfbg_1200.jpg',
+  [BackgroundImageSrc.md]: '/assets/images/pfbg_992.jpg',
+  [BackgroundImageSrc.md2x]: '/assets/images/pfbg_992@2x.jpg',
+  [BackgroundImageSrc.sm]: '/assets/images/pfbg_768.jpg',
+  [BackgroundImageSrc.sm2x]: '/assets/images/pfbg_768@2x.jpg',
+  [BackgroundImageSrc.xl]: '/assets/images/pfbg_2000.jpg',
+  [BackgroundImageSrc.xs]: '/assets/images/pfbg_576.jpg',
+  [BackgroundImageSrc.xs2x]: '/assets/images/pfbg_576@2x.jpg',
+  [BackgroundImageSrc.filter]: '/assets/images/background-filter.svg'
+};
+
 Object.values([true, false]).forEach(isRead => {
   test(`BackgroundImage`, () => {
-    const view = shallow(<BackgroundImage />);
+    const view = shallow(<BackgroundImage src={images} />);
     expect(view).toMatchSnapshot();
   });
+});
+
+test('allows passing in a single string as the image src', () => {
+  const view = shallow(<BackgroundImage src={images.xl} />);
+  expect(view).toMatchSnapshot();
 });

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/__snapshots__/BackgroundImage.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/__snapshots__/BackgroundImage.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BackgroundImage 1`] = `
-.pf-c-background-image {
+.pf-c-background-image.css-jrvmr5 {
   display: block;
   position: fixed;
   top: 0px;
@@ -17,12 +17,12 @@ exports[`BackgroundImage 1`] = `
 }
 
 <div
-  className="pf-c-background-image"
+  className="pf-c-background-image css-jrvmr5"
 />
 `;
 
 exports[`BackgroundImage 2`] = `
-.pf-c-background-image {
+.pf-c-background-image.css-jrvmr5 {
   display: block;
   position: fixed;
   top: 0px;
@@ -38,6 +38,27 @@ exports[`BackgroundImage 2`] = `
 }
 
 <div
-  className="pf-c-background-image"
+  className="pf-c-background-image css-jrvmr5"
+/>
+`;
+
+exports[`allows passing in a single string as the image src 1`] = `
+.pf-c-background-image.css-1eio177 {
+  display: block;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  z-index: -1;
+  width: 100%;
+  height: 100%;
+  background-color: #393f44;
+  background-image: url(../../assets/images/pfbg_576.jpg);
+  filter: url("../../assets/images/background-filter.svg#image_overlay");
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
+<div
+  className="pf-c-background-image css-1eio177"
 />
 `;

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/examples/SimpleBackgroundImage.js
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/examples/SimpleBackgroundImage.js
@@ -1,12 +1,24 @@
 import React from 'react';
-import { BackgroundImage } from '@patternfly/react-core';
+import { BackgroundImage, BackgroundImageSrc } from '@patternfly/react-core';
+
+const images = {
+  [BackgroundImageSrc.lg]: '/assets/images/pfbg_1200.jpg',
+  [BackgroundImageSrc.md]: '/assets/images/pfbg_992.jpg',
+  [BackgroundImageSrc.md2x]: '/assets/images/pfbg_992@2x.jpg',
+  [BackgroundImageSrc.sm]: '/assets/images/pfbg_768.jpg',
+  [BackgroundImageSrc.sm2x]: '/assets/images/pfbg_768@2x.jpg',
+  [BackgroundImageSrc.xl]: '/assets/images/pfbg_2000.jpg',
+  [BackgroundImageSrc.xs]: '/assets/images/pfbg_576.jpg',
+  [BackgroundImageSrc.xs2x]: '/assets/images/pfbg_576@2x.jpg',
+  [BackgroundImageSrc.filter]: '/assets/images/background-filter.svg'
+};
 
 class SimpleBackgroundImage extends React.Component {
   static title = 'Simple Background Image';
 
   render() {
-    return <BackgroundImage />;
+    return <BackgroundImage src={images} />;
   }
-}
+};
 
 export default SimpleBackgroundImage;

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/index.d.ts
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/index.d.ts
@@ -1,1 +1,1 @@
-export { default as BackgroundImage, BackgroundImageProps } from './BackgroundImage';
+export { default as BackgroundImage, BackgroundImageSrc } from './BackgroundImage';

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/index.js
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/index.js
@@ -1,1 +1,1 @@
-export { default as BackgroundImage } from './BackgroundImage';
+export { default as BackgroundImage, BackgroundImageSrc } from './BackgroundImage';

--- a/packages/patternfly-4/react-styles/src/StyleSheet.js
+++ b/packages/patternfly-4/react-styles/src/StyleSheet.js
@@ -9,14 +9,19 @@ import {
 } from './utils';
 
 export const StyleSheet = {
-  create: styleObj =>
-    Object.keys(styleObj).reduce(
-      (prev, key) => ({
-        ...prev,
-        [key]: emotionCSS(styleObj[key])
-      }),
-      {}
-    ),
+  create(styleObj) {
+    const keys = Object.keys(styleObj);
+    if (keys.length > 0) {
+      return keys.reduce(
+        (prev, key) => ({
+          ...prev,
+          [key]: emotionCSS(styleObj[key])
+        }),
+        {}
+      );
+    }
+    return emotionCSS(styleObj);
+  },
   parse(input) {
     const classes = getCSSClasses(input);
     if (!classes) {

--- a/packages/patternfly-4/react-tokens/package.json
+++ b/packages/patternfly-4/react-tokens/package.json
@@ -27,7 +27,7 @@
     "build": "node build/generateTokens.js"
   },
   "devDependencies": {
-    "@patternfly/patternfly-next": "1.0.55",
+    "@patternfly/patternfly-next": "1.0.57",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -330,6 +330,10 @@
   version "1.0.55"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.55.tgz#67016ea68a010e382247b3e2fe17d171e4e96602"
 
+"@patternfly/patternfly-next@1.0.57":
+  version "1.0.57"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.57.tgz#8facd55ce1b337cef55aaf526d792b251f11bd39"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -4578,7 +4582,7 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
-cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@^0.3.4:
+cssom@0.3.4, cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
 
@@ -5252,19 +5256,19 @@ entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
 enzyme-adapter-react-16.3@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16.3/-/enzyme-adapter-react-16.3-1.2.0.tgz#4e197fe7ea324ceae3e4171f30492dc5f813b079"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16.3/-/enzyme-adapter-react-16.3-1.3.0.tgz#4e8ad4c2c885469311b30786a78e1dd9e803758e"
   dependencies:
-    enzyme-adapter-utils "^1.6.0"
+    enzyme-adapter-utils "^1.8.0"
     function.prototype.name "^1.1.0"
     object.assign "^4.1.0"
     object.values "^1.0.4"
     prop-types "^15.6.2"
-    react-is "^16.4.2"
+    react-is "^16.5.2"
     react-reconciler "^0.7.0"
     react-test-renderer "~16.3.0-0"
 
-enzyme-adapter-utils@^1.6.0:
+enzyme-adapter-utils@^1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.8.1.tgz#a927d840ce2c14b42892a533aec836809d4e022b"
   dependencies:
@@ -12315,7 +12319,7 @@ react-is@^16.3.2:
   version "16.4.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.0.tgz#cc9fdc855ac34d2e7d9d2eb7059bbc240d35ffcf"
 
-react-is@^16.4.2:
+react-is@^16.5.2:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
 


### PR DESCRIPTION
Since we import pf-next CSS into each component, we need a way to override the image paths generated by pf-next -- those paths are not valid for react-core. In addition, the imported CSS is wrapped by JavaScript. In order to load those image paths, each application would need to host their own images.

For pf-next, I was able to create variables to allow the image paths of `pf-c-background-image` to be overridden. See PR https://github.com/patternfly/patternfly-next/pull/776. Now the backgroundImage component can accept image paths to help override those patternfly-next styles.

Note that I've ensured the backgroundImage component works with the react-docs examples in addition to the Koku UI login page.

Koku UI Login Example:
![screen shot 2018-10-04 at 5 21 34 pm](https://user-images.githubusercontent.com/17481322/46503839-156cbf80-c7fa-11e8-862b-246bd67940d6.png)
