### PR TITLE
fix(formComponent): removes Children props checking

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Form/FormGroup.js
+++ b/packages/patternfly-4/react-core/src/components/Form/FormGroup.js
@@ -5,40 +5,9 @@ import { ASTERISK } from '../../internal/htmlConstants';
 import { FormContext } from '../Form/FormContext';
 import { css, getModifier } from '@patternfly/react-styles';
 
-const childrenArrayContains = (childrenArray, attribute, errorMessage) => {
-  let throwError = true;
-  childrenArray.forEach(child => {
-    if (child.props[attribute]) {
-      throwError = false;
-    }
-  });
-  if (throwError) {
-    return new Error(errorMessage);
-  }
-  return null;
-};
-
 const propTypes = {
   /** Anything that can be rendered as FormGroup content. */
-  children: props => {
-    if (!props.label) {
-      if (Array.isArray(props.children)) {
-        return childrenArrayContains(
-          props.children,
-          'aria-label',
-          `When label is not defined, at least one of Form Group children should have an aria-label attribute.`
-        );
-      } else if (!props.children.props['aria-label']) {
-        return new Error(`When label is not defined, a Form Group child should have an aria-label attribute.`);
-      }
-    }
-    if (Array.isArray(props.children)) {
-      return childrenArrayContains(props.children, 'id', `At least one of Form Group children should have an id.`);
-    } else if (!props.children.props.id) {
-      return new Error(`A child element of Form Group has to have an id.`);
-    }
-    return null;
-  },
+  children: PropTypes.node,
   /** Additional classes added to the FormGroup. */
   className: PropTypes.string,
   /** Label text before the field. */


### PR DESCRIPTION
**What**:

As we discussed [here](https://github.com/patternfly/patternfly-react/pull/667#discussion_r223453507), we started using formGroup component in one of our projects, however the **checking of children props is failing**:

`demo.js:48632 Warning: Failed prop type: Cannot read property 'props' of undefined
    in FormGroup (created by FinalFormField)`

The code:

 ```
<FormGroup
            isRequired={ isRequired }
            label={ label }
            fieldId={ rest.id }
            isValid={ !showError }
            helperText={ helperText }
            helperTextInvalid={ meta.error }
>
            { description && <TextContent><Text component={ TextVariants.small }>{ description }</Text></TextContent> }
            { selectComponent({ componentType, ...rest, isValid: !showError })() }
</FormGroup>
```

When I removed the selectComponent function and replace it with what it returns, it works well. However, to not deal with problems like that, we think that **we should remove all checking logic from the formGroup component and let input components control it themselves**: have `props` `id` and `aria-label` required for all input components to maintain accessibility. It would be easier to manage and quicker to render.

ping @Hyperkid123 @martinpovolny