### PR TITLE
feat(radioComponent): updated according to PF-next demo

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.d.ts
@@ -1,11 +1,15 @@
-import { HTMLProps, FormEvent } from 'react';
+import { HTMLProps, FormEvent, ReactNode } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface RadioProps
   extends Omit<HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled'> {
-  isDisabled: boolean;
-  isValid: boolean;
-  onChange(checked: boolean, event: FormEvent<HTMLInputElement>): void;
+  isDisabled?: boolean;
+  isValid?: boolean;
+  onChange?(checked: boolean, event: FormEvent<HTMLInputElement>): void;
+  id: string;
+  'aria-label': string;
+  label?: ReactNode;
+  name: string;
 }
 
 declare const Radio: React.SFC<RadioProps>;

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.docs.js
@@ -1,12 +1,13 @@
-import { Checkbox } from '@patternfly/react-core';
 import Controlled from './examples/ControlledRadio';
 import Uncontrolled from './examples/UncontrolledRadio';
 import Disabled from './examples/DisabledRadio';
+import Custom from './examples/CustomLabelRadio';
+import { Radio } from '@patternfly/react-core';
 
 export default {
   title: 'Radio',
   components: {
-    Checkbox
+    Radio
   },
-  examples: [Controlled, Uncontrolled, Disabled]
+  examples: [Controlled, Uncontrolled, Disabled, Custom]
 };

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.js
@@ -1,24 +1,33 @@
 import React from 'react';
 import styles from '@patternfly/patternfly-next/components/Check/check.css';
-import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
+import { css, getModifier } from '@patternfly/react-styles';
 
 const propTypes = {
-  /** additional classes added to the Radio */
+  /** Additional classes added to the Radio. */
   className: PropTypes.string,
   /** Flag to show if the Radio selection is valid or invalid. */
   isValid: PropTypes.bool,
   /** Flag to show if the Radio is disabled. */
   isDisabled: PropTypes.bool,
   /** A callback for when the Radio selection changes. */
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  /** Label text of the Radio. */
+  label: PropTypes.node,
+  /** Id of the Radio. */
+  id: PropTypes.string.isRequired,
+  /** Aria-label of the Radio. */
+  'aria-label': PropTypes.any.isRequired,
+  /** Name for group of Radios */
+  name: PropTypes.string.isRequired
 };
 
 const defaultProps = {
   className: '',
   isValid: true,
   isDisabled: false,
-  onChange: () => undefined
+  onChange: () => undefined,
+  label: undefined
 };
 
 class Radio extends React.Component {
@@ -27,16 +36,23 @@ class Radio extends React.Component {
   };
 
   render() {
-    const { className, onChange, isValid, isDisabled, ...props } = this.props;
+    const { className, onChange, isValid, isDisabled, label, ...props } = this.props;
     return (
-      <input
-        {...props}
-        className={css(styles.check, className)}
-        type="radio"
-        onChange={onChange ? this.handleChange : null}
-        aria-invalid={!isValid}
-        disabled={isDisabled}
-      />
+      <div className={css(styles.check, className)}>
+        <input
+          {...props}
+          className={css(styles.checkInput)}
+          type="radio"
+          onChange={this.handleChange}
+          aria-invalid={!isValid}
+          disabled={isDisabled}
+        />
+        {label && (
+          <label className={css(styles.checkLabel, getModifier(styles, isDisabled && 'disabled'))} htmlFor={props.id}>
+            {label}
+          </label>
+        )}
+      </div>
     );
   }
 }

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.test.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.test.js
@@ -1,33 +1,65 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import Radio from './Radio';
+import { shallow } from 'enzyme';
 
 const props = {
   onChange: jest.fn(),
   checked: false
 };
 
-test('controlled', () => {
-  const view = shallow(<Radio checked />);
-  expect(view).toMatchSnapshot();
-});
+describe('Radio check component', () => {
+  test('controlled', () => {
+    const view = shallow(<Radio checked id="check" aria-label="check" name="check" />);
+    expect(view).toMatchSnapshot();
+  });
 
-test('uncontrolled', () => {
-  const view = shallow(<Radio />);
-  expect(view).toMatchSnapshot();
-});
+  test('uncontrolled', () => {
+    const view = shallow(<Radio id="check" aria-label="check" name="check" />);
+    expect(view).toMatchSnapshot();
+  });
 
-test('isDisabled', () => {
-  const view = shallow(<Radio isDisabled />);
-  expect(view).toMatchSnapshot();
-});
+  test('isDisabled', () => {
+    const view = shallow(<Radio id="check" isDisabled aria-label="check" name="check" />);
+    expect(view).toMatchSnapshot();
+  });
 
-test('radio passes value and event to onChange handler', () => {
-  const newValue = true;
-  const event = {
-    currentTarget: { checked: newValue }
-  };
-  const view = shallow(<Radio {...props} />);
-  view.find('input').simulate('change', event);
-  expect(props.onChange).toBeCalledWith(newValue, event);
+  test('label is string', () => {
+    const view = shallow(<Radio label="Label" id="check" checked aria-label="check" name="check" />);
+    expect(view).toMatchSnapshot();
+  });
+
+  test('label is function', () => {
+    const functionLabel = () => <h1>Header</h1>;
+    const view = shallow(<Radio label={functionLabel()} id="check" checked aria-label="check" name="check" />);
+    expect(view).toMatchSnapshot();
+  });
+
+  test('label is node', () => {
+    const view = shallow(<Radio label={<h1>Header</h1>} id="check" checked aria-label="check" name="check" />);
+    expect(view).toMatchSnapshot();
+  });
+
+  test('passing class', () => {
+    const view = shallow(
+      <Radio label="label" className="class-123" id="check" checked aria-label="check" name="check" />
+    );
+    expect(view).toMatchSnapshot();
+  });
+
+  test('passing HTML attribute', () => {
+    const view = shallow(
+      <Radio label="label" aria-labelledby="labelId" id="check" checked aria-label="check" name="check" />
+    );
+    expect(view).toMatchSnapshot();
+  });
+
+  test('Radio passes value and event to onChange handler', () => {
+    const newValue = true;
+    const event = {
+      currentTarget: { checked: newValue }
+    };
+    const view = shallow(<Radio id="check" {...props} aria-label="check" name="check" />);
+    view.find('input').simulate('change', event);
+    expect(props.onChange).toBeCalledWith(newValue, event);
+  });
 });

--- a/packages/patternfly-4/react-core/src/components/Radio/__snapshots__/Radio.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Radio/__snapshots__/Radio.test.js.snap
@@ -1,44 +1,249 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`controlled 1`] = `
+exports[`Radio check component controlled 1`] = `
+.pf-c-check__input {
+  display: block;
+}
 .pf-c-check {
   display: block;
 }
 
-<input
-  aria-invalid={false}
-  checked={true}
+<div
   className="pf-c-check"
-  disabled={false}
-  onChange={[Function]}
-  type="radio"
-/>
+>
+  <input
+    aria-invalid={false}
+    aria-label="check"
+    checked={true}
+    className="pf-c-check__input"
+    disabled={false}
+    id="check"
+    name="check"
+    onChange={[Function]}
+    type="radio"
+  />
+</div>
 `;
 
-exports[`isDisabled 1`] = `
+exports[`Radio check component isDisabled 1`] = `
+.pf-c-check__input {
+  display: block;
+}
 .pf-c-check {
   display: block;
 }
 
-<input
-  aria-invalid={false}
+<div
   className="pf-c-check"
-  disabled={true}
-  onChange={[Function]}
-  type="radio"
-/>
+>
+  <input
+    aria-invalid={false}
+    aria-label="check"
+    className="pf-c-check__input"
+    disabled={true}
+    id="check"
+    name="check"
+    onChange={[Function]}
+    type="radio"
+  />
+</div>
 `;
 
-exports[`uncontrolled 1`] = `
+exports[`Radio check component label is function 1`] = `
+.pf-c-check__input {
+  display: block;
+}
+.pf-c-check__label {
+  display: block;
+}
 .pf-c-check {
   display: block;
 }
 
-<input
-  aria-invalid={false}
+<div
   className="pf-c-check"
-  disabled={false}
-  onChange={[Function]}
-  type="radio"
-/>
+>
+  <input
+    aria-invalid={false}
+    aria-label="check"
+    checked={true}
+    className="pf-c-check__input"
+    disabled={false}
+    id="check"
+    name="check"
+    onChange={[Function]}
+    type="radio"
+  />
+  <label
+    className="pf-c-check__label"
+    htmlFor="check"
+  >
+    <h1>
+      Header
+    </h1>
+  </label>
+</div>
+`;
+
+exports[`Radio check component label is node 1`] = `
+.pf-c-check__input {
+  display: block;
+}
+.pf-c-check__label {
+  display: block;
+}
+.pf-c-check {
+  display: block;
+}
+
+<div
+  className="pf-c-check"
+>
+  <input
+    aria-invalid={false}
+    aria-label="check"
+    checked={true}
+    className="pf-c-check__input"
+    disabled={false}
+    id="check"
+    name="check"
+    onChange={[Function]}
+    type="radio"
+  />
+  <label
+    className="pf-c-check__label"
+    htmlFor="check"
+  >
+    <h1>
+      Header
+    </h1>
+  </label>
+</div>
+`;
+
+exports[`Radio check component label is string 1`] = `
+.pf-c-check__input {
+  display: block;
+}
+.pf-c-check__label {
+  display: block;
+}
+.pf-c-check {
+  display: block;
+}
+
+<div
+  className="pf-c-check"
+>
+  <input
+    aria-invalid={false}
+    aria-label="check"
+    checked={true}
+    className="pf-c-check__input"
+    disabled={false}
+    id="check"
+    name="check"
+    onChange={[Function]}
+    type="radio"
+  />
+  <label
+    className="pf-c-check__label"
+    htmlFor="check"
+  >
+    Label
+  </label>
+</div>
+`;
+
+exports[`Radio check component passing HTML attribute 1`] = `
+.pf-c-check__input {
+  display: block;
+}
+.pf-c-check__label {
+  display: block;
+}
+.pf-c-check {
+  display: block;
+}
+
+<div
+  className="pf-c-check"
+>
+  <input
+    aria-invalid={false}
+    aria-label="check"
+    aria-labelledby="labelId"
+    checked={true}
+    className="pf-c-check__input"
+    disabled={false}
+    id="check"
+    name="check"
+    onChange={[Function]}
+    type="radio"
+  />
+  <label
+    className="pf-c-check__label"
+    htmlFor="check"
+  >
+    label
+  </label>
+</div>
+`;
+
+exports[`Radio check component passing class 1`] = `
+.pf-c-check__input {
+  display: block;
+}
+.pf-c-check__label {
+  display: block;
+}
+.pf-c-check.class-123 {
+  display: block;
+}
+
+<div
+  className="pf-c-check class-123"
+>
+  <input
+    aria-invalid={false}
+    aria-label="check"
+    checked={true}
+    className="pf-c-check__input"
+    disabled={false}
+    id="check"
+    name="check"
+    onChange={[Function]}
+    type="radio"
+  />
+  <label
+    className="pf-c-check__label"
+    htmlFor="check"
+  >
+    label
+  </label>
+</div>
+`;
+
+exports[`Radio check component uncontrolled 1`] = `
+.pf-c-check__input {
+  display: block;
+}
+.pf-c-check {
+  display: block;
+}
+
+<div
+  className="pf-c-check"
+>
+  <input
+    aria-invalid={false}
+    aria-label="check"
+    className="pf-c-check__input"
+    disabled={false}
+    id="check"
+    name="check"
+    onChange={[Function]}
+    type="radio"
+  />
+</div>
 `;

--- a/packages/patternfly-4/react-core/src/components/Radio/examples/ControlledRadio.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/examples/ControlledRadio.js
@@ -21,14 +21,18 @@ class ControlledRadio extends React.Component {
           checked={this.state.value === '3'}
           name="pf-version"
           onChange={this.handleChange}
-          aria-label="Patternfly 3"
+          aria-label="Controlled radio 1"
+          label="Controlled radio 1"
+          id="radio-1"
         />{' '}
         <Radio
           value="4"
           checked={this.state.value === '4'}
           name="pf-version"
           onChange={this.handleChange}
-          aria-label="Patternfly 3"
+          aria-label="Controlled radio 2"
+          label="Controlled radio 2"
+          id="radio-2"
         />
       </React.Fragment>
     );

--- a/packages/patternfly-4/react-core/src/components/Radio/examples/CustomLabelRadio.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/examples/CustomLabelRadio.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import getContainerProps from './common/getContainerProps';
+import { Radio, Badge } from '@patternfly/react-core';
+
+class CustomLabelRadio extends React.Component {
+  static title = 'Custom label Radio';
+  static getContainerProps = getContainerProps;
+
+  render() {
+    return (
+      <React.Fragment>
+        <Radio label={<Badge>Badge here!</Badge>} id="radio-6" name="radios-custom" aria-label="custom-label-1" />
+        <Radio
+          label={<Badge isRead>Different badge!</Badge>}
+          id="radio-7"
+          name="radios-custom"
+          aria-label="custom-label-2"
+        />
+      </React.Fragment>
+    );
+  }
+}
+
+export default CustomLabelRadio;

--- a/packages/patternfly-4/react-core/src/components/Radio/examples/DisabledRadio.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/examples/DisabledRadio.js
@@ -7,8 +7,21 @@ class DisabledRadio extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Radio aria-label="disabled checked radio example" defaultChecked isDisabled />{' '}
-        <Radio aria-label="disabled radio example" isDisabled />
+        <Radio
+          label="Disabled checked radio example"
+          aria-label="disabled checked radio example"
+          defaultChecked
+          isDisabled
+          name="group-2"
+          id="radio-disabled"
+        />{' '}
+        <Radio
+          id="radio-disabled-2"
+          label="Disabled radio example"
+          aria-label="disabled radio example"
+          isDisabled
+          name="group-2"
+        />
       </React.Fragment>
     );
   }

--- a/packages/patternfly-4/react-core/src/components/Radio/examples/UncontrolledRadio.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/examples/UncontrolledRadio.js
@@ -5,7 +5,9 @@ class UncontrolledRadio extends React.Component {
   static title = 'Uncontrolled Radio';
 
   render() {
-    return <Radio aria-label="uncontrolled radio example" />;
+    return (
+      <Radio label="Uncontrolled radio example" id="radio-4" name="radio-4" aria-label="uncontrolled radio example" />
+    );
   }
 }
 

--- a/packages/patternfly-4/react-core/src/components/Radio/examples/common/getContainerProps.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/examples/common/getContainerProps.js
@@ -1,0 +1,9 @@
+import { css, StyleSheet } from '@patternfly/react-styles';
+
+const styles = StyleSheet.create({
+  demoLayout: {
+    backgroundColor: '#fff'
+  }
+});
+
+export default () => ({ className: css(styles.demoLayout) });


### PR DESCRIPTION
**What**:

This PR updates radio component according to PF-next demo (https://pf-next.com/components/Check/examples/)

- adds label
- adds more tests

It's basically same component as Checkbox (https://github.com/patternfly/patternfly-react/pull/717), but with `radio` type and required `name` prop.

**Link to docs**:
https://756-pr-patternfly-react-patternfly.surge.sh/patternfly-4/components/radio