### PR TITLE
translate strings to English in mockClientPaginationTable.js

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Table/__mocks__/mockClientPaginationTable.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Table/__mocks__/mockClientPaginationTable.js
@@ -716,7 +716,7 @@ export class MockClientPaginationTable extends React.Component {
       this.setPage(this.state.pagination.page - 1);
     }
   };
-  onNextPage () => {
+  onNextPage = () => {
     const { page } = this.state.pagination;
     if (page < this.totalPages()) {
       this.setPage(this.state.pagination.page + 1);

--- a/packages/patternfly-3/patternfly-react/src/components/Table/__mocks__/mockClientPaginationTable.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Table/__mocks__/mockClientPaginationTable.js
@@ -75,12 +75,12 @@ export class MockClientPaginationTable extends React.Component {
         {
           property: 'select',
           header: {
-            label: 'Vyberte všechny řádky',
+            label: 'Select all rows',
             props: {
               index: 0,
               rowSpan: 1,
               colSpan: 1,
-              id: 'vybrat vše'
+              id: 'Select all'
             },
             customFormatters: [selectionHeaderCellFormatter]
           },
@@ -93,8 +93,8 @@ export class MockClientPaginationTable extends React.Component {
                 selectionCellFormatter(
                   { rowData, rowIndex },
                   this.onSelectRow,
-                  `vybrat${rowIndex}`,
-                  `vyberte řádek ${rowIndex}`
+                  `Select ${rowIndex}`,
+                  `Select line ${rowIndex}`
                 )
             ]
           }
@@ -499,12 +499,12 @@ export class MockClientPaginationTable extends React.Component {
         {
           property: 'select',
           header: {
-            label: 'Vyberte všechny řádky',
+            label: 'Select all rows',
             props: {
               index: 0,
               rowSpan: 1,
               colSpan: 1,
-              id: 'vybrat vše'
+              id: 'Select all'
             },
             customFormatters: [selectionHeaderCellFormatter]
           },
@@ -517,7 +517,7 @@ export class MockClientPaginationTable extends React.Component {
                 return selectionCellFormatter(
                   { rowData, rowIndex },
                   this.onSelectRow,
-                  \`vybrat \${rowIndex}\`, \`vyberte řádek \${rowIndex}\`
+                  \`Select \${rowIndex}\`, \`Select line \${rowIndex}\`
                 );
               }
             ]


### PR DESCRIPTION
I see it pointless to have Czech strings in mockClientPaginationTable.js, so I've translated them back to English. I've used Google Translate, so I hope that my translations are correct. :smile: 