### PR TITLE
fix(react-core): add missing component to index type definitions

### DIFF
--- a/packages/patternfly-4/react-core/src/components/index.d.ts
+++ b/packages/patternfly-4/react-core/src/components/index.d.ts
@@ -19,3 +19,4 @@ export * from './Select';
 export * from './TextArea';
 export * from './TextInput';
 export * from './Title';
+export * from './Text';


### PR DESCRIPTION
Add missing Text component to index list for typescript