### PR TITLE
feat(page layout): adds the condensed header feature to the page header

### DIFF
--- a/packages/patternfly-4/react-core/package.json
+++ b/packages/patternfly-4/react-core/package.json
@@ -47,7 +47,7 @@
     "@patternfly/react-tokens": "^1.0.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly-next": "1.0.63",
+    "@patternfly/patternfly-next": "1.0.64",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/PageLayoutDemo.docs.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/PageLayoutDemo.docs.js
@@ -3,6 +3,7 @@ import PageLayoutExpandableNav from './examples/PageLayoutExpandableNav';
 import PageLayoutGroupsNav from './examples/PageLayoutGroupsNav';
 import PageLayoutHorizontalNav from './examples/PageLayoutHorizontalNav';
 import PageLayoutSimpleNav from './examples/PageLayoutSimpleNav';
+import PageLayoutCondensedHeader from './examples/PageLayoutCondensedHeader';
 
 export default {
   title: 'Page Layout Demos',
@@ -11,7 +12,8 @@ export default {
     PageLayoutExpandableNav,
     PageLayoutGroupsNav,
     PageLayoutHorizontalNav,
-    PageLayoutSimpleNav
+    PageLayoutSimpleNav,
+    PageLayoutCondensedHeader
   ],
   fullPageOnly: true
 };

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutCondensedHeader.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutCondensedHeader.js
@@ -1,0 +1,245 @@
+import React from 'react';
+import {
+  Avatar,
+  BackgroundImage,
+  BackgroundImageSrc,
+  Brand,
+  Button,
+  ButtonVariant,
+  Card,
+  CardBody,
+  Dropdown,
+  DropdownToggle,
+  DropdownItem,
+  DropdownSeparator,
+  Gallery,
+  GalleryItem,
+  KebabToggle,
+  Nav,
+  NavExpandable,
+  NavItem,
+  NavList,
+  Page,
+  PageHeader,
+  PageSection,
+  PageSectionVariants,
+  PageSidebar,
+  TextContent,
+  Text,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem
+} from '@patternfly/react-core';
+import { global_breakpoint_md as breakpointMd } from '@patternfly/react-tokens';
+import accessibleStyles from '@patternfly/patternfly-next/utilities/Accessibility/accessibility.css';
+import spacingStyles from '@patternfly/patternfly-next/utilities/Spacing/spacing.css';
+import { css } from '@patternfly/react-styles';
+import { BellIcon, CogIcon } from '@patternfly/react-icons';
+import brandImg from './l_pf-reverse-164x11.png';
+import avatarImg from './img_avatar.png';
+
+class PageLayoutCondensedHeader extends React.Component {
+  static title = 'Using condensed header';
+
+  constructor(props) {
+    super(props);
+    // Set initial isNavOpen state based on window width
+    const isNavOpen = typeof window !== 'undefined' && window.innerWidth >= parseInt(breakpointMd.value, 10);
+    this.state = {
+      isDropdownOpen: false,
+      isKebabDropdownOpen: false,
+      isNavOpen,
+      activeGroup: 'grp-1',
+      activeItem: 'grp-1_itm-1'
+    };
+  }
+
+  onDropdownToggle = isDropdownOpen => {
+    this.setState({
+      isDropdownOpen
+    });
+  };
+
+  onDropdownSelect = event => {
+    this.setState({
+      isDropdownOpen: !this.state.isDropdownOpen
+    });
+  };
+
+  onKebabDropdownToggle = isKebabDropdownOpen => {
+    this.setState({
+      isKebabDropdownOpen
+    });
+  };
+
+  onKebabDropdownSelect = event => {
+    this.setState({
+      isKebabDropdownOpen: !this.state.isKebabDropdownOpen
+    });
+  };
+
+  onNavSelect = result => {
+    this.setState({
+      activeItem: result.itemId,
+      activeGroup: result.groupId
+    });
+  };
+
+  onNavToggle = () => {
+    this.setState({
+      isNavOpen: !this.state.isNavOpen
+    });
+  };
+
+  render() {
+    const { isDropdownOpen, isKebabDropdownOpen, activeItem, isNavOpen, activeGroup } = this.state;
+
+    const PageNav = (
+      <Nav onSelect={this.onNavSelect} aria-label="Nav">
+        <NavList>
+          <NavExpandable title="System Panel" groupId="grp-1" isActive={activeGroup === 'grp-1'} isExpanded>
+            <NavItem to="#expandable-1" groupId="grp-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
+              Overview
+            </NavItem>
+            <NavItem to="#expandable-2" groupId="grp-1" itemId="grp-1_itm-2" isActive={activeItem === 'grp-1_itm-2'}>
+              Resource Usage
+            </NavItem>
+            <NavItem to="#expandable-3" groupId="grp-1" itemId="grp-1_itm-3" isActive={activeItem === 'grp-1_itm-3'}>
+              Hypervisors
+            </NavItem>
+            <NavItem to="#expandable-4" groupId="grp-1" itemId="grp-1_itm-4" isActive={activeItem === 'grp-1_itm-4'}>
+              Instances
+            </NavItem>
+            <NavItem to="#expandable-5" groupId="grp-1" itemId="grp-1_itm-5" isActive={activeItem === 'grp-1_itm-5'}>
+              Volumes
+            </NavItem>
+            <NavItem to="#expandable-6" groupId="grp-1" itemId="grp-1_itm-6" isActive={activeItem === 'grp-1_itm-6'}>
+              Network
+            </NavItem>
+          </NavExpandable>
+          <NavExpandable title="Policy" groupId="grp-2" isActive={activeGroup === 'grp-2'}>
+            <NavItem to="#expandable-4" groupId="grp-2" itemId="grp-2_itm-1" isActive={activeItem === 'grp-2_itm-1'}>
+              Subnav Link 1
+            </NavItem>
+            <NavItem to="#expandable-5" groupId="grp-2" itemId="grp-2_itm-2" isActive={activeItem === 'grp-2_itm-2'}>
+              Subnav Link 2
+            </NavItem>
+          </NavExpandable>
+          <NavExpandable title="Authentication" groupId="grp-3" isActive={activeGroup === 'grp-3'}>
+            <NavItem to="#expandable-7" groupId="grp-3" itemId="grp-3_itm-1" isActive={activeItem === 'grp-3_itm-1'}>
+              Subnav Link 1
+            </NavItem>
+            <NavItem to="#expandable-8" groupId="grp-3" itemId="grp-3_itm-2" isActive={activeItem === 'grp-3_itm-2'}>
+              Subnav Link 2
+            </NavItem>
+          </NavExpandable>
+        </NavList>
+      </Nav>
+    );
+    const PageToolbar = (
+      <Toolbar>
+        <ToolbarGroup className={css(accessibleStyles.srOnly, accessibleStyles.visibleOnLg)}>
+          <ToolbarItem>
+            <Button id="nav-toggle" aria-label="Overflow actions" variant={ButtonVariant.plain}>
+              <BellIcon />
+            </Button>
+          </ToolbarItem>
+          <ToolbarItem>
+            <Button id="nav-toggle" aria-label="Overflow actions" variant={ButtonVariant.plain}>
+              <CogIcon />
+            </Button>
+          </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarGroup>
+          <ToolbarItem className={css(accessibleStyles.hiddenOnLg, spacingStyles.mr_0)}>
+            <Dropdown
+              isPlain
+              position="right"
+              onSelect={this.onKebabDropdownSelect}
+              toggle={<KebabToggle onToggle={this.onKebabDropdownToggle} />}
+              isOpen={isKebabDropdownOpen}
+            >
+              <DropdownItem>
+                <BellIcon /> Notifications
+              </DropdownItem>
+              <DropdownItem>
+                <CogIcon /> Settings
+              </DropdownItem>
+            </Dropdown>
+          </ToolbarItem>
+          <ToolbarItem className={css(accessibleStyles.srOnly, accessibleStyles.visibleOnMd)}>
+            <Dropdown
+              isPlain
+              position="right"
+              onSelect={this.onDropdownSelect}
+              isOpen={isDropdownOpen}
+              toggle={<DropdownToggle onToggle={this.onDropdownToggle}>Kyle Baker</DropdownToggle>}
+            >
+              <DropdownItem>Link</DropdownItem>
+              <DropdownItem component="button">Action</DropdownItem>
+              <DropdownItem isDisabled>Disabled Link</DropdownItem>
+              <DropdownItem isDisabled component="button">
+                Disabled Action
+              </DropdownItem>
+              <DropdownSeparator />
+              <DropdownItem>Separated Link</DropdownItem>
+              <DropdownItem component="button">Separated Action</DropdownItem>
+            </Dropdown>
+          </ToolbarItem>
+        </ToolbarGroup>
+      </Toolbar>
+    );
+    const bgImages = {
+      [BackgroundImageSrc.lg]: '/assets/images/pfbg_1200.jpg',
+      [BackgroundImageSrc.md]: '/assets/images/pfbg_992.jpg',
+      [BackgroundImageSrc.md2x]: '/assets/images/pfbg_992@2x.jpg',
+      [BackgroundImageSrc.sm]: '/assets/images/pfbg_768.jpg',
+      [BackgroundImageSrc.sm2x]: '/assets/images/pfbg_768@2x.jpg',
+      [BackgroundImageSrc.xl]: '/assets/images/pfbg_2000.jpg',
+      [BackgroundImageSrc.xs]: '/assets/images/pfbg_576.jpg',
+      [BackgroundImageSrc.xs2x]: '/assets/images/pfbg_576@2x.jpg',
+      [BackgroundImageSrc.filter]: '/assets/images/background-filter.svg'
+    };
+
+    const Header = (
+      <PageHeader
+        logo={<Brand src={brandImg} alt="Patternfly Logo" />}
+        toolbar={PageToolbar}
+        avatar={<Avatar src={avatarImg} alt="Avatar image" />}
+        showNavToggle
+        onNavToggle={this.onNavToggle}
+      />
+    );
+    const Sidebar = <PageSidebar nav={PageNav} isNavOpen={isNavOpen} />;
+
+    return (
+      <React.Fragment>
+        <BackgroundImage src={bgImages} />
+        <Page header={Header} sidebar={Sidebar} condensedHeader>
+          <PageSection variant={PageSectionVariants.light}>
+            <TextContent>
+              <Text component="h1">Main Title</Text>
+              <Text component="p">
+                Body text should be Overpass Regular at 16px. It should have leading of 24px because <br />
+                of it’s relative line height of 1.5.
+              </Text>
+            </TextContent>
+          </PageSection>
+          <PageSection>
+            <Gallery gutter="md">
+              {Array.apply(0, Array(50)).map((x, i) => (
+                <GalleryItem key={i}>
+                  <Card>
+                    <CardBody>This is a card</CardBody>
+                  </Card>
+                </GalleryItem>
+              ))}
+            </Gallery>
+          </PageSection>
+        </Page>
+      </React.Fragment>
+    );
+  }
+}
+
+export default PageLayoutCondensedHeader;

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutCondensedHeader.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutCondensedHeader.js
@@ -215,7 +215,7 @@ class PageLayoutCondensedHeader extends React.Component {
     return (
       <React.Fragment>
         <BackgroundImage src={bgImages} />
-        <Page header={Header} sidebar={Sidebar} condensedHeader>
+        <Page header={Header} sidebar={Sidebar} useCondensed>
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main Title</Text>

--- a/packages/patternfly-4/react-core/src/internal/util.js
+++ b/packages/patternfly-4/react-core/src/internal/util.js
@@ -10,3 +10,11 @@ export function getUniqueId(prefix = 'pf') {
       .slice(2);
   return `${prefix}-${uid}`;
 }
+
+export function debounce(func, wait) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func.apply(this, args), wait);
+  };
+}

--- a/packages/patternfly-4/react-core/src/internal/util.test.js
+++ b/packages/patternfly-4/react-core/src/internal/util.test.js
@@ -1,4 +1,4 @@
-import { capitalize, getUniqueId } from './util';
+import { capitalize, getUniqueId, debounce } from './util';
 
 test('capitalize', () => {
   expect(capitalize('foo')).toBe('Foo');
@@ -11,4 +11,21 @@ test('getUniqueId', () => {
 test('getUniqueId prefixed', () => {
   expect(getUniqueId().substring(0, 3)).toBe('pf-');
   expect(getUniqueId('pf-switch').substring(0, 10)).toBe('pf-switch-');
+});
+
+test('debounce', () => {
+  jest.useFakeTimers();
+  const callback = jest.fn();
+  const debouncedFunction = debounce(callback, 50);
+
+  debouncedFunction();
+  // At this point in time, the callback should not have been called yet
+  expect(callback).toHaveBeenCalledTimes(0);
+
+  for (let i = 0; i < 10; i++) {
+    jest.advanceTimersByTime(50);
+    debouncedFunction();
+  }
+
+  expect(callback).toBeCalledTimes(10);
 });

--- a/packages/patternfly-4/react-core/src/layouts/Page/Page.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Page/Page.d.ts
@@ -6,8 +6,8 @@ export interface PageProps extends HTMLProps<HTMLDivElement> {
   className?: string;
   header?: ReactNode;
   sidebar?: ReactNode;
-  condensedHeader?: boolean;
-  condensedHeight?: number;
+  useCondensed?: boolean;
+  scrollingDistance?: number;
 }
 
 declare const Page: SFC<PageProps>;

--- a/packages/patternfly-4/react-core/src/layouts/Page/Page.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Page/Page.d.ts
@@ -6,8 +6,8 @@ export interface PageProps extends HTMLProps<HTMLDivElement> {
   className?: string;
   header?: ReactNode;
   sidebar?: ReactNode;
-  condensedHeader: boolean;
-  condensedHeight: number;
+  condensedHeader?: boolean;
+  condensedHeight?: number;
 }
 
 declare const Page: SFC<PageProps>;

--- a/packages/patternfly-4/react-core/src/layouts/Page/Page.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Page/Page.d.ts
@@ -6,6 +6,8 @@ export interface PageProps extends HTMLProps<HTMLDivElement> {
   className?: string;
   header?: ReactNode;
   sidebar?: ReactNode;
+  condensedHeader: boolean;
+  condensedHeight: number;
 }
 
 declare const Page: SFC<PageProps>;

--- a/packages/patternfly-4/react-core/src/layouts/Page/Page.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/Page.js
@@ -19,7 +19,7 @@ const propTypes = {
   /** Sidebar component for a side nav (e.g. <PageSidebar />) */
   sidebar: PropTypes.node,
   /** condensed header on scroll */
-  isCondensed: PropTypes.bool,
+  useCondensed: PropTypes.bool,
   /** condensed height override */
   scrollingDistance: PropTypes.number
 };
@@ -29,53 +29,53 @@ const defaultProps = {
   className: '',
   header: null,
   sidebar: null,
-  isCondensed: false,
+  useCondensed: false,
   scrollingDistance: 20
 };
 
 class Page extends React.Component {
-  state = { isHeaderCondensed: false };
+  state = { isCondensed: false };
 
   constructor(props) {
     super(props);
     this.mainRef = React.createRef();
   }
   componentDidMount() {
-    const { isCondensed } = this.props;
-    if (isCondensed) {
+    const { useCondensed } = this.props;
+    if (useCondensed) {
       // I picked this because it's approx 1 frame (ie: 16.7ms)
       this.mainRef.current.addEventListener('scroll', debounce(this.handleScroll, 16));
     }
   }
   componentWillUnmount() {
-    const { isCondensed } = this.props;
-    if (isCondensed) {
+    const { useCondensed } = this.props;
+    if (useCondensed) {
       this.mainRef.current.removeEventListener('scroll', this.handleScroll);
     }
   }
 
   handleScroll = e => {
     window.requestAnimationFrame(() => {
-      const { isHeaderCondensed } = this.state;
+      const { isCondensed } = this.state;
       const { scrollingDistance } = this.props;
       const main = e.target;
       const mainPosition = main.scrollTop;
-      if (mainPosition > scrollingDistance && !isHeaderCondensed) {
-        this.setState({ isHeaderCondensed: true });
-      } else if (mainPosition < scrollingDistance && isHeaderCondensed) {
-        this.setState({ isHeaderCondensed: false });
+      if (mainPosition > scrollingDistance && !isCondensed) {
+        this.setState({ isCondensed: true });
+      } else if (mainPosition < scrollingDistance && isCondensed) {
+        this.setState({ isCondensed: false });
       }
     });
   };
 
   render() {
-    const { className, children, header, sidebar, isCondensed, scrollingDistance, ...rest } = this.props;
-    const { isHeaderCondensed } = this.state;
+    const { className, children, header, sidebar, useCondensed, scrollingDistance, ...rest } = this.props;
+    const { isCondensed } = this.state;
 
-    const clonedHeader = React.cloneElement(header, { condensed: isHeaderCondensed });
+    const clonedHeader = React.cloneElement(header, { condensed: isCondensed });
     return (
       <div {...rest} className={css(styles.page, className)}>
-        {isCondensed ? clonedHeader : header}
+        {useCondensed ? clonedHeader : header}
         {sidebar}
         <main ref={this.mainRef} role="main" className={css(styles.pageMain)}>
           {children}

--- a/packages/patternfly-4/react-core/src/layouts/Page/Page.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/Page.js
@@ -72,7 +72,7 @@ class Page extends React.Component {
     const { className, children, header, sidebar, useCondensed, scrollingDistance, ...rest } = this.props;
     const { isCondensed } = this.state;
 
-    const clonedHeader = React.cloneElement(header, { condensed: isCondensed });
+    const clonedHeader = React.cloneElement(header, { isCondensed });
     return (
       <div {...rest} className={css(styles.page, className)}>
         {useCondensed ? clonedHeader : header}

--- a/packages/patternfly-4/react-core/src/layouts/Page/Page.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/Page.js
@@ -43,6 +43,7 @@ class Page extends React.Component {
   componentDidMount() {
     const { condensedHeader } = this.props;
     if (condensedHeader) {
+      // I picked this because it's approx 1 frame (ie: 16.7ms)
       this.mainRef.current.addEventListener('scroll', debounce(this.handleScroll, 16));
     }
   }
@@ -54,15 +55,17 @@ class Page extends React.Component {
   }
 
   handleScroll = e => {
-    const { headerCondensed } = this.state;
-    const { condensedHeight } = this.props;
-    const main = e.target;
-    const mainPosition = main.scrollTop;
-    if (mainPosition > condensedHeight && !headerCondensed) {
-      this.setState({ headerCondensed: true });
-    } else if (mainPosition < condensedHeight && headerCondensed) {
-      this.setState({ headerCondensed: false });
-    }
+    window.requestAnimationFrame(() => {
+      const { headerCondensed } = this.state;
+      const { condensedHeight } = this.props;
+      const main = e.target;
+      const mainPosition = main.scrollTop;
+      if (mainPosition > condensedHeight && !headerCondensed) {
+        this.setState({ headerCondensed: true });
+      } else if (mainPosition < condensedHeight && headerCondensed) {
+        this.setState({ headerCondensed: false });
+      }
+    });
   };
 
   render() {

--- a/packages/patternfly-4/react-core/src/layouts/Page/Page.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/Page.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styles from '@patternfly/patternfly-next/layouts/Page/page.css';
 import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
+import { debounce } from '../../internal/util';
 
 export const PageLayouts = {
   vertical: 'vertical',
@@ -16,25 +17,70 @@ const propTypes = {
   /** Header component (e.g. <PageHeader />) */
   header: PropTypes.node,
   /** Sidebar component for a side nav (e.g. <PageSidebar />) */
-  sidebar: PropTypes.node
+  sidebar: PropTypes.node,
+  /** condensed header on scroll */
+  condensedHeader: PropTypes.bool,
+  /** codensed height override */
+  condensedHeight: PropTypes.number
 };
 
 const defaultProps = {
   children: null,
   className: '',
   header: null,
-  sidebar: null
+  sidebar: null,
+  condensedHeader: false,
+  condensedHeight: 20
 };
 
-const Page = ({ className, children, header, sidebar, ...props }) => (
-  <div {...props} className={css(styles.page, className)}>
-    {header}
-    {sidebar}
-    <main role="main" className={css(styles.pageMain)}>
-      {children}
-    </main>
-  </div>
-);
+class Page extends React.Component {
+  state = { headerCondensed: false };
+
+  constructor(props) {
+    super(props);
+    this.mainRef = React.createRef();
+  }
+  componentDidMount() {
+    const { condensedHeader } = this.props;
+    if (condensedHeader) {
+      this.mainRef.current.addEventListener('scroll', debounce(this.handleScroll, 16));
+    }
+  }
+  componentWillUnmount() {
+    const { condensedHeader } = this.props;
+    if (condensedHeader) {
+      this.mainRef.current.removeEventListener('scroll', this.handleScroll);
+    }
+  }
+
+  handleScroll = e => {
+    const { headerCondensed } = this.state;
+    const { condensedHeight } = this.props;
+    const main = e.target;
+    const mainPosition = main.scrollTop;
+    if (mainPosition > condensedHeight && !headerCondensed) {
+      this.setState({ headerCondensed: true });
+    } else if (mainPosition < condensedHeight && headerCondensed) {
+      this.setState({ headerCondensed: false });
+    }
+  };
+
+  render() {
+    const { className, children, header, sidebar, condensedHeader, condensedHeight, ...rest } = this.props;
+    const { headerCondensed } = this.state;
+
+    const clonedHeader = React.cloneElement(header, { condensed: headerCondensed });
+    return (
+      <div {...rest} className={css(styles.page, className)}>
+        {condensedHeader ? clonedHeader : header}
+        {sidebar}
+        <main ref={this.mainRef} role="main" className={css(styles.pageMain)}>
+          {children}
+        </main>
+      </div>
+    );
+  }
+}
 
 Page.propTypes = propTypes;
 Page.defaultProps = defaultProps;

--- a/packages/patternfly-4/react-core/src/layouts/Page/Page.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/Page.js
@@ -19,9 +19,9 @@ const propTypes = {
   /** Sidebar component for a side nav (e.g. <PageSidebar />) */
   sidebar: PropTypes.node,
   /** condensed header on scroll */
-  condensedHeader: PropTypes.bool,
-  /** codensed height override */
-  condensedHeight: PropTypes.number
+  isCondensed: PropTypes.bool,
+  /** condensed height override */
+  scrollingDistance: PropTypes.number
 };
 
 const defaultProps = {
@@ -29,53 +29,53 @@ const defaultProps = {
   className: '',
   header: null,
   sidebar: null,
-  condensedHeader: false,
-  condensedHeight: 20
+  isCondensed: false,
+  scrollingDistance: 20
 };
 
 class Page extends React.Component {
-  state = { headerCondensed: false };
+  state = { isHeaderCondensed: false };
 
   constructor(props) {
     super(props);
     this.mainRef = React.createRef();
   }
   componentDidMount() {
-    const { condensedHeader } = this.props;
-    if (condensedHeader) {
+    const { isCondensed } = this.props;
+    if (isCondensed) {
       // I picked this because it's approx 1 frame (ie: 16.7ms)
       this.mainRef.current.addEventListener('scroll', debounce(this.handleScroll, 16));
     }
   }
   componentWillUnmount() {
-    const { condensedHeader } = this.props;
-    if (condensedHeader) {
+    const { isCondensed } = this.props;
+    if (isCondensed) {
       this.mainRef.current.removeEventListener('scroll', this.handleScroll);
     }
   }
 
   handleScroll = e => {
     window.requestAnimationFrame(() => {
-      const { headerCondensed } = this.state;
-      const { condensedHeight } = this.props;
+      const { isHeaderCondensed } = this.state;
+      const { scrollingDistance } = this.props;
       const main = e.target;
       const mainPosition = main.scrollTop;
-      if (mainPosition > condensedHeight && !headerCondensed) {
-        this.setState({ headerCondensed: true });
-      } else if (mainPosition < condensedHeight && headerCondensed) {
-        this.setState({ headerCondensed: false });
+      if (mainPosition > scrollingDistance && !isHeaderCondensed) {
+        this.setState({ isHeaderCondensed: true });
+      } else if (mainPosition < scrollingDistance && isHeaderCondensed) {
+        this.setState({ isHeaderCondensed: false });
       }
     });
   };
 
   render() {
-    const { className, children, header, sidebar, condensedHeader, condensedHeight, ...rest } = this.props;
-    const { headerCondensed } = this.state;
+    const { className, children, header, sidebar, isCondensed, scrollingDistance, ...rest } = this.props;
+    const { isHeaderCondensed } = this.state;
 
-    const clonedHeader = React.cloneElement(header, { condensed: headerCondensed });
+    const clonedHeader = React.cloneElement(header, { condensed: isHeaderCondensed });
     return (
       <div {...rest} className={css(styles.page, className)}>
-        {condensedHeader ? clonedHeader : header}
+        {isCondensed ? clonedHeader : header}
         {sidebar}
         <main ref={this.mainRef} role="main" className={css(styles.pageMain)}>
           {children}

--- a/packages/patternfly-4/react-core/src/layouts/Page/Page.test.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/Page.test.js
@@ -25,6 +25,20 @@ test('Check page vertical layout example against snapshot', () => {
   expect(view).toMatchSnapshot();
 });
 
+test('Check page condensed header example against snapshot', () => {
+  const Header = <PageHeader logo="Logo" toolbar="Toolbar" avatar=" | Avatar" onNavToggle={() => undefined} />;
+  const Sidebar = <PageSidebar nav="Navigation" isNavOpen />;
+  const view = mount(
+    <Page {...props} header={Header} sidebar={Sidebar} condensedHeader>
+      <PageSection variant="default">Section with default background</PageSection>
+      <PageSection variant="light">Section with light background</PageSection>
+      <PageSection variant="dark">Section with dark background</PageSection>
+      <PageSection variant="darker">Section with darker background</PageSection>
+    </Page>
+  );
+  expect(view).toMatchSnapshot();
+});
+
 test('Check page horizontal layout example against snapshot', () => {
   const Header = <PageHeader logo="Logo" toolbar="Toolbar" avatar=" | Avatar" nav="Navigation" />;
   const Sidebar = <PageSidebar isNavOpen />;

--- a/packages/patternfly-4/react-core/src/layouts/Page/Page.test.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/Page.test.js
@@ -29,7 +29,7 @@ test('Check page condensed header example against snapshot', () => {
   const Header = <PageHeader logo="Logo" toolbar="Toolbar" avatar=" | Avatar" onNavToggle={() => undefined} />;
   const Sidebar = <PageSidebar nav="Navigation" isNavOpen />;
   const view = mount(
-    <Page {...props} header={Header} sidebar={Sidebar} condensedHeader>
+    <Page {...props} header={Header} sidebar={Sidebar} useCondensed>
       <PageSection variant="default">Section with default background</PageSection>
       <PageSection variant="light">Section with light background</PageSection>
       <PageSection variant="dark">Section with dark background</PageSection>

--- a/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.d.ts
@@ -9,7 +9,7 @@ export interface PageHeaderProps extends HTMLProps<HTMLDivElement> {
   topNav?: ReactNode;
   showNavToggle?: boolean;
   onNavToggle?: Function;
-  condensed: boolean;
+  isCondensed?: boolean;
 }
 
 declare const PageHeader: SFC<PageHeaderProps>;

--- a/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.d.ts
@@ -9,6 +9,7 @@ export interface PageHeaderProps extends HTMLProps<HTMLDivElement> {
   topNav?: ReactNode;
   showNavToggle?: boolean;
   onNavToggle?: Function;
+  condensed: boolean;
 }
 
 declare const PageHeader: SFC<PageHeaderProps>;

--- a/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.js
@@ -19,7 +19,9 @@ const propTypes = {
   /** True to show the nav toggle button (toggles side nav) */
   showNavToggle: PropTypes.bool,
   /** Callback function to handle the side nav toggle button */
-  onNavToggle: PropTypes.func
+  onNavToggle: PropTypes.func,
+  /** condensed header */
+  condensed: PropTypes.bool
 };
 
 const defaultProps = {
@@ -29,38 +31,42 @@ const defaultProps = {
   avatar: null,
   topNav: null,
   showNavToggle: false,
-  onNavToggle: () => undefined
+  onNavToggle: () => undefined,
+  condensed: false
 };
 
 /* Added temporary style as a workaround to make dropdowns work until fix is made (patternfly-next #780) */
-const PageHeader = ({ className, logo, toolbar, avatar, topNav, showNavToggle, onNavToggle, ...props }) => (
-  <header role="banner" className={css(styles.pageHeader, className)} style={{ overflowX: 'unset' }} {...props}>
-    <div className={css(styles.pageHeaderBrand)}>
-      {showNavToggle && (
-        <div className={css(styles.pageHeaderBrandToggle)}>
-          <Button
-            id="nav-toggle"
-            onClick={onNavToggle}
-            aria-label="Toggle primary navigation"
-            variant={ButtonVariant.plain}
-          >
-            <BarsIcon />
-          </Button>
-        </div>
-      )}
-      <a className={css(styles.pageHeaderBrandLink)}>{logo}</a>
-    </div>
-    {/* Hide for now until we have the context selector component */}
-    {/* <div className={css(styles.pageHeaderSelector)}>
-        pf-c-context-selector
-      </div> */}
-    {topNav && <div className={css(styles.pageHeaderNav)}>{topNav}</div>}
-    <div className={css(styles.pageHeaderTools)}>
-      {toolbar}
-      {avatar}
-    </div>
-  </header>
-);
+const PageHeader = ({ className, logo, toolbar, avatar, topNav, showNavToggle, onNavToggle, condensed, ...props }) => {
+  const customClassName = css(styles.pageHeader, condensed && 'pf-m-condensed', className);
+  return (
+    <header role="banner" className={customClassName} style={{ overflowX: 'unset' }} {...props}>
+      <div className={css(styles.pageHeaderBrand)}>
+        {showNavToggle && (
+          <div className={css(styles.pageHeaderBrandToggle)}>
+            <Button
+              id="nav-toggle"
+              onClick={onNavToggle}
+              aria-label="Toggle primary navigation"
+              variant={ButtonVariant.plain}
+            >
+              <BarsIcon />
+            </Button>
+          </div>
+        )}
+        <a className={css(styles.pageHeaderBrandLink)}>{logo}</a>
+      </div>
+      {/* Hide for now until we have the context selector component */}
+      {/* <div className={css(styles.pageHeaderSelector)}>
+          pf-c-context-selector
+        </div> */}
+      {topNav && <div className={css(styles.pageHeaderNav)}>{topNav}</div>}
+      <div className={css(styles.pageHeaderTools)}>
+        {toolbar}
+        {avatar}
+      </div>
+    </header>
+  );
+};
 
 PageHeader.propTypes = propTypes;
 PageHeader.defaultProps = defaultProps;

--- a/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.js
@@ -20,8 +20,8 @@ const propTypes = {
   showNavToggle: PropTypes.bool,
   /** Callback function to handle the side nav toggle button */
   onNavToggle: PropTypes.func,
-  /** condensed header */
-  condensed: PropTypes.bool
+  /** header should be condensed */
+  isCondensed: PropTypes.bool
 };
 
 const defaultProps = {
@@ -32,12 +32,22 @@ const defaultProps = {
   topNav: null,
   showNavToggle: false,
   onNavToggle: () => undefined,
-  condensed: false
+  isCondensed: false
 };
 
 /* Added temporary style as a workaround to make dropdowns work until fix is made (patternfly-next #780) */
-const PageHeader = ({ className, logo, toolbar, avatar, topNav, showNavToggle, onNavToggle, condensed, ...props }) => {
-  const customClassName = css(styles.pageHeader, condensed && 'pf-m-condensed', className);
+const PageHeader = ({
+  className,
+  logo,
+  toolbar,
+  avatar,
+  topNav,
+  showNavToggle,
+  onNavToggle,
+  isCondensed,
+  ...props
+}) => {
+  const customClassName = css(styles.pageHeader, isCondensed && 'pf-m-isCondensed', className);
   return (
     <header role="banner" className={customClassName} style={{ overflowX: 'unset' }} {...props}>
       <div className={css(styles.pageHeaderBrand)}>

--- a/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.js
@@ -47,7 +47,7 @@ const PageHeader = ({
   isCondensed,
   ...props
 }) => {
-  const customClassName = css(styles.pageHeader, isCondensed && 'pf-m-isCondensed', className);
+  const customClassName = css(styles.pageHeader, isCondensed && styles.modifiers.condensed, className);
   return (
     <header role="banner" className={customClassName} style={{ overflowX: 'unset' }} {...props}>
       <div className={css(styles.pageHeaderBrand)}>

--- a/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.test.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import PageHeader from './PageHeader';
+
+test('Check page vertical layout example against snapshot', () => {
+  const Header = (
+    <PageHeader logo="Logo" toolbar="Toolbar" avatar=" | Avatar" onNavToggle={() => undefined} condensed />
+  );
+  const view = shallow(Header);
+  expect(view).toMatchSnapshot();
+});

--- a/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.test.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.test.js
@@ -4,7 +4,7 @@ import PageHeader from './PageHeader';
 
 test('Check page vertical layout example against snapshot', () => {
   const Header = (
-    <PageHeader logo="Logo" toolbar="Toolbar" avatar=" | Avatar" onNavToggle={() => undefined} condensed />
+    <PageHeader logo="Logo" toolbar="Toolbar" avatar=" | Avatar" onNavToggle={() => undefined} isCondensed />
   );
   const view = shallow(Header);
   expect(view).toMatchSnapshot();

--- a/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/Page.test.js.snap
+++ b/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/Page.test.js.snap
@@ -91,7 +91,6 @@ exports[`Check page condensed header example against snapshot 1`] = `
     />
   }
   id="PageId"
-  isCondensed={false}
   scrollingDistance={20}
   sidebar={
     <PageSidebar
@@ -100,6 +99,7 @@ exports[`Check page condensed header example against snapshot 1`] = `
       nav="Navigation"
     />
   }
+  useCondensed={false}
 >
   <div
     aria-label="Page layout"
@@ -294,7 +294,6 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
     />
   }
   id="PageId"
-  isCondensed={false}
   layout="horizontal"
   scrollingDistance={20}
   sidebar={
@@ -304,6 +303,7 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
       nav={null}
     />
   }
+  useCondensed={false}
 >
   <div
     aria-label="Page layout"
@@ -497,7 +497,6 @@ exports[`Check page vertical layout example against snapshot 1`] = `
     />
   }
   id="PageId"
-  isCondensed={false}
   scrollingDistance={20}
   sidebar={
     <PageSidebar
@@ -506,6 +505,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
       nav="Navigation"
     />
   }
+  useCondensed={false}
 >
   <div
     aria-label="Page layout"

--- a/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/Page.test.js.snap
+++ b/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/Page.test.js.snap
@@ -78,12 +78,11 @@ exports[`Check page condensed header example against snapshot 1`] = `
   aria-label="Page layout"
   className="my-page-class"
   condensedHeader={true}
-  condensedHeight={20}
   header={
     <PageHeader
       avatar=" | Avatar"
       className=""
-      condensed={false}
+      isCondensed={false}
       logo="Logo"
       onNavToggle={[Function]}
       showNavToggle={false}
@@ -92,6 +91,8 @@ exports[`Check page condensed header example against snapshot 1`] = `
     />
   }
   id="PageId"
+  isCondensed={false}
+  scrollingDistance={20}
   sidebar={
     <PageSidebar
       className=""
@@ -103,12 +104,13 @@ exports[`Check page condensed header example against snapshot 1`] = `
   <div
     aria-label="Page layout"
     className="pf-l-page my-page-class"
+    condensedHeader={true}
     id="PageId"
   >
     <PageHeader
       avatar=" | Avatar"
       className=""
-      condensed={false}
+      isCondensed={false}
       logo="Logo"
       onNavToggle={[Function]}
       showNavToggle={false}
@@ -278,13 +280,11 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
 <Page
   aria-label="Page layout"
   className="my-page-class"
-  condensedHeader={false}
-  condensedHeight={20}
   header={
     <PageHeader
       avatar=" | Avatar"
       className=""
-      condensed={false}
+      isCondensed={false}
       logo="Logo"
       nav="Navigation"
       onNavToggle={[Function]}
@@ -294,7 +294,9 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
     />
   }
   id="PageId"
+  isCondensed={false}
   layout="horizontal"
+  scrollingDistance={20}
   sidebar={
     <PageSidebar
       className=""
@@ -312,7 +314,7 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
     <PageHeader
       avatar=" | Avatar"
       className=""
-      condensed={false}
+      isCondensed={false}
       logo="Logo"
       nav="Navigation"
       onNavToggle={[Function]}
@@ -482,13 +484,11 @@ exports[`Check page vertical layout example against snapshot 1`] = `
 <Page
   aria-label="Page layout"
   className="my-page-class"
-  condensedHeader={false}
-  condensedHeight={20}
   header={
     <PageHeader
       avatar=" | Avatar"
       className=""
-      condensed={false}
+      isCondensed={false}
       logo="Logo"
       onNavToggle={[Function]}
       showNavToggle={false}
@@ -497,6 +497,8 @@ exports[`Check page vertical layout example against snapshot 1`] = `
     />
   }
   id="PageId"
+  isCondensed={false}
+  scrollingDistance={20}
   sidebar={
     <PageSidebar
       className=""
@@ -513,7 +515,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
     <PageHeader
       avatar=" | Avatar"
       className=""
-      condensed={false}
+      isCondensed={false}
       logo="Logo"
       onNavToggle={[Function]}
       showNavToggle={false}

--- a/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/Page.test.js.snap
+++ b/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/Page.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Check page horizontal layout example against snapshot 1`] = `
+exports[`Check page condensed header example against snapshot 1`] = `
 .pf-l-page__header-brand-link {
   display: flex;
   align-items: center;
@@ -25,7 +25,6 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
   align-items: flex-end;
   max-width: 100%;
   min-height: 6.875rem;
-  overflow-x: hidden;
 }
 .pf-l-page__sidebar.pf-m-expanded {
   display: block;
@@ -34,7 +33,8 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
   width: 80%;
   padding-top: 1rem;
   padding-bottom: 1rem;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   background-color: #ffffff;
   transform: translate3d(0,0,0);
   box-shadow: 0.75rem 0 0.625rem -0.25rem rgba(3, 3, 3, 0.07);
@@ -65,11 +65,10 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
   flex-direction: column;
   padding-right: 0px;
   overflow-x: hidden;
-  overflow-y: visible;
+  overflow-y: auto;
 }
 .pf-l-page.my-page-class {
   display: grid;
-  min-height: 100vh;
   grid-template-columns: 1fr;
   grid-template-rows: max-content 1fr;
   grid-template-areas: "header" "main";
@@ -78,10 +77,214 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
 <Page
   aria-label="Page layout"
   className="my-page-class"
+  condensedHeader={true}
+  condensedHeight={20}
   header={
     <PageHeader
       avatar=" | Avatar"
       className=""
+      condensed={false}
+      logo="Logo"
+      onNavToggle={[Function]}
+      showNavToggle={false}
+      toolbar="Toolbar"
+      topNav={null}
+    />
+  }
+  id="PageId"
+  sidebar={
+    <PageSidebar
+      className=""
+      isNavOpen={true}
+      nav="Navigation"
+    />
+  }
+>
+  <div
+    aria-label="Page layout"
+    className="pf-l-page my-page-class"
+    id="PageId"
+  >
+    <PageHeader
+      avatar=" | Avatar"
+      className=""
+      condensed={false}
+      logo="Logo"
+      onNavToggle={[Function]}
+      showNavToggle={false}
+      toolbar="Toolbar"
+      topNav={null}
+    >
+      <header
+        className="pf-l-page__header"
+        role="banner"
+        style={
+          Object {
+            "overflowX": "unset",
+          }
+        }
+      >
+        <div
+          className="pf-l-page__header-brand"
+        >
+          <a
+            className="pf-l-page__header-brand-link"
+          >
+            Logo
+          </a>
+        </div>
+        <div
+          className="pf-l-page__header-tools"
+        >
+          Toolbar
+           | Avatar
+        </div>
+      </header>
+    </PageHeader>
+    <PageSidebar
+      className=""
+      isNavOpen={true}
+      nav="Navigation"
+    >
+      <aside
+        className="pf-l-page__sidebar pf-m-expanded"
+      >
+        Navigation
+      </aside>
+    </PageSidebar>
+    <main
+      className="pf-l-page__main"
+      role="main"
+    >
+      <PageSection
+        className=""
+        variant="default"
+      >
+        <section
+          className="pf-l-page__main-section"
+        >
+          Section with default background
+        </section>
+      </PageSection>
+      <PageSection
+        className=""
+        variant="light"
+      >
+        <section
+          className="pf-l-page__main-section pf-m-light"
+        >
+          Section with light background
+        </section>
+      </PageSection>
+      <PageSection
+        className=""
+        variant="dark"
+      >
+        <section
+          className="pf-l-page__main-section pf-m-dark-200"
+        >
+          Section with dark background
+        </section>
+      </PageSection>
+      <PageSection
+        className=""
+        variant="darker"
+      >
+        <section
+          className="pf-l-page__main-section pf-m-dark-100"
+        >
+          Section with darker background
+        </section>
+      </PageSection>
+    </main>
+  </div>
+</Page>
+`;
+
+exports[`Check page horizontal layout example against snapshot 1`] = `
+.pf-l-page__header-brand-link {
+  display: flex;
+  align-items: center;
+  min-height: 2.5rem;
+}
+.pf-l-page__header-brand {
+  display: block;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  padding-left: 2rem;
+}
+.pf-l-page__header-tools {
+  display: block;
+  align-items: center;
+  margin-right: 2rem;
+  margin-left: auto;
+}
+.pf-l-page__header {
+  display: flex;
+  grid-area: header;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  max-width: 100%;
+  min-height: 6.875rem;
+}
+.pf-l-page__sidebar.pf-m-expanded {
+  display: block;
+  grid-area: 2 / 1;
+  z-index: 500;
+  width: 80%;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  overflow-x: hidden;
+  overflow-y: auto;
+  background-color: #ffffff;
+  transform: translate3d(0,0,0);
+  box-shadow: 0.75rem 0 0.625rem -0.25rem rgba(3, 3, 3, 0.07);
+}
+.pf-l-page__main-section {
+  display: block;
+  padding: 2rem 2rem 2rem 2rem;
+  background-color: #ededed;
+}
+.pf-l-page__main-section.pf-m-light {
+  display: block;
+  padding: 2rem 2rem 2rem 2rem;
+  background-color: #ffffff;
+}
+.pf-l-page__main-section.pf-m-dark-200 {
+  display: block;
+  padding: 2rem 2rem 2rem 2rem;
+  background-color: rgba(3, 3, 3, 0.32);
+}
+.pf-l-page__main-section.pf-m-dark-100 {
+  display: block;
+  padding: 2rem 2rem 2rem 2rem;
+  background-color: rgba(3, 3, 3, 0.62);
+}
+.pf-l-page__main {
+  display: flex;
+  grid-area: main;
+  flex-direction: column;
+  padding-right: 0px;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.pf-l-page.my-page-class {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: max-content 1fr;
+  grid-template-areas: "header" "main";
+}
+
+<Page
+  aria-label="Page layout"
+  className="my-page-class"
+  condensedHeader={false}
+  condensedHeight={20}
+  header={
+    <PageHeader
+      avatar=" | Avatar"
+      className=""
+      condensed={false}
       logo="Logo"
       nav="Navigation"
       onNavToggle={[Function]}
@@ -109,6 +312,7 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
     <PageHeader
       avatar=" | Avatar"
       className=""
+      condensed={false}
       logo="Logo"
       nav="Navigation"
       onNavToggle={[Function]}
@@ -226,7 +430,6 @@ exports[`Check page vertical layout example against snapshot 1`] = `
   align-items: flex-end;
   max-width: 100%;
   min-height: 6.875rem;
-  overflow-x: hidden;
 }
 .pf-l-page__sidebar.pf-m-expanded {
   display: block;
@@ -235,7 +438,8 @@ exports[`Check page vertical layout example against snapshot 1`] = `
   width: 80%;
   padding-top: 1rem;
   padding-bottom: 1rem;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   background-color: #ffffff;
   transform: translate3d(0,0,0);
   box-shadow: 0.75rem 0 0.625rem -0.25rem rgba(3, 3, 3, 0.07);
@@ -266,11 +470,10 @@ exports[`Check page vertical layout example against snapshot 1`] = `
   flex-direction: column;
   padding-right: 0px;
   overflow-x: hidden;
-  overflow-y: visible;
+  overflow-y: auto;
 }
 .pf-l-page.my-page-class {
   display: grid;
-  min-height: 100vh;
   grid-template-columns: 1fr;
   grid-template-rows: max-content 1fr;
   grid-template-areas: "header" "main";
@@ -279,10 +482,13 @@ exports[`Check page vertical layout example against snapshot 1`] = `
 <Page
   aria-label="Page layout"
   className="my-page-class"
+  condensedHeader={false}
+  condensedHeight={20}
   header={
     <PageHeader
       avatar=" | Avatar"
       className=""
+      condensed={false}
       logo="Logo"
       onNavToggle={[Function]}
       showNavToggle={false}
@@ -307,6 +513,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
     <PageHeader
       avatar=" | Avatar"
       className=""
+      condensed={false}
       logo="Logo"
       onNavToggle={[Function]}
       showNavToggle={false}

--- a/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/Page.test.js.snap
+++ b/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/Page.test.js.snap
@@ -77,7 +77,6 @@ exports[`Check page condensed header example against snapshot 1`] = `
 <Page
   aria-label="Page layout"
   className="my-page-class"
-  condensedHeader={true}
   header={
     <PageHeader
       avatar=" | Avatar"
@@ -99,17 +98,17 @@ exports[`Check page condensed header example against snapshot 1`] = `
       nav="Navigation"
     />
   }
-  useCondensed={false}
+  useCondensed={true}
 >
   <div
     aria-label="Page layout"
     className="pf-l-page my-page-class"
-    condensedHeader={true}
     id="PageId"
   >
     <PageHeader
       avatar=" | Avatar"
       className=""
+      condensed={false}
       isCondensed={false}
       logo="Logo"
       onNavToggle={[Function]}
@@ -119,6 +118,7 @@ exports[`Check page condensed header example against snapshot 1`] = `
     >
       <header
         className="pf-l-page__header"
+        condensed={false}
         role="banner"
         style={
           Object {

--- a/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/Page.test.js.snap
+++ b/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/Page.test.js.snap
@@ -108,7 +108,6 @@ exports[`Check page condensed header example against snapshot 1`] = `
     <PageHeader
       avatar=" | Avatar"
       className=""
-      condensed={false}
       isCondensed={false}
       logo="Logo"
       onNavToggle={[Function]}
@@ -118,7 +117,6 @@ exports[`Check page condensed header example against snapshot 1`] = `
     >
       <header
         className="pf-l-page__header"
-        condensed={false}
         role="banner"
         style={
           Object {

--- a/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/PageHeader.test.js.snap
+++ b/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/PageHeader.test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Check page vertical layout example against snapshot 1`] = `
+.pf-l-page__header-brand-link {
+  display: flex;
+  align-items: center;
+  min-height: 2.5rem;
+}
+.pf-l-page__header-brand {
+  display: block;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  padding-left: 2rem;
+}
+.pf-l-page__header-tools {
+  display: block;
+  align-items: center;
+  margin-right: 2rem;
+  margin-left: auto;
+}
+.pf-l-page__header.pf-m-condensed {
+  display: flex;
+  grid-area: header;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  max-width: 100%;
+  min-height: 1.25rem;
+}
+
+<header
+  className="pf-l-page__header pf-m-condensed"
+  role="banner"
+  style={
+    Object {
+      "overflowX": "unset",
+    }
+  }
+>
+  <div
+    className="pf-l-page__header-brand"
+  >
+    <a
+      className="pf-l-page__header-brand-link"
+    >
+      Logo
+    </a>
+  </div>
+  <div
+    className="pf-l-page__header-tools"
+  >
+    Toolbar
+     | Avatar
+  </div>
+</header>
+`;

--- a/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/PageHeader.test.js.snap
+++ b/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/PageHeader.test.js.snap
@@ -18,7 +18,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
   margin-right: 2rem;
   margin-left: auto;
 }
-.pf-l-page__header {
+.pf-l-page__header.pf-m-isCondensed {
   display: flex;
   grid-area: header;
   flex-wrap: wrap;
@@ -28,8 +28,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
 }
 
 <header
-  className="pf-l-page__header"
-  condensed={true}
+  className="pf-l-page__header pf-m-isCondensed"
   role="banner"
   style={
     Object {

--- a/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/PageHeader.test.js.snap
+++ b/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/PageHeader.test.js.snap
@@ -18,17 +18,17 @@ exports[`Check page vertical layout example against snapshot 1`] = `
   margin-right: 2rem;
   margin-left: auto;
 }
-.pf-l-page__header.pf-m-isCondensed {
+.pf-l-page__header.pf-m-condensed {
   display: flex;
   grid-area: header;
   flex-wrap: wrap;
   align-items: flex-end;
   max-width: 100%;
-  min-height: 6.875rem;
+  min-height: 1.25rem;
 }
 
 <header
-  className="pf-l-page__header pf-m-isCondensed"
+  className="pf-l-page__header pf-m-condensed"
   role="banner"
   style={
     Object {

--- a/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/PageHeader.test.js.snap
+++ b/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/PageHeader.test.js.snap
@@ -18,17 +18,18 @@ exports[`Check page vertical layout example against snapshot 1`] = `
   margin-right: 2rem;
   margin-left: auto;
 }
-.pf-l-page__header.pf-m-condensed {
+.pf-l-page__header {
   display: flex;
   grid-area: header;
   flex-wrap: wrap;
   align-items: flex-end;
   max-width: 100%;
-  min-height: 1.25rem;
+  min-height: 6.875rem;
 }
 
 <header
-  className="pf-l-page__header pf-m-condensed"
+  className="pf-l-page__header"
+  condensed={true}
   role="banner"
   style={
     Object {

--- a/packages/patternfly-4/react-tokens/package.json
+++ b/packages/patternfly-4/react-tokens/package.json
@@ -27,7 +27,7 @@
     "build": "node build/generateTokens.js"
   },
   "devDependencies": {
-    "@patternfly/patternfly-next": "1.0.63",
+    "@patternfly/patternfly-next": "1.0.64",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2"

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.3.1",
-    "@patternfly/patternfly-next": "1.0.63",
+    "@patternfly/patternfly-next": "1.0.64",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "node-plop": "^0.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,9 +326,9 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@novnc/novnc/-/novnc-1.0.0.tgz#76b0e89e6f8738ca8154195baf5b8e6a80bc9105"
 
-"@patternfly/patternfly-next@1.0.63":
-  version "1.0.63"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.63.tgz#8ccf2c281483d71b5338b907ef5a11d235e50dd8"
+"@patternfly/patternfly-next@1.0.64":
+  version "1.0.64"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.64.tgz#d9a59c4361dea66b52573e2af0c9807896eeccfb"
 
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Condensed header option for Page/PageHeader components.

This allows you to simply pass `condensedHeader` boolean to the Page component (and it will be applied automatically on scroll of the Page main contents, or if you prefer to explicitly set condensed mode via prop, you can do this as well on `PageHeader` using `condensed` prop. 

Closes #827

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

Demo:
https://843-pr-patternfly-react-patternfly.surge.sh/patternfly-4/demos/pagelayout/examples/page-layout-condensed-header/
<!-- feel free to add additional comments -->
