### PR TITLE
feat(Wizard.Pattern): allow hiding cancel and back buttons

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Wizard/Patterns/StatefulWizardPattern.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Wizard/Patterns/StatefulWizardPattern.js
@@ -36,7 +36,13 @@ class StatefulWizardPattern extends React.Component {
   };
 
   render() {
-    const { shouldDisableNextStep, shouldDisablePreviousStep, ...otherProps } = this.props;
+    const {
+      shouldDisableNextStep,
+      shouldDisablePreviousStep,
+      shouldHidePreviousStep,
+      shouldHideCancelButton,
+      ...otherProps
+    } = this.props;
     const { activeStepIndex } = this.state;
     // NOTE: the steps array is passed down with ...otherProps, including any shouldPreventEnter or shouldPreventExit functions inside it.
     // These functions are for StatefulWizardPattern only and should not be used in WizardPattern despite being passed down here.
@@ -44,6 +50,8 @@ class StatefulWizardPattern extends React.Component {
       <WizardPattern
         nextStepDisabled={shouldDisableNextStep(activeStepIndex)}
         previousStepDisabled={shouldDisablePreviousStep(activeStepIndex)}
+        previousStepHidden={shouldHidePreviousStep(activeStepIndex)}
+        cancelButtonHidden={shouldHideCancelButton(activeStepIndex)}
         {...excludeKeys(otherProps, ['shouldPreventStepChange'])}
         activeStepIndex={activeStepIndex} // Value from state, as set by getDerivedStateFromProps
         onStepChanged={this.onStepChanged}
@@ -53,7 +61,13 @@ class StatefulWizardPattern extends React.Component {
 }
 
 StatefulWizardPattern.propTypes = {
-  ...excludeKeys(WizardPattern.propTypes, ['activeStepIndex', 'nextStepDisabled', 'previousStepDisabled']),
+  ...excludeKeys(WizardPattern.propTypes, [
+    'activeStepIndex',
+    'nextStepDisabled',
+    'previousStepDisabled',
+    'previousStepHidden',
+    'cancelButtonHidden'
+  ]),
   steps: PropTypes.arrayOf(
     PropTypes.shape({
       ...wizardStepShape,
@@ -63,13 +77,23 @@ StatefulWizardPattern.propTypes = {
   ),
   shouldDisableNextStep: PropTypes.func,
   shouldDisablePreviousStep: PropTypes.func,
+  shouldHidePreviousStep: PropTypes.func,
+  shouldHideCancelButton: PropTypes.func,
   shouldPreventStepChange: PropTypes.func
 };
 
 StatefulWizardPattern.defaultProps = {
-  ...excludeKeys(WizardPattern.defaultProps, ['activeStepIndex', 'nextStepDisabled', 'previousStepDisabled']),
+  ...excludeKeys(WizardPattern.defaultProps, [
+    'activeStepIndex',
+    'nextStepDisabled',
+    'previousStepDisabled',
+    'previousStepHidden',
+    'cancelButtonHidden'
+  ]),
   shouldDisableNextStep: noop,
   shouldDisablePreviousStep: noop,
+  shouldHidePreviousStep: noop,
+  shouldHideCancelButton: noop,
   shouldPreventStepChange: noop
 };
 

--- a/packages/patternfly-3/patternfly-react/src/components/Wizard/Patterns/WizardPattern.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Wizard/Patterns/WizardPattern.js
@@ -15,6 +15,8 @@ const WizardPattern = ({
   onBack,
   nextStepDisabled,
   previousStepDisabled,
+  previousStepHidden,
+  cancelButtonHidden,
   title,
   loadingTitle,
   loadingMessage,
@@ -90,6 +92,26 @@ const WizardPattern = ({
   const nextStepUnreachable =
     nextStepDisabled || activeStep.isInvalid || activeStep.preventExit || getNextStep().preventEnter;
 
+  let cancelButton;
+  let backButton;
+
+  if (!cancelButtonHidden) {
+    cancelButton = (
+      <Button bsStyle="default" className="btn-cancel" onClick={onHideClick}>
+        {cancelText}
+      </Button>
+    );
+  }
+
+  if (!previousStepHidden) {
+    backButton = (
+      <Button bsStyle="default" onClick={onBackClick} disabled={prevStepUnreachable}>
+        <Icon type="fa" name="angle-left" />
+        {backText}
+      </Button>
+    );
+  }
+
   return (
     <Wizard show={show} onHide={onHideClick} onExited={onExited} {...props}>
       <Wizard.Header onClose={onHideClick} title={title} />
@@ -108,13 +130,8 @@ const WizardPattern = ({
         />
       </Wizard.Body>
       <Wizard.Footer>
-        <Button bsStyle="default" className="btn-cancel" onClick={onHideClick}>
-          {cancelText}
-        </Button>
-        <Button bsStyle="default" onClick={onBackClick} disabled={prevStepUnreachable}>
-          <Icon type="fa" name="angle-left" />
-          {backText}
-        </Button>
+        {cancelButton}
+        {backButton}
         <Button
           bsStyle="primary"
           onClick={onFinalStep ? onHideClick : onNextClick}
@@ -156,6 +173,8 @@ WizardPattern.propTypes = {
   nextStepDisabled: PropTypes.bool,
   previousStepDisabled: PropTypes.bool,
   stepButtonsDisabled: PropTypes.bool,
+  previousStepHidden: PropTypes.bool,
+  cancelButtonHidden: PropTypes.bool,
   nextButtonRef: PropTypes.func,
   bodyHeader: PropTypes.node,
   children: PropTypes.node
@@ -180,6 +199,8 @@ WizardPattern.defaultProps = {
   nextStepDisabled: false,
   previousStepDisabled: false,
   stepButtonsDisabled: false,
+  previousStepHidden: false,
+  cancelButtonHidden: false,
   nextButtonRef: noop,
   bodyHeader: null,
   children: null

--- a/packages/patternfly-3/patternfly-react/src/components/Wizard/Wizard.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Wizard/Wizard.test.js
@@ -383,13 +383,14 @@ const testDisablePreviousStepWizard = props => {
   const onHide = jest.fn();
   const onExited = jest.fn();
   const onStepChanged = jest.fn();
+
   return (
     <Wizard.Pattern.Stateful
       show
       onHide={onHide}
       onExited={onExited}
       onStepChanged={onStepChanged}
-      title="Wizard Disable Next Step"
+      title="Wizard Disable Previous Step"
       shouldDisablePreviousStep={() => true}
       steps={[
         { title: '1', render: () => <p>1</p> },
@@ -400,6 +401,24 @@ const testDisablePreviousStepWizard = props => {
     />
   );
 };
+
+const testHideButtonsStepWizard = props => (
+  <Wizard.Pattern.Stateful
+    show
+    onHide={jest.fn()}
+    onExited={jest.fn()}
+    onStepChanged={jest.fn()}
+    title="Wizard Hide Cancel and Back Button"
+    shouldHidePreviousStep={idx => idx > 0}
+    shouldHideCancelButton={idx => idx === 2}
+    steps={[
+      { title: '1', render: () => <p>1</p> },
+      { title: '2', render: () => <p className=".step2">2</p> },
+      { title: '3', render: () => <p>3</p> }
+    ]}
+    {...props}
+  />
+);
 
 test('Wizard Stateful with shouldDisableNextStep should disable next step', () => {
   const component = mount(testDisableNextStepWizard());
@@ -424,4 +443,22 @@ test('Wizard Stateful with shouldDisablePreviousStep should disable previous ste
       .at(1)
       .getDOMNode().disabled
   ).toBe(true);
+});
+
+test('Wizard Stateful with shouldHidePreviousStep and shouldHideCancelButton should hide cancel and back Button', () => {
+  const component = mount(testHideButtonsStepWizard());
+  expect(component.find('.wizard-pf-footer .btn')).toHaveLength(3);
+
+  component
+    .find('.wizard-pf-footer .btn')
+    .at(2)
+    .simulate('click');
+  expect(component.exists('.step2')).toEqual(true);
+  expect(component.find('.wizard-pf-footer .btn')).toHaveLength(2);
+
+  component
+    .find('.wizard-pf-footer .btn')
+    .at(1)
+    .simulate('click');
+  expect(component.find('.wizard-pf-footer .btn')).toHaveLength(1);
 });

--- a/packages/patternfly-3/patternfly-react/src/components/Wizard/__snapshots__/Wizard.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/Wizard/__snapshots__/Wizard.test.js.snap
@@ -96,6 +96,7 @@ exports[`Wizard Stateful Pattern renders properly: Wizard stateful pattern snaps
   activeStepIndex={0}
   backText="Back"
   bodyHeader={null}
+  cancelButtonHidden={false}
   cancelText="Cancel"
   closeText="Close"
   loading={false}
@@ -110,6 +111,7 @@ exports[`Wizard Stateful Pattern renders properly: Wizard stateful pattern snaps
   onNext={[Function]}
   onStepChanged={[Function]}
   previousStepDisabled={false}
+  previousStepHidden={false}
   show={true}
   stepButtonsDisabled={false}
   steps={


### PR DESCRIPTION
Adds a possibility to remove `Cancel` and `Back` buttons from Wizard.Pattern. It is useful for the last final step, if we do not wish to have a  possibility to go back. The last step also has a `Close` button and other buttons would be superfluous (even if disabled).

Additional info:
disscused in https://github.com/kubevirt/web-ui-components/pull/10#issuecomment-428771202