### PR TITLE
fix(modal transition): Reduce translate3d (right offset) positioning for right-side-modal-pf to 25%

### DIFF
--- a/packages/patternfly-3/patternfly-react/less/modeless-overlay.less
+++ b/packages/patternfly-3/patternfly-react/less/modeless-overlay.less
@@ -10,8 +10,8 @@
   }
 
   &.fade:not(.in) .modal-dialog {
-    -webkit-transform: translate3d(-75%, 0, 0);
-    transform: translate3d(75%, 0, 0);
+    -webkit-transform: translate3d(-25%, 0, 0);
+    transform: translate3d(25%, 0, 0);
   }
 }
 

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_modeless-overlay.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_modeless-overlay.scss
@@ -10,8 +10,8 @@
   }
 
   &.fade:not(.in) .modal-dialog {
-    -webkit-transform: translate3d(-75%, 0, 0);
-    transform: translate3d(75%, 0, 0);
+    -webkit-transform: translate3d(-25%, 0, 0);
+    transform: translate3d(25%, 0, 0);
   }
 }
 


### PR DESCRIPTION
This is a requested modification related to the OpenShift Console Catalog pr
https://github.com/openshift/console/pull/666

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Reduce offset position for right-side-modal-pf to lessen transition distance and ui movement.

<!-- Are there any upstream issues or separate issues you need to reference? -->

@jeff-phillips-18 

**Additional issues**:
Requested for OpenShift Console Catalog from pr https://github.com/openshift/console/pull/666

<!-- feel free to add additional comments -->
