### PR TITLE
Fix sub-component references in react-console

### DIFF
--- a/packages/patternfly-3/react-console/package.json
+++ b/packages/patternfly-3/react-console/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "patternfly": "^3.58.0",
-    "patternfly-react": "^2.22.5",
+    "patternfly-react": "^2.24.0",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-bootstrap": "^0.32.1",

--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 
 import { Grid, Form, Dropdown, MenuItem } from 'patternfly-react';
 
-import { NONE_TYPE, SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE } from '../common/constants';
+import constants from '../common/constants';
 
+const { NONE_TYPE, SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE } = constants;
 const { Row, Col } = Grid;
 const { Checkbox, FormGroup } = Form;
 
@@ -155,5 +156,7 @@ AccessConsoles.defaultProps = {
 
   disconnectByChange: true /** By default, console is unmounted (disconnected) when switching to other type */
 };
+
+AccessConsoles.constants = constants;
 
 export default AccessConsoles;

--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Grid, Row, Col, Form, FormGroup, Dropdown, MenuItem, Checkbox } from 'patternfly-react';
+import { Grid, Form, Dropdown, MenuItem } from 'patternfly-react';
 
 import { NONE_TYPE, SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE } from '../common/constants';
+
+const { Row, Col } = Grid;
+const { Checkbox, FormGroup } = Form;
 
 class AccessConsoles extends React.Component {
   state = {

--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.stories.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.stories.js
@@ -8,8 +8,9 @@ import { storybookPackageName } from 'storybook/constants/siteConstants';
 import { noop } from 'patternfly-react';
 import { AccessConsoles, VncConsole } from '../index';
 import { SerialConsoleConnector } from '../SerialConsole/SerialConsole.stories'; // contains mock backend
-import { DISCONNECTED } from '../SerialConsole/constants';
-import { SERIAL_CONSOLE_TYPE } from '../common/constants';
+import constants from '../common/constants';
+
+const { DISCONNECTED, SERIAL_CONSOLE_TYPE } = constants;
 
 const stories = storiesOf(`${storybookPackageName(name)}/AccessConsoles`, module);
 

--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.test.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.test.js
@@ -4,9 +4,10 @@ import { noop } from 'patternfly-react';
 
 import { AccessConsoles } from './index';
 import { SerialConsole } from '../SerialConsole';
-import { SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE } from '../common/constants';
-import { LOADING } from '../SerialConsole/constants';
 import { VncConsole } from '../VncConsole';
+import constants from '../common/constants';
+
+const { SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE, LOADING } = constants;
 
 const MyVncConsoleTestWrapper = () => <p>This can be VncConsole component or a wrapper</p>;
 

--- a/packages/patternfly-3/react-console/src/DesktopViewer/DesktopViewer.test.js
+++ b/packages/patternfly-3/react-console/src/DesktopViewer/DesktopViewer.test.js
@@ -5,7 +5,9 @@ import { render, mount } from 'enzyme';
 import DesktopViewer from './DesktopViewer';
 import MoreInformationDefaultContent from './MoreInformationDefaultContent';
 import { generateVVFile } from './vvFileGenerator';
-import { SPICE_CONSOLE_TYPE } from '../common/constants';
+import constants from '../common/constants';
+
+const { SPICE_CONSOLE_TYPE } = constants;
 
 const spice = {
   address: 'my.host.com',

--- a/packages/patternfly-3/react-console/src/DesktopViewer/vvFileGenerator.js
+++ b/packages/patternfly-3/react-console/src/DesktopViewer/vvFileGenerator.js
@@ -1,7 +1,8 @@
 import 'blob-polyfill';
 import { saveAs } from 'file-saver';
+import constants from '../common/constants';
 
-import { VNC_CONSOLE_TYPE, SPICE_CONSOLE_TYPE } from '../common/constants';
+const { VNC_CONSOLE_TYPE, SPICE_CONSOLE_TYPE } = constants;
 
 export function downloadFile(fileName, content, mimeType) {
   const blob = new Blob([content], { type: mimeType });

--- a/packages/patternfly-3/react-console/src/SerialConsole/SerialConsole.js
+++ b/packages/patternfly-3/react-console/src/SerialConsole/SerialConsole.js
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { EmptyState, Button, noop } from 'patternfly-react';
+import { EmptyState, Button, helpers } from 'patternfly-react';
 import { CONNECTED, DISCONNECTED, LOADING } from './constants';
 
 import XTerm from './XTerm';
 import SerialConsoleActions from './SerialConsoleActions';
+
+const { noop } = helpers;
 
 /**
  * SerialConsole Component for PatternFly React

--- a/packages/patternfly-3/react-console/src/SerialConsole/SerialConsole.js
+++ b/packages/patternfly-3/react-console/src/SerialConsole/SerialConsole.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { EmptyState, Button, helpers } from 'patternfly-react';
-import { CONNECTED, DISCONNECTED, LOADING } from './constants';
+import constants from '../common/constants';
 
+const { CONNECTED, DISCONNECTED, LOADING } = constants;
 import XTerm from './XTerm';
 import SerialConsoleActions from './SerialConsoleActions';
 
@@ -139,7 +140,7 @@ SerialConsole.propTypes = {
   onTitleChanged: PropTypes.func,
 
   /** Connection status, a value from [''connected', 'disconnected', 'loading']. Default is 'loading' for a not matching value. */
-  status: PropTypes.string.isRequired,
+  status: PropTypes.oneOf([CONNECTED, DISCONNECTED, LOADING]).isRequired,
   id: PropTypes.string,
 
   /** Size of the terminal component */

--- a/packages/patternfly-3/react-console/src/SerialConsole/SerialConsole.stories.js
+++ b/packages/patternfly-3/react-console/src/SerialConsole/SerialConsole.stories.js
@@ -7,7 +7,9 @@ import { defaultTemplate } from 'storybook/decorators/storyTemplates';
 import { storybookPackageName } from 'storybook/constants/siteConstants';
 
 import { SerialConsole } from './index';
-import { CONNECTED, DISCONNECTED, LOADING } from './constants';
+import constants from '../common/constants';
+
+const { CONNECTED, DISCONNECTED, LOADING } = constants;
 
 import { name } from '../../package.json';
 

--- a/packages/patternfly-3/react-console/src/SerialConsole/SerialConsole.test.js
+++ b/packages/patternfly-3/react-console/src/SerialConsole/SerialConsole.test.js
@@ -2,7 +2,9 @@
 import React from 'react';
 import { shallow, render } from 'enzyme';
 import SerialConsole from './SerialConsole';
-import { CONNECTED, DISCONNECTED, LOADING } from './constants';
+import constants from '../common/constants';
+
+const { CONNECTED, DISCONNECTED, LOADING } = constants;
 
 test('SerialConsole in the LOADING state', () => {
   const view = shallow(

--- a/packages/patternfly-3/react-console/src/SerialConsole/SerialConsoleActions.js
+++ b/packages/patternfly-3/react-console/src/SerialConsole/SerialConsoleActions.js
@@ -2,7 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { noop } from 'patternfly-react';
+import { helpers } from 'patternfly-react';
+
+const { noop } = helpers;
 
 const SerialConsoleActions = ({
   idPrefix,

--- a/packages/patternfly-3/react-console/src/SerialConsole/XTerm.js
+++ b/packages/patternfly-3/react-console/src/SerialConsole/XTerm.js
@@ -4,8 +4,11 @@ import PropTypes from 'prop-types';
 import { Terminal } from 'xterm';
 import { proposeGeometry } from 'xterm/lib/addons/fit/fit';
 
-import { noop } from 'patternfly-react';
 import { debounce } from '../common/helpers';
+
+import { helpers } from 'patternfly-react';
+
+const { noop } = helpers;
 
 /**
  * Wraps terminal to a React Component.

--- a/packages/patternfly-3/react-console/src/SerialConsole/constants.js
+++ b/packages/patternfly-3/react-console/src/SerialConsole/constants.js
@@ -1,3 +1,0 @@
-export const CONNECTED = 'connected';
-export const DISCONNECTED = 'disconnected';
-export const LOADING = 'loading';

--- a/packages/patternfly-3/react-console/src/VncConsole/VncActions.js
+++ b/packages/patternfly-3/react-console/src/VncConsole/VncActions.js
@@ -1,13 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { DropdownButton, MenuItem, noop } from 'patternfly-react';
+import { MenuItem, Button, helpers } from 'patternfly-react';
+
+const { Dropdown } = Button;
+const { noop } = helpers;
 
 const VncActions = ({ textSendShortcut, textCtrlAltDel, onCtrlAltDel }) => (
-  <DropdownButton bsStyle="default" title={textSendShortcut} id="console-send-shortcut" onClick={noop}>
+  <Dropdown bsStyle="default" title={textSendShortcut} id="console-send-shortcut" onClick={noop}>
     <MenuItem eventKey="1" onClick={onCtrlAltDel}>
       {textCtrlAltDel}
     </MenuItem>
-  </DropdownButton>
+  </Dropdown>
 );
 
 VncActions.propTypes = {

--- a/packages/patternfly-3/react-console/src/VncConsole/VncConsole.js
+++ b/packages/patternfly-3/react-console/src/VncConsole/VncConsole.js
@@ -8,12 +8,10 @@ import classNames from 'classnames';
 import { Toolbar, helpers } from 'patternfly-react';
 
 import VncActions from './VncActions';
+import constants from '../common/constants';
 
+const { CONNECTED, CONNECTING, DISCONNECTED } = constants;
 const { noop } = helpers;
-
-const CONNECTING = 'connecting';
-const CONNECTED = 'connected';
-const DISCONNECTED = 'disconnected';
 
 /* eslint no-console: ["warn", { allow: ["error"] }] */
 

--- a/packages/patternfly-3/react-console/src/VncConsole/VncConsole.js
+++ b/packages/patternfly-3/react-console/src/VncConsole/VncConsole.js
@@ -5,9 +5,11 @@ import * as NovncLog from '@novnc/novnc/core/util/logging';
 import RFB from '@novnc/novnc/core/rfb';
 
 import classNames from 'classnames';
-import { Toolbar, noop } from 'patternfly-react';
+import { Toolbar, helpers } from 'patternfly-react';
 
 import VncActions from './VncActions';
+
+const { noop } = helpers;
 
 const CONNECTING = 'connecting';
 const CONNECTED = 'connected';

--- a/packages/patternfly-3/react-console/src/common/constants.js
+++ b/packages/patternfly-3/react-console/src/common/constants.js
@@ -1,4 +1,23 @@
-export const NONE_TYPE = '_none_';
-export const SERIAL_CONSOLE_TYPE = 'SerialConsole';
-export const SPICE_CONSOLE_TYPE = 'SpiceConsole';
-export const VNC_CONSOLE_TYPE = 'VncConsole';
+const NONE_TYPE = '_none_';
+const SERIAL_CONSOLE_TYPE = 'SerialConsole';
+const SPICE_CONSOLE_TYPE = 'SpiceConsole';
+const VNC_CONSOLE_TYPE = 'VncConsole';
+
+const CONNECTING = 'connecting';
+const CONNECTED = 'connected';
+const DISCONNECTED = 'disconnected';
+const LOADING = 'loading';
+
+const constants = {
+  NONE_TYPE,
+  SERIAL_CONSOLE_TYPE,
+  SPICE_CONSOLE_TYPE,
+  VNC_CONSOLE_TYPE,
+
+  CONNECTING,
+  CONNECTED,
+  DISCONNECTED,
+  LOADING
+};
+
+export default constants;

--- a/packages/patternfly-3/react-console/src/index.js
+++ b/packages/patternfly-3/react-console/src/index.js
@@ -1,6 +1,3 @@
-export * from './common/helpers';
-export * from './common/constants';
-
 export * from './SerialConsole';
 export * from './VncConsole';
 export * from './AccessConsoles';


### PR DESCRIPTION
Follow-up for 1f3411a6e708e833e48921380ae736cf5f79862b , resp #853.

Sub-components (like Grid.Col) are no more exported individually.
