### PR TITLE
Adds the Backdrop component to the main index files

### DIFF
--- a/packages/patternfly-4/react-core/src/components/index.d.ts
+++ b/packages/patternfly-4/react-core/src/components/index.d.ts
@@ -2,6 +2,7 @@
 export * from './AboutModal';
 export * from './Alert';
 export * from './Avatar';
+export * from './Backdrop';
 export * from './BackgroundImage';
 export * from './Badge';
 export * from './Brand';

--- a/packages/patternfly-4/react-core/src/components/index.js
+++ b/packages/patternfly-4/react-core/src/components/index.js
@@ -2,6 +2,7 @@
 export * from './AboutModal';
 export * from './Alert';
 export * from './Avatar';
+export * from './Backdrop';
 export * from './BackgroundImage';
 export * from './Badge';
 export * from './Brand';


### PR DESCRIPTION
Forgot to include the Backdrop component in the main index files.

Fixes https://github.com/patternfly/patternfly-react/issues/802
