### PR TITLE
fix(BackgroundImage): remove children from props

### DIFF
--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.d.ts
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.d.ts
@@ -14,7 +14,6 @@ export const BackgroundImageSrc: {
 };
 
 export interface BackgroundImageProps extends HTMLProps<HTMLDivElement> {
-  children?: ReactNode;
   src: string | {
     lg?: string;
     md?: string;

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.js
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.js
@@ -42,8 +42,6 @@ const variableMap = {
 };
 
 export const propTypes = {
-  /** Content rendered inside the background */
-  children: PropTypes.node,
   /** Additional classes added to the background. */
   className: PropTypes.string,
   /** Override image styles using a string or BackgroundImageSrc */
@@ -64,11 +62,10 @@ export const propTypes = {
 };
 
 export const defaultProps = {
-  children: '',
   className: ''
 };
 
-const BackgroundImage = ({ className, children, src, ...props }) => {
+const BackgroundImage = ({ className, src, ...props }) => {
   // Default string value to handle all sizes
   const variableOverrides =
     typeof src === 'string'
@@ -90,11 +87,7 @@ const BackgroundImage = ({ className, children, src, ...props }) => {
     }`
   });
 
-  return (
-    <div className={css(styles.backgroundImage, bgStyles.bgOverrides, className)} >
-      {children}
-    </div>
-  );
+  return <div className={css(styles.backgroundImage, bgStyles.bgOverrides, className)} />;
 };
 
 BackgroundImage.propTypes = propTypes;


### PR DESCRIPTION
When the BackgroundImage component is used as a container (e.g., to wrap a component like Page layout), nothing inside it is clickable; however, works fine (clicks events can be received) as a sibling. This is due to the .pf-c-background-image selector using a z-index of -1.

Fixes https://github.com/patternfly/patternfly-react/issues/747
