### PR TITLE
fix(Storybook): Fix horizontal masthead examples using iconImg instead of titleImg

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/HorizontalNav.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/HorizontalNav.stories.js
@@ -34,7 +34,7 @@ stories.addDecorator(
 stories.addWithInfo('Single-Level Menu Bar', '', () => (
   <HorizontalNav>
     {mastheadMock({
-      iconImg: pfFitBrand,
+      titleImg: pfFitBrand,
       title: 'Patternfly React',
       navToggle: false,
       thin: true
@@ -46,7 +46,7 @@ stories.addWithInfo('Single-Level Menu Bar', '', () => (
 stories.addWithInfo('Two-Level Menu Bar', '', () => (
   <HorizontalNav>
     {mastheadMock({
-      iconImg: pfFitBrand,
+      titleImg: pfFitBrand,
       title: 'Patternfly React',
       navToggle: false,
       thin: true
@@ -58,7 +58,7 @@ stories.addWithInfo('Two-Level Menu Bar', '', () => (
 stories.addWithInfo('Menu Bar with Dropdowns', '', () => (
   <HorizontalNav>
     {mastheadMock({
-      iconImg: pfFitBrand,
+      titleImg: pfFitBrand,
       title: 'Patternfly React',
       navToggle: false,
       thin: true

--- a/packages/patternfly-3/patternfly-react/src/components/Masthead/__mocks__/mockHorizontalMasthead.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Masthead/__mocks__/mockHorizontalMasthead.js
@@ -30,7 +30,7 @@ export class MockHorizontalMasthead extends React.Component {
       in: !menuCollapsed
     });
     return (
-      <Masthead iconImg={pfFitBrand} title="Patternfly React" navToggle thin onNavToggleClick={this.onNavToggleClick}>
+      <Masthead titleImg={pfFitBrand} title="Patternfly React" navToggle thin onNavToggleClick={this.onNavToggleClick}>
         <Masthead.Collapse>
           <Masthead.Dropdown
             id="app-help-dropdown"
@@ -116,7 +116,7 @@ export class MockHorizontalMasthead extends React.Component {
     });
     return (
       <Masthead
-        iconImg={pfFitBrand}
+        titleImg={pfFitBrand}
         title="Patternfly React"
         navToggle
         thin


### PR DESCRIPTION
Fix #767

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: See #767. Our horizontal nav examples look broken because both a title image and title text are being rendered, due to the use of the wrong prop.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
