### PR TITLE
fix(Alert): Use the correct css class name for screen readers

### DIFF
--- a/packages/patternfly-4/react-core/package.json
+++ b/packages/patternfly-4/react-core/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "dependencies": {
     "@patternfly/react-icons": "^2.5.0",
-    "@patternfly/react-styles": "^2.0.0",
+    "@patternfly/react-styles": "^2.1.0",
     "exenv": "^1.2.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
closes #601

react-core is using an old version of react-styles which does not parse class name: "pf-u-something" to "something" but to "uSomething".

To fix this problem updating react-styles to 2.1.x in package.json solves the problem.
