### PR TITLE
fix(CatalogTile): Style update for tile with focus

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
@@ -14,12 +14,15 @@
     border-top-width: 2px;
   }
 
-  &:hover {
+  &:hover,
+  &:focus {
     box-shadow: 0 1px 10px rgba(3, 3, 3, 0.175);
+    outline-style: none;
   }
 
   &:active,
   &:hover,
+  &:focus,
   &:visited {
     color: inherit;
     text-decoration: none;

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
@@ -14,12 +14,15 @@
     border-top-width: 2px;
   }
 
-  &:hover {
+  &:hover,
+  &:focus {
     box-shadow: 0 1px 10px rgba(3, 3, 3, 0.175);
+    outline-style: none;
   }
 
   &:active,
   &:hover,
+  &:focus,
   &:visited {
     color: inherit;
     text-decoration: none;


### PR DESCRIPTION
Update the style on focused catalog tiles to not show underline text or outline, use the box-shadow
to indicate focus.

