### PR TITLE
fix(ModelessOverlay): Fix for animation on open in Firefox browser

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/ModelessOverlay.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ModelessOverlay/ModelessOverlay.js
@@ -8,7 +8,7 @@ class ModelessOverlay extends React.Component {
   constructor(props) {
     super(props);
     this.state = { isIn: false };
-    this.inTimer = new Timer(null, 150);
+    this.inTimer = new Timer(this.updateForTransitions, 150);
   }
 
   componentWillUnmount() {
@@ -30,7 +30,8 @@ class ModelessOverlay extends React.Component {
     );
 
     if (isIn !== show) {
-      this.inTimer.startTimer(() => this.updateForTransitions(), show ? 0 : 150);
+      this.inTimer.clearTimer();
+      this.inTimer.startTimer();
     }
 
     const dialogClasses = classNames('modal-dialog', {


### PR DESCRIPTION
Use a 150ms delay to update show & in classes for both open and close

fixes #774

