### PR TITLE
Fix broken image paths for patternfly-4 docs hosted by surge

### DIFF
--- a/.travis/release.sh
+++ b/.travis/release.sh
@@ -29,6 +29,7 @@ yarn storybook:build
 yarn build:prdocs
 cp -r .out/ .public/patternfly-3
 cp -r packages/patternfly-4/react-docs/public .public/patternfly-4
+cp -r packages/patternfly-4/react-docs/public/assets .public/assets
 
 if [ "${TRAVIS_REPO_SLUG}" != "${TRIGGER_REPO_SLUG}" -o "${TRAVIS_BRANCH}" != "${TRIGGER_REPO_BRANCH}" ]; then
   echo -e "${RED}Exiting, this is not a production release.${NC}"


### PR DESCRIPTION
This fixes the broken image paths for the patternfly-4 docs hosted by surge. 

Currently, image paths are set to `/assets/images`, which works fine when running react-docs locally. However, Travis runs a script to copy the public directory for patternfly-4. This means that `/assets/images` is no longer at the root, but `/patternfly-4/assets/images`. 

This change simply copies the images to the expected location.
