### PR TITLE
fix(table-grid): use package import rather than relative path in TableGrid

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/TableGridHead.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/TableGrid/TableGridHead.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Button, Grid, Icon, OverlayTrigger, noop } from 'patternfly-react';
-import { Tooltip } from '../../../../patternfly-react/src/components/Tooltip';
+import { Button, Grid, Icon, OverlayTrigger, Tooltip, noop } from 'patternfly-react';
 
 /**
  * TableGridHead Component for PatternFly


### PR DESCRIPTION


<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
I am having issues consuming TableGrid downstream due to the following error:
```
ERROR in ./node_modules/patternfly-react-extensions/dist/esm/components/TableGrid/TableGridHead.js
Module not found: Error: Can't resolve '../../../../patternfly-react/src/components/Tooltip' in '/Users/priley/GitHub/web-ui/frontend/node_modules/patternfly-react-extensions/dist/esm/components/TableGrid'
```

This fixes that by consuming Tooltip from `patternfly-react` instead.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
