### PR TITLE
chore(react-core, react-docs): added ability to add demos to react-docs.

### DIFF
--- a/packages/patternfly-4/react-core/.babelrc
+++ b/packages/patternfly-4/react-core/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": ["../.babelrc.js"],
+  "ignore": ["demos"],
   "env": {
     "production:esm": {
       "plugins": [

--- a/packages/patternfly-4/react-core/src/demos/README.md
+++ b/packages/patternfly-4/react-core/src/demos/README.md
@@ -1,0 +1,1 @@
+This folder contains demos that show case the PatternFly components used in a variety of use cases. Demos should be placed in a sub folder with the name of the demo. For example a demo for PageLayout would found in src/demos/PageLayout.

--- a/packages/patternfly-4/react-docs/gatsby-node.js
+++ b/packages/patternfly-4/react-docs/gatsby-node.js
@@ -34,7 +34,7 @@ exports.modifyWebpackConfig = ({ config, stage }) => {
   return config;
 };
 
-const componentPathRegEx = /(components|layouts)\//;
+const componentPathRegEx = /(components|layouts|demos)\//;
 
 exports.onCreateNode = ({ node, boundActionCreators }) => {
   const { createNodeField } = boundActionCreators;

--- a/packages/patternfly-4/react-docs/src/components/navigation/navigation.js
+++ b/packages/patternfly-4/react-docs/src/components/navigation/navigation.js
@@ -14,12 +14,14 @@ const routeShape = PropTypes.shape({
 
 const propTypes = {
   componentRoutes: PropTypes.arrayOf(routeShape),
-  layoutRoutes: PropTypes.arrayOf(routeShape)
+  layoutRoutes: PropTypes.arrayOf(routeShape),
+  demoRoutes: PropTypes.arrayOf(routeShape)
 };
 
 const defaultProps = {
   componentRoutes: [],
-  layoutRoutes: []
+  layoutRoutes: [],
+  demoRoutes: []
 };
 
 class Navigation extends React.Component {
@@ -37,13 +39,15 @@ class Navigation extends React.Component {
   };
 
   render() {
-    const { componentRoutes, layoutRoutes } = this.props;
+    const { componentRoutes, layoutRoutes, demoRoutes } = this.props;
     const { searchValue } = this.state;
     const searchRE = new RegExp(searchValue, 'i');
 
     const filteredComponentRoutes = componentRoutes.filter(c => searchRE.test(c.label));
 
     const filteredLayoutRoutes = layoutRoutes.filter(c => searchRE.test(c.label));
+
+    const filteredDemoRoutes = demoRoutes.filter(c => searchRE.test(c.label));
 
     return (
       <div className={css(styles.navigation)}>
@@ -78,6 +82,15 @@ class Navigation extends React.Component {
           {Boolean(filteredLayoutRoutes.length) && (
             <NavigationItemGroup title="Layouts">
               {filteredLayoutRoutes.map(route => (
+                <NavigationItem key={route.label} to={route.to}>
+                  {route.label}
+                </NavigationItem>
+              ))}
+            </NavigationItemGroup>
+          )}
+          {Boolean(filteredDemoRoutes.length) && (
+            <NavigationItemGroup title="Demos">
+              {filteredDemoRoutes.map(route => (
                 <NavigationItem key={route.label} to={route.to}>
                   {route.label}
                 </NavigationItem>

--- a/packages/patternfly-4/react-docs/src/layouts/index.js
+++ b/packages/patternfly-4/react-docs/src/layouts/index.js
@@ -20,15 +20,26 @@ const propTypes = {
 };
 
 const Layout = ({ children, data }) => {
-  const componentRoutes = data.componentPages.edges.map(e => ({
-    to: e.node.path,
-    label: e.node.fields.label
-  }));
+  const componentRoutes = data.componentPages
+    ? data.componentPages.edges.map(e => ({
+        to: e.node.path,
+        label: e.node.fields.label
+      }))
+    : [];
 
-  const layoutRoutes = data.layoutPages.edges.map(e => ({
-    to: e.node.path,
-    label: e.node.fields.label
-  }));
+  const layoutRoutes = data.layoutPages
+    ? data.layoutPages.edges.map(e => ({
+        to: e.node.path,
+        label: e.node.fields.label
+      }))
+    : [];
+
+  const demoRoutes = data.demoPages
+    ? data.demoPages.edges.map(e => ({
+        to: e.node.path,
+        label: e.node.fields.label
+      }))
+    : [];
 
   return (
     <React.Fragment>
@@ -41,7 +52,9 @@ const Layout = ({ children, data }) => {
       </Helmet>
       <Page
         title="Patternfly React"
-        navigation={<Navigation componentRoutes={componentRoutes} layoutRoutes={layoutRoutes} />}
+        navigation={
+          <Navigation componentRoutes={componentRoutes} layoutRoutes={layoutRoutes} demoRoutes={demoRoutes} />
+        }
       >
         {children()}
       </Page>
@@ -72,6 +85,16 @@ export const query = graphql`
       filter: { path: { glob: "**/layouts/*" } }
       sort: { fields: [fields___label], order: ASC }
     ) {
+      edges {
+        node {
+          path
+          fields {
+            label
+          }
+        }
+      }
+    }
+    demoPages: allSitePage(filter: { path: { glob: "**/demos/*" } }, sort: { fields: [fields___label], order: ASC }) {
       edges {
         node {
           path


### PR DESCRIPTION
affects: @patternfly/react-core, @patternfly/react-docs

ISSUES CLOSED: #690

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:  Updates to add support to allow demo section for react documentation.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:  Updated react-core so that the demo section is excluded from the distribution.

<!-- feel free to add additional comments -->
