### PR TITLE
fix(Progress): import progress style object

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Progress/ProgressBar.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/ProgressBar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { progressBar, progressIndicator, progressMeasure } from '@patternfly/patternfly-next/components/Progress/progress.css';
+import progressStyle from '@patternfly/patternfly-next/components/Progress/progress.css';
 import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
 
@@ -18,9 +18,9 @@ const defaultProps = {
 };
 
 const ProgressBar = ({ className, children, value, ...props }) => (
-  <div {...props} className={css(progressBar, className)}>
-    <div className={css(progressIndicator)} style={{ width: `${value}%` }}>
-      <span className={css(progressMeasure)}>{children}</span>
+  <div {...props} className={css(progressStyle.progressBar, className)}>
+    <div className={css(progressStyle.progressIndicator)} style={{ width: `${value}%` }}>
+      <span className={css(progressStyle.progressMeasure)}>{children}</span>
     </div>
   </div>
 );

--- a/packages/patternfly-4/react-core/src/components/Progress/ProgressContainer.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/ProgressContainer.js
@@ -1,11 +1,6 @@
 import React, { Fragment } from 'react';
-import {
-  progressDescription,
-  progressMeasure,
-  progressStatusIcon,
-  progressStatus
-} from '@patternfly/patternfly-next/components/Progress/progress.css';
-import { css, StyleSheet } from '@patternfly/react-styles';
+import progressStyle from '@patternfly/patternfly-next/components/Progress/progress.css';
+import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
 import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 import ProgressBar from './ProgressBar';
@@ -53,18 +48,16 @@ const ProgressContainer = ({ value, title, parentId, label, variant, measureLoca
   const StatusIcon = variantToIcon.hasOwnProperty(variant) && variantToIcon[variant];
   return (
     <Fragment>
-      <div className={css(progressDescription)} id={`${parentId}-description`}>
+      <div className={css(progressStyle.progressDescription)} id={`${parentId}-description`}>
         {title}
       </div>
-      <div className={css(progressStatus)}>
+      <div className={css(progressStyle.progressStatus)}>
         {(measureLocation === ProgressMeasureLocation.top || measureLocation === ProgressMeasureLocation.outside) && (
-          <span className={css(progressMeasure)}>
-            {label || `${value}%`}
-          </span>
+          <span className={css(progressStyle.progressMeasure)}>{label || `${value}%`}</span>
         )}
         {measureLocation !== ProgressMeasureLocation.none &&
           variantToIcon.hasOwnProperty(variant) && (
-            <span className={css(progressStatusIcon)}>
+            <span className={css(progressStyle.progressStatusIcon)}>
               <StatusIcon />
             </span>
           )}


### PR DESCRIPTION
Updating to `1.28.1` shows the following error message.

![screenshot-2018-10-30 react app](https://user-images.githubusercontent.com/2453279/47717355-333d1100-dc4e-11e8-88e2-82fbabb73714.png)

It looks like `../../@patternfly/patternfly-next/components/Progress/progress.css.js` exports a default object. However, progressBar, progressIndicator, progressMeasure, progressDescription, progressStatusIcon and progressStatus are imported.

I am not sure whether it's a problem on babeljs side or that's an innocent mistake. Nevertheless, it fixed the problem for me.