### PR TITLE
feat(PF4-Dropdown): Dropdown keyboard interaction

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.js
@@ -53,18 +53,35 @@ const defaultProps = {
 
 class Dropdown extends React.Component {
   state = {
-    focusedItemRef: null
+    focusedItemRef: null,
+    focusOnReentry: null
+  };
+
+  componentDidUpdate = (prevProps, prevState) => {
+    if (prevState.focusOnReentry !== this.state.focusOnReentry && !this.state.focusOnReentry) {
+      prevState.focusOnReentry.focus();
+    }
   };
 
   setFocusedItemRef = focusedItemRef => this.setState({ focusedItemRef });
 
-  handleOnFocus = () => this.setState({ focusedItemRef: this.parentRef });
+  handleOnFocus = () => {
+    const { focusOnReentry } = this.state;
+
+    if (focusOnReentry) {
+      this.setFocusedItemRef(focusOnReentry);
+      this.setState({ focusOnReentry: null });
+      return;
+    }
+
+    this.setState({ focusedItemRef: this.parentRef });
+  };
 
   handleOnKeyDown = e => {
     const { focusedItemRef } = this.state;
 
     if (e.key === 'Tab' && !e.shiftKey && focusedItemRef === this.menuRef.lastChild) {
-      this.setState({ focusedItemRef: null });
+      this.setState({ focusedItemRef: null, focusOnReentry: this.menuRef.lastChild });
     }
     if (e.key === 'Tab' && e.shiftKey && focusedItemRef === this.parentRef) {
       this.setState({ focusedItemRef: null });
@@ -94,7 +111,12 @@ class Dropdown extends React.Component {
       >
         {toggle &&
           Children.map(toggle, oneToggle =>
-            cloneElement(oneToggle, { parentRef: this.parentRef, focusedItemRef: this.state.focusedItemRef, isOpen })
+            cloneElement(oneToggle, {
+              parentRef: this.parentRef,
+              focusedItemRef: this.state.focusedItemRef,
+              focusOnReentry: this.state.focusOnReentry,
+              isOpen
+            })
           )}
         <DropdownMenu
           isOpen={isOpen && focusedItemRef}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.test.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.test.js
@@ -150,4 +150,36 @@ describe('API', () => {
     expect(mockToggle.mock.calls).toHaveLength(0);
     expect(mockSelect.mock.calls).toHaveLength(1);
   });
+
+  test('tabbing forward out of menu closes dropdown', () => {
+    const view = mount(
+      <Dropdown id="Dropdown" isOpen>
+        <DropdownItem>Link</DropdownItem>
+      </Dropdown>
+    );
+    view
+      .find(DropdownItem)
+      .childAt(0)
+      .simulate('focus');
+    view.simulate('keydown', { key: 'Tab' });
+
+    expect(view.find('.pf-c-dropdown').hasClass('pf-m-expanded')).toBeFalsy();
+    view.unmount();
+  });
+
+  test('tabbing backward out of menu closes dropdown', () => {
+    const view = mount(
+      <Dropdown id="Dropdown" isOpen>
+        <DropdownItem>Link</DropdownItem>
+      </Dropdown>
+    );
+    view
+      .find(Dropdown)
+      .childAt(0)
+      .simulate('focus');
+    view.simulate('keydown', { key: 'Tab', shiftKey: true });
+
+    expect(view.find('.pf-c-dropdown').hasClass('pf-m-expanded')).toBeFalsy();
+    view.unmount();
+  });
 });

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -18,7 +18,9 @@ const propTypes = {
   /** Accesibility role */
   role: PropTypes.string,
   /** Default hyperlink location */
-  href: PropTypes.string
+  href: PropTypes.string,
+  /** Sets focusedItemRef component state in Dropdown */
+  setFocusedItemRef: PropTypes.func
 };
 
 const defaultProps = {
@@ -28,27 +30,50 @@ const defaultProps = {
   component: 'a',
   isDisabled: false,
   href: '#',
-  role: 'menuitem'
+  role: 'menuitem',
+  setFocusedItemRef: Function.prototype
 };
 
-const DropdownItem = ({ className, children, isHovered, component: Component, isDisabled, role, ...props }) => {
-  const aditionalProps = props;
-  if (Component === 'a') {
-    aditionalProps['aria-disabled'] = isDisabled;
-    aditionalProps.tabIndex = isDisabled ? -1 : aditionalProps.tabIndex;
-  } else if (Component === 'button') {
-    aditionalProps.disabled = isDisabled;
+class DropdownItem extends React.Component {
+  handleOnFocus = e => {
+    e.stopPropagation();
+    this.props.setFocusedItemRef(this.itemRef);
+  };
+
+  render() {
+    const {
+      className,
+      children,
+      isHovered,
+      component: Component,
+      isDisabled,
+      role,
+      setFocusedItemRef,
+      ...props
+    } = this.props;
+    const aditionalProps = props;
+    if (Component === 'a') {
+      aditionalProps['aria-disabled'] = isDisabled;
+      aditionalProps.tabIndex = isDisabled ? -1 : aditionalProps.tabIndex;
+    } else if (Component === 'button') {
+      aditionalProps.disabled = isDisabled;
+    }
+
+    return (
+      <Component
+        {...aditionalProps}
+        className={css(isDisabled && styles.modifiers.disabled, isHovered && styles.modifiers.hover, className)}
+        role={role}
+        ref={ref => {
+          this.itemRef = ref;
+        }}
+        onFocus={this.handleOnFocus}
+      >
+        {children}
+      </Component>
+    );
   }
-  return (
-    <Component
-      {...aditionalProps}
-      className={css(isDisabled && styles.modifiers.disabled, isHovered && styles.modifiers.hover, className)}
-      role={role}
-    >
-      {children}
-    </Component>
-  );
-};
+}
 
 DropdownItem.propTypes = propTypes;
 DropdownItem.defaultProps = defaultProps;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.test.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.test.js
@@ -19,6 +19,17 @@ describe('dropdown items', () => {
     expect(view).toMatchSnapshot();
   });
 
+  test('sets focusedItemRef on focus', () => {
+    const setFocusedItemRef = jest.fn();
+    const stopPropagation = jest.fn();
+    const view = shallow(<DropdownItem setFocusedItemRef={setFocusedItemRef}>Something</DropdownItem>);
+
+    view.find('a').simulate('focus', { stopPropagation });
+
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(setFocusedItemRef).toHaveBeenCalled();
+  });
+
   describe('hover', () => {
     test('a', () => {
       const view = shallow(<DropdownItem isHovered>Something</DropdownItem>);

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
@@ -18,11 +18,11 @@ const defaultProps = {
   isOpen: true
 };
 
-const DropdownMenu = ({ className, isOpen, children, ...props }) => (
-  <div {...props} className={css(styles.dropdownMenu, className)} role="menu" hidden={!isOpen}>
+const DropdownMenu = React.forwardRef(({ className, isOpen, children, ...props }, ref) => (
+  <div {...props} className={css(styles.dropdownMenu, className)} role="menu" hidden={!isOpen} ref={ref}>
     {children}
   </div>
-);
+));
 
 DropdownMenu.propTypes = propTypes;
 DropdownMenu.defaultProps = defaultProps;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.test.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.test.js
@@ -6,7 +6,11 @@ describe('API', () => {
   test('click on closed', () => {
     const mockToggle = jest.fn();
     const view = mount(
-      <DropdownToggle onToggle={mockToggle} parentRef={document.createElement('div')}>
+      <DropdownToggle
+        onToggle={mockToggle}
+        parentRef={document.createElement('div')}
+        focusedItemRef={document.createElement('div')}
+      >
         Dropdown
       </DropdownToggle>
     );
@@ -21,7 +25,12 @@ describe('API', () => {
   test('click on opened', () => {
     const mockToggle = jest.fn();
     const view = mount(
-      <DropdownToggle onToggle={mockToggle} isOpen parentRef={document.createElement('div')}>
+      <DropdownToggle
+        onToggle={mockToggle}
+        isOpen
+        parentRef={document.createElement('div')}
+        focusedItemRef={document.createElement('div')}
+      >
         Dropdown
       </DropdownToggle>
     );

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.test.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.test.js
@@ -78,6 +78,37 @@ describe('API', () => {
   });
 });
 
+test('esc keypress fires onToggle callback if dropdown contains focus', () => {
+  const map = {};
+  const mockToggle = jest.fn();
+  const element = document.createElement('div');
+  document.addEventListener = jest.fn((event, cb) => {
+    map[event] = cb;
+  });
+  const view = mount(
+    <DropdownToggle onToggle={mockToggle} parentRef={element} focusedItemRef={element}>
+      Dropdown
+    </DropdownToggle>
+  );
+
+  map.keydown({ keyCode: 27 });
+  expect(mockToggle).toHaveBeenCalled();
+  view.unmount();
+});
+
+test('fires onToggle if keyboard user refocuses dropdown after having tabbed away', () => {
+  const mockToggle = jest.fn();
+  const element = document.createElement('div');
+  const view = mount(
+    <DropdownToggle onToggle={mockToggle} parentRef={element} focusOnReentry={element}>
+      Dropdown
+    </DropdownToggle>
+  );
+
+  view.find(DropdownToggle).simulate('focus');
+  expect(mockToggle).toHaveBeenCalledWith(true);
+});
+
 describe('state', () => {
   test('hover', () => {
     const view = mount(

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Toggle.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Toggle.js
@@ -19,7 +19,9 @@ const propTypes = {
   /** Forces hover state */
   isHovered: PropTypes.bool,
   /** Forces active state */
-  isActive: PropTypes.bool
+  isActive: PropTypes.bool,
+  /** Focused DropdownItem */
+  focusedItemRef: PropTypes.object
 };
 
 const defaultProps = {
@@ -30,13 +32,24 @@ const defaultProps = {
   isFocused: false,
   isHovered: false,
   isActive: false,
-  onToggle: Function.prototype
+  onToggle: Function.prototype,
+  focusedItemRef: null
 };
 
 class DropdownToggle extends Component {
+  state = {
+    focused: false
+  };
+
   componentDidMount = () => {
     document.addEventListener('mousedown', this.onDocClick);
     document.addEventListener('keydown', this.onEscPress);
+  };
+
+  componentDidUpdate = prevProps => {
+    if (this.props.focusedItemRef !== prevProps.focusedItemRef && !this.props.focusedItemRef) {
+      this.props.onToggle && this.props.onToggle(false);
+    }
   };
 
   componentWillUnmount = () => {
@@ -51,15 +64,30 @@ class DropdownToggle extends Component {
   };
 
   onEscPress = event => {
+    const { parentRef, focusedItemRef } = this.props;
     const keyCode = event.keyCode || event.which;
-    if (keyCode === 27) {
+    if (keyCode === 27 && ((parentRef && parentRef.contains(focusedItemRef)) || this.state.focused)) {
       this.props.onToggle && this.props.onToggle(false);
       this.toggle.focus();
     }
   };
 
+  handleOnFocus = () => this.setState({ focused: true });
+  handleOnBlur = () => this.setState({ focused: false });
+
   render() {
-    const { className, children, isOpen, isFocused, isActive, isHovered, onToggle, parentRef, ...props } = this.props;
+    const {
+      className,
+      children,
+      isOpen,
+      isFocused,
+      isActive,
+      isHovered,
+      onToggle,
+      parentRef,
+      focusedItemRef,
+      ...props
+    } = this.props;
     return (
       <button
         {...props}
@@ -76,6 +104,8 @@ class DropdownToggle extends Component {
         onClick={_event => onToggle && onToggle(!isOpen)}
         aria-haspopup="true"
         aria-expanded={isOpen}
+        onFocus={this.handleOnFocus}
+        onBlur={this.handleOnBlur}
       >
         {children}
       </button>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Toggle.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Toggle.js
@@ -21,7 +21,9 @@ const propTypes = {
   /** Forces active state */
   isActive: PropTypes.bool,
   /** Focused DropdownItem */
-  focusedItemRef: PropTypes.object
+  focusedItemRef: PropTypes.object,
+  /** Element that will receive focus when reentering menu via keyboard */
+  focusOnReentry: PropTypes.any
 };
 
 const defaultProps = {
@@ -33,7 +35,8 @@ const defaultProps = {
   isHovered: false,
   isActive: false,
   onToggle: Function.prototype,
-  focusedItemRef: null
+  focusedItemRef: null,
+  focusOnReentry: null
 };
 
 class DropdownToggle extends Component {
@@ -72,7 +75,24 @@ class DropdownToggle extends Component {
     }
   };
 
-  handleOnFocus = () => this.setState({ focused: true });
+  handleOnClickCapture = event => {
+    if (!this.props.parentRef.isEqualNode(this.props.focusedItemRef)) {
+      this.toggle.focus();
+      event.stopPropagation();
+    }
+  };
+
+  handleOnFocus = () => {
+    const { focusOnReentry, onToggle } = this.props;
+
+    if (focusOnReentry) {
+      onToggle && onToggle(true);
+      return;
+    }
+
+    this.setState({ focused: true });
+  };
+
   handleOnBlur = () => this.setState({ focused: false });
 
   render() {
@@ -86,6 +106,7 @@ class DropdownToggle extends Component {
       onToggle,
       parentRef,
       focusedItemRef,
+      focusOnReentry,
       ...props
     } = this.props;
     return (
@@ -102,6 +123,7 @@ class DropdownToggle extends Component {
           className
         )}
         onClick={_event => onToggle && onToggle(!isOpen)}
+        onClickCapture={this.handleOnClickCapture}
         aria-haspopup="true"
         aria-expanded={isOpen}
         onFocus={this.handleOnFocus}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -70,10 +70,13 @@ exports[`KebabToggle dropup + right aligned 1`] = `
   <div
     className="pf-c-dropdown pf-m-top pf-m-align-right"
     id="Dropdown"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
   >
     <Kebab
       aria-label="Actions"
       className=""
+      focusedItemRef={null}
       isActive={false}
       isFocused={false}
       isHovered={false}
@@ -85,6 +88,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
       <DropdownToggle
         aria-label="Actions"
         className=""
+        focusedItemRef={null}
         isActive={false}
         isFocused={false}
         isHovered={false}
@@ -97,7 +101,9 @@ exports[`KebabToggle dropup + right aligned 1`] = `
           aria-haspopup="true"
           aria-label="Actions"
           className="pf-c-dropdown__toggle"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
         >
           <EllipsisVIcon
             color="currentColor"
@@ -122,7 +128,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         </button>
       </DropdownToggle>
     </Kebab>
-    <DropdownMenu
+    <[object Object]
       aria-labelledby="Dropdown"
       className=""
       isOpen={false}
@@ -135,7 +141,10 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         onClick={[Function]}
         role="menu"
       >
-        <DropItems>
+        <DropItems
+          key=".0"
+          setFocusedItemRef={[Function]}
+        >
           <DropdownItem
             className=""
             component="a"
@@ -143,11 +152,13 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Link
@@ -160,11 +171,13 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Action
@@ -177,11 +190,13 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={true}
               className="pf-m-disabled"
               href="#"
+              onFocus={[Function]}
               role="menuitem"
               tabIndex={-1}
             >
@@ -195,11 +210,13 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className="pf-m-disabled"
               disabled={true}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Disabled Action
@@ -220,10 +237,12 @@ exports[`KebabToggle dropup + right aligned 1`] = `
               isDisabled={false}
               isHovered={false}
               role="separator"
+              setFocusedItemRef={[Function]}
             >
               <div
                 className="pf-c-dropdown__separator"
                 href="#"
+                onFocus={[Function]}
                 role="separator"
               />
             </DropdownItem>
@@ -235,11 +254,13 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Link
@@ -252,11 +273,13 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Action
@@ -264,7 +287,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
           </DropdownItem>
         </DropItems>
       </div>
-    </DropdownMenu>
+    </[object Object]>
   </div>
 </Dropdown>
 `;
@@ -339,10 +362,13 @@ exports[`KebabToggle dropup 1`] = `
   <div
     className="pf-c-dropdown pf-m-top"
     id="Dropdown"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
   >
     <Kebab
       aria-label="Actions"
       className=""
+      focusedItemRef={null}
       isActive={false}
       isFocused={false}
       isHovered={false}
@@ -354,6 +380,7 @@ exports[`KebabToggle dropup 1`] = `
       <DropdownToggle
         aria-label="Actions"
         className=""
+        focusedItemRef={null}
         isActive={false}
         isFocused={false}
         isHovered={false}
@@ -366,7 +393,9 @@ exports[`KebabToggle dropup 1`] = `
           aria-haspopup="true"
           aria-label="Actions"
           className="pf-c-dropdown__toggle"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
         >
           <EllipsisVIcon
             color="currentColor"
@@ -391,7 +420,7 @@ exports[`KebabToggle dropup 1`] = `
         </button>
       </DropdownToggle>
     </Kebab>
-    <DropdownMenu
+    <[object Object]
       aria-labelledby="Dropdown"
       className=""
       isOpen={false}
@@ -404,7 +433,10 @@ exports[`KebabToggle dropup 1`] = `
         onClick={[Function]}
         role="menu"
       >
-        <DropItems>
+        <DropItems
+          key=".0"
+          setFocusedItemRef={[Function]}
+        >
           <DropdownItem
             className=""
             component="a"
@@ -412,11 +444,13 @@ exports[`KebabToggle dropup 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Link
@@ -429,11 +463,13 @@ exports[`KebabToggle dropup 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Action
@@ -446,11 +482,13 @@ exports[`KebabToggle dropup 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={true}
               className="pf-m-disabled"
               href="#"
+              onFocus={[Function]}
               role="menuitem"
               tabIndex={-1}
             >
@@ -464,11 +502,13 @@ exports[`KebabToggle dropup 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className="pf-m-disabled"
               disabled={true}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Disabled Action
@@ -489,10 +529,12 @@ exports[`KebabToggle dropup 1`] = `
               isDisabled={false}
               isHovered={false}
               role="separator"
+              setFocusedItemRef={[Function]}
             >
               <div
                 className="pf-c-dropdown__separator"
                 href="#"
+                onFocus={[Function]}
                 role="separator"
               />
             </DropdownItem>
@@ -504,11 +546,13 @@ exports[`KebabToggle dropup 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Link
@@ -521,11 +565,13 @@ exports[`KebabToggle dropup 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Action
@@ -533,7 +579,7 @@ exports[`KebabToggle dropup 1`] = `
           </DropdownItem>
         </DropItems>
       </div>
-    </DropdownMenu>
+    </[object Object]>
   </div>
 </Dropdown>
 `;
@@ -579,7 +625,7 @@ exports[`KebabToggle expanded 1`] = `
   border: 1px solid transparent;
   box-shadow: 0 0.0625rem 0.0625rem 0rem rgba(3, 3, 3, 0.05), 0 0.25rem 0.5rem 0.25rem rgba(3, 3, 3, 0.06);
 }
-.pf-c-dropdown.pf-m-expanded {
+.pf-c-dropdown {
   display: inline-block;
   position: relative;
 }
@@ -606,12 +652,15 @@ exports[`KebabToggle expanded 1`] = `
   }
 >
   <div
-    className="pf-c-dropdown pf-m-expanded"
+    className="pf-c-dropdown"
     id="Dropdown"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
   >
     <Kebab
       aria-label="Actions"
       className=""
+      focusedItemRef={null}
       isActive={false}
       isFocused={false}
       isHovered={false}
@@ -623,6 +672,7 @@ exports[`KebabToggle expanded 1`] = `
       <DropdownToggle
         aria-label="Actions"
         className=""
+        focusedItemRef={null}
         isActive={false}
         isFocused={false}
         isHovered={false}
@@ -635,7 +685,9 @@ exports[`KebabToggle expanded 1`] = `
           aria-haspopup="true"
           aria-label="Actions"
           className="pf-c-dropdown__toggle"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
         >
           <EllipsisVIcon
             color="currentColor"
@@ -660,20 +712,23 @@ exports[`KebabToggle expanded 1`] = `
         </button>
       </DropdownToggle>
     </Kebab>
-    <DropdownMenu
+    <[object Object]
       aria-labelledby="Dropdown"
       className=""
-      isOpen={true}
+      isOpen={null}
       onClick={[Function]}
     >
       <div
         aria-labelledby="Dropdown"
         className="pf-c-dropdown__menu"
-        hidden={false}
+        hidden={true}
         onClick={[Function]}
         role="menu"
       >
-        <DropItems>
+        <DropItems
+          key=".0"
+          setFocusedItemRef={[Function]}
+        >
           <DropdownItem
             className=""
             component="a"
@@ -681,11 +736,13 @@ exports[`KebabToggle expanded 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Link
@@ -698,11 +755,13 @@ exports[`KebabToggle expanded 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Action
@@ -715,11 +774,13 @@ exports[`KebabToggle expanded 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={true}
               className="pf-m-disabled"
               href="#"
+              onFocus={[Function]}
               role="menuitem"
               tabIndex={-1}
             >
@@ -733,11 +794,13 @@ exports[`KebabToggle expanded 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className="pf-m-disabled"
               disabled={true}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Disabled Action
@@ -758,10 +821,12 @@ exports[`KebabToggle expanded 1`] = `
               isDisabled={false}
               isHovered={false}
               role="separator"
+              setFocusedItemRef={[Function]}
             >
               <div
                 className="pf-c-dropdown__separator"
                 href="#"
+                onFocus={[Function]}
                 role="separator"
               />
             </DropdownItem>
@@ -773,11 +838,13 @@ exports[`KebabToggle expanded 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Link
@@ -790,11 +857,13 @@ exports[`KebabToggle expanded 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Action
@@ -802,7 +871,7 @@ exports[`KebabToggle expanded 1`] = `
           </DropdownItem>
         </DropItems>
       </div>
-    </DropdownMenu>
+    </[object Object]>
   </div>
 </Dropdown>
 `;
@@ -877,10 +946,13 @@ exports[`KebabToggle plain 1`] = `
   <div
     className="pf-c-dropdown pf-m-plain"
     id="Dropdown"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
   >
     <Kebab
       aria-label="Actions"
       className=""
+      focusedItemRef={null}
       isActive={false}
       isFocused={false}
       isHovered={false}
@@ -892,6 +964,7 @@ exports[`KebabToggle plain 1`] = `
       <DropdownToggle
         aria-label="Actions"
         className=""
+        focusedItemRef={null}
         isActive={false}
         isFocused={false}
         isHovered={false}
@@ -904,7 +977,9 @@ exports[`KebabToggle plain 1`] = `
           aria-haspopup="true"
           aria-label="Actions"
           className="pf-c-dropdown__toggle"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
         >
           <EllipsisVIcon
             color="currentColor"
@@ -929,7 +1004,7 @@ exports[`KebabToggle plain 1`] = `
         </button>
       </DropdownToggle>
     </Kebab>
-    <DropdownMenu
+    <[object Object]
       aria-labelledby="Dropdown"
       className=""
       isOpen={false}
@@ -942,7 +1017,10 @@ exports[`KebabToggle plain 1`] = `
         onClick={[Function]}
         role="menu"
       >
-        <DropItems>
+        <DropItems
+          key=".0"
+          setFocusedItemRef={[Function]}
+        >
           <DropdownItem
             className=""
             component="a"
@@ -950,11 +1028,13 @@ exports[`KebabToggle plain 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Link
@@ -967,11 +1047,13 @@ exports[`KebabToggle plain 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Action
@@ -984,11 +1066,13 @@ exports[`KebabToggle plain 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={true}
               className="pf-m-disabled"
               href="#"
+              onFocus={[Function]}
               role="menuitem"
               tabIndex={-1}
             >
@@ -1002,11 +1086,13 @@ exports[`KebabToggle plain 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className="pf-m-disabled"
               disabled={true}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Disabled Action
@@ -1027,10 +1113,12 @@ exports[`KebabToggle plain 1`] = `
               isDisabled={false}
               isHovered={false}
               role="separator"
+              setFocusedItemRef={[Function]}
             >
               <div
                 className="pf-c-dropdown__separator"
                 href="#"
+                onFocus={[Function]}
                 role="separator"
               />
             </DropdownItem>
@@ -1042,11 +1130,13 @@ exports[`KebabToggle plain 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Link
@@ -1059,11 +1149,13 @@ exports[`KebabToggle plain 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Action
@@ -1071,7 +1163,7 @@ exports[`KebabToggle plain 1`] = `
           </DropdownItem>
         </DropItems>
       </div>
-    </DropdownMenu>
+    </[object Object]>
   </div>
 </Dropdown>
 `;
@@ -1146,10 +1238,13 @@ exports[`KebabToggle regular 1`] = `
   <div
     className="pf-c-dropdown"
     id="Dropdown"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
   >
     <Kebab
       aria-label="Actions"
       className=""
+      focusedItemRef={null}
       isActive={false}
       isFocused={false}
       isHovered={false}
@@ -1161,6 +1256,7 @@ exports[`KebabToggle regular 1`] = `
       <DropdownToggle
         aria-label="Actions"
         className=""
+        focusedItemRef={null}
         isActive={false}
         isFocused={false}
         isHovered={false}
@@ -1173,7 +1269,9 @@ exports[`KebabToggle regular 1`] = `
           aria-haspopup="true"
           aria-label="Actions"
           className="pf-c-dropdown__toggle"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
         >
           <EllipsisVIcon
             color="currentColor"
@@ -1198,7 +1296,7 @@ exports[`KebabToggle regular 1`] = `
         </button>
       </DropdownToggle>
     </Kebab>
-    <DropdownMenu
+    <[object Object]
       aria-labelledby="Dropdown"
       className=""
       isOpen={false}
@@ -1211,7 +1309,10 @@ exports[`KebabToggle regular 1`] = `
         onClick={[Function]}
         role="menu"
       >
-        <DropItems>
+        <DropItems
+          key=".0"
+          setFocusedItemRef={[Function]}
+        >
           <DropdownItem
             className=""
             component="a"
@@ -1219,11 +1320,13 @@ exports[`KebabToggle regular 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Link
@@ -1236,11 +1339,13 @@ exports[`KebabToggle regular 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Action
@@ -1253,11 +1358,13 @@ exports[`KebabToggle regular 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={true}
               className="pf-m-disabled"
               href="#"
+              onFocus={[Function]}
               role="menuitem"
               tabIndex={-1}
             >
@@ -1271,11 +1378,13 @@ exports[`KebabToggle regular 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className="pf-m-disabled"
               disabled={true}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Disabled Action
@@ -1296,10 +1405,12 @@ exports[`KebabToggle regular 1`] = `
               isDisabled={false}
               isHovered={false}
               role="separator"
+              setFocusedItemRef={[Function]}
             >
               <div
                 className="pf-c-dropdown__separator"
                 href="#"
+                onFocus={[Function]}
                 role="separator"
               />
             </DropdownItem>
@@ -1311,11 +1422,13 @@ exports[`KebabToggle regular 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Link
@@ -1328,11 +1441,13 @@ exports[`KebabToggle regular 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Action
@@ -1340,7 +1455,7 @@ exports[`KebabToggle regular 1`] = `
           </DropdownItem>
         </DropItems>
       </div>
-    </DropdownMenu>
+    </[object Object]>
   </div>
 </Dropdown>
 `;
@@ -1415,10 +1530,13 @@ exports[`KebabToggle right aligned 1`] = `
   <div
     className="pf-c-dropdown pf-m-align-right"
     id="Dropdown"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
   >
     <Kebab
       aria-label="Actions"
       className=""
+      focusedItemRef={null}
       isActive={false}
       isFocused={false}
       isHovered={false}
@@ -1430,6 +1548,7 @@ exports[`KebabToggle right aligned 1`] = `
       <DropdownToggle
         aria-label="Actions"
         className=""
+        focusedItemRef={null}
         isActive={false}
         isFocused={false}
         isHovered={false}
@@ -1442,7 +1561,9 @@ exports[`KebabToggle right aligned 1`] = `
           aria-haspopup="true"
           aria-label="Actions"
           className="pf-c-dropdown__toggle"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
         >
           <EllipsisVIcon
             color="currentColor"
@@ -1467,7 +1588,7 @@ exports[`KebabToggle right aligned 1`] = `
         </button>
       </DropdownToggle>
     </Kebab>
-    <DropdownMenu
+    <[object Object]
       aria-labelledby="Dropdown"
       className=""
       isOpen={false}
@@ -1480,7 +1601,10 @@ exports[`KebabToggle right aligned 1`] = `
         onClick={[Function]}
         role="menu"
       >
-        <DropItems>
+        <DropItems
+          key=".0"
+          setFocusedItemRef={[Function]}
+        >
           <DropdownItem
             className=""
             component="a"
@@ -1488,11 +1612,13 @@ exports[`KebabToggle right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Link
@@ -1505,11 +1631,13 @@ exports[`KebabToggle right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Action
@@ -1522,11 +1650,13 @@ exports[`KebabToggle right aligned 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={true}
               className="pf-m-disabled"
               href="#"
+              onFocus={[Function]}
               role="menuitem"
               tabIndex={-1}
             >
@@ -1540,11 +1670,13 @@ exports[`KebabToggle right aligned 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className="pf-m-disabled"
               disabled={true}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Disabled Action
@@ -1565,10 +1697,12 @@ exports[`KebabToggle right aligned 1`] = `
               isDisabled={false}
               isHovered={false}
               role="separator"
+              setFocusedItemRef={[Function]}
             >
               <div
                 className="pf-c-dropdown__separator"
                 href="#"
+                onFocus={[Function]}
                 role="separator"
               />
             </DropdownItem>
@@ -1580,11 +1714,13 @@ exports[`KebabToggle right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Link
@@ -1597,11 +1733,13 @@ exports[`KebabToggle right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Action
@@ -1609,7 +1747,7 @@ exports[`KebabToggle right aligned 1`] = `
           </DropdownItem>
         </DropItems>
       </div>
-    </DropdownMenu>
+    </[object Object]>
   </div>
 </Dropdown>
 `;
@@ -1691,9 +1829,12 @@ exports[`dropdown dropup + right aligned 1`] = `
   <div
     className="pf-c-dropdown pf-m-top pf-m-align-right"
     id="Dropdown"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
   >
     <DropdownToggle
       className=""
+      focusedItemRef={null}
       isActive={false}
       isFocused={false}
       isHovered={false}
@@ -1704,6 +1845,7 @@ exports[`dropdown dropup + right aligned 1`] = `
     >
       <DropdownToggle
         className=""
+        focusedItemRef={null}
         isActive={false}
         isFocused={false}
         isHovered={false}
@@ -1715,7 +1857,9 @@ exports[`dropdown dropup + right aligned 1`] = `
           aria-expanded={false}
           aria-haspopup="true"
           className="pf-c-dropdown__toggle"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
         >
           Dropdown
           <CaretDownIcon
@@ -1743,7 +1887,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         </button>
       </DropdownToggle>
     </DropdownToggle>
-    <DropdownMenu
+    <[object Object]
       aria-labelledby="Dropdown"
       className=""
       isOpen={false}
@@ -1756,7 +1900,10 @@ exports[`dropdown dropup + right aligned 1`] = `
         onClick={[Function]}
         role="menu"
       >
-        <DropItems>
+        <DropItems
+          key=".0"
+          setFocusedItemRef={[Function]}
+        >
           <DropdownItem
             className=""
             component="a"
@@ -1764,11 +1911,13 @@ exports[`dropdown dropup + right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Link
@@ -1781,11 +1930,13 @@ exports[`dropdown dropup + right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Action
@@ -1798,11 +1949,13 @@ exports[`dropdown dropup + right aligned 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={true}
               className="pf-m-disabled"
               href="#"
+              onFocus={[Function]}
               role="menuitem"
               tabIndex={-1}
             >
@@ -1816,11 +1969,13 @@ exports[`dropdown dropup + right aligned 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className="pf-m-disabled"
               disabled={true}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Disabled Action
@@ -1841,10 +1996,12 @@ exports[`dropdown dropup + right aligned 1`] = `
               isDisabled={false}
               isHovered={false}
               role="separator"
+              setFocusedItemRef={[Function]}
             >
               <div
                 className="pf-c-dropdown__separator"
                 href="#"
+                onFocus={[Function]}
                 role="separator"
               />
             </DropdownItem>
@@ -1856,11 +2013,13 @@ exports[`dropdown dropup + right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Link
@@ -1873,11 +2032,13 @@ exports[`dropdown dropup + right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Action
@@ -1885,7 +2046,7 @@ exports[`dropdown dropup + right aligned 1`] = `
           </DropdownItem>
         </DropItems>
       </div>
-    </DropdownMenu>
+    </[object Object]>
   </div>
 </Dropdown>
 `;
@@ -1967,9 +2128,12 @@ exports[`dropdown dropup 1`] = `
   <div
     className="pf-c-dropdown pf-m-top"
     id="Dropdown"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
   >
     <DropdownToggle
       className=""
+      focusedItemRef={null}
       isActive={false}
       isFocused={false}
       isHovered={false}
@@ -1980,6 +2144,7 @@ exports[`dropdown dropup 1`] = `
     >
       <DropdownToggle
         className=""
+        focusedItemRef={null}
         isActive={false}
         isFocused={false}
         isHovered={false}
@@ -1991,7 +2156,9 @@ exports[`dropdown dropup 1`] = `
           aria-expanded={false}
           aria-haspopup="true"
           className="pf-c-dropdown__toggle"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
         >
           Dropdown
           <CaretDownIcon
@@ -2019,7 +2186,7 @@ exports[`dropdown dropup 1`] = `
         </button>
       </DropdownToggle>
     </DropdownToggle>
-    <DropdownMenu
+    <[object Object]
       aria-labelledby="Dropdown"
       className=""
       isOpen={false}
@@ -2032,7 +2199,10 @@ exports[`dropdown dropup 1`] = `
         onClick={[Function]}
         role="menu"
       >
-        <DropItems>
+        <DropItems
+          key=".0"
+          setFocusedItemRef={[Function]}
+        >
           <DropdownItem
             className=""
             component="a"
@@ -2040,11 +2210,13 @@ exports[`dropdown dropup 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Link
@@ -2057,11 +2229,13 @@ exports[`dropdown dropup 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Action
@@ -2074,11 +2248,13 @@ exports[`dropdown dropup 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={true}
               className="pf-m-disabled"
               href="#"
+              onFocus={[Function]}
               role="menuitem"
               tabIndex={-1}
             >
@@ -2092,11 +2268,13 @@ exports[`dropdown dropup 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className="pf-m-disabled"
               disabled={true}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Disabled Action
@@ -2117,10 +2295,12 @@ exports[`dropdown dropup 1`] = `
               isDisabled={false}
               isHovered={false}
               role="separator"
+              setFocusedItemRef={[Function]}
             >
               <div
                 className="pf-c-dropdown__separator"
                 href="#"
+                onFocus={[Function]}
                 role="separator"
               />
             </DropdownItem>
@@ -2132,11 +2312,13 @@ exports[`dropdown dropup 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Link
@@ -2149,11 +2331,13 @@ exports[`dropdown dropup 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Action
@@ -2161,7 +2345,7 @@ exports[`dropdown dropup 1`] = `
           </DropdownItem>
         </DropItems>
       </div>
-    </DropdownMenu>
+    </[object Object]>
   </div>
 </Dropdown>
 `;
@@ -2213,7 +2397,7 @@ exports[`dropdown expanded 1`] = `
   border: 1px solid transparent;
   box-shadow: 0 0.0625rem 0.0625rem 0rem rgba(3, 3, 3, 0.05), 0 0.25rem 0.5rem 0.25rem rgba(3, 3, 3, 0.06);
 }
-.pf-c-dropdown.pf-m-expanded {
+.pf-c-dropdown {
   display: inline-block;
   position: relative;
 }
@@ -2241,11 +2425,14 @@ exports[`dropdown expanded 1`] = `
   }
 >
   <div
-    className="pf-c-dropdown pf-m-expanded"
+    className="pf-c-dropdown"
     id="Dropdown"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
   >
     <DropdownToggle
       className=""
+      focusedItemRef={null}
       isActive={false}
       isFocused={false}
       isHovered={false}
@@ -2256,6 +2443,7 @@ exports[`dropdown expanded 1`] = `
     >
       <DropdownToggle
         className=""
+        focusedItemRef={null}
         isActive={false}
         isFocused={false}
         isHovered={false}
@@ -2267,7 +2455,9 @@ exports[`dropdown expanded 1`] = `
           aria-expanded={true}
           aria-haspopup="true"
           className="pf-c-dropdown__toggle"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
         >
           Dropdown
           <CaretDownIcon
@@ -2295,20 +2485,23 @@ exports[`dropdown expanded 1`] = `
         </button>
       </DropdownToggle>
     </DropdownToggle>
-    <DropdownMenu
+    <[object Object]
       aria-labelledby="Dropdown"
       className=""
-      isOpen={true}
+      isOpen={null}
       onClick={[Function]}
     >
       <div
         aria-labelledby="Dropdown"
         className="pf-c-dropdown__menu"
-        hidden={false}
+        hidden={true}
         onClick={[Function]}
         role="menu"
       >
-        <DropItems>
+        <DropItems
+          key=".0"
+          setFocusedItemRef={[Function]}
+        >
           <DropdownItem
             className=""
             component="a"
@@ -2316,11 +2509,13 @@ exports[`dropdown expanded 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Link
@@ -2333,11 +2528,13 @@ exports[`dropdown expanded 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Action
@@ -2350,11 +2547,13 @@ exports[`dropdown expanded 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={true}
               className="pf-m-disabled"
               href="#"
+              onFocus={[Function]}
               role="menuitem"
               tabIndex={-1}
             >
@@ -2368,11 +2567,13 @@ exports[`dropdown expanded 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className="pf-m-disabled"
               disabled={true}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Disabled Action
@@ -2393,10 +2594,12 @@ exports[`dropdown expanded 1`] = `
               isDisabled={false}
               isHovered={false}
               role="separator"
+              setFocusedItemRef={[Function]}
             >
               <div
                 className="pf-c-dropdown__separator"
                 href="#"
+                onFocus={[Function]}
                 role="separator"
               />
             </DropdownItem>
@@ -2408,11 +2611,13 @@ exports[`dropdown expanded 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Link
@@ -2425,11 +2630,13 @@ exports[`dropdown expanded 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Action
@@ -2437,7 +2644,7 @@ exports[`dropdown expanded 1`] = `
           </DropdownItem>
         </DropItems>
       </div>
-    </DropdownMenu>
+    </[object Object]>
   </div>
 </Dropdown>
 `;
@@ -2519,9 +2726,12 @@ exports[`dropdown regular 1`] = `
   <div
     className="pf-c-dropdown"
     id="Dropdown"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
   >
     <DropdownToggle
       className=""
+      focusedItemRef={null}
       isActive={false}
       isFocused={false}
       isHovered={false}
@@ -2532,6 +2742,7 @@ exports[`dropdown regular 1`] = `
     >
       <DropdownToggle
         className=""
+        focusedItemRef={null}
         isActive={false}
         isFocused={false}
         isHovered={false}
@@ -2543,7 +2754,9 @@ exports[`dropdown regular 1`] = `
           aria-expanded={false}
           aria-haspopup="true"
           className="pf-c-dropdown__toggle"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
         >
           Dropdown
           <CaretDownIcon
@@ -2571,7 +2784,7 @@ exports[`dropdown regular 1`] = `
         </button>
       </DropdownToggle>
     </DropdownToggle>
-    <DropdownMenu
+    <[object Object]
       aria-labelledby="Dropdown"
       className=""
       isOpen={false}
@@ -2584,7 +2797,10 @@ exports[`dropdown regular 1`] = `
         onClick={[Function]}
         role="menu"
       >
-        <DropItems>
+        <DropItems
+          key=".0"
+          setFocusedItemRef={[Function]}
+        >
           <DropdownItem
             className=""
             component="a"
@@ -2592,11 +2808,13 @@ exports[`dropdown regular 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Link
@@ -2609,11 +2827,13 @@ exports[`dropdown regular 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Action
@@ -2626,11 +2846,13 @@ exports[`dropdown regular 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={true}
               className="pf-m-disabled"
               href="#"
+              onFocus={[Function]}
               role="menuitem"
               tabIndex={-1}
             >
@@ -2644,11 +2866,13 @@ exports[`dropdown regular 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className="pf-m-disabled"
               disabled={true}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Disabled Action
@@ -2669,10 +2893,12 @@ exports[`dropdown regular 1`] = `
               isDisabled={false}
               isHovered={false}
               role="separator"
+              setFocusedItemRef={[Function]}
             >
               <div
                 className="pf-c-dropdown__separator"
                 href="#"
+                onFocus={[Function]}
                 role="separator"
               />
             </DropdownItem>
@@ -2684,11 +2910,13 @@ exports[`dropdown regular 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Link
@@ -2701,11 +2929,13 @@ exports[`dropdown regular 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Action
@@ -2713,7 +2943,7 @@ exports[`dropdown regular 1`] = `
           </DropdownItem>
         </DropItems>
       </div>
-    </DropdownMenu>
+    </[object Object]>
   </div>
 </Dropdown>
 `;
@@ -2795,9 +3025,12 @@ exports[`dropdown right aligned 1`] = `
   <div
     className="pf-c-dropdown pf-m-align-right"
     id="Dropdown"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
   >
     <DropdownToggle
       className=""
+      focusedItemRef={null}
       isActive={false}
       isFocused={false}
       isHovered={false}
@@ -2808,6 +3041,7 @@ exports[`dropdown right aligned 1`] = `
     >
       <DropdownToggle
         className=""
+        focusedItemRef={null}
         isActive={false}
         isFocused={false}
         isHovered={false}
@@ -2819,7 +3053,9 @@ exports[`dropdown right aligned 1`] = `
           aria-expanded={false}
           aria-haspopup="true"
           className="pf-c-dropdown__toggle"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
         >
           Dropdown
           <CaretDownIcon
@@ -2847,7 +3083,7 @@ exports[`dropdown right aligned 1`] = `
         </button>
       </DropdownToggle>
     </DropdownToggle>
-    <DropdownMenu
+    <[object Object]
       aria-labelledby="Dropdown"
       className=""
       isOpen={false}
@@ -2860,7 +3096,10 @@ exports[`dropdown right aligned 1`] = `
         onClick={[Function]}
         role="menu"
       >
-        <DropItems>
+        <DropItems
+          key=".0"
+          setFocusedItemRef={[Function]}
+        >
           <DropdownItem
             className=""
             component="a"
@@ -2868,11 +3107,13 @@ exports[`dropdown right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Link
@@ -2885,11 +3126,13 @@ exports[`dropdown right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Action
@@ -2902,11 +3145,13 @@ exports[`dropdown right aligned 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={true}
               className="pf-m-disabled"
               href="#"
+              onFocus={[Function]}
               role="menuitem"
               tabIndex={-1}
             >
@@ -2920,11 +3165,13 @@ exports[`dropdown right aligned 1`] = `
             isDisabled={true}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className="pf-m-disabled"
               disabled={true}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Disabled Action
@@ -2945,10 +3192,12 @@ exports[`dropdown right aligned 1`] = `
               isDisabled={false}
               isHovered={false}
               role="separator"
+              setFocusedItemRef={[Function]}
             >
               <div
                 className="pf-c-dropdown__separator"
                 href="#"
+                onFocus={[Function]}
                 role="separator"
               />
             </DropdownItem>
@@ -2960,11 +3209,13 @@ exports[`dropdown right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <a
               aria-disabled={false}
               className=""
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Link
@@ -2977,11 +3228,13 @@ exports[`dropdown right aligned 1`] = `
             isDisabled={false}
             isHovered={false}
             role="menuitem"
+            setFocusedItemRef={[Function]}
           >
             <button
               className=""
               disabled={false}
               href="#"
+              onFocus={[Function]}
               role="menuitem"
             >
               Separated Action
@@ -2989,7 +3242,7 @@ exports[`dropdown right aligned 1`] = `
           </DropdownItem>
         </DropItems>
       </div>
-    </DropdownMenu>
+    </[object Object]>
   </div>
 </Dropdown>
 `;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -76,6 +76,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      focusOnReentry={null}
       focusedItemRef={null}
       isActive={false}
       isFocused={false}
@@ -88,6 +89,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
       <DropdownToggle
         aria-label="Actions"
         className=""
+        focusOnReentry={null}
         focusedItemRef={null}
         isActive={false}
         isFocused={false}
@@ -103,6 +105,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
           className="pf-c-dropdown__toggle"
           onBlur={[Function]}
           onClick={[Function]}
+          onClickCapture={[Function]}
           onFocus={[Function]}
         >
           <EllipsisVIcon
@@ -368,6 +371,7 @@ exports[`KebabToggle dropup 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      focusOnReentry={null}
       focusedItemRef={null}
       isActive={false}
       isFocused={false}
@@ -380,6 +384,7 @@ exports[`KebabToggle dropup 1`] = `
       <DropdownToggle
         aria-label="Actions"
         className=""
+        focusOnReentry={null}
         focusedItemRef={null}
         isActive={false}
         isFocused={false}
@@ -395,6 +400,7 @@ exports[`KebabToggle dropup 1`] = `
           className="pf-c-dropdown__toggle"
           onBlur={[Function]}
           onClick={[Function]}
+          onClickCapture={[Function]}
           onFocus={[Function]}
         >
           <EllipsisVIcon
@@ -660,6 +666,7 @@ exports[`KebabToggle expanded 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      focusOnReentry={null}
       focusedItemRef={null}
       isActive={false}
       isFocused={false}
@@ -672,6 +679,7 @@ exports[`KebabToggle expanded 1`] = `
       <DropdownToggle
         aria-label="Actions"
         className=""
+        focusOnReentry={null}
         focusedItemRef={null}
         isActive={false}
         isFocused={false}
@@ -687,6 +695,7 @@ exports[`KebabToggle expanded 1`] = `
           className="pf-c-dropdown__toggle"
           onBlur={[Function]}
           onClick={[Function]}
+          onClickCapture={[Function]}
           onFocus={[Function]}
         >
           <EllipsisVIcon
@@ -952,6 +961,7 @@ exports[`KebabToggle plain 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      focusOnReentry={null}
       focusedItemRef={null}
       isActive={false}
       isFocused={false}
@@ -964,6 +974,7 @@ exports[`KebabToggle plain 1`] = `
       <DropdownToggle
         aria-label="Actions"
         className=""
+        focusOnReentry={null}
         focusedItemRef={null}
         isActive={false}
         isFocused={false}
@@ -979,6 +990,7 @@ exports[`KebabToggle plain 1`] = `
           className="pf-c-dropdown__toggle"
           onBlur={[Function]}
           onClick={[Function]}
+          onClickCapture={[Function]}
           onFocus={[Function]}
         >
           <EllipsisVIcon
@@ -1244,6 +1256,7 @@ exports[`KebabToggle regular 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      focusOnReentry={null}
       focusedItemRef={null}
       isActive={false}
       isFocused={false}
@@ -1256,6 +1269,7 @@ exports[`KebabToggle regular 1`] = `
       <DropdownToggle
         aria-label="Actions"
         className=""
+        focusOnReentry={null}
         focusedItemRef={null}
         isActive={false}
         isFocused={false}
@@ -1271,6 +1285,7 @@ exports[`KebabToggle regular 1`] = `
           className="pf-c-dropdown__toggle"
           onBlur={[Function]}
           onClick={[Function]}
+          onClickCapture={[Function]}
           onFocus={[Function]}
         >
           <EllipsisVIcon
@@ -1536,6 +1551,7 @@ exports[`KebabToggle right aligned 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      focusOnReentry={null}
       focusedItemRef={null}
       isActive={false}
       isFocused={false}
@@ -1548,6 +1564,7 @@ exports[`KebabToggle right aligned 1`] = `
       <DropdownToggle
         aria-label="Actions"
         className=""
+        focusOnReentry={null}
         focusedItemRef={null}
         isActive={false}
         isFocused={false}
@@ -1563,6 +1580,7 @@ exports[`KebabToggle right aligned 1`] = `
           className="pf-c-dropdown__toggle"
           onBlur={[Function]}
           onClick={[Function]}
+          onClickCapture={[Function]}
           onFocus={[Function]}
         >
           <EllipsisVIcon
@@ -1834,6 +1852,7 @@ exports[`dropdown dropup + right aligned 1`] = `
   >
     <DropdownToggle
       className=""
+      focusOnReentry={null}
       focusedItemRef={null}
       isActive={false}
       isFocused={false}
@@ -1845,6 +1864,7 @@ exports[`dropdown dropup + right aligned 1`] = `
     >
       <DropdownToggle
         className=""
+        focusOnReentry={null}
         focusedItemRef={null}
         isActive={false}
         isFocused={false}
@@ -1859,6 +1879,7 @@ exports[`dropdown dropup + right aligned 1`] = `
           className="pf-c-dropdown__toggle"
           onBlur={[Function]}
           onClick={[Function]}
+          onClickCapture={[Function]}
           onFocus={[Function]}
         >
           Dropdown
@@ -2133,6 +2154,7 @@ exports[`dropdown dropup 1`] = `
   >
     <DropdownToggle
       className=""
+      focusOnReentry={null}
       focusedItemRef={null}
       isActive={false}
       isFocused={false}
@@ -2144,6 +2166,7 @@ exports[`dropdown dropup 1`] = `
     >
       <DropdownToggle
         className=""
+        focusOnReentry={null}
         focusedItemRef={null}
         isActive={false}
         isFocused={false}
@@ -2158,6 +2181,7 @@ exports[`dropdown dropup 1`] = `
           className="pf-c-dropdown__toggle"
           onBlur={[Function]}
           onClick={[Function]}
+          onClickCapture={[Function]}
           onFocus={[Function]}
         >
           Dropdown
@@ -2432,6 +2456,7 @@ exports[`dropdown expanded 1`] = `
   >
     <DropdownToggle
       className=""
+      focusOnReentry={null}
       focusedItemRef={null}
       isActive={false}
       isFocused={false}
@@ -2443,6 +2468,7 @@ exports[`dropdown expanded 1`] = `
     >
       <DropdownToggle
         className=""
+        focusOnReentry={null}
         focusedItemRef={null}
         isActive={false}
         isFocused={false}
@@ -2457,6 +2483,7 @@ exports[`dropdown expanded 1`] = `
           className="pf-c-dropdown__toggle"
           onBlur={[Function]}
           onClick={[Function]}
+          onClickCapture={[Function]}
           onFocus={[Function]}
         >
           Dropdown
@@ -2731,6 +2758,7 @@ exports[`dropdown regular 1`] = `
   >
     <DropdownToggle
       className=""
+      focusOnReentry={null}
       focusedItemRef={null}
       isActive={false}
       isFocused={false}
@@ -2742,6 +2770,7 @@ exports[`dropdown regular 1`] = `
     >
       <DropdownToggle
         className=""
+        focusOnReentry={null}
         focusedItemRef={null}
         isActive={false}
         isFocused={false}
@@ -2756,6 +2785,7 @@ exports[`dropdown regular 1`] = `
           className="pf-c-dropdown__toggle"
           onBlur={[Function]}
           onClick={[Function]}
+          onClickCapture={[Function]}
           onFocus={[Function]}
         >
           Dropdown
@@ -3030,6 +3060,7 @@ exports[`dropdown right aligned 1`] = `
   >
     <DropdownToggle
       className=""
+      focusOnReentry={null}
       focusedItemRef={null}
       isActive={false}
       isFocused={false}
@@ -3041,6 +3072,7 @@ exports[`dropdown right aligned 1`] = `
     >
       <DropdownToggle
         className=""
+        focusOnReentry={null}
         focusedItemRef={null}
         isActive={false}
         isFocused={false}
@@ -3055,6 +3087,7 @@ exports[`dropdown right aligned 1`] = `
           className="pf-c-dropdown__toggle"
           onBlur={[Function]}
           onClick={[Function]}
+          onClickCapture={[Function]}
           onFocus={[Function]}
         >
           Dropdown

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownItem.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownItem.test.js.snap
@@ -5,6 +5,7 @@ exports[`dropdown items a 1`] = `
   aria-disabled={false}
   className=""
   href="#"
+  onFocus={[Function]}
   role="menuitem"
 >
   Something
@@ -16,6 +17,7 @@ exports[`dropdown items button 1`] = `
   className=""
   disabled={false}
   href="#"
+  onFocus={[Function]}
   role="menuitem"
 >
   Something
@@ -31,6 +33,7 @@ exports[`dropdown items disabled a 1`] = `
   aria-disabled={true}
   className="pf-m-disabled"
   href="#"
+  onFocus={[Function]}
   role="menuitem"
   tabIndex={-1}
 >
@@ -47,6 +50,7 @@ exports[`dropdown items disabled button 1`] = `
   className="pf-m-disabled"
   disabled={true}
   href="#"
+  onFocus={[Function]}
   role="menuitem"
 >
   Something
@@ -62,6 +66,7 @@ exports[`dropdown items hover a 1`] = `
   aria-disabled={false}
   className="pf-m-hover"
   href="#"
+  onFocus={[Function]}
   role="menuitem"
 >
   Something
@@ -77,6 +82,7 @@ exports[`dropdown items hover button 1`] = `
   className="pf-m-hover"
   disabled={false}
   href="#"
+  onFocus={[Function]}
   role="menuitem"
 >
   Something
@@ -97,5 +103,6 @@ exports[`dropdown items separator 1`] = `
   isDisabled={false}
   isHovered={false}
   role="separator"
+  setFocusedItemRef={[Function]}
 />
 `;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
@@ -31,6 +31,7 @@ exports[`state active 1`] = `
 >
   <DropdownToggle
     className=""
+    focusOnReentry={null}
     focusedItemRef={null}
     isActive={true}
     isFocused={false}
@@ -45,6 +46,7 @@ exports[`state active 1`] = `
       className="pf-c-dropdown__toggle pf-m-active"
       onBlur={[Function]}
       onClick={[Function]}
+      onClickCapture={[Function]}
       onFocus={[Function]}
     >
       Dropdown
@@ -106,6 +108,7 @@ exports[`state focus 1`] = `
 >
   <DropdownToggle
     className=""
+    focusOnReentry={null}
     focusedItemRef={null}
     isActive={false}
     isFocused={true}
@@ -120,6 +123,7 @@ exports[`state focus 1`] = `
       className="pf-c-dropdown__toggle pf-m-focus"
       onBlur={[Function]}
       onClick={[Function]}
+      onClickCapture={[Function]}
       onFocus={[Function]}
     >
       Dropdown
@@ -181,6 +185,7 @@ exports[`state hover 1`] = `
 >
   <DropdownToggle
     className=""
+    focusOnReentry={null}
     focusedItemRef={null}
     isActive={false}
     isFocused={false}
@@ -195,6 +200,7 @@ exports[`state hover 1`] = `
       className="pf-c-dropdown__toggle pf-m-hover"
       onBlur={[Function]}
       onClick={[Function]}
+      onClickCapture={[Function]}
       onFocus={[Function]}
     >
       Dropdown

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
@@ -31,6 +31,7 @@ exports[`state active 1`] = `
 >
   <DropdownToggle
     className=""
+    focusedItemRef={null}
     isActive={true}
     isFocused={false}
     isHovered={false}
@@ -42,7 +43,9 @@ exports[`state active 1`] = `
       aria-expanded={false}
       aria-haspopup="true"
       className="pf-c-dropdown__toggle pf-m-active"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
     >
       Dropdown
       <CaretDownIcon
@@ -103,6 +106,7 @@ exports[`state focus 1`] = `
 >
   <DropdownToggle
     className=""
+    focusedItemRef={null}
     isActive={false}
     isFocused={true}
     isHovered={false}
@@ -114,7 +118,9 @@ exports[`state focus 1`] = `
       aria-expanded={false}
       aria-haspopup="true"
       className="pf-c-dropdown__toggle pf-m-focus"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
     >
       Dropdown
       <CaretDownIcon
@@ -175,6 +181,7 @@ exports[`state hover 1`] = `
 >
   <DropdownToggle
     className=""
+    focusedItemRef={null}
     isActive={false}
     isFocused={false}
     isHovered={true}
@@ -186,7 +193,9 @@ exports[`state hover 1`] = `
       aria-expanded={false}
       aria-haspopup="true"
       className="pf-c-dropdown__toggle pf-m-hover"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
     >
       Dropdown
       <CaretDownIcon

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
@@ -31,6 +31,7 @@ exports[`Dropdown toggle 1`] = `
 >
   <DropdownToggle
     className=""
+    focusOnReentry={null}
     focusedItemRef={null}
     isActive={false}
     isFocused={false}
@@ -45,6 +46,7 @@ exports[`Dropdown toggle 1`] = `
       className="pf-c-dropdown__toggle"
       onBlur={[Function]}
       onClick={[Function]}
+      onClickCapture={[Function]}
       onFocus={[Function]}
     >
       Dropdown
@@ -102,6 +104,7 @@ exports[`Kebab toggle 1`] = `
   <DropdownToggle
     aria-label="Actions"
     className=""
+    focusOnReentry={null}
     focusedItemRef={null}
     isActive={false}
     isFocused={false}
@@ -117,6 +120,7 @@ exports[`Kebab toggle 1`] = `
       className="pf-c-dropdown__toggle"
       onBlur={[Function]}
       onClick={[Function]}
+      onClickCapture={[Function]}
       onFocus={[Function]}
     >
       <EllipsisVIcon

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
@@ -31,6 +31,7 @@ exports[`Dropdown toggle 1`] = `
 >
   <DropdownToggle
     className=""
+    focusedItemRef={null}
     isActive={false}
     isFocused={false}
     isHovered={false}
@@ -42,7 +43,9 @@ exports[`Dropdown toggle 1`] = `
       aria-expanded={false}
       aria-haspopup="true"
       className="pf-c-dropdown__toggle"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
     >
       Dropdown
       <CaretDownIcon
@@ -99,6 +102,7 @@ exports[`Kebab toggle 1`] = `
   <DropdownToggle
     aria-label="Actions"
     className=""
+    focusedItemRef={null}
     isActive={false}
     isFocused={false}
     isHovered={false}
@@ -111,7 +115,9 @@ exports[`Kebab toggle 1`] = `
       aria-haspopup="true"
       aria-label="Actions"
       className="pf-c-dropdown__toggle"
+      onBlur={[Function]}
       onClick={[Function]}
+      onFocus={[Function]}
     >
       <EllipsisVIcon
         color="currentColor"


### PR DESCRIPTION
Fixes #557

**What**:
1. Scope `esc` keypress to the dropdown containing the currently focused DOM element
2. Automatically close dropdown if user tabs all the way through the menu (forwards or backwards)
3. Automatically reopen dropdown and focus last menu item under the following conditions.  
    - Keyboard user tabs all the way through the menu (so that it autocloses)
    - Keyboard user uses `shift + tab` to move focus back to the recently closed dropdown

**TODO**:

1.  ~Add type definitions~
2.  ~Add tests~
