### PR TITLE
fix(CatalogItemHeader): Make subtitle optional

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/catalog-item.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/catalog-item.less
@@ -15,6 +15,7 @@
 
 .catalog-item-header-pf-title {
   font-weight: 400;
+  margin-bottom: 0;
   margin-top: 0;
 }
 

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-item.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-item.scss
@@ -15,6 +15,7 @@
 
 .catalog-item-header-pf-title {
   font-weight: 400;
+  margin-bottom: 0;
   margin-top: 0;
 }
 

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogItemHeader/CatalogItemHeader.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogItemHeader/CatalogItemHeader.js
@@ -11,7 +11,7 @@ const CatalogItemHeader = ({ className, iconImg, iconClass, title, vendor, ...pr
       {!iconImg && iconClass && <span className={`catalog-item-header-pf-icon ${iconClass}`} />}
       <div className="catalog-item-header-pf-text">
         <h1 className="catalog-item-header-pf-title">{title}</h1>
-        <h5 className="catalog-item-header-pf-subtitle">{vendor}</h5>
+        {vendor && <h5 className="catalog-item-header-pf-subtitle">{vendor}</h5>}
       </div>
     </header>
   );

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogItemHeader/CatalogItemHeader.stories.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogItemHeader/CatalogItemHeader.stories.js
@@ -46,7 +46,7 @@ stories.add(
         />
       </div>
       <div style={{ marginBottom: '40px' }}>
-        <CatalogItemHeader iconImg={ngnix} title="Nginx" vendor={<span>provided by Nginx</span>} />
+        <CatalogItemHeader iconImg={ngnix} title="Nginx" />
       </div>
       <div style={{ marginBottom: '40px' }}>
         <CatalogItemHeader iconClass="fa fa-codepen" title="CodePen" vendor="provided by CodePen" />

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogItemHeader/CatalogItemHeader.test.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogItemHeader/CatalogItemHeader.test.js
@@ -27,7 +27,7 @@ test('CatalogItemHeader renders properly', () => {
           </span>
         }
       />
-      <CatalogItemHeader iconImg={ngnix} title="Nginx" vendor={<span>provided by Nginx</span>} />
+      <CatalogItemHeader iconImg={ngnix} title="Nginx" />
       <CatalogItemHeader
         className="test-catalog-item-header-icon-class"
         iconClass="fa fa-codepen"

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogItemHeader/__snapshots__/CatalogItemHeader.test.js.snap
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogItemHeader/__snapshots__/CatalogItemHeader.test.js.snap
@@ -78,13 +78,6 @@ exports[`CatalogItemHeader renders properly 1`] = `
       >
         Nginx
       </h1>
-      <h5
-        class="catalog-item-header-pf-subtitle"
-      >
-        <span>
-          provided by Nginx
-        </span>
-      </h5>
     </div>
   </header>
   <header


### PR DESCRIPTION
If a vendor (displayed in the subtitle) is not provided, the component emits an empty subtitle
element, which creates a visual defect

Before:
![screen shot 2018-10-18 at 9 13 10 am](https://user-images.githubusercontent.com/895728/47156949-359a8500-d2b6-11e8-99c4-d8a14a5adedd.PNG)

After:
![screen shot 2018-10-18 at 9 13 58 am](https://user-images.githubusercontent.com/895728/47156959-3a5f3900-d2b6-11e8-905f-f290925ff93f.PNG)

attn: @jeff-phillips-18, @dtaylor113 
