### PR TITLE
fix(FilterSidePanel/VerticalTabs): Adjust top and bottom spacing of f…

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/filter-side-panel.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/filter-side-panel.less
@@ -1,5 +1,6 @@
 .filter-panel-pf {
-  padding: 20px 15px;
+  margin: 0 0 30px;
+  padding: 0 15px;
 }
 
 .filter-panel-pf-category {

--- a/packages/patternfly-3/patternfly-react-extensions/less/vertical-tabs.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/vertical-tabs.less
@@ -1,6 +1,11 @@
 .vertical-tabs-pf {
-  padding: 0;
   list-style: none;
+  margin: 0 0 30px;
+  padding: 0;
+
+  .vertical-tabs-pf {
+    margin-bottom: 0;
+  }
 }
 
 .vertical-tabs-pf-tab {

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_filter-side-panel.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_filter-side-panel.scss
@@ -1,5 +1,6 @@
 .filter-panel-pf {
-  padding: 20px 15px;
+  margin: 0 0 30px;
+  padding: 0 15px;
 }
 
 .filter-panel-pf-category {

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_vertical-tabs.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_vertical-tabs.scss
@@ -1,6 +1,11 @@
 .vertical-tabs-pf {
-  padding: 0;
   list-style: none;
+  margin: 0 0 30px;
+  padding: 0;
+
+  .vertical-tabs-pf {
+    margin-bottom: 0;
+  }
 }
 
 .vertical-tabs-pf-tab {

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/FilterSidePanel/FilterSidePanel.stories.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/FilterSidePanel/FilterSidePanel.stories.js
@@ -18,7 +18,7 @@ const stories = storiesOf(
 stories.addDecorator(
   defaultTemplate({
     title: 'Filter Side Panel',
-    description: 'Note: the width and border styling is not part of the FilterSidePanel.'
+    description: 'Note: the width, border, and top padding styling are not part of the FilterSidePanel.'
   })
 );
 
@@ -49,7 +49,7 @@ stories.add(
       step: 1
     });
     return (
-      <div style={{ width: '195px', border: '1px solid grey' }}>
+      <div style={{ width: '195px', border: '1px solid grey', paddingTop: '20px' }}>
         <MockFilterSidePanelExample maxShowCount={maxShowCountValue} leeway={leewayValue} />
       </div>
     );


### PR DESCRIPTION
…ilter-side-panel and vertical-tabs-pf

.filter-panel-pf has top and bottom padding, which causes layout issues when it's the only item
being used.  Removing the top and bottom padding and adding a bottom margin fixes the bug and
provides the proper spacing if another element is used.  As a result of these changes,
.vertical-tabs-pf needs to have a larger bottom margin set on it.

Before:
![screen shot 2018-11-02 at 10 09 34 am](https://user-images.githubusercontent.com/895728/47920103-94035e00-de87-11e8-819e-02a4eb5d9cdf.PNG)
![screen shot 2018-11-02 at 10 09 44 am](https://user-images.githubusercontent.com/895728/47920104-94035e00-de87-11e8-9e28-5a85e15b0bea.PNG)

After:
![screen shot 2018-11-02 at 10 09 11 am](https://user-images.githubusercontent.com/895728/47920117-9e255c80-de87-11e8-95f0-3ad5b3a41e2e.PNG)
![screen shot 2018-11-02 at 10 09 04 am](https://user-images.githubusercontent.com/895728/47920116-9e255c80-de87-11e8-9dbd-b82acf74f167.PNG)

attn: @jeff-phillips-18 