### PR TITLE
fix(pf4 NavExpandable): Add animation of expandable nav based on PF4 core with react-transition-group

### DIFF
--- a/packages/patternfly-4/react-core/package.json
+++ b/packages/patternfly-4/react-core/package.json
@@ -28,7 +28,8 @@
     "@patternfly/react-icons": "^2.6.0",
     "@patternfly/react-styles": "^2.3.0",
     "exenv": "^1.2.2",
-    "focus-trap-react": "^4.0.1"
+    "focus-trap-react": "^4.0.1",
+    "react-transition-group": "2.x"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",

--- a/packages/patternfly-4/react-core/src/components/Nav/NavExpandable.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/NavExpandable.js
@@ -3,6 +3,7 @@ import styles from '@patternfly/patternfly-next/components/Nav/nav.css';
 import a11yStyles from '@patternfly/patternfly-next/utilities/Accessibility/accessibility.css';
 import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
+import Transition from 'react-transition-group/Transition';
 import NavToggle from './NavToggle';
 import { AngleRightIcon } from '@patternfly/react-icons';
 import { NavContext } from './Nav';
@@ -58,43 +59,47 @@ class NavExpandable extends React.Component {
         {context => (
           <NavToggle defaultValue={defaultExpanded} groupId={groupId} onToggle={context.onToggle}>
             {({ value: isExpanded, toggle }) => (
-              <li
-                className={css(
-                  styles.navItem,
-                  isExpanded && styles.modifiers.expanded,
-                  isActive && styles.modifiers.current,
-                  className
+              <Transition in={isExpanded} timeout={{ enter: 50, exit: 600 }}>
+                {(transitionState) => (
+                  <li
+                    className={css(
+                      styles.navItem,
+                      transitionState === 'entered' && styles.modifiers.expanded,
+                      isActive && styles.modifiers.current,
+                      className
+                    )}
+                    onClick={toggle}
+                    {...props}
+                  >
+                    <a
+                      data-component="pf-nav-expandable"
+                      className={css(styles.navLink)}
+                      id={srText ? null : this.id}
+                      href="#"
+                      onClick={e => e.preventDefault()}
+                      onMouseDown={e => e.preventDefault()}
+                      aria-expanded={transitionState === 'entered' || transitionState === 'exiting'}
+                    >
+                      {title}
+                      <span className={css(styles.navToggle)}>
+                        <AngleRightIcon aria-hidden="true" />
+                      </span>
+                    </a>
+                    <section
+                      className={css(styles.navSubnav)}
+                      aria-labelledby={this.id}
+                      hidden={transitionState === 'exited'}
+                    >
+                      {srText && (
+                        <h2 className={css(a11yStyles.srOnly)} id={this.id}>
+                          {srText}
+                        </h2>
+                      )}
+                      <ul className={css(styles.navSimpleList)}>{children}</ul>
+                    </section>
+                  </li>
                 )}
-                onClick={toggle}
-                {...props}
-              >
-                <a
-                  data-component="pf-nav-expandable"
-                  className={css(styles.navLink)}
-                  id={srText ? null : this.id}
-                  href="#"
-                  onClick={e => e.preventDefault()}
-                  onMouseDown={e => e.preventDefault()}
-                  aria-expanded={isExpanded}
-                >
-                  {title}
-                  <span className={css(styles.navToggle)}>
-                    <AngleRightIcon aria-hidden="true" />
-                  </span>
-                </a>
-                <section
-                  className={css(styles.navSubnav)}
-                  aria-labelledby={this.id}
-                  hidden={isExpanded ? null : true}
-                >
-                  {srText && (
-                    <h2 className={css(a11yStyles.srOnly)} id={this.id}>
-                      {srText}
-                    </h2>
-                  )}
-                  <ul className={css(styles.navSimpleList)}>{children}</ul>
-                </section>
-              </li>
+              </Transition>
             )}
           </NavToggle>
         )}

--- a/packages/patternfly-4/react-core/src/components/Nav/__snapshots__/Nav.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Nav/__snapshots__/Nav.test.js.snap
@@ -392,149 +392,170 @@ exports[`Expandable Nav List - Trigger toggle 1`] = `
             groupId={null}
             onToggle={[Function]}
           >
-            <li
-              className="pf-c-nav__item pf-m-expanded expandable-group"
-              onClick={[Function]}
+            <Transition
+              appear={false}
+              enter={true}
+              exit={true}
+              in={true}
+              mountOnEnter={false}
+              onEnter={[Function]}
+              onEntered={[Function]}
+              onEntering={[Function]}
+              onExit={[Function]}
+              onExited={[Function]}
+              onExiting={[Function]}
+              timeout={
+                Object {
+                  "enter": 50,
+                  "exit": 600,
+                }
+              }
+              unmountOnExit={false}
             >
-              <a
-                aria-expanded={true}
-                className="pf-c-nav__link"
-                data-component="pf-nav-expandable"
-                href="#"
-                id="grp-1"
+              <li
+                className="pf-c-nav__item pf-m-expanded expandable-group"
                 onClick={[Function]}
-                onMouseDown={[Function]}
               >
-                Section 1
-                <span
-                  className="pf-c-nav__toggle"
+                <a
+                  aria-expanded={true}
+                  className="pf-c-nav__link"
+                  data-component="pf-nav-expandable"
+                  href="#"
+                  id="grp-1"
+                  onClick={[Function]}
+                  onMouseDown={[Function]}
                 >
-                  <AngleRightIcon
-                    aria-hidden="true"
-                    color="currentColor"
-                    size="sm"
-                    title={null}
+                  Section 1
+                  <span
+                    className="pf-c-nav__toggle"
                   >
-                    <svg
+                    <AngleRightIcon
                       aria-hidden="true"
-                      aria-labelledby={null}
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 256 512"
-                      width="1em"
+                      color="currentColor"
+                      size="sm"
+                      title={null}
                     >
-                      <path
-                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                        transform=""
-                      />
-                    </svg>
-                  </AngleRightIcon>
-                </span>
-              </a>
-              <section
-                aria-labelledby="grp-1"
-                className="pf-c-nav__subnav"
-                hidden={null}
-              >
-                <ul
-                  className="pf-c-nav__simple-list"
+                      <svg
+                        aria-hidden="true"
+                        aria-labelledby={null}
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 256 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                          transform=""
+                        />
+                      </svg>
+                    </AngleRightIcon>
+                  </span>
+                </a>
+                <section
+                  aria-labelledby="grp-1"
+                  className="pf-c-nav__subnav"
+                  hidden={false}
                 >
-                  <NavItem
-                    className=""
-                    groupId={null}
-                    isActive={false}
-                    itemId={null}
-                    key="#link1"
-                    onClick={null}
-                    preventDefault={false}
-                    to="#link1"
+                  <ul
+                    className="pf-c-nav__simple-list"
                   >
-                    <li
-                      className="pf-c-nav__item"
+                    <NavItem
+                      className=""
+                      groupId={null}
+                      isActive={false}
+                      itemId={null}
+                      key="#link1"
+                      onClick={null}
+                      preventDefault={false}
+                      to="#link1"
                     >
-                      <a
-                        aria-current={null}
-                        className="pf-c-nav__link"
-                        href="#link1"
-                        onClick={[Function]}
+                      <li
+                        className="pf-c-nav__item"
                       >
-                        Link 1
-                      </a>
-                    </li>
-                  </NavItem>
-                  <NavItem
-                    className=""
-                    groupId={null}
-                    isActive={false}
-                    itemId={null}
-                    key="#link2"
-                    onClick={null}
-                    preventDefault={false}
-                    to="#link2"
-                  >
-                    <li
-                      className="pf-c-nav__item"
+                        <a
+                          aria-current={null}
+                          className="pf-c-nav__link"
+                          href="#link1"
+                          onClick={[Function]}
+                        >
+                          Link 1
+                        </a>
+                      </li>
+                    </NavItem>
+                    <NavItem
+                      className=""
+                      groupId={null}
+                      isActive={false}
+                      itemId={null}
+                      key="#link2"
+                      onClick={null}
+                      preventDefault={false}
+                      to="#link2"
                     >
-                      <a
-                        aria-current={null}
-                        className="pf-c-nav__link"
-                        href="#link2"
-                        onClick={[Function]}
+                      <li
+                        className="pf-c-nav__item"
                       >
-                        Link 2
-                      </a>
-                    </li>
-                  </NavItem>
-                  <NavItem
-                    className=""
-                    groupId={null}
-                    isActive={false}
-                    itemId={null}
-                    key="#link3"
-                    onClick={null}
-                    preventDefault={false}
-                    to="#link3"
-                  >
-                    <li
-                      className="pf-c-nav__item"
+                        <a
+                          aria-current={null}
+                          className="pf-c-nav__link"
+                          href="#link2"
+                          onClick={[Function]}
+                        >
+                          Link 2
+                        </a>
+                      </li>
+                    </NavItem>
+                    <NavItem
+                      className=""
+                      groupId={null}
+                      isActive={false}
+                      itemId={null}
+                      key="#link3"
+                      onClick={null}
+                      preventDefault={false}
+                      to="#link3"
                     >
-                      <a
-                        aria-current={null}
-                        className="pf-c-nav__link"
-                        href="#link3"
-                        onClick={[Function]}
+                      <li
+                        className="pf-c-nav__item"
                       >
-                        Link 3
-                      </a>
-                    </li>
-                  </NavItem>
-                  <NavItem
-                    className=""
-                    groupId={null}
-                    isActive={false}
-                    itemId={null}
-                    key="#link4"
-                    onClick={null}
-                    preventDefault={false}
-                    to="#link4"
-                  >
-                    <li
-                      className="pf-c-nav__item"
+                        <a
+                          aria-current={null}
+                          className="pf-c-nav__link"
+                          href="#link3"
+                          onClick={[Function]}
+                        >
+                          Link 3
+                        </a>
+                      </li>
+                    </NavItem>
+                    <NavItem
+                      className=""
+                      groupId={null}
+                      isActive={false}
+                      itemId={null}
+                      key="#link4"
+                      onClick={null}
+                      preventDefault={false}
+                      to="#link4"
                     >
-                      <a
-                        aria-current={null}
-                        className="pf-c-nav__link"
-                        href="#link4"
-                        onClick={[Function]}
+                      <li
+                        className="pf-c-nav__item"
                       >
-                        Link 4
-                      </a>
-                    </li>
-                  </NavItem>
-                </ul>
-              </section>
-            </li>
+                        <a
+                          aria-current={null}
+                          className="pf-c-nav__link"
+                          href="#link4"
+                          onClick={[Function]}
+                        >
+                          Link 4
+                        </a>
+                      </li>
+                    </NavItem>
+                  </ul>
+                </section>
+              </li>
+            </Transition>
           </NavToggle>
         </NavExpandable>
       </ul>
@@ -635,149 +656,170 @@ exports[`Expandable Nav List 1`] = `
             groupId={null}
             onToggle={[Function]}
           >
-            <li
-              className="pf-c-nav__item"
-              onClick={[Function]}
+            <Transition
+              appear={false}
+              enter={true}
+              exit={true}
+              in={false}
+              mountOnEnter={false}
+              onEnter={[Function]}
+              onEntered={[Function]}
+              onEntering={[Function]}
+              onExit={[Function]}
+              onExited={[Function]}
+              onExiting={[Function]}
+              timeout={
+                Object {
+                  "enter": 50,
+                  "exit": 600,
+                }
+              }
+              unmountOnExit={false}
             >
-              <a
-                aria-expanded={false}
-                className="pf-c-nav__link"
-                data-component="pf-nav-expandable"
-                href="#"
-                id="grp-1"
+              <li
+                className="pf-c-nav__item"
                 onClick={[Function]}
-                onMouseDown={[Function]}
               >
-                Section 1
-                <span
-                  className="pf-c-nav__toggle"
+                <a
+                  aria-expanded={false}
+                  className="pf-c-nav__link"
+                  data-component="pf-nav-expandable"
+                  href="#"
+                  id="grp-1"
+                  onClick={[Function]}
+                  onMouseDown={[Function]}
                 >
-                  <AngleRightIcon
-                    aria-hidden="true"
-                    color="currentColor"
-                    size="sm"
-                    title={null}
+                  Section 1
+                  <span
+                    className="pf-c-nav__toggle"
                   >
-                    <svg
+                    <AngleRightIcon
                       aria-hidden="true"
-                      aria-labelledby={null}
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 256 512"
-                      width="1em"
+                      color="currentColor"
+                      size="sm"
+                      title={null}
                     >
-                      <path
-                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                        transform=""
-                      />
-                    </svg>
-                  </AngleRightIcon>
-                </span>
-              </a>
-              <section
-                aria-labelledby="grp-1"
-                className="pf-c-nav__subnav"
-                hidden={true}
-              >
-                <ul
-                  className="pf-c-nav__simple-list"
+                      <svg
+                        aria-hidden="true"
+                        aria-labelledby={null}
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 256 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                          transform=""
+                        />
+                      </svg>
+                    </AngleRightIcon>
+                  </span>
+                </a>
+                <section
+                  aria-labelledby="grp-1"
+                  className="pf-c-nav__subnav"
+                  hidden={true}
                 >
-                  <NavItem
-                    className=""
-                    groupId={null}
-                    isActive={false}
-                    itemId={null}
-                    key="#link1"
-                    onClick={null}
-                    preventDefault={false}
-                    to="#link1"
+                  <ul
+                    className="pf-c-nav__simple-list"
                   >
-                    <li
-                      className="pf-c-nav__item"
+                    <NavItem
+                      className=""
+                      groupId={null}
+                      isActive={false}
+                      itemId={null}
+                      key="#link1"
+                      onClick={null}
+                      preventDefault={false}
+                      to="#link1"
                     >
-                      <a
-                        aria-current={null}
-                        className="pf-c-nav__link"
-                        href="#link1"
-                        onClick={[Function]}
+                      <li
+                        className="pf-c-nav__item"
                       >
-                        Link 1
-                      </a>
-                    </li>
-                  </NavItem>
-                  <NavItem
-                    className=""
-                    groupId={null}
-                    isActive={false}
-                    itemId={null}
-                    key="#link2"
-                    onClick={null}
-                    preventDefault={false}
-                    to="#link2"
-                  >
-                    <li
-                      className="pf-c-nav__item"
+                        <a
+                          aria-current={null}
+                          className="pf-c-nav__link"
+                          href="#link1"
+                          onClick={[Function]}
+                        >
+                          Link 1
+                        </a>
+                      </li>
+                    </NavItem>
+                    <NavItem
+                      className=""
+                      groupId={null}
+                      isActive={false}
+                      itemId={null}
+                      key="#link2"
+                      onClick={null}
+                      preventDefault={false}
+                      to="#link2"
                     >
-                      <a
-                        aria-current={null}
-                        className="pf-c-nav__link"
-                        href="#link2"
-                        onClick={[Function]}
+                      <li
+                        className="pf-c-nav__item"
                       >
-                        Link 2
-                      </a>
-                    </li>
-                  </NavItem>
-                  <NavItem
-                    className=""
-                    groupId={null}
-                    isActive={false}
-                    itemId={null}
-                    key="#link3"
-                    onClick={null}
-                    preventDefault={false}
-                    to="#link3"
-                  >
-                    <li
-                      className="pf-c-nav__item"
+                        <a
+                          aria-current={null}
+                          className="pf-c-nav__link"
+                          href="#link2"
+                          onClick={[Function]}
+                        >
+                          Link 2
+                        </a>
+                      </li>
+                    </NavItem>
+                    <NavItem
+                      className=""
+                      groupId={null}
+                      isActive={false}
+                      itemId={null}
+                      key="#link3"
+                      onClick={null}
+                      preventDefault={false}
+                      to="#link3"
                     >
-                      <a
-                        aria-current={null}
-                        className="pf-c-nav__link"
-                        href="#link3"
-                        onClick={[Function]}
+                      <li
+                        className="pf-c-nav__item"
                       >
-                        Link 3
-                      </a>
-                    </li>
-                  </NavItem>
-                  <NavItem
-                    className=""
-                    groupId={null}
-                    isActive={false}
-                    itemId={null}
-                    key="#link4"
-                    onClick={null}
-                    preventDefault={false}
-                    to="#link4"
-                  >
-                    <li
-                      className="pf-c-nav__item"
+                        <a
+                          aria-current={null}
+                          className="pf-c-nav__link"
+                          href="#link3"
+                          onClick={[Function]}
+                        >
+                          Link 3
+                        </a>
+                      </li>
+                    </NavItem>
+                    <NavItem
+                      className=""
+                      groupId={null}
+                      isActive={false}
+                      itemId={null}
+                      key="#link4"
+                      onClick={null}
+                      preventDefault={false}
+                      to="#link4"
                     >
-                      <a
-                        aria-current={null}
-                        className="pf-c-nav__link"
-                        href="#link4"
-                        onClick={[Function]}
+                      <li
+                        className="pf-c-nav__item"
                       >
-                        Link 4
-                      </a>
-                    </li>
-                  </NavItem>
-                </ul>
-              </section>
-            </li>
+                        <a
+                          aria-current={null}
+                          className="pf-c-nav__link"
+                          href="#link4"
+                          onClick={[Function]}
+                        >
+                          Link 4
+                        </a>
+                      </li>
+                    </NavItem>
+                  </ul>
+                </section>
+              </li>
+            </Transition>
           </NavToggle>
         </NavExpandable>
       </ul>
@@ -886,155 +928,176 @@ exports[`Expandable Nav List with aria label 1`] = `
             groupId={null}
             onToggle={[Function]}
           >
-            <li
-              className="pf-c-nav__item"
-              onClick={[Function]}
+            <Transition
+              appear={false}
+              enter={true}
+              exit={true}
+              in={false}
+              mountOnEnter={false}
+              onEnter={[Function]}
+              onEntered={[Function]}
+              onEntering={[Function]}
+              onExit={[Function]}
+              onExited={[Function]}
+              onExiting={[Function]}
+              timeout={
+                Object {
+                  "enter": 50,
+                  "exit": 600,
+                }
+              }
+              unmountOnExit={false}
             >
-              <a
-                aria-expanded={false}
-                className="pf-c-nav__link"
-                data-component="pf-nav-expandable"
-                href="#"
-                id={null}
+              <li
+                className="pf-c-nav__item"
                 onClick={[Function]}
-                onMouseDown={[Function]}
               >
-                Section 1
-                <span
-                  className="pf-c-nav__toggle"
+                <a
+                  aria-expanded={false}
+                  className="pf-c-nav__link"
+                  data-component="pf-nav-expandable"
+                  href="#"
+                  id={null}
+                  onClick={[Function]}
+                  onMouseDown={[Function]}
                 >
-                  <AngleRightIcon
-                    aria-hidden="true"
-                    color="currentColor"
-                    size="sm"
-                    title={null}
+                  Section 1
+                  <span
+                    className="pf-c-nav__toggle"
                   >
-                    <svg
+                    <AngleRightIcon
                       aria-hidden="true"
-                      aria-labelledby={null}
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 256 512"
-                      width="1em"
+                      color="currentColor"
+                      size="sm"
+                      title={null}
                     >
-                      <path
-                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                        transform=""
-                      />
-                    </svg>
-                  </AngleRightIcon>
-                </span>
-              </a>
-              <section
-                aria-labelledby="grp-1"
-                className="pf-c-nav__subnav"
-                hidden={true}
-              >
-                <h2
-                  className="pf-u-sr-only"
-                  id="grp-1"
+                      <svg
+                        aria-hidden="true"
+                        aria-labelledby={null}
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 256 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                          transform=""
+                        />
+                      </svg>
+                    </AngleRightIcon>
+                  </span>
+                </a>
+                <section
+                  aria-labelledby="grp-1"
+                  className="pf-c-nav__subnav"
+                  hidden={true}
                 >
-                  Section 1 - Example sub-navigation
-                </h2>
-                <ul
-                  className="pf-c-nav__simple-list"
-                >
-                  <NavItem
-                    className=""
-                    groupId={null}
-                    isActive={false}
-                    itemId={null}
-                    key="#link1"
-                    onClick={null}
-                    preventDefault={false}
-                    to="#link1"
+                  <h2
+                    className="pf-u-sr-only"
+                    id="grp-1"
                   >
-                    <li
-                      className="pf-c-nav__item"
-                    >
-                      <a
-                        aria-current={null}
-                        className="pf-c-nav__link"
-                        href="#link1"
-                        onClick={[Function]}
-                      >
-                        Link 1
-                      </a>
-                    </li>
-                  </NavItem>
-                  <NavItem
-                    className=""
-                    groupId={null}
-                    isActive={false}
-                    itemId={null}
-                    key="#link2"
-                    onClick={null}
-                    preventDefault={false}
-                    to="#link2"
+                    Section 1 - Example sub-navigation
+                  </h2>
+                  <ul
+                    className="pf-c-nav__simple-list"
                   >
-                    <li
-                      className="pf-c-nav__item"
+                    <NavItem
+                      className=""
+                      groupId={null}
+                      isActive={false}
+                      itemId={null}
+                      key="#link1"
+                      onClick={null}
+                      preventDefault={false}
+                      to="#link1"
                     >
-                      <a
-                        aria-current={null}
-                        className="pf-c-nav__link"
-                        href="#link2"
-                        onClick={[Function]}
+                      <li
+                        className="pf-c-nav__item"
                       >
-                        Link 2
-                      </a>
-                    </li>
-                  </NavItem>
-                  <NavItem
-                    className=""
-                    groupId={null}
-                    isActive={false}
-                    itemId={null}
-                    key="#link3"
-                    onClick={null}
-                    preventDefault={false}
-                    to="#link3"
-                  >
-                    <li
-                      className="pf-c-nav__item"
+                        <a
+                          aria-current={null}
+                          className="pf-c-nav__link"
+                          href="#link1"
+                          onClick={[Function]}
+                        >
+                          Link 1
+                        </a>
+                      </li>
+                    </NavItem>
+                    <NavItem
+                      className=""
+                      groupId={null}
+                      isActive={false}
+                      itemId={null}
+                      key="#link2"
+                      onClick={null}
+                      preventDefault={false}
+                      to="#link2"
                     >
-                      <a
-                        aria-current={null}
-                        className="pf-c-nav__link"
-                        href="#link3"
-                        onClick={[Function]}
+                      <li
+                        className="pf-c-nav__item"
                       >
-                        Link 3
-                      </a>
-                    </li>
-                  </NavItem>
-                  <NavItem
-                    className=""
-                    groupId={null}
-                    isActive={false}
-                    itemId={null}
-                    key="#link4"
-                    onClick={null}
-                    preventDefault={false}
-                    to="#link4"
-                  >
-                    <li
-                      className="pf-c-nav__item"
+                        <a
+                          aria-current={null}
+                          className="pf-c-nav__link"
+                          href="#link2"
+                          onClick={[Function]}
+                        >
+                          Link 2
+                        </a>
+                      </li>
+                    </NavItem>
+                    <NavItem
+                      className=""
+                      groupId={null}
+                      isActive={false}
+                      itemId={null}
+                      key="#link3"
+                      onClick={null}
+                      preventDefault={false}
+                      to="#link3"
                     >
-                      <a
-                        aria-current={null}
-                        className="pf-c-nav__link"
-                        href="#link4"
-                        onClick={[Function]}
+                      <li
+                        className="pf-c-nav__item"
                       >
-                        Link 4
-                      </a>
-                    </li>
-                  </NavItem>
-                </ul>
-              </section>
-            </li>
+                        <a
+                          aria-current={null}
+                          className="pf-c-nav__link"
+                          href="#link3"
+                          onClick={[Function]}
+                        >
+                          Link 3
+                        </a>
+                      </li>
+                    </NavItem>
+                    <NavItem
+                      className=""
+                      groupId={null}
+                      isActive={false}
+                      itemId={null}
+                      key="#link4"
+                      onClick={null}
+                      preventDefault={false}
+                      to="#link4"
+                    >
+                      <li
+                        className="pf-c-nav__item"
+                      >
+                        <a
+                          aria-current={null}
+                          className="pf-c-nav__link"
+                          href="#link4"
+                          onClick={[Function]}
+                        >
+                          Link 4
+                        </a>
+                      </li>
+                    </NavItem>
+                  </ul>
+                </section>
+              </li>
+            </Transition>
           </NavToggle>
         </NavExpandable>
       </ul>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9448,7 +9448,7 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   dependencies:
     js-tokens "^3.0.0"
 
-loose-envify@^1.3.0:
+loose-envify@^1.3.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -12493,6 +12493,15 @@ react-textarea-autosize@^5.2.1:
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.2.1.tgz#2b78f9067180f41b08ac59f78f1581abadd61e54"
   dependencies:
     prop-types "^15.6.0"
+
+react-transition-group@2.x:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.0.tgz#70bca0e3546102c4dc5cf3f5f57f73447cce6874"
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
 
 react-transition-group@^2.0.0, react-transition-group@^2.2.0:
   version "2.3.1"


### PR DESCRIPTION
This PR uses `react-transition-group@2.x` to apply classes and attributes at appropriate delays to take advantage of the pre-existing CSS transitions in core.