### PR TITLE
feat(CatalogTile): Use a link for tiles with href or onClick props

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
@@ -1,6 +1,7 @@
 .catalog-tile-pf {
   background: @card-pf-bg-color;
   border: 1px solid rgba(209, 209, 209, 0.75);
+  color: inherit;
   display: flex;
   flex-direction: column;
   height: @catalog-tile-pf-height;
@@ -15,6 +16,13 @@
 
   &:hover {
     box-shadow: 0 1px 10px rgba(3, 3, 3, 0.175);
+  }
+
+  &:active,
+  &:hover,
+  &:visited {
+    color: inherit;
+    text-decoration: none;
   }
 }
 

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
@@ -1,6 +1,7 @@
 .catalog-tile-pf {
   background: $card-pf-bg-color;
   border: 1px solid rgba(209, 209, 209, 0.75);
+  color: inherit;
   display: flex;
   flex-direction: column;
   height: $catalog-tile-pf-height;
@@ -15,6 +16,13 @@
 
   &:hover {
     box-shadow: 0 1px 10px rgba(3, 3, 3, 0.175);
+  }
+
+  &:active,
+  &:hover,
+  &:visited {
+    color: inherit;
+    text-decoration: none;
   }
 }
 

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.js
@@ -8,6 +8,8 @@ const CatalogTile = ({
   id,
   className,
   featured,
+  href,
+  onClick,
   iconImg,
   iconClass,
   badges,
@@ -49,8 +51,8 @@ const CatalogTile = ({
 
   const truncateDescription = truncateDescriptionFn || defaultTruncateDescription;
 
-  return (
-    <div id={id} className={classes} {...props}>
+  const renderInner = () => (
+    <React.Fragment>
       <div className="catalog-tile-pf-header">
         {iconImg && <img className="catalog-tile-pf-icon" src={iconImg} alt="" />}
         {!iconImg && iconClass && <span className={`catalog-tile-pf-icon ${iconClass}`} />}
@@ -61,6 +63,29 @@ const CatalogTile = ({
         <div className="catalog-tile-pf-subtitle">{vendor}</div>
         <div className="catalog-tile-pf-description">{truncateDescription(description, maxDescriptionLength, id)}</div>
       </div>
+    </React.Fragment>
+  );
+
+  const handleClick = e => {
+    if (!href) {
+      e.preventDefault();
+    }
+    if (onClick) {
+      onClick(e);
+    }
+  };
+
+  if (href || onClick) {
+    return (
+      <a id={id} className={classes} href={href || '#'} {...props} onClick={e => handleClick(e)}>
+        {renderInner()}
+      </a>
+    );
+  }
+
+  return (
+    <div id={id} className={classes} {...props}>
+      {renderInner()}
     </div>
   );
 };
@@ -72,6 +97,10 @@ CatalogTile.propTypes = {
   className: PropTypes.string,
   /** Flag if the tile is 'featured' */
   featured: PropTypes.bool,
+  /** href for the tile if used as a link */
+  href: PropTypes.string,
+  /** Callback for a click on the tile */
+  onClick: PropTypes.func,
   /** URL of an image for the item's icon */
   iconImg: PropTypes.string,
   /** Class for the image when an icon is to be used (exclusive from iconImg) */
@@ -94,6 +123,8 @@ CatalogTile.defaultProps = {
   id: null,
   className: '',
   featured: false,
+  href: null,
+  onClick: null,
   iconImg: null,
   iconClass: null,
   badges: [],

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.stories.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.stories.js
@@ -29,6 +29,7 @@ stories.add(
       <CatalogTile
         id="long-description-test"
         featured
+        href="https://github.com/patternfly/patternfly-react"
         iconImg={pfBrand}
         badges={[
           <CatalogTileBadge title="Certified" id="certified">
@@ -36,11 +37,7 @@ stories.add(
           </CatalogTileBadge>
         ]}
         title="Patternfly-React"
-        vendor={
-          <span>
-            provided by <a href="redhat.com">Red Hat</a>
-          </span>
-        }
+        vendor="provided by Red Hat"
         description={
           'This is a very long description that should be truncated after 112 characters. ' +
           '112 is the default but can be overridden if need be. You can also provide a custom truncation function ' +

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.test.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.test.js
@@ -101,3 +101,42 @@ test('CatalogTile renders properly', () => {
   );
   expect(component.render()).toMatchSnapshot();
 });
+
+test('CatalogTile href renders properly', () => {
+  const component = mount(
+    <CatalogTile
+      id="test-href"
+      href="http://patternfly.org"
+      featured
+      iconImg={pfBrand}
+      title="Patternfly"
+      vendor="Provided by Red Hat"
+      description="1234567890123"
+    />
+  );
+  expect(component.render()).toMatchSnapshot();
+});
+
+test('CatalogTile onClick behaves properly', () => {
+  const onClickMock = jest.fn();
+
+  const component = mount(
+    <CatalogTile
+      id="test-on-click"
+      className="test-click-class"
+      onClick={onClickMock}
+      featured
+      iconImg={pfBrand}
+      title="Patternfly"
+      vendor="Provided by Red Hat"
+      description="1234567890123"
+    />
+  );
+
+  component
+    .find('#test-on-click.test-click-class')
+    .hostNodes()
+    .simulate('click');
+  expect(component.render()).toMatchSnapshot();
+  expect(onClickMock).toBeCalled();
+});

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/__snapshots__/CatalogTile.test.js.snap
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/__snapshots__/CatalogTile.test.js.snap
@@ -1,5 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CatalogTile href renders properly 1`] = `
+<a
+  class="catalog-tile-pf featured"
+  href="http://patternfly.org"
+  id="test-href"
+>
+  <div
+    class="catalog-tile-pf-header"
+  >
+    <img
+      alt=""
+      class="catalog-tile-pf-icon"
+      src="<PatternFly Brand Image here>"
+    />
+  </div>
+  <div
+    class="catalog-tile-pf-body"
+  >
+    <div
+      class="catalog-tile-pf-title"
+    >
+      Patternfly
+    </div>
+    <div
+      class="catalog-tile-pf-subtitle"
+    >
+      Provided by Red Hat
+    </div>
+    <div
+      class="catalog-tile-pf-description"
+    >
+      1234567890123
+    </div>
+  </div>
+</a>
+`;
+
+exports[`CatalogTile onClick behaves properly 1`] = `
+<a
+  class="catalog-tile-pf featured test-click-class"
+  href="#"
+  id="test-on-click"
+>
+  <div
+    class="catalog-tile-pf-header"
+  >
+    <img
+      alt=""
+      class="catalog-tile-pf-icon"
+      src="<PatternFly Brand Image here>"
+    />
+  </div>
+  <div
+    class="catalog-tile-pf-body"
+  >
+    <div
+      class="catalog-tile-pf-title"
+    >
+      Patternfly
+    </div>
+    <div
+      class="catalog-tile-pf-subtitle"
+    >
+      Provided by Red Hat
+    </div>
+    <div
+      class="catalog-tile-pf-description"
+    >
+      1234567890123
+    </div>
+  </div>
+</a>
+`;
+
 exports[`CatalogTile renders properly 1`] = `
 <div>
   <div


### PR DESCRIPTION
Allows applications to pass `href` or `onClick` attributes and if given creates the tile as an `<a>` for accessibility.

https://763-pr-patternfly-react-patternfly.surge.sh/patternfly-3/index.html?selectedKind=patternfly-react-extensions%2FCatalog%20Components%2FCatalog%20Tile&selectedStory=Catalog%20Tile