### PR TITLE
fix(Alert): [TS] action type is string while it should've been node

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Alert/Alert.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Alert/Alert.d.ts
@@ -1,5 +1,5 @@
 import { SFC, HTMLProps, ReactNode } from 'react';
-import { OneOf } from '../../typeUtils';
+import { OneOf, Omit } from '../../typeUtils';
 
 export const AlertVariant: {
   success: 'success';
@@ -8,9 +8,10 @@ export const AlertVariant: {
   info: 'info';
 };
 
-export interface AlertProps extends HTMLProps<HTMLDivElement> {
+export interface AlertProps extends Omit<HTMLProps<HTMLDivElement>, 'action'> {
   variant: OneOf<typeof AlertVariant, keyof typeof AlertVariant>;
   children?: ReactNode;
+  action?: ReactNode;
 }
 
 declare const Alert: SFC<AlertProps>;


### PR DESCRIPTION
When adding an action button to Alert, Typescript fails to compile saying action is supposed to be a string.

![ts_fix](https://user-images.githubusercontent.com/2453279/46682292-d4a7e880-cbf5-11e8-8339-00a88d751388.png)

This commit fixes Alert.d.ts so action accepts ReactNode.
