### PR TITLE
fix(doc): list full steps required to start pf4 dev environment

### DIFF
--- a/packages/patternfly-4/react-core/README.md
+++ b/packages/patternfly-4/react-core/README.md
@@ -64,7 +64,7 @@ Note: All commands below assume you are on the root directory in this repository
 Run to install all the dependencies
 
 ```sh
-yarn bootstrap
+yarn && yarn bootstrap && yarn build && yarn build:docs
 ```
 
 ### Running
@@ -72,7 +72,7 @@ yarn bootstrap
 To start the site locally.
 
 ```sh
-yarn start:docs
+yarn start:pf4
 ```
 
 ### Building


### PR DESCRIPTION
This PR makes a small adjustment to the readme for FP4. Users who are first getting started with PF4 would be disappointed to find that [the first few steps mentioned in our docs](https://github.com/patternfly/patternfly-react/blob/master/packages/patternfly-4/react-core/README.md#documentation) simply do not work as described. With these updates in place, users can follow the steps as described, without being met with issues along the way.

**What**: Improve the getting started docs

**Additional issues**: https://github.com/patternfly/patternfly-react/issues/729
