### PR TITLE
fix(Masthead): fix Horizontal Menu example in Storybook

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Masthead/__mocks__/mockHorizontalMasthead.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Masthead/__mocks__/mockHorizontalMasthead.js
@@ -30,7 +30,7 @@ export class MockHorizontalMasthead extends React.Component {
       in: !menuCollapsed
     });
     return (
-      <Masthead iconImg={pfFitBrand} title="Patternfly React" navToggle thin onNavToggleClick={this.onNavToggleClick}>
+      <Masthead titleImg={pfFitBrand} title="Patternfly React" navToggle thin onNavToggleClick={this.onNavToggleClick}>
         <Masthead.Collapse>
           <Masthead.Dropdown
             id="app-help-dropdown"
@@ -116,7 +116,7 @@ export class MockHorizontalMasthead extends React.Component {
     });
     return (
       <Masthead
-        iconImg={pfFitBrand}
+        titleImg={pfFitBrand}
         title="Patternfly React"
         navToggle
         thin


### PR DESCRIPTION
**What**:

Fixes storybook example issue introduced with https://github.com/patternfly/patternfly-react/pull/758 - example shows both the image and title. Fixed by changing `iconImg` property to `titleImg` property as suggested in the above PR.

