### PR TITLE
fix(Select/TextInput): fix components typescript interfaces

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Select/Select.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.d.ts
@@ -6,9 +6,9 @@ export interface SelectProps extends Omit<HTMLProps<HTMLInputElement>, 'onChange
   value?: any;
   isValid?: boolean;
   isDisabled?: boolean;
-  onBlur(event: React.FormEvent<HTMLSelectElement>): void;
-  onFocus(event: React.FormEvent<HTMLSelectElement>): void;
-  onChange(event: React.FormEvent<HTMLSelectElement>): void;
+  onBlur?(event: React.FormEvent<HTMLSelectElement>): void;
+  onFocus?(event: React.FormEvent<HTMLSelectElement>): void;
+  onChange?(event: React.FormEvent<HTMLSelectElement>): void;
 }
 
 declare const Select: React.SFC<SelectProps>;

--- a/packages/patternfly-4/react-core/src/components/TextInput/TextInput.d.ts
+++ b/packages/patternfly-4/react-core/src/components/TextInput/TextInput.d.ts
@@ -9,7 +9,7 @@ export interface TextInputProps extends Omit<HTMLProps<HTMLInputElement>, 'type'
   isValid?: boolean;
   isDisabled?: boolean;
   isAlt?: boolean;
-  onChange(checked: boolean, event: FormEvent<HTMLInputElement>): void;
+  onChange?(checked: boolean, event: FormEvent<HTMLInputElement>): void;
   isReadOnly?: boolean;
   'aria-label'?: string;
 }


### PR DESCRIPTION
A small fix to the typescript check when using `TextInput` and `Select`.
There is inconsistency between PropTypes  and TypeScript checks.

For example, in `TextInput` according to PropTypes `onChange` is optional and its default value is `noop` (http://patternfly-react.surge.sh/patternfly-4/components/textinput). However, in TypeScript it's a required prop.

![text_input](https://user-images.githubusercontent.com/2453279/47517030-9f56f800-d88f-11e8-9577-1b9a7a10d324.png)

Another example is in `Select`, on one hand `onBlur` is not required, TS check fails saying `onBlur` is required.

![select](https://user-images.githubusercontent.com/2453279/47517029-9f56f800-d88f-11e8-972f-bf8903dbd848.png)

I updated TS check according to what is given in http://patternfly-react.surge.sh/patternfly-4/