### PR TITLE
fix(CatalogTileView): Remove unused styling of CatalogTileViewCategory column children

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
@@ -108,8 +108,4 @@
   flex-wrap: wrap;
   overflow: hidden;
   margin-top: 10px;
-
-  [class*='col-'] {
-    padding: 0 20px 0 0;
-  }
 }

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
@@ -107,8 +107,4 @@
   display: flex;
   flex-wrap: wrap;
   margin-top: 10px;
-
-  [class*='col-'] {
-    padding: 0 20px 0 0;
-  }
 }


### PR DESCRIPTION
Remove the leftover style of bootstrap col children as it is unused and broad in scope.

#765
