### PR TITLE
fix(ExpandCollapse): Fix to export ALIGN_LEFT and ALIGN_CENTER constants

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.js
@@ -5,7 +5,10 @@ import classNames from 'classnames';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
 
-import { ALIGN_LEFT, ALIGN_CENTER, ALIGN_TYPES } from './constants';
+const ALIGN_LEFT = 'left';
+const ALIGN_CENTER = 'center';
+
+const ALIGN_TYPES = [ALIGN_LEFT, ALIGN_CENTER];
 
 class ExpandCollapse extends React.Component {
   state = { expanded: false, mirroredExpanded: false };
@@ -54,7 +57,7 @@ ExpandCollapse.propTypes = {
   textCollapsed: PropTypes.string,
   /** Text for the link in expanded state */
   textExpanded: PropTypes.string,
-  /** Align the link to the left or center. Default: left. */
+  /** Align the link to the left or center. */
   align: PropTypes.oneOf(ALIGN_TYPES),
   /** Flag to show a separation border line */
   bordered: PropTypes.bool,
@@ -70,5 +73,9 @@ ExpandCollapse.defaultProps = {
   bordered: true,
   expanded: false
 };
+
+ExpandCollapse.ALIGN_LEFT = ALIGN_LEFT;
+ExpandCollapse.ALIGN_CENTER = ALIGN_CENTER;
+ExpandCollapse.ALIGN_TYPES = ALIGN_TYPES;
 
 export default ExpandCollapse;

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.stories.js
@@ -7,7 +7,6 @@ import { name } from '../../../package.json';
 import { boolean, select, text, withKnobs } from '@storybook/addon-knobs';
 
 import { ExpandCollapse } from './index';
-import { ALIGN_TYPES } from './constants';
 
 const stories = storiesOf(
   `${storybookPackageName(name)}/${STORYBOOK_CATEGORY.FORMS_AND_CONTROLS}/Expand Collapse`,
@@ -26,7 +25,7 @@ stories.add(
   withInfo(`This is the ExpandCollapse component.`)(() => (
     <div style={{ width: '600px', border: '1px solid lightgray' }}>
       <ExpandCollapse
-        align={select('align', ALIGN_TYPES)}
+        align={select('align', ExpandCollapse.ALIGN_TYPES)}
         bordered={boolean('bordered', true)}
         textExpanded={text('textExpanded', 'Hide Advanced Options')}
         textCollapsed={text('textCollapsed', 'Show Advanced Options')}

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { mount, render } from 'enzyme';
 
 import ExpandCollapse from './ExpandCollapse';
-import { ALIGN_LEFT, ALIGN_CENTER } from './constants';
 
 test('ExpandCollapse with content', () => {
   const view = mount(
@@ -50,14 +49,14 @@ test('aligned ExpandCollapse', () => {
   expect(def.find('.expand-collapse-pf-separator')).toHaveLength(1);
 
   const left = render(
-    <ExpandCollapse align={ALIGN_LEFT}>
+    <ExpandCollapse align={ExpandCollapse.ALIGN_LEFT}>
       <div id="content">My text</div>
     </ExpandCollapse>
   );
   expect(left.find('.expand-collapse-pf-separator')).toHaveLength(1);
 
   const center = render(
-    <ExpandCollapse align={ALIGN_CENTER}>
+    <ExpandCollapse align={ExpandCollapse.ALIGN_CENTER}>
       <div id="content">My text</div>
     </ExpandCollapse>
   );
@@ -81,14 +80,14 @@ test('ExpandCollapse with separator', () => {
   expect(noSep.find('.expand-collapse-pf-separator.bordered')).toHaveLength(0);
 
   const center = render(
-    <ExpandCollapse align={ALIGN_CENTER}>
+    <ExpandCollapse align={ExpandCollapse.ALIGN_CENTER}>
       <div id="content">My text</div>
     </ExpandCollapse>
   );
   expect(center.find('.expand-collapse-pf-separator.bordered')).toHaveLength(2);
 
   const centerNoSep = render(
-    <ExpandCollapse align={ALIGN_CENTER} bordered={false}>
+    <ExpandCollapse align={ExpandCollapse.ALIGN_CENTER} bordered={false}>
       <div id="content">My text</div>
     </ExpandCollapse>
   );

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/constants.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/constants.js
@@ -1,3 +1,12 @@
+/**
+ * UNUSED/DEPRECATED
+ *
+ * These constants have been moved directly into the ExpandCollapse component.
+ * The separate file constants do not display correctly in storybook and were not exported outside of this file
+ * so they weren't accessible unless this file was expressly imported.
+ *
+ * Leaving this file for the case that an application did expressly import this file.
+ */
 export const ALIGN_LEFT = 'left';
 export const ALIGN_CENTER = 'center';
 


### PR DESCRIPTION
Added the constants to ExpandCollapse rather than requiring applications to expressly import the
constants file. Fixes the storybook display of the align type values to show the values rather than
the constant.
