### PR TITLE
fix(charts): address typescript issues

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/AreaChart/examples/common/getContainerProps.js
+++ b/packages/patternfly-4/react-charts/src/components/AreaChart/examples/common/getContainerProps.js
@@ -4,7 +4,7 @@ const styles = StyleSheet.create({
   demoLayout: {
     '& > *': {
       '.chart-overflow': {
-        ':not(foo) svg': {
+        '& svg': {
           overflow: 'visible'
         }
       },

--- a/packages/patternfly-4/react-charts/src/components/AreaChart/examples/common/getContainerProps.js
+++ b/packages/patternfly-4/react-charts/src/components/AreaChart/examples/common/getContainerProps.js
@@ -6,10 +6,6 @@ const styles = StyleSheet.create({
       '.chart-overflow': {
         ':not(foo) svg': {
           overflow: 'visible'
-        },
-        ':not(foo) text': {
-          fontSize: '12px',
-          length: '12px'
         }
       },
       '.chart-title': {

--- a/packages/patternfly-4/react-charts/src/components/AreaChart/examples/common/getContainerPropsDark.js
+++ b/packages/patternfly-4/react-charts/src/components/AreaChart/examples/common/getContainerPropsDark.js
@@ -13,7 +13,7 @@ const styles = StyleSheet.create({
     backgroundSize: 'cover',
     '& > *': {
       '.chart-overflow': {
-        ':not(foo) svg': {
+        '& svg': {
           overflow: 'visible'
         }
       },

--- a/packages/patternfly-4/react-charts/src/components/AreaChart/examples/common/getContainerPropsDark.js
+++ b/packages/patternfly-4/react-charts/src/components/AreaChart/examples/common/getContainerPropsDark.js
@@ -15,10 +15,6 @@ const styles = StyleSheet.create({
       '.chart-overflow': {
         ':not(foo) svg': {
           overflow: 'visible'
-        },
-        ':not(foo) text': {
-          fontSize: '12px',
-          length: '12px'
         }
       },
       '.chart-title': {

--- a/packages/patternfly-4/react-charts/src/components/BarChart/examples/common/getContainerProps.js
+++ b/packages/patternfly-4/react-charts/src/components/BarChart/examples/common/getContainerProps.js
@@ -14,10 +14,6 @@ const styles = StyleSheet.create({
       '.chart-overflow': {
         ':not(foo) svg': {
           overflow: 'visible'
-        },
-        ':not(foo) text': {
-          fontSize: '12px',
-          length: '12px'
         }
       },
       '.chart-title': {

--- a/packages/patternfly-4/react-charts/src/components/BarChart/examples/common/getContainerProps.js
+++ b/packages/patternfly-4/react-charts/src/components/BarChart/examples/common/getContainerProps.js
@@ -12,7 +12,7 @@ const styles = StyleSheet.create({
         marginLeft: '20px'
       },
       '.chart-overflow': {
-        ':not(foo) svg': {
+        '& svg': {
           overflow: 'visible'
         }
       },

--- a/packages/patternfly-4/react-charts/src/components/Chart/Chart.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/Chart/Chart.d.ts
@@ -1,4 +1,4 @@
-import { victory } from '@types/victory';
+import * as victory from 'victory';
 
 export interface ChartProps extends victory.VictoryChartProps {}
 

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/ChartArea.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/ChartArea.d.ts
@@ -1,4 +1,4 @@
-import { victory } from '@types/victory';
+import * as victory from 'victory';
 
 export interface ChartAreaProps extends victory.VictoryAreaProps {}
 

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/ChartBar.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/ChartBar.d.ts
@@ -1,4 +1,4 @@
-import { victory } from '@types/victory';
+import * as victory from 'victory';
 
 export interface ChartBarProps extends victory.VictoryBarProps {}
 

--- a/packages/patternfly-4/react-charts/src/components/ChartContainer/ChartContainer.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartContainer/ChartContainer.d.ts
@@ -1,4 +1,4 @@
-import { victory } from '@types/victory';
+import * as victory from 'victory';
 
 export interface ChartContainerProps extends victory.VictoryContainerProps {}
 

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.d.ts
@@ -1,9 +1,7 @@
-import { HTMLProps, SFC, ReactType, ReactNode } from 'react';
-import { OneOf } from '../../typeUtils';
+import * as victory from 'victory';
 
-export interface ChartDonutProps extends HTMLProps<HTMLDivElement> {
-}
+export interface ChartDonutProps extends victory.VictoryPieProps {}
 
-declare const ChartDonut: SFC<ChartDonutProps>;
+declare const ChartDonut: React.ComponentClass<ChartDonutProps>;
 
 export default ChartDonut;

--- a/packages/patternfly-4/react-charts/src/components/ChartGroup/ChartGroup.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartGroup/ChartGroup.d.ts
@@ -1,4 +1,4 @@
-import { victory } from '@types/victory';
+import * as victory from 'victory';
 
 export interface ChartGroupProps extends victory.VictoryGroupProps {}
 

--- a/packages/patternfly-4/react-charts/src/components/ChartLabel/ChartLabel.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartLabel/ChartLabel.d.ts
@@ -1,4 +1,4 @@
-import { victory } from '@types/victory';
+import * as victory from 'victory';
 
 export interface ChartLabelProps extends victory.VictoryLabelProps {}
 

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.d.ts
@@ -1,6 +1,9 @@
-import { victory } from '@types/victory';
+import * as victory from 'victory';
+import { OneOf } from '../../typeUtils';
 
-export interface ChartLegendProps extends victory.VictoryLegendProps {}
+export interface ChartLegendProps extends victory.VictoryLegendProps {
+  title?: OneOf<string, []>;
+}
 
 declare const ChartLegend: React.ComponentClass<ChartLegendProps>;
 

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/ChartLine.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/ChartLine.d.ts
@@ -1,4 +1,4 @@
-import { victory } from '@types/victory';
+import * as victory from 'victory';
 
 export interface ChartLineProps extends victory.VictoryLineProps {}
 

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/ChartPie.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/ChartPie.d.ts
@@ -1,4 +1,4 @@
-import { victory } from '@types/victory';
+import * as victory from 'victory';
 
 export interface ChartPieProps extends victory.VictoryPieProps {}
 

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/ChartStack.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/ChartStack.d.ts
@@ -1,4 +1,4 @@
-import { victory } from '@types/victory';
+import * as victory from 'victory';
 
 export interface ChartStackProps extends victory.VictoryStackProps {}
 

--- a/packages/patternfly-4/react-charts/src/components/ChartTooltip/ChartTooltip.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTooltip/ChartTooltip.d.ts
@@ -1,4 +1,4 @@
-import { victory } from '@types/victory';
+import * as victory from 'victory';
 
 export interface ChartTooltipProps extends victory.VictoryTooltipProps {}
 

--- a/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.d.ts
@@ -1,4 +1,4 @@
-import { victory } from '@types/victory';
+import * as victory from 'victory';
 
 export interface ChartVoronoiContainerProps extends
     victory.VictoryCommonProps,

--- a/packages/patternfly-4/react-charts/src/components/LineChart/examples/common/getContainerProps.js
+++ b/packages/patternfly-4/react-charts/src/components/LineChart/examples/common/getContainerProps.js
@@ -15,7 +15,7 @@ const styles = StyleSheet.create({
         display: 'inline-flex'
       },
       '.chart-overflow': {
-        ':not(foo) svg': {
+        '& svg': {
           overflow: 'visible'
         }
       },

--- a/packages/patternfly-4/react-charts/src/components/LineChart/examples/common/getContainerProps.js
+++ b/packages/patternfly-4/react-charts/src/components/LineChart/examples/common/getContainerProps.js
@@ -17,10 +17,6 @@ const styles = StyleSheet.create({
       '.chart-overflow': {
         ':not(foo) svg': {
           overflow: 'visible'
-        },
-        ':not(foo) text': {
-          fontSize: '12px',
-          length: '12px'
         }
       },
       '.chart-title': {

--- a/packages/patternfly-4/react-charts/src/components/StackChart/examples/common/getContainerProps.js
+++ b/packages/patternfly-4/react-charts/src/components/StackChart/examples/common/getContainerProps.js
@@ -14,10 +14,6 @@ const styles = StyleSheet.create({
       '.chart-overflow': {
         ':not(foo) svg': {
           overflow: 'visible'
-        },
-        ':not(foo) text': {
-          fontSize: '12px',
-          length: '12px'
         }
       },
       '.chart-title': {

--- a/packages/patternfly-4/react-charts/src/components/StackChart/examples/common/getContainerProps.js
+++ b/packages/patternfly-4/react-charts/src/components/StackChart/examples/common/getContainerProps.js
@@ -12,7 +12,7 @@ const styles = StyleSheet.create({
         marginLeft: '40px'
       },
       '.chart-overflow': {
-        ':not(foo) svg': {
+        '& svg': {
           overflow: 'visible'
         }
       },


### PR DESCRIPTION
Fixed various typescript issues encountered while using charts in Koku UI. For example, we needed to add a missing title to ChartLegned.

I also cleaned up a couple unused styles from the examples.
