### PR TITLE
fix(typescript): Export LoginBox and make PageSection props optional

### DIFF
--- a/packages/patternfly-4/react-core/src/components/index.d.ts
+++ b/packages/patternfly-4/react-core/src/components/index.d.ts
@@ -12,6 +12,7 @@ export * from './Checkbox';
 export * from './Dropdown';
 export * from './Form';
 export * from './List';
+export * from './LoginBox';
 export * from './Modal';
 export * from './Nav';
 export * from './Progress';

--- a/packages/patternfly-4/react-core/src/layouts/Page/PageSection.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Page/PageSection.d.ts
@@ -9,9 +9,9 @@ export const PageSectionVariants: {
 };
 
 export interface PageSectionProps extends HTMLProps<HTMLDivElement> {
-  children: ReactNode;
-  className: string;
-  variant: OneOf<typeof PageSectionVariants, keyof typeof PageSectionVariants>;
+  children?: ReactNode;
+  className?: string;
+  variant?: OneOf<typeof PageSectionVariants, keyof typeof PageSectionVariants>;
 }
 
 declare const PageSection: SFC<PageSectionProps>;


### PR DESCRIPTION
**What**:

Export LoginBox in typescript definitions file and make PageSection props optional

Closes:
#879 
