### PR TITLE
fix(Progress): missing ProgressSize added to exported types

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Progress/index.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Progress/index.d.ts
@@ -1,1 +1,1 @@
-export { default as Progress, ProgressVariant, ProgressMeasureLocation, ProgressStatus, ProgressProps } from './Progress';
+export { default as Progress, ProgressVariant, ProgressMeasureLocation, ProgressSize, ProgressProps } from './Progress';


### PR DESCRIPTION
Resolves: #782

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Wrong attribute was exported as ProgressSize and that made it impossible to use Progress. This PR fixes such issue by exporting correct attribute.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
