### PR TITLE
fix(Form): Do not add any class if action modifier is missing

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Form/ActionGroup.js
+++ b/packages/patternfly-4/react-core/src/components/Form/ActionGroup.js
@@ -17,7 +17,7 @@ const defaultProps = {
 };
 
 const ActionGroup = ({ className, children, ...props }) => {
-  const customClassName = css(styles.formGroup, getModifier(styles, 'action'), className);
+  const customClassName = css(styles.formGroup, styles.modifiers.action, className);
   const classesHorizontal = css(styles.formHorizontalGroup);
 
   return (


### PR DESCRIPTION
Fixes currently broken master, because there is no info modifier for FormGroup.