### PR TITLE
fix(CatalogTile): Catalog Tiles can shrink

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
@@ -3,6 +3,7 @@
   border: 1px solid rgba(209, 209, 209, 0.75);
   color: inherit;
   display: flex;
+  flex: 0 0 auto;
   flex-direction: column;
   height: @catalog-tile-pf-height;
   margin: 0 15px @catalog-tile-pf-margin-bottom 0;

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
@@ -3,6 +3,7 @@
   border: 1px solid rgba(209, 209, 209, 0.75);
   color: inherit;
   display: flex;
+  flex: 0 0 auto;
   flex-direction: column;
   height: $catalog-tile-pf-height;
   margin: 0 15px $catalog-tile-pf-margin-bottom 0;


### PR DESCRIPTION
Catalog tiles are supposed to have a fixed size.  If the viewport gets small, the tiles shrink.

Before:
![screen shot 2018-10-18 at 10 25 52 am](https://user-images.githubusercontent.com/895728/47161617-667fb780-d2c0-11e8-925e-519a54afa365.PNG)

After:
![screen shot 2018-10-18 at 10 27 12 am](https://user-images.githubusercontent.com/895728/47161627-6aabd500-d2c0-11e8-9b3b-c6e354bb5578.PNG)

attn: @jeff-phillips-18, @dtaylor113 
