### PR TITLE
fix(CatalogTile): Fade end of description text rather than truncate

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
@@ -8,6 +8,7 @@
   height: @catalog-tile-pf-height;
   margin: 0 15px @catalog-tile-pf-margin-bottom 0;
   padding: 15px;
+  position: relative;
   width: @catalog-tile-pf-width;
 
   &.featured {
@@ -79,7 +80,18 @@
   .catalog-tile-pf-description {
     flex: 1;
     margin-top: 15px;
-    overflow-y: hidden;
+    overflow: hidden;
+
+    &::after {
+      background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%);
+      bottom: 20px;
+      content: "";
+      height: 25px;
+      position: absolute;
+      right: 15px;
+      width: 20%;
+      text-align: right;
+    }
   }
 }
 

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
@@ -8,6 +8,7 @@
   height: $catalog-tile-pf-height;
   margin: 0 15px $catalog-tile-pf-margin-bottom 0;
   padding: 15px;
+  position: relative;
   width: $catalog-tile-pf-width;
 
   &.featured {
@@ -79,7 +80,18 @@
   .catalog-tile-pf-description {
     flex: 1;
     margin-top: 15px;
-    overflow-y: hidden;
+    overflow: hidden;
+
+    &::after {
+      background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%);
+      bottom: 20px;
+      content: "";
+      height: 25px;
+      position: absolute;
+      right: 15px;
+      width: 20%;
+      text-align: right;
+    }
   }
 }
 

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.js
@@ -23,7 +23,7 @@ const CatalogTile = ({
   const classes = classNames('catalog-tile-pf', { featured }, className);
 
   const defaultTruncateDescription = (text, max) => {
-    if (typeof text !== 'string' || text.length <= max) {
+    if (max === -1 || typeof text !== 'string' || text.length <= max) {
       return text;
     }
 
@@ -113,7 +113,7 @@ CatalogTile.propTypes = {
   vendor: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /** Description of the catalog item */
   description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  /** Max description length before applying truncation (when description is a string) */
+  /** Max description length before applying truncation (when description is a string), -1 for auto truncate to last visible line */
   maxDescriptionLength: PropTypes.number,
   /** Truncation function(description, max, id) used to truncate description when necessary (defaults to using ellipses) */
   truncateDescriptionFn: PropTypes.func
@@ -130,7 +130,7 @@ CatalogTile.defaultProps = {
   badges: [],
   vendor: null,
   description: null,
-  maxDescriptionLength: 112,
+  maxDescriptionLength: -1,
   truncateDescriptionFn: null
 };
 

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.test.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.test.js
@@ -70,6 +70,7 @@ test('CatalogTile renders properly', () => {
           '112 is the default but can be overridden if need be. You can also provide a custom truncation function ' +
           'to truncate the description how you see fit. It will be passed the description and max length.'
         }
+        maxDescriptionLength={112}
       />
       <CatalogTile
         id="test-iconClass"

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTileView/__mocks__/mockItems.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTileView/__mocks__/mockItems.js
@@ -83,8 +83,9 @@ export const mockItems = [
           </span>
         ),
         description:
-          'This is a very long description that should be truncated after 112 characters. ' +
-          '112 is the default but can be overridden if need be. You can also provide a custom truncation function ' +
+          'This is a very long description that should fade the last visible line to indicate truncation. ' +
+          'The default is the last visible line but can be overridden to truncate to a max number of characters ' +
+          'if need be. You can also provide a custom truncation function ' +
           'to truncate the description how you see fit. It will be passed the description and max length.',
         featured: true,
         certified: true,


### PR DESCRIPTION
By default, fade the text of the description rather than truncating. Truncation can still be
accomplished by setting the maxDescriptionLength parameter.
