### PR TITLE
docs(custom-icon): describe how to add custom icons

### DIFF
--- a/packages/react-icons/README.md
+++ b/packages/react-icons/README.md
@@ -16,3 +16,13 @@ For a list of the available icons please refer to the [PatternFly React Docs](ht
 ## Adding Icons
 
 Icons for this package are generated from the `@fortawesome/free-solid-svg-icons` package. To add more to what is generated, modify the [icons.js](./build/icons.js) file in the build folder.
+
+If you have some custom icon defined by svg path the best way to add such icon to this repository is to add it's path definition in [pfIcons.js](./build/pfIcons.js) file in the build folder.
+```JS
+module.exports = {
+  pfIcons: {
+    // ... other icon defintions
+    bigPlus: {width: 1024, height: 1024, svgPathData: 'M2 1 h1 v1 h1 v1 h-1 v1 h-1 v-1 h-1 v-1 h1 z'}
+  }
+}
+```


### PR DESCRIPTION
affects: @patternfly/react-icons
**What**:

Documentation about how to write custom icons as svg path.

**Additional issues**:
closes: https://github.com/patternfly/patternfly-react/issues/623
