### PR TITLE
fix(react-core 1.24.1 failing build): Failing build

### DIFF
--- a/packages/patternfly-4/react-core/package.json
+++ b/packages/patternfly-4/react-core/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^15.6.2 || ^16.4.0"
   },
   "scripts": {
-    "build": "yarn build:babel; yarn build:ts",
+    "build": "yarn build:babel && yarn build:ts",
     "build:babel": "concurrently \"yarn build:babel:cjs\" \"yarn build:babel:esm\"",
     "build:babel:cjs": "cross-env BABEL_ENV=production:cjs babel src --out-dir dist/js",
     "build:babel:esm": "cross-env BABEL_ENV=production:esm babel src --out-dir dist/esm",

--- a/packages/patternfly-4/react-core/src/components/Form/ActionGroup.js
+++ b/packages/patternfly-4/react-core/src/components/Form/ActionGroup.js
@@ -17,7 +17,7 @@ const defaultProps = {
 };
 
 const ActionGroup = ({ className, children, ...props }) => {
-  const customClassName = css(styles.formGroup, getModifier(styles, 'action', styles.modifiers.info), className);
+  const customClassName = css(styles.formGroup, getModifier(styles, 'action'), className);
   const classesHorizontal = css(styles.formHorizontalGroup);
 
   return (

--- a/packages/patternfly-4/react-core/src/components/Form/Form.js
+++ b/packages/patternfly-4/react-core/src/components/Form/Form.js
@@ -20,10 +20,7 @@ const defaultProps = {
 };
 
 const Form = ({ className, children, isHorizontal, ...props }) => (
-  <form
-    {...props}
-    className={css(styles.form, isHorizontal ? styles.modifiers.horizontal : styles.modifiers.info, className)}
-  >
+  <form {...props} className={css(styles.form, isHorizontal && styles.modifiers.horizontal, className)}>
     <FormContext.Provider value={{ isHorizontal }}>{children}</FormContext.Provider>
   </form>
 );

--- a/packages/patternfly-4/react-core/src/components/Form/FormGroup.js
+++ b/packages/patternfly-4/react-core/src/components/Form/FormGroup.js
@@ -80,33 +80,33 @@ const FormGroup = ({
   fieldId,
   ...props
 }) => (
-    <FormContext.Consumer>
-      {({ isHorizontal }) => (
-        <div {...props} className={css(styles.formGroup, getModifier(styles, isInline && 'inline'), className)}>
-          {label && (
-            <label className={css(styles.formLabel)} htmlFor={fieldId}>
-              {label}
-              {isRequired && (
-                <span className={css(styles.formLabelRequired)} aria-hidden="true">
-                  {ASTERISK}
-                </span>
-              )}
-            </label>
-          )}
-          {isHorizontal ? <div className={css(styles.formHorizontalGroup)}>{children}</div> : children}
-          {((isValid && helperText) || (!isValid && helperTextInvalid)) && (
-            <div
-              className={css(styles.formHelperText, getModifier(styles, !isValid && 'error', styles.modifiers.info))}
-              id={`${fieldId}-helper`}
-              aria-live="polite"
-            >
-              {isValid ? helperText : helperTextInvalid}
-            </div>
-          )}
-        </div>
-      )}
-    </FormContext.Consumer>
-  );
+  <FormContext.Consumer>
+    {({ isHorizontal }) => (
+      <div {...props} className={css(styles.formGroup, getModifier(styles, isInline && 'inline'), className)}>
+        {label && (
+          <label className={css(styles.formLabel)} htmlFor={fieldId}>
+            {label}
+            {isRequired && (
+              <span className={css(styles.formLabelRequired)} aria-hidden="true">
+                {ASTERISK}
+              </span>
+            )}
+          </label>
+        )}
+        {isHorizontal ? <div className={css(styles.formHorizontalGroup)}>{children}</div> : children}
+        {((isValid && helperText) || (!isValid && helperTextInvalid)) && (
+          <div
+            className={css(styles.formHelperText, getModifier(styles, !isValid && 'error'))}
+            id={`${fieldId}-helper`}
+            aria-live="polite"
+          >
+            {isValid ? helperText : helperTextInvalid}
+          </div>
+        )}
+      </div>
+    )}
+  </FormContext.Consumer>
+);
 
 FormGroup.propTypes = propTypes;
 FormGroup.defaultProps = defaultProps;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4586,7 +4586,7 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
-cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@^0.3.4:
+cssom@0.3.4, cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
 


### PR DESCRIPTION
fix 791

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

Distribution package form @patternfly/react-core 1.24.1 did not contain index.js (source of component). As a result build was not usable. More info here: https://github.com/patternfly/patternfly-react/issues/791.

The build was not passing even locally, because of some incorrect style modifier values.

CI did not catch it because the build command was `"build": "yarn build:babel; yarn build:ts"` and it should be `"build": "yarn build:babel && yarn build:ts",` (credit to @dmiller9911 for this)

<!-- Are there any upstream issues or separate issues you need to reference? -->
