### PR TITLE
introduce preselectedType for AccessConsoles component

### DIFF
--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
@@ -9,6 +9,14 @@ const { NONE_TYPE, SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE } = constants;
 const { Row, Col } = Grid;
 const { Checkbox, FormGroup } = Form;
 
+const getChildTypeName = child => (
+  child.props.type ?
+    child.props.type :
+    (child.type && child.type.name) || null);
+
+const isChildOfType = (child, type) =>
+  getChildTypeName(child) === type;
+
 class AccessConsoles extends React.Component {
   state = {
     type: NONE_TYPE,
@@ -40,23 +48,29 @@ class AccessConsoles extends React.Component {
     return this.getConsoleForType(this.state.type);
   }
 
+  isChildOfTypePresent(type) {
+    let found = false;
+    React.Children.forEach(
+      this.props.children,
+      child => {
+        found = found || isChildOfType(child, type);
+      }
+    );
+
+    return found;
+  }
+
   getConsoleForType(type) {
-    if (!this.props.children) {
-      return null;
-    }
-
-    const getChildTypeName = child => (child.props.type ? child.props.type : (child.type && child.type.name) || null);
-    const isChildOfType = child => getChildTypeName(child) === type;
-
     // To keep connection, render all consoles but hide those unused
     return React.Children.map(
       this.props.children,
-      child =>
+      child => (
         this.state.keptConnection[getChildTypeName(child)] ? (
-          <div key={getChildTypeName(child)} hidden={!isChildOfType(child)}>
+          <div key={getChildTypeName(child)} hidden={!isChildOfType(child, type)}>
             {child}
           </div>
         ) : null
+      )
     );
   }
 
@@ -77,12 +91,12 @@ class AccessConsoles extends React.Component {
                   {this.props.children ? items[this.state.type] : this.props.textEmptyConsoleList}
                 </Dropdown.Toggle>
                 <Dropdown.Menu>
-                  {this.getConsoleForType(SERIAL_CONSOLE_TYPE) && (
+                  {this.isChildOfTypePresent(SERIAL_CONSOLE_TYPE) && (
                     <MenuItem eventKey="1" onClick={() => this.onTypeChange(SERIAL_CONSOLE_TYPE)}>
                       {items[SERIAL_CONSOLE_TYPE]}
                     </MenuItem>
                   )}
-                  {this.getConsoleForType(VNC_CONSOLE_TYPE) && (
+                  {this.isChildOfTypePresent(VNC_CONSOLE_TYPE) && (
                     <MenuItem eventKey="2" onClick={() => this.onTypeChange(VNC_CONSOLE_TYPE)}>
                       {items[VNC_CONSOLE_TYPE]}
                     </MenuItem>

--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
@@ -9,19 +9,17 @@ const { NONE_TYPE, SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE } = constants;
 const { Row, Col } = Grid;
 const { Checkbox, FormGroup } = Form;
 
-const getChildTypeName = child => (
-  child.props.type ?
-    child.props.type :
-    (child.type && child.type.name) || null);
+const getChildTypeName = child => (child.props.type ? child.props.type : (child.type && child.type.name) || null);
 
-const isChildOfType = (child, type) =>
-  getChildTypeName(child) === type;
+const isChildOfType = (child, type) => getChildTypeName(child) === type;
 
 class AccessConsoles extends React.Component {
   state = {
-    type: NONE_TYPE,
+    type: this.props.preselectedType,
     disconnectByChange: this.props.disconnectByChange,
-    keptConnection: {} // no connection exists when mounted
+    keptConnection: {
+      [this.props.preselectedType]: true
+    }
   };
 
   onTypeChange(type) {
@@ -50,12 +48,9 @@ class AccessConsoles extends React.Component {
 
   isChildOfTypePresent(type) {
     let found = false;
-    React.Children.forEach(
-      this.props.children,
-      child => {
-        found = found || isChildOfType(child, type);
-      }
-    );
+    React.Children.forEach(this.props.children, child => {
+      found = found || isChildOfType(child, type);
+    });
 
     return found;
   }
@@ -64,13 +59,12 @@ class AccessConsoles extends React.Component {
     // To keep connection, render all consoles but hide those unused
     return React.Children.map(
       this.props.children,
-      child => (
+      child =>
         this.state.keptConnection[getChildTypeName(child)] ? (
           <div key={getChildTypeName(child)} hidden={!isChildOfType(child, type)}>
             {child}
           </div>
         ) : null
-      )
     );
   }
 
@@ -155,6 +149,11 @@ AccessConsoles.propTypes = {
   textDisconnectByChange: PropTypes.string /** Internationalization */,
   textEmptyConsoleList: PropTypes.string /** Internationalization */,
 
+  preselectedType: PropTypes.oneOf([
+    NONE_TYPE,
+    SERIAL_CONSOLE_TYPE,
+    VNC_CONSOLE_TYPE
+  ]) /** Initial selection of the dropdown */,
   disconnectByChange:
     PropTypes.bool /** Initial value of "Disconnect before switching" checkbox, "false" to disconnect when console type changed */
 };
@@ -168,6 +167,7 @@ AccessConsoles.defaultProps = {
   textDisconnectByChange: 'Disconnect before switching',
   textEmptyConsoleList: 'No console available',
 
+  preselectedType: NONE_TYPE,
   disconnectByChange: true /** By default, console is unmounted (disconnected) when switching to other type */
 };
 

--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.stories.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.stories.js
@@ -34,6 +34,21 @@ stories.add(
 );
 
 stories.add(
+    'AccessConsoles - single',
+    withInfo()(() => {
+        const story = (
+            <AccessConsoles>
+                <SerialConsoleConnector onConnect={noop} onDisconnect={noop} status={DISCONNECTED} type={SERIAL_CONSOLE_TYPE} />
+            </AccessConsoles>
+        );
+        return inlineTemplate({
+            story,
+            title: 'AccessConsoles - single'
+        });
+    })
+);
+
+stories.add(
   'AccessConsoles - empty',
   withInfo()(() => {
     const story = <AccessConsoles />;

--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.stories.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.stories.js
@@ -34,18 +34,18 @@ stories.add(
 );
 
 stories.add(
-    'AccessConsoles - single',
-    withInfo()(() => {
-        const story = (
-            <AccessConsoles>
-                <SerialConsoleConnector onConnect={noop} onDisconnect={noop} status={DISCONNECTED} type={SERIAL_CONSOLE_TYPE} />
-            </AccessConsoles>
-        );
-        return inlineTemplate({
-            story,
-            title: 'AccessConsoles - single'
-        });
-    })
+  'AccessConsoles - single',
+  withInfo()(() => {
+    const story = (
+      <AccessConsoles preselectedType={SERIAL_CONSOLE_TYPE}>
+        <SerialConsoleConnector onConnect={noop} onDisconnect={noop} status={DISCONNECTED} type={SERIAL_CONSOLE_TYPE} />
+      </AccessConsoles>
+    );
+    return inlineTemplate({
+      story,
+      title: 'AccessConsoles - single'
+    });
+  })
 );
 
 stories.add(

--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.test.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.test.js
@@ -54,6 +54,21 @@ test('AccessConsoles with wrapped SerialConsole as a child', () => {
   expect(view).toMatchSnapshot();
 });
 
+test('AccessConsoles with preselected SerialConsole', () => {
+  const wrapper = mount(
+    <AccessConsoles preselectedType={SERIAL_CONSOLE_TYPE}>
+      <SerialConsoleConnected type={SERIAL_CONSOLE_TYPE} />
+    </AccessConsoles>
+  );
+  expect(wrapper).toMatchSnapshot();
+  expect(wrapper.find('SerialConsoleConnected')).toHaveLength(1);
+
+  const button = wrapper.find('button #console-type-selector');
+  expect(button).toHaveLength(1);
+  const consoleItems = wrapper.find('ul li');
+  expect(consoleItems).toHaveLength(1); // single value only
+});
+
 test('AccessConsoles switching SerialConsole and VncConsole', () => {
   const wrapper = mount(
     <AccessConsoles>

--- a/packages/patternfly-3/react-console/src/AccessConsoles/__snapshots__/AccessConsoles.test.js.snap
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/__snapshots__/AccessConsoles.test.js.snap
@@ -3,6 +3,7 @@
 exports[`AccessConsoles keeps connection when switching types 1`] = `
 <AccessConsoles
   disconnectByChange={false}
+  preselectedType="_none_"
   textDisconnectByChange="Disconnect before switching"
   textEmptyConsoleList="No console available"
   textSelectConsoleType="Select Console Type"
@@ -362,6 +363,7 @@ exports[`AccessConsoles keeps connection when switching types 1`] = `
 exports[`AccessConsoles switching SerialConsole and VncConsole 1`] = `
 <AccessConsoles
   disconnectByChange={true}
+  preselectedType="_none_"
   textDisconnectByChange="Disconnect before switching"
   textEmptyConsoleList="No console available"
   textSelectConsoleType="Select Console Type"
@@ -808,16 +810,6 @@ exports[`AccessConsoles with SerialConsole as a single child 1`] = `
             >
               Serial Console
             </MenuItem>
-            <MenuItem
-              bsClass="dropdown"
-              disabled={false}
-              divider={false}
-              eventKey="2"
-              header={false}
-              onClick={[Function]}
-            >
-              VNC Console
-            </MenuItem>
           </DropdownMenu>
         </Uncontrolled(Dropdown)>
       </Col>
@@ -877,16 +869,6 @@ exports[`AccessConsoles with VncConsole as a single child 1`] = `
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="1"
-              header={false}
-              onClick={[Function]}
-            >
-              Serial Console
-            </MenuItem>
-            <MenuItem
-              bsClass="dropdown"
-              disabled={false}
-              divider={false}
               eventKey="2"
               header={false}
               onClick={[Function]}
@@ -908,6 +890,240 @@ exports[`AccessConsoles with VncConsole as a single child 1`] = `
     />
   </Row>
 </Grid>
+`;
+
+exports[`AccessConsoles with preselected SerialConsole 1`] = `
+<AccessConsoles
+  disconnectByChange={true}
+  preselectedType="SerialConsole"
+  textDisconnectByChange="Disconnect before switching"
+  textEmptyConsoleList="No console available"
+  textSelectConsoleType="Select Console Type"
+  textSerialConsole="Serial Console"
+  textVncConsole="VNC Console"
+>
+  <Grid
+    bsClass="container"
+    componentClass="div"
+    fluid={true}
+  >
+    <div
+      className="container-fluid"
+    >
+      <Form
+        bsClass="form"
+        componentClass="form"
+        horizontal={true}
+        inline={false}
+      >
+        <form
+          className="form-horizontal"
+        >
+          <FormGroup
+            bsClass="form-group"
+            className="console-selector-pf"
+            controlId="console-type"
+          >
+            <div
+              className="console-selector-pf form-group"
+            >
+              <Col
+                bsClass="col"
+                componentClass="div"
+              >
+                <div
+                  className=""
+                >
+                  <Uncontrolled(Dropdown)
+                    disabled={false}
+                    id="console-type-selector"
+                  >
+                    <Dropdown
+                      bsClass="dropdown"
+                      componentClass={[Function]}
+                      disabled={false}
+                      id="console-type-selector"
+                      onToggle={[Function]}
+                    >
+                      <ButtonGroup
+                        block={false}
+                        bsClass="btn-group"
+                        className="dropdown"
+                        justified={false}
+                        vertical={false}
+                      >
+                        <div
+                          className="dropdown btn-group"
+                        >
+                          <DropdownToggle
+                            bsClass="dropdown-toggle"
+                            bsRole="toggle"
+                            disabled={false}
+                            id="console-type-selector"
+                            key=".0"
+                            onClick={[Function]}
+                            onKeyDown={[Function]}
+                            open={false}
+                            useAnchor={false}
+                          >
+                            <Button
+                              active={false}
+                              aria-expanded={false}
+                              aria-haspopup={true}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="dropdown-toggle"
+                              disabled={false}
+                              id="console-type-selector"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              role="button"
+                            >
+                              <button
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                className="dropdown-toggle btn btn-default"
+                                disabled={false}
+                                id="console-type-selector"
+                                onClick={[Function]}
+                                onKeyDown={[Function]}
+                                role="button"
+                                type="button"
+                              >
+                                Serial Console
+                                 
+                                <span
+                                  className="caret"
+                                />
+                              </button>
+                            </Button>
+                          </DropdownToggle>
+                          <DropdownMenu
+                            bsClass="dropdown-menu"
+                            bsRole="menu"
+                            key=".1"
+                            labelledBy="console-type-selector"
+                            onClose={[Function]}
+                            onSelect={[Function]}
+                            pullRight={false}
+                          >
+                            <RootCloseWrapper
+                              disabled={true}
+                              event="click"
+                              onRootClose={[Function]}
+                            >
+                              <ul
+                                aria-labelledby="console-type-selector"
+                                className="dropdown-menu"
+                                role="menu"
+                              >
+                                <MenuItem
+                                  bsClass="dropdown"
+                                  disabled={false}
+                                  divider={false}
+                                  eventKey="1"
+                                  header={false}
+                                  key=".0"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  onSelect={[Function]}
+                                >
+                                  <li
+                                    className=""
+                                    role="presentation"
+                                  >
+                                    <SafeAnchor
+                                      componentClass="a"
+                                      onClick={[Function]}
+                                      onKeyDown={[Function]}
+                                      role="menuitem"
+                                      tabIndex="-1"
+                                    >
+                                      <a
+                                        href="#"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
+                                      >
+                                        Serial Console
+                                      </a>
+                                    </SafeAnchor>
+                                  </li>
+                                </MenuItem>
+                              </ul>
+                            </RootCloseWrapper>
+                          </DropdownMenu>
+                        </div>
+                      </ButtonGroup>
+                    </Dropdown>
+                  </Uncontrolled(Dropdown)>
+                  <Checkbox
+                    bsClass="checkbox"
+                    className="console-selector-pf-disconnect-switch"
+                    defaultChecked={true}
+                    disabled={false}
+                    inline={true}
+                    onChange={[Function]}
+                    title=""
+                  >
+                    <label
+                      className="console-selector-pf-disconnect-switch checkbox-inline"
+                      title=""
+                    >
+                      <input
+                        defaultChecked={true}
+                        disabled={false}
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      Disconnect before switching
+                    </label>
+                  </Checkbox>
+                </div>
+              </Col>
+            </div>
+          </FormGroup>
+        </form>
+      </Form>
+      <Row
+        bsClass="row"
+        componentClass="div"
+      >
+        <div
+          className="row"
+        >
+          <Col
+            bsClass="col"
+            componentClass="div"
+          >
+            <div
+              className=""
+            >
+              <div
+                hidden={false}
+                key="SerialConsole/.0"
+              >
+                <SerialConsoleConnected
+                  type="SerialConsole"
+                >
+                  <p>
+                    Whatever component, preferably wrapping 
+                    <i>
+                      SerialConsole
+                    </i>
+                     with callbacks adapted to a particular backend.
+                  </p>
+                </SerialConsoleConnected>
+              </div>
+            </div>
+          </Col>
+        </div>
+      </Row>
+    </div>
+  </Grid>
+</AccessConsoles>
 `;
 
 exports[`AccessConsoles with wrapped SerialConsole as a child 1`] = `
@@ -957,16 +1173,6 @@ exports[`AccessConsoles with wrapped SerialConsole as a child 1`] = `
               onClick={[Function]}
             >
               Serial Console
-            </MenuItem>
-            <MenuItem
-              bsClass="dropdown"
-              disabled={false}
-              divider={false}
-              eventKey="2"
-              header={false}
-              onClick={[Function]}
-            >
-              VNC Console
             </MenuItem>
           </DropdownMenu>
         </Uncontrolled(Dropdown)>


### PR DESCRIPTION
**What**: introduce `preselectedType` for `AccessConsoles` component
Prior this patch, the component started "empty" (no console rendered).
The new property can be used to pre-select particular component for initial state.

As a part of this PR, fix for not-rendering unlisted console types is provided.