### PR TITLE
fix(CatalogTileView): Fix to not render hidden tiles in catalog tile view categories

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
@@ -97,19 +97,6 @@
   flex-wrap: wrap;
   overflow: hidden;
   margin-top: 10px;
-  max-height:   ~"calc(3 * #{@catalog-tile-pf-total-height})";
-
-  @media (min-width: @screen-sm-min) {
-    max-height: ~"calc(2 * #{@catalog-tile-pf-total-height})";
-  }
-
-  @media (min-width: @screen-md-min) {
-    max-height: @catalog-tile-pf-total-height;
-  }
-
-  &.view-all {
-    max-height: initial;
-  }
 
   [class*='col-'] {
     padding: 0 20px 0 0;

--- a/packages/patternfly-3/patternfly-react-extensions/less/variables.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/variables.less
@@ -1,6 +1,5 @@
 @catalog-tile-pf-height:                230px;
 @catalog-tile-pf-width:                 220px;
 @catalog-tile-pf-margin-bottom:         15px;
-@catalog-tile-pf-total-height:          ~"calc(@{catalog-tile-pf-height} + @{catalog-tile-pf-margin-bottom} - 2px)";
 @vertical-tab-pf-color:                 initial;
 @vertical-tab-pf-active-color:          @color-pf-blue-400;

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
@@ -41,8 +41,8 @@
     font-size: 16px;
     padding-left: 5px;
 
-    >.fa,
-    >.pficon {
+    > .fa,
+    > .pficon {
       vertical-align: top;
     }
   }
@@ -95,21 +95,7 @@
 .catalog-tile-view-pf-category-body {
   display: flex;
   flex-wrap: wrap;
-  overflow: hidden;
   margin-top: 10px;
-  max-height: calc(3 * #{$catalog-tile-pf-total-height});
-
-  @media (min-width: $screen-sm-min) {
-    max-height: calc(2 * #{$catalog-tile-pf-total-height});
-  }
-
-  @media (min-width: $screen-md-min) {
-    max-height: $catalog-tile-pf-total-height;
-  }
-
-  &.view-all {
-    max-height: initial;
-  }
 
   [class*='col-'] {
     padding: 0 20px 0 0;

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_variables.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_variables.scss
@@ -1,6 +1,5 @@
 $catalog-tile-pf-height:                230px;
 $catalog-tile-pf-width:                 220px;
 $catalog-tile-pf-margin-bottom:         15px;
-$catalog-tile-pf-total-height:          calc(#{$catalog-tile-pf-height} + #{$catalog-tile-pf-margin-bottom} - 2px);
 $vertical-tab-pf-color:                 initial;
 $vertical-tab-pf-active-color:          $color-pf-blue-400;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.js
@@ -103,6 +103,8 @@ CatalogTile.defaultProps = {
   truncateDescriptionFn: null
 };
 
+CatalogTile.displayName = 'CatalogTile';
+
 CatalogTile.Badge = CatalogTileBadge;
 
 export default CatalogTile;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTileView/CatalogTileViewCategory.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTileView/CatalogTileViewCategory.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Button, debounce, noop } from 'patternfly-react';
+import { Button, debounce, filterChildren, hasDisplayName, noop } from 'patternfly-react';
 import { ResizeSensor } from 'css-element-queries';
 import Break from 'breakjs';
+import CatalogTile from '../CatalogTile/CatalogTile';
 
 const layout =
   window && typeof window.matchMedia === 'function'
@@ -57,7 +58,12 @@ class CatalogTileViewCategory extends React.Component {
     const { children, className, title, totalItems, viewAllText, viewAll, onViewAll, ...props } = this.props;
     const { numShown, rightSpacerWidth } = this.state;
     const classes = classNames('catalog-tile-view-pf-category', className);
-    const bodyClasses = classNames('catalog-tile-view-pf-category-body', { 'view-all': viewAll });
+
+    // Only show the tiles that fit in a single row, unless viewAll is specified
+    let catalogTiles = filterChildren(children, child => hasDisplayName(child, CatalogTile.displayName));
+    if (!viewAll && numShown && numShown < totalItems) {
+      catalogTiles = catalogTiles.slice(0, numShown);
+    }
 
     return (
       <div className={classes} {...props} ref={this.handleRef}>
@@ -77,7 +83,7 @@ class CatalogTileViewCategory extends React.Component {
               </span>
             )}
         </div>
-        <div className={bodyClasses}>{children}</div>
+        <div className="catalog-tile-view-pf-category-body">{catalogTiles}</div>
       </div>
     );
   }

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTileView/__snapshots__/CatalogTileView.test.js.snap
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTileView/__snapshots__/CatalogTileView.test.js.snap
@@ -286,7 +286,7 @@ exports[`CatalogTile renders properly 1`] = `
       </span>
     </div>
     <div
-      class="catalog-tile-view-pf-category-body view-all"
+      class="catalog-tile-view-pf-category-body"
     >
       <div
         class="catalog-tile-pf featured"


### PR DESCRIPTION
When a catalog was showing a limited set of tiles, the hidden tiles were still being rendered but not shown due to the height limitation on the container. This allowed the hidden tiles' text to still be considered in the browsers find component.

This PR prevents the category from rendering tiles that are not shown.

@serenamarie125 