### PR TITLE
refactor(Radio/Checkbox): replace checked with isChecked in API

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.d.ts
@@ -4,6 +4,7 @@ import { Omit } from '../../typeUtils';
 export interface CheckboxProps extends Omit<HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled' | 'label'> {
   isDisabled?: boolean;
   isValid?: boolean;
+  isChecked?: boolean;
   onChange?(checked: boolean, event: FormEvent<HTMLInputElement>): void;
   id: string;
   'aria-label': string;

--- a/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.js
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.js
@@ -10,6 +10,8 @@ const propTypes = {
   isValid: PropTypes.bool,
   /** Flag to show if the Checkbox is disabled. */
   isDisabled: PropTypes.bool,
+  /** Flag to show if the Checkbox is checked. */
+  isChecked: PropTypes.bool,
   /** A callback for when the Checkbox selection changes. */
   onChange: PropTypes.func,
   /** Label text of the checkbox. */
@@ -24,6 +26,7 @@ const defaultProps = {
   className: '',
   isValid: true,
   isDisabled: false,
+  isChecked: null,
   onChange: () => undefined,
   label: undefined
 };
@@ -34,7 +37,7 @@ class Checkbox extends React.Component {
   };
 
   render() {
-    const { className, onChange, isValid, isDisabled, label, ...props } = this.props;
+    const { className, onChange, isValid, isDisabled, isChecked, label, checked, ...props } = this.props;
     return (
       <div className={css(styles.check, className)}>
         <input
@@ -44,6 +47,7 @@ class Checkbox extends React.Component {
           onChange={this.handleChange}
           aria-invalid={!isValid}
           disabled={isDisabled}
+          checked={isChecked || checked}
         />
         {label && (
           <label className={css(styles.checkLabel, getModifier(styles, isDisabled && 'disabled'))} htmlFor={props.id}>

--- a/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.test.js
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.test.js
@@ -4,11 +4,11 @@ import Checkbox from './Checkbox';
 
 const props = {
   onChange: jest.fn(),
-  checked: false
+  isChecked: false
 };
 
 test('controlled', () => {
-  const view = shallow(<Checkbox checked id="check" aria-label="check" />);
+  const view = shallow(<Checkbox isChecked id="check" aria-label="check" />);
   expect(view).toMatchSnapshot();
 });
 
@@ -23,28 +23,28 @@ test('isDisabled', () => {
 });
 
 test('label is string', () => {
-  const view = shallow(<Checkbox label="Label" id="check" checked aria-label="check" />);
+  const view = shallow(<Checkbox label="Label" id="check" isChecked aria-label="check" />);
   expect(view).toMatchSnapshot();
 });
 
 test('label is function', () => {
   const functionLabel = () => <h1>Header</h1>;
-  const view = shallow(<Checkbox label={functionLabel()} id="check" checked aria-label="check" />);
+  const view = shallow(<Checkbox label={functionLabel()} id="check" isChecked aria-label="check" />);
   expect(view).toMatchSnapshot();
 });
 
 test('label is node', () => {
-  const view = shallow(<Checkbox label={<h1>Header</h1>} id="check" checked aria-label="check" />);
+  const view = shallow(<Checkbox label={<h1>Header</h1>} id="check" isChecked aria-label="check" />);
   expect(view).toMatchSnapshot();
 });
 
 test('passing class', () => {
-  const view = shallow(<Checkbox label="label" className="class-123" id="check" checked aria-label="check" />);
+  const view = shallow(<Checkbox label="label" className="class-123" id="check" isChecked aria-label="check" />);
   expect(view).toMatchSnapshot();
 });
 
 test('passing HTML attribute', () => {
-  const view = shallow(<Checkbox label="label" aria-labelledby="labelId" id="check" checked aria-label="check" />);
+  const view = shallow(<Checkbox label="label" aria-labelledby="labelId" id="check" isChecked aria-label="check" />);
   expect(view).toMatchSnapshot();
 });
 

--- a/packages/patternfly-4/react-core/src/components/Checkbox/examples/ControlledCheckbox.js
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/examples/ControlledCheckbox.js
@@ -16,7 +16,7 @@ class ControlledCheckbox extends React.Component {
     return (
       <Checkbox
         label="Controlled CheckBox"
-        checked={this.state.checked}
+        isChecked={this.state.checked}
         onChange={this.handleChange}
         aria-label="controlled checkbox example"
         id="check-1"

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.d.ts
@@ -4,6 +4,7 @@ import { Omit } from '../../typeUtils';
 export interface RadioProps extends Omit<HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled' | 'label'> {
   isDisabled?: boolean;
   isValid?: boolean;
+  isChecked?: boolean;
   onChange?(checked: boolean, event: FormEvent<HTMLInputElement>): void;
   id: string;
   'aria-label': string;

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.js
@@ -10,6 +10,8 @@ const propTypes = {
   isValid: PropTypes.bool,
   /** Flag to show if the Radio is disabled. */
   isDisabled: PropTypes.bool,
+  /** Flag to show if the Radio is checked. */
+  isChecked: PropTypes.bool,
   /** A callback for when the Radio selection changes. */
   onChange: PropTypes.func,
   /** Label text of the Radio. */
@@ -26,6 +28,7 @@ const defaultProps = {
   className: '',
   isValid: true,
   isDisabled: false,
+  isChecked: null,
   onChange: () => undefined,
   label: undefined
 };
@@ -36,7 +39,7 @@ class Radio extends React.Component {
   };
 
   render() {
-    const { className, onChange, isValid, isDisabled, label, ...props } = this.props;
+    const { className, onChange, isValid, isDisabled, isChecked, label, checked, ...props } = this.props;
     return (
       <div className={css(styles.check, className)}>
         <input
@@ -46,6 +49,7 @@ class Radio extends React.Component {
           onChange={this.handleChange}
           aria-invalid={!isValid}
           disabled={isDisabled}
+          checked={isChecked || checked}
         />
         {label && (
           <label className={css(styles.checkLabel, getModifier(styles, isDisabled && 'disabled'))} htmlFor={props.id}>

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.test.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.test.js
@@ -3,13 +3,12 @@ import Radio from './Radio';
 import { shallow } from 'enzyme';
 
 const props = {
-  onChange: jest.fn(),
-  checked: false
+  onChange: jest.fn()
 };
 
 describe('Radio check component', () => {
   test('controlled', () => {
-    const view = shallow(<Radio checked id="check" aria-label="check" name="check" />);
+    const view = shallow(<Radio isChecked id="check" aria-label="check" name="check" />);
     expect(view).toMatchSnapshot();
   });
 
@@ -24,31 +23,31 @@ describe('Radio check component', () => {
   });
 
   test('label is string', () => {
-    const view = shallow(<Radio label="Label" id="check" checked aria-label="check" name="check" />);
+    const view = shallow(<Radio label="Label" id="check" isChecked aria-label="check" name="check" />);
     expect(view).toMatchSnapshot();
   });
 
   test('label is function', () => {
     const functionLabel = () => <h1>Header</h1>;
-    const view = shallow(<Radio label={functionLabel()} id="check" checked aria-label="check" name="check" />);
+    const view = shallow(<Radio label={functionLabel()} id="check" isChecked aria-label="check" name="check" />);
     expect(view).toMatchSnapshot();
   });
 
   test('label is node', () => {
-    const view = shallow(<Radio label={<h1>Header</h1>} id="check" checked aria-label="check" name="check" />);
+    const view = shallow(<Radio label={<h1>Header</h1>} id="check" isChecked aria-label="check" name="check" />);
     expect(view).toMatchSnapshot();
   });
 
   test('passing class', () => {
     const view = shallow(
-      <Radio label="label" className="class-123" id="check" checked aria-label="check" name="check" />
+      <Radio label="label" className="class-123" id="check" isChecked aria-label="check" name="check" />
     );
     expect(view).toMatchSnapshot();
   });
 
   test('passing HTML attribute', () => {
     const view = shallow(
-      <Radio label="label" aria-labelledby="labelId" id="check" checked aria-label="check" name="check" />
+      <Radio label="label" aria-labelledby="labelId" id="check" isChecked aria-label="check" name="check" />
     );
     expect(view).toMatchSnapshot();
   });

--- a/packages/patternfly-4/react-core/src/components/Radio/examples/ControlledRadio.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/examples/ControlledRadio.js
@@ -18,7 +18,7 @@ class ControlledRadio extends React.Component {
       <React.Fragment>
         <Radio
           value="3"
-          checked={this.state.value === '3'}
+          isChecked={this.state.value === '3'}
           name="pf-version"
           onChange={this.handleChange}
           aria-label="Controlled radio 1"
@@ -27,7 +27,7 @@ class ControlledRadio extends React.Component {
         />{' '}
         <Radio
           value="4"
-          checked={this.state.value === '4'}
+          isChecked={this.state.value === '4'}
           name="pf-version"
           onChange={this.handleChange}
           aria-label="Controlled radio 2"


### PR DESCRIPTION
I think there is some inconsistency in Radio and Checkbox API.
IMHO, it's expected the `isChecked` prop to set the item as checked (the same way `isDisabled` renders the item disabled). However, to check the item the `checked` props is used.

In this PR, I am attempting to fix this behaviour/API.