### PR TITLE
feat(DropdownToggle - noCaret option): Adds the noCaret option

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.d.ts
@@ -9,7 +9,7 @@ export interface DropdownToggleProps extends HTMLProps<HTMLButtonElement> {
   isFocused?: boolean;
   isHovered?: boolean;
   isActive?: boolean;
-  IconComponent?: ReactNode;
+  IconComponent?: Function;
 }
 
 declare const DropdownToggle: SFC<DropdownToggleProps>;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.d.ts
@@ -9,7 +9,7 @@ export interface DropdownToggleProps extends HTMLProps<HTMLButtonElement> {
   isFocused?: boolean;
   isHovered?: boolean;
   isActive?: boolean;
-  IconComponent?: Function;
+  iconComponent?: Function;
 }
 
 declare const DropdownToggle: SFC<DropdownToggleProps>;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.d.ts
@@ -9,6 +9,7 @@ export interface DropdownToggleProps extends HTMLProps<HTMLButtonElement> {
   isFocused?: boolean;
   isHovered?: boolean;
   isActive?: boolean;
+  IconComponent?: ReactNode;
 }
 
 declare const DropdownToggle: SFC<DropdownToggleProps>;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.d.ts
@@ -9,7 +9,7 @@ export interface DropdownToggleProps extends HTMLProps<HTMLButtonElement> {
   isFocused?: boolean;
   isHovered?: boolean;
   isActive?: boolean;
-  iconComponent?: Function;
+  iconComponent?: ReactType;
 }
 
 declare const DropdownToggle: SFC<DropdownToggleProps>;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.js
@@ -5,7 +5,7 @@ import Toggle from './Toggle';
 import styles from '@patternfly/patternfly-next/components/Dropdown/dropdown.css';
 import { css } from '@patternfly/react-styles';
 
-const DropdownToggle = ({ children, IconComponent, ...props }) => (
+const DropdownToggle = ({ children, iconComponent: IconComponent, ...props }) => (
   <Toggle {...props}>
     {children}
     {IconComponent && <IconComponent className={css(styles.dropdownToggleIcon)} />}
@@ -32,7 +32,7 @@ DropdownToggle.propTypes = {
   /** Forces active state */
   isActive: PropTypes.bool,
   /** The icon to display for the toggle. Defaults to CaretDownIcon. Set to null to not show an icon. */
-  IconComponent: PropTypes.func
+  iconComponent: PropTypes.func
 };
 
 DropdownToggle.defaultProps = {
@@ -44,7 +44,7 @@ DropdownToggle.defaultProps = {
   isHovered: false,
   isActive: false,
   onToggle: Function.prototype,
-  IconComponent: CaretDownIcon
+  iconComponent: CaretDownIcon
 };
 
 export default DropdownToggle;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.js
@@ -5,10 +5,10 @@ import Toggle from './Toggle';
 import styles from '@patternfly/patternfly-next/components/Dropdown/dropdown.css';
 import { css } from '@patternfly/react-styles';
 
-const DropdownToggle = ({ children, noCaret, ...props }) => (
+const DropdownToggle = ({ children, IconComponent, ...props }) => (
   <Toggle {...props}>
     {children}
-    {!noCaret && <CaretDownIcon className={css(styles.dropdownToggleIcon)} />}
+    {IconComponent && <IconComponent className={css(styles.dropdownToggleIcon)} />}
   </Toggle>
 );
 
@@ -31,8 +31,8 @@ DropdownToggle.propTypes = {
   isHovered: PropTypes.bool,
   /** Forces active state */
   isActive: PropTypes.bool,
-  /** If true does not display a caret */
-  noCaret: PropTypes.bool
+  /** The icon to display for the toggle. Defaults to CaretDownIcon. Set to null to not show an icon. */
+  IconComponent: PropTypes.node
 };
 
 DropdownToggle.defaultProps = {
@@ -44,7 +44,7 @@ DropdownToggle.defaultProps = {
   isHovered: false,
   isActive: false,
   onToggle: Function.prototype,
-  noCaret: false
+  IconComponent: CaretDownIcon
 };
 
 export default DropdownToggle;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.js
@@ -5,10 +5,10 @@ import Toggle from './Toggle';
 import styles from '@patternfly/patternfly-next/components/Dropdown/dropdown.css';
 import { css } from '@patternfly/react-styles';
 
-const DropdownToggle = ({ children, ...props }) => (
+const DropdownToggle = ({ children, noCaret, ...props }) => (
   <Toggle {...props}>
     {children}
-    <CaretDownIcon className={css(styles.dropdownToggleIcon)} />
+    {!noCaret && <CaretDownIcon className={css(styles.dropdownToggleIcon)} />}
   </Toggle>
 );
 
@@ -30,7 +30,9 @@ DropdownToggle.propTypes = {
   /** Forces hover state */
   isHovered: PropTypes.bool,
   /** Forces active state */
-  isActive: PropTypes.bool
+  isActive: PropTypes.bool,
+  /** If true does not display a caret */
+  noCaret: PropTypes.bool
 };
 
 DropdownToggle.defaultProps = {
@@ -41,7 +43,8 @@ DropdownToggle.defaultProps = {
   isFocused: false,
   isHovered: false,
   isActive: false,
-  onToggle: Function.prototype
+  onToggle: Function.prototype,
+  noCaret: false
 };
 
 export default DropdownToggle;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.js
@@ -32,7 +32,7 @@ DropdownToggle.propTypes = {
   /** Forces active state */
   isActive: PropTypes.bool,
   /** The icon to display for the toggle. Defaults to CaretDownIcon. Set to null to not show an icon. */
-  IconComponent: PropTypes.node
+  IconComponent: PropTypes.func
 };
 
 DropdownToggle.defaultProps = {

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -1347,13 +1347,13 @@ exports[`dropdown basic 1`] = `
   position="left"
   toggle={
     <DropdownToggle
+      IconComponent={[Function]}
       className=""
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
       isHovered={false}
       isOpen={false}
-      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1365,6 +1365,7 @@ exports[`dropdown basic 1`] = `
     className="pf-c-dropdown pf-m-expanded"
   >
     <DropdownToggle
+      IconComponent={[Function]}
       className=""
       id="Dropdown Toggle"
       isActive={false}
@@ -1372,7 +1373,6 @@ exports[`dropdown basic 1`] = `
       isHovered={false}
       isOpen={true}
       key=".0"
-      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1537,13 +1537,13 @@ exports[`dropdown dropup + right aligned 1`] = `
   position="right"
   toggle={
     <DropdownToggle
+      IconComponent={[Function]}
       className=""
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
       isHovered={false}
       isOpen={false}
-      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1555,6 +1555,7 @@ exports[`dropdown dropup + right aligned 1`] = `
     className="pf-c-dropdown pf-m-top"
   >
     <DropdownToggle
+      IconComponent={[Function]}
       className=""
       id="Dropdown Toggle"
       isActive={false}
@@ -1562,7 +1563,6 @@ exports[`dropdown dropup + right aligned 1`] = `
       isHovered={false}
       isOpen={false}
       key=".0"
-      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1710,13 +1710,13 @@ exports[`dropdown dropup 1`] = `
   position="left"
   toggle={
     <DropdownToggle
+      IconComponent={[Function]}
       className=""
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
       isHovered={false}
       isOpen={false}
-      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1728,6 +1728,7 @@ exports[`dropdown dropup 1`] = `
     className="pf-c-dropdown pf-m-top"
   >
     <DropdownToggle
+      IconComponent={[Function]}
       className=""
       id="Dropdown Toggle"
       isActive={false}
@@ -1735,7 +1736,6 @@ exports[`dropdown dropup 1`] = `
       isHovered={false}
       isOpen={false}
       key=".0"
-      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1911,13 +1911,13 @@ exports[`dropdown expanded 1`] = `
   position="left"
   toggle={
     <DropdownToggle
+      IconComponent={[Function]}
       className=""
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
       isHovered={false}
       isOpen={false}
-      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1929,6 +1929,7 @@ exports[`dropdown expanded 1`] = `
     className="pf-c-dropdown pf-m-expanded"
   >
     <DropdownToggle
+      IconComponent={[Function]}
       className=""
       id="Dropdown Toggle"
       isActive={false}
@@ -1936,7 +1937,6 @@ exports[`dropdown expanded 1`] = `
       isHovered={false}
       isOpen={true}
       key=".0"
-      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -2244,13 +2244,13 @@ exports[`dropdown regular 1`] = `
   position="left"
   toggle={
     <DropdownToggle
+      IconComponent={[Function]}
       className=""
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
       isHovered={false}
       isOpen={false}
-      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -2262,6 +2262,7 @@ exports[`dropdown regular 1`] = `
     className="pf-c-dropdown"
   >
     <DropdownToggle
+      IconComponent={[Function]}
       className=""
       id="Dropdown Toggle"
       isActive={false}
@@ -2269,7 +2270,6 @@ exports[`dropdown regular 1`] = `
       isHovered={false}
       isOpen={false}
       key=".0"
-      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -2417,13 +2417,13 @@ exports[`dropdown right aligned 1`] = `
   position="right"
   toggle={
     <DropdownToggle
+      IconComponent={[Function]}
       className=""
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
       isHovered={false}
       isOpen={false}
-      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -2435,6 +2435,7 @@ exports[`dropdown right aligned 1`] = `
     className="pf-c-dropdown"
   >
     <DropdownToggle
+      IconComponent={[Function]}
       className=""
       id="Dropdown Toggle"
       isActive={false}
@@ -2442,7 +2443,6 @@ exports[`dropdown right aligned 1`] = `
       isHovered={false}
       isOpen={false}
       key=".0"
-      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -1347,8 +1347,8 @@ exports[`dropdown basic 1`] = `
   position="left"
   toggle={
     <DropdownToggle
-      IconComponent={[Function]}
       className=""
+      iconComponent={[Function]}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -1365,8 +1365,8 @@ exports[`dropdown basic 1`] = `
     className="pf-c-dropdown pf-m-expanded"
   >
     <DropdownToggle
-      IconComponent={[Function]}
       className=""
+      iconComponent={[Function]}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -1537,8 +1537,8 @@ exports[`dropdown dropup + right aligned 1`] = `
   position="right"
   toggle={
     <DropdownToggle
-      IconComponent={[Function]}
       className=""
+      iconComponent={[Function]}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -1555,8 +1555,8 @@ exports[`dropdown dropup + right aligned 1`] = `
     className="pf-c-dropdown pf-m-top"
   >
     <DropdownToggle
-      IconComponent={[Function]}
       className=""
+      iconComponent={[Function]}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -1710,8 +1710,8 @@ exports[`dropdown dropup 1`] = `
   position="left"
   toggle={
     <DropdownToggle
-      IconComponent={[Function]}
       className=""
+      iconComponent={[Function]}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -1728,8 +1728,8 @@ exports[`dropdown dropup 1`] = `
     className="pf-c-dropdown pf-m-top"
   >
     <DropdownToggle
-      IconComponent={[Function]}
       className=""
+      iconComponent={[Function]}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -1911,8 +1911,8 @@ exports[`dropdown expanded 1`] = `
   position="left"
   toggle={
     <DropdownToggle
-      IconComponent={[Function]}
       className=""
+      iconComponent={[Function]}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -1929,8 +1929,8 @@ exports[`dropdown expanded 1`] = `
     className="pf-c-dropdown pf-m-expanded"
   >
     <DropdownToggle
-      IconComponent={[Function]}
       className=""
+      iconComponent={[Function]}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -2244,8 +2244,8 @@ exports[`dropdown regular 1`] = `
   position="left"
   toggle={
     <DropdownToggle
-      IconComponent={[Function]}
       className=""
+      iconComponent={[Function]}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -2262,8 +2262,8 @@ exports[`dropdown regular 1`] = `
     className="pf-c-dropdown"
   >
     <DropdownToggle
-      IconComponent={[Function]}
       className=""
+      iconComponent={[Function]}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -2417,8 +2417,8 @@ exports[`dropdown right aligned 1`] = `
   position="right"
   toggle={
     <DropdownToggle
-      IconComponent={[Function]}
       className=""
+      iconComponent={[Function]}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -2435,8 +2435,8 @@ exports[`dropdown right aligned 1`] = `
     className="pf-c-dropdown"
   >
     <DropdownToggle
-      IconComponent={[Function]}
       className=""
+      iconComponent={[Function]}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -1353,6 +1353,7 @@ exports[`dropdown basic 1`] = `
       isFocused={false}
       isHovered={false}
       isOpen={false}
+      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1371,6 +1372,7 @@ exports[`dropdown basic 1`] = `
       isHovered={false}
       isOpen={true}
       key=".0"
+      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1541,6 +1543,7 @@ exports[`dropdown dropup + right aligned 1`] = `
       isFocused={false}
       isHovered={false}
       isOpen={false}
+      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1559,6 +1562,7 @@ exports[`dropdown dropup + right aligned 1`] = `
       isHovered={false}
       isOpen={false}
       key=".0"
+      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1712,6 +1716,7 @@ exports[`dropdown dropup 1`] = `
       isFocused={false}
       isHovered={false}
       isOpen={false}
+      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1730,6 +1735,7 @@ exports[`dropdown dropup 1`] = `
       isHovered={false}
       isOpen={false}
       key=".0"
+      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1911,6 +1917,7 @@ exports[`dropdown expanded 1`] = `
       isFocused={false}
       isHovered={false}
       isOpen={false}
+      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -1929,6 +1936,7 @@ exports[`dropdown expanded 1`] = `
       isHovered={false}
       isOpen={true}
       key=".0"
+      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -2242,6 +2250,7 @@ exports[`dropdown regular 1`] = `
       isFocused={false}
       isHovered={false}
       isOpen={false}
+      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -2260,6 +2269,7 @@ exports[`dropdown regular 1`] = `
       isHovered={false}
       isOpen={false}
       key=".0"
+      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -2413,6 +2423,7 @@ exports[`dropdown right aligned 1`] = `
       isFocused={false}
       isHovered={false}
       isOpen={false}
+      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >
@@ -2431,6 +2442,7 @@ exports[`dropdown right aligned 1`] = `
       isHovered={false}
       isOpen={false}
       key=".0"
+      noCaret={false}
       onToggle={[Function]}
       parentRef={null}
     >

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
@@ -27,6 +27,7 @@ exports[`state active 1`] = `
   isFocused={false}
   isHovered={false}
   isOpen={false}
+  noCaret={false}
   onToggle={[Function]}
   parentRef={<div />}
 >
@@ -101,6 +102,7 @@ exports[`state focus 1`] = `
   isFocused={true}
   isHovered={false}
   isOpen={false}
+  noCaret={false}
   onToggle={[Function]}
   parentRef={<div />}
 >
@@ -175,6 +177,7 @@ exports[`state hover 1`] = `
   isFocused={false}
   isHovered={true}
   isOpen={false}
+  noCaret={false}
   onToggle={[Function]}
   parentRef={<div />}
 >

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
@@ -21,8 +21,8 @@ exports[`state active 1`] = `
 }
 
 <DropdownToggle
-  IconComponent={[Function]}
   className=""
+  iconComponent={[Function]}
   id="Dropdown Toggle"
   isActive={true}
   isFocused={false}
@@ -96,8 +96,8 @@ exports[`state focus 1`] = `
 }
 
 <DropdownToggle
-  IconComponent={[Function]}
   className=""
+  iconComponent={[Function]}
   id="Dropdown Toggle"
   isActive={false}
   isFocused={true}
@@ -171,8 +171,8 @@ exports[`state hover 1`] = `
 }
 
 <DropdownToggle
-  IconComponent={[Function]}
   className=""
+  iconComponent={[Function]}
   id="Dropdown Toggle"
   isActive={false}
   isFocused={false}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
@@ -21,13 +21,13 @@ exports[`state active 1`] = `
 }
 
 <DropdownToggle
+  IconComponent={[Function]}
   className=""
   id="Dropdown Toggle"
   isActive={true}
   isFocused={false}
   isHovered={false}
   isOpen={false}
-  noCaret={false}
   onToggle={[Function]}
   parentRef={<div />}
 >
@@ -96,13 +96,13 @@ exports[`state focus 1`] = `
 }
 
 <DropdownToggle
+  IconComponent={[Function]}
   className=""
   id="Dropdown Toggle"
   isActive={false}
   isFocused={true}
   isHovered={false}
   isOpen={false}
-  noCaret={false}
   onToggle={[Function]}
   parentRef={<div />}
 >
@@ -171,13 +171,13 @@ exports[`state hover 1`] = `
 }
 
 <DropdownToggle
+  IconComponent={[Function]}
   className=""
   id="Dropdown Toggle"
   isActive={false}
   isFocused={false}
   isHovered={true}
   isOpen={false}
-  noCaret={false}
   onToggle={[Function]}
   parentRef={<div />}
 >

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
@@ -21,13 +21,13 @@ exports[`Dropdown toggle 1`] = `
 }
 
 <DropdownToggle
+  IconComponent={[Function]}
   className=""
   id="Dropdown Toggle"
   isActive={false}
   isFocused={false}
   isHovered={false}
   isOpen={false}
-  noCaret={false}
   onToggle={[Function]}
   parentRef={null}
 >

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
@@ -21,8 +21,8 @@ exports[`Dropdown toggle 1`] = `
 }
 
 <DropdownToggle
-  IconComponent={[Function]}
   className=""
+  iconComponent={[Function]}
   id="Dropdown Toggle"
   isActive={false}
   isFocused={false}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
@@ -27,6 +27,7 @@ exports[`Dropdown toggle 1`] = `
   isFocused={false}
   isHovered={false}
   isOpen={false}
+  noCaret={false}
   onToggle={[Function]}
   parentRef={null}
 >


### PR DESCRIPTION
**What**:

OpenShift needs an option to disable the caret from displaying for the DropdownToggle

Addresses:
https://github.com/patternfly/patternfly-react/issues/889#issuecomment-436458249