### PR TITLE
chore(pf4): move static fields out of examples

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/AreaChart/AreaChart.docs.js
+++ b/packages/patternfly-4/react-charts/src/components/AreaChart/AreaChart.docs.js
@@ -1,12 +1,8 @@
-import {
-  ChartArea,
-  ChartGroup,
-  ChartLegend,
-  ChartVoronoiContainer
-} from '@patternfly/react-charts';
+import { ChartArea, ChartGroup, ChartLegend, ChartVoronoiContainer } from '@patternfly/react-charts';
 import CustomColorsChart from './examples/CustomColorsChart';
 import SimpleChart from './examples/SimpleChart';
 import DarkGreenThemeChart from './examples/DarkGreenThemeChart';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Area Chart',
@@ -16,5 +12,9 @@ export default {
     ChartLegend,
     ChartVoronoiContainer
   },
-  examples: [SimpleChart, CustomColorsChart, DarkGreenThemeChart]
+  examples: [
+    { component: SimpleChart, title: 'Simple Chart', getContainerProps },
+    { component: CustomColorsChart, title: 'Custom Colors Chart', getContainerProps },
+    { component: DarkGreenThemeChart, title: 'Dark, Green Theme Chart', getContainerProps }
+  ]
 };

--- a/packages/patternfly-4/react-charts/src/components/AreaChart/examples/CustomColorsChart.js
+++ b/packages/patternfly-4/react-charts/src/components/AreaChart/examples/CustomColorsChart.js
@@ -5,12 +5,8 @@ import {
   ChartLegend,
   ChartVoronoiContainer
 } from '@patternfly/react-charts';
-import getContainerProps from './common/getContainerProps';
 
 class CustomColorsChart extends React.Component {
-  static getContainerProps = getContainerProps;
-  static title = 'Custom Colors Chart';
-
   containerRef = React.createRef();
   state = {
     width: 0
@@ -38,7 +34,7 @@ class CustomColorsChart extends React.Component {
   render() {
     const { width } = this.state;
     const container = (
-      <ChartVoronoiContainer labels={this.getTooltipLabel}/>
+      <ChartVoronoiContainer labels={this.getTooltipLabel} />
     );
     const cats = {
       data: {

--- a/packages/patternfly-4/react-charts/src/components/AreaChart/examples/DarkGreenThemeChart.js
+++ b/packages/patternfly-4/react-charts/src/components/AreaChart/examples/DarkGreenThemeChart.js
@@ -6,12 +6,8 @@ import {
   ChartTheme,
   ChartVoronoiContainer
 } from '@patternfly/react-charts';
-import getContainerProps from './common/getContainerPropsDark';
 
 class DarkGreenThemeChart extends React.Component {
-  static getContainerProps = getContainerProps;
-  static title = 'Dark, Green Theme Chart';
-
   containerRef = React.createRef();
   state = {
     width: 0

--- a/packages/patternfly-4/react-charts/src/components/AreaChart/examples/SimpleChart.js
+++ b/packages/patternfly-4/react-charts/src/components/AreaChart/examples/SimpleChart.js
@@ -5,12 +5,8 @@ import {
   ChartLegend,
   ChartVoronoiContainer
 } from '@patternfly/react-charts';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleChart extends React.Component {
-  static getContainerProps = getContainerProps;
-  static title = 'Simple Chart';
-
   containerRef = React.createRef();
   state = {
     width: 0
@@ -38,7 +34,7 @@ class SimpleChart extends React.Component {
   render() {
     const { width } = this.state;
     const container = (
-      <ChartVoronoiContainer labels={this.getTooltipLabel}/>
+      <ChartVoronoiContainer labels={this.getTooltipLabel} />
     );
 
     return (

--- a/packages/patternfly-4/react-charts/src/components/BarChart/BarChart.docs.js
+++ b/packages/patternfly-4/react-charts/src/components/BarChart/BarChart.docs.js
@@ -1,9 +1,6 @@
-import {
-  Chart,
-  ChartBar,
-  ChartGroup
-} from '@patternfly/react-charts';
+import { Chart, ChartBar, ChartGroup } from '@patternfly/react-charts';
 import SimpleChart from './examples/SimpleChart';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Bar Chart',
@@ -12,5 +9,5 @@ export default {
     ChartBar,
     ChartGroup
   },
-  examples: [SimpleChart]
+  examples: [{ component: SimpleChart, title: 'Simple Chart', getContainerProps }]
 };

--- a/packages/patternfly-4/react-charts/src/components/BarChart/examples/SimpleChart.js
+++ b/packages/patternfly-4/react-charts/src/components/BarChart/examples/SimpleChart.js
@@ -11,12 +11,8 @@ import {
   Text,
   TextVariants
 } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleChart extends React.Component {
-  static getContainerProps = getContainerProps;
-  static title = 'Simple Chart';
-
   getChart = (theme) => (
     <Chart
       domainPadding={{ x: [30, 25] }}
@@ -25,10 +21,10 @@ class SimpleChart extends React.Component {
       width={300}
     >
       <ChartGroup offset={11}>
-        <ChartBar data={[{ x: 'Cats', y: 1 }, { x: 'Dogs', y: 2 }, { x: 'Birds', y: 5 }, { x: 'Mice', y: 3 }]}/>
-        <ChartBar data={[{ x: 'Cats', y: 2 }, { x: 'Dogs', y: 1 }, { x: 'Birds', y: 7 }, { x: 'Mice', y: 4 }]}/>
-        <ChartBar data={[{ x: 'Cats', y: 4 }, { x: 'Dogs', y: 4 }, { x: 'Birds', y: 9 }, { x: 'Mice', y: 7 }]}/>
-        <ChartBar data={[{ x: 'Cats', y: 3 }, { x: 'Dogs', y: 3 }, { x: 'Birds', y: 8 }, { x: 'Mice', y: 5 }]}/>
+        <ChartBar data={[{ x: 'Cats', y: 1 }, { x: 'Dogs', y: 2 }, { x: 'Birds', y: 5 }, { x: 'Mice', y: 3 }]} />
+        <ChartBar data={[{ x: 'Cats', y: 2 }, { x: 'Dogs', y: 1 }, { x: 'Birds', y: 7 }, { x: 'Mice', y: 4 }]} />
+        <ChartBar data={[{ x: 'Cats', y: 4 }, { x: 'Dogs', y: 4 }, { x: 'Birds', y: 9 }, { x: 'Mice', y: 7 }]} />
+        <ChartBar data={[{ x: 'Cats', y: 3 }, { x: 'Dogs', y: 3 }, { x: 'Birds', y: 8 }, { x: 'Mice', y: 5 }]} />
       </ChartGroup>
     </Chart>
   );

--- a/packages/patternfly-4/react-charts/src/components/DonutChart/DonutChart.docs.js
+++ b/packages/patternfly-4/react-charts/src/components/DonutChart/DonutChart.docs.js
@@ -1,9 +1,6 @@
-import {
-  ChartDonut,
-  ChartLabel,
-  ChartLegend
-} from '@patternfly/react-charts';
+import { ChartDonut, ChartLabel, ChartLegend } from '@patternfly/react-charts';
 import SimpleChart from './examples/SimpleChart';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Donut Chart',
@@ -12,5 +9,5 @@ export default {
     ChartLabel,
     ChartLegend
   },
-  examples: [SimpleChart]
+  examples: [{ component: SimpleChart, title: 'Simple Chart', getContainerProps }]
 };

--- a/packages/patternfly-4/react-charts/src/components/DonutChart/examples/SimpleChart.js
+++ b/packages/patternfly-4/react-charts/src/components/DonutChart/examples/SimpleChart.js
@@ -11,12 +11,8 @@ import {
   Text,
   TextVariants
 } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleChart extends React.Component {
-  static getContainerProps = getContainerProps;
-  static title = 'Simple Chart';
-
   getChart = (theme) => (
     <ChartDonut
       data={[
@@ -56,7 +52,7 @@ class SimpleChart extends React.Component {
         width={this.size}
       >
         <ChartLabel
-          style={{fontSize: 20}}
+          style={{ fontSize: 20 }}
           text="100"
           textAnchor="middle"
           verticalAnchor="middle"
@@ -64,7 +60,7 @@ class SimpleChart extends React.Component {
           y={90}
         />
         <ChartLabel
-          style={{fill: '#bbb'}}
+          style={{ fill: '#bbb' }}
           text="Pets"
           textAnchor="middle"
           verticalAnchor="middle"

--- a/packages/patternfly-4/react-charts/src/components/LineChart/LineChart.docs.js
+++ b/packages/patternfly-4/react-charts/src/components/LineChart/LineChart.docs.js
@@ -1,9 +1,6 @@
-import {
-  Chart,
-  ChartGroup,
-  ChartLine,
-} from '@patternfly/react-charts';
+import { Chart, ChartGroup, ChartLine } from '@patternfly/react-charts';
 import SimpleChart from './examples/SimpleChart';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Line Chart',
@@ -12,5 +9,5 @@ export default {
     ChartGroup,
     ChartLine
   },
-  examples: [SimpleChart]
+  examples: [{ component: SimpleChart, title: 'Simple Chart', getContainerProps }]
 };

--- a/packages/patternfly-4/react-charts/src/components/LineChart/examples/SimpleChart.js
+++ b/packages/patternfly-4/react-charts/src/components/LineChart/examples/SimpleChart.js
@@ -11,12 +11,8 @@ import {
   Text,
   TextVariants
 } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleChart extends React.Component {
-  static getContainerProps = getContainerProps;
-  static title = 'Simple Chart';
-
   // interpolation="natural"
 
   getChart = (theme) => (
@@ -27,10 +23,10 @@ class SimpleChart extends React.Component {
       width={300}
     >
       <ChartGroup>
-        <ChartLine data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 5 }, { x: 4, y: 3 }]}/>
-        <ChartLine data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 7 }, { x: 4, y: 4 }]}/>
-        <ChartLine data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 9 }, { x: 4, y: 5 }]}/>
-        <ChartLine data={[{ x: 1, y: 3 }, { x: 2, y: 3 }, { x: 3, y: 8 }, { x: 4, y: 7 }]}/>
+        <ChartLine data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 5 }, { x: 4, y: 3 }]} />
+        <ChartLine data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 7 }, { x: 4, y: 4 }]} />
+        <ChartLine data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 9 }, { x: 4, y: 5 }]} />
+        <ChartLine data={[{ x: 1, y: 3 }, { x: 2, y: 3 }, { x: 3, y: 8 }, { x: 4, y: 7 }]} />
       </ChartGroup>
     </Chart>
   );

--- a/packages/patternfly-4/react-charts/src/components/PieChart/PieChart.docs.js
+++ b/packages/patternfly-4/react-charts/src/components/PieChart/PieChart.docs.js
@@ -1,8 +1,6 @@
-import {
-  ChartLegend,
-  ChartPie
-} from '@patternfly/react-charts';
+import { ChartLegend, ChartPie } from '@patternfly/react-charts';
 import SimpleChart from './examples/SimpleChart';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Pie Chart',
@@ -10,5 +8,5 @@ export default {
     ChartLegend,
     ChartPie
   },
-  examples: [SimpleChart]
+  examples: [{ component: SimpleChart, title: 'Simple Chart', getContainerProps }]
 };

--- a/packages/patternfly-4/react-charts/src/components/PieChart/examples/SimpleChart.js
+++ b/packages/patternfly-4/react-charts/src/components/PieChart/examples/SimpleChart.js
@@ -10,12 +10,8 @@ import {
   Text,
   TextVariants
 } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleChart extends React.Component {
-  static getContainerProps = getContainerProps;
-  static title = 'Simple Chart';
-
   getChart = (theme) => (
     <ChartPie
       data={[

--- a/packages/patternfly-4/react-charts/src/components/StackChart/StackChart.docs.js
+++ b/packages/patternfly-4/react-charts/src/components/StackChart/StackChart.docs.js
@@ -1,11 +1,7 @@
-import {
-  Chart,
-  ChartBar,
-  ChartLegend,
-  ChartStack
-} from '@patternfly/react-charts';
+import { Chart, ChartBar, ChartLegend, ChartStack } from '@patternfly/react-charts';
 import HorizontalChart from './examples/HorizontalChart';
 import SimpleChart from './examples/SimpleChart';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Stack Chart',
@@ -15,5 +11,8 @@ export default {
     ChartLegend,
     ChartStack
   },
-  examples: [SimpleChart, HorizontalChart]
+  examples: [
+    { component: SimpleChart, title: 'Simple Chart', getContainerProps },
+    { component: HorizontalChart, title: 'Horizontal Chart', getContainerProps }
+  ]
 };

--- a/packages/patternfly-4/react-charts/src/components/StackChart/examples/HorizontalChart.js
+++ b/packages/patternfly-4/react-charts/src/components/StackChart/examples/HorizontalChart.js
@@ -11,12 +11,8 @@ import {
   Text,
   TextVariants
 } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class HorizontalChart extends React.Component {
-  static getContainerProps = getContainerProps;
-  static title = 'Horizontal Chart';
-
   getChart = (theme) => (
     <Chart
       domainPadding={{ y: [30, 25] }}
@@ -25,10 +21,10 @@ class HorizontalChart extends React.Component {
       width={300}
     >
       <ChartStack horizontal>
-        <ChartBar data={[{ x: 'Cats', y: 1 }, { x: 'Dogs', y: 2 }, { x: 'Birds', y: 5 }, { x: 'Mice', y: 3 }]}/>
-        <ChartBar data={[{ x: 'Cats', y: 2 }, { x: 'Dogs', y: 1 }, { x: 'Birds', y: 7 }, { x: 'Mice', y: 4 }]}/>
-        <ChartBar data={[{ x: 'Cats', y: 4 }, { x: 'Dogs', y: 4 }, { x: 'Birds', y: 9 }, { x: 'Mice', y: 7 }]}/>
-        <ChartBar data={[{ x: 'Cats', y: 3 }, { x: 'Dogs', y: 3 }, { x: 'Birds', y: 8 }, { x: 'Mice', y: 5 }]}/>
+        <ChartBar data={[{ x: 'Cats', y: 1 }, { x: 'Dogs', y: 2 }, { x: 'Birds', y: 5 }, { x: 'Mice', y: 3 }]} />
+        <ChartBar data={[{ x: 'Cats', y: 2 }, { x: 'Dogs', y: 1 }, { x: 'Birds', y: 7 }, { x: 'Mice', y: 4 }]} />
+        <ChartBar data={[{ x: 'Cats', y: 4 }, { x: 'Dogs', y: 4 }, { x: 'Birds', y: 9 }, { x: 'Mice', y: 7 }]} />
+        <ChartBar data={[{ x: 'Cats', y: 3 }, { x: 'Dogs', y: 3 }, { x: 'Birds', y: 8 }, { x: 'Mice', y: 5 }]} />
       </ChartStack>
     </Chart>
   );

--- a/packages/patternfly-4/react-charts/src/components/StackChart/examples/SimpleChart.js
+++ b/packages/patternfly-4/react-charts/src/components/StackChart/examples/SimpleChart.js
@@ -11,12 +11,8 @@ import {
   Text,
   TextVariants
 } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleChart extends React.Component {
-  static getContainerProps = getContainerProps;
-  static title = 'Simple Chart';
-
   getChart = (theme) => (
     <Chart
       domainPadding={{ x: [30, 5] }}
@@ -25,10 +21,10 @@ class SimpleChart extends React.Component {
       width={300}
     >
       <ChartStack>
-        <ChartBar data={[{ x: 'Cats', y: 1 }, { x: 'Dogs', y: 2 }, { x: 'Birds', y: 5 }, { x: 'Mice', y: 3 }]}/>
-        <ChartBar data={[{ x: 'Cats', y: 2 }, { x: 'Dogs', y: 1 }, { x: 'Birds', y: 7 }, { x: 'Mice', y: 4 }]}/>
-        <ChartBar data={[{ x: 'Cats', y: 4 }, { x: 'Dogs', y: 4 }, { x: 'Birds', y: 9 }, { x: 'Mice', y: 7 }]}/>
-        <ChartBar data={[{ x: 'Cats', y: 3 }, { x: 'Dogs', y: 3 }, { x: 'Birds', y: 8 }, { x: 'Mice', y: 5 }]}/>
+        <ChartBar data={[{ x: 'Cats', y: 1 }, { x: 'Dogs', y: 2 }, { x: 'Birds', y: 5 }, { x: 'Mice', y: 3 }]} />
+        <ChartBar data={[{ x: 'Cats', y: 2 }, { x: 'Dogs', y: 1 }, { x: 'Birds', y: 7 }, { x: 'Mice', y: 4 }]} />
+        <ChartBar data={[{ x: 'Cats', y: 4 }, { x: 'Dogs', y: 4 }, { x: 'Birds', y: 9 }, { x: 'Mice', y: 7 }]} />
+        <ChartBar data={[{ x: 'Cats', y: 3 }, { x: 'Dogs', y: 3 }, { x: 'Birds', y: 8 }, { x: 'Mice', y: 5 }]} />
       </ChartStack>
     </Chart>
   );

--- a/packages/patternfly-4/react-core/.npmignore
+++ b/packages/patternfly-4/react-core/.npmignore
@@ -1,3 +1,7 @@
 src
 build
 dist/**/demos
+dist/**/examples
+dist/**/__snapshots__
+dist/**/*.docs.js
+dist/**/*.test.js

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.docs.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.docs.js
@@ -6,5 +6,10 @@ export default {
   components: {
     AboutModal
   },
-  examples: [SimpleAboutModal]
+  examples: [
+    {
+      component: SimpleAboutModal,
+      title: 'Simple AboutModal'
+    }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/AboutModal/examples/SimpleAboutModal.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/examples/SimpleAboutModal.js
@@ -5,8 +5,6 @@ import logoImg from './pf_logo.svg';
 import heroImg from './pfbg_992.jpg';
 
 class SimpleAboutModal extends React.Component {
-  static title = 'Simple AboutModal';
-
   state = {
     isModalOpen: false
   };

--- a/packages/patternfly-4/react-core/src/components/Alert/Alert.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/Alert.docs.js
@@ -3,6 +3,7 @@ import SuccessExample from './examples/SuccessAlert';
 import DangerExample from './examples/DangerAlert';
 import InfoExample from './examples/InfoAlert';
 import WarningExample from './examples/WarningAlert';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Alert',
@@ -12,5 +13,26 @@ export default {
   enumValues: {
     'Object.values(AlertVariant)': Object.values(AlertVariant)
   },
-  examples: [SuccessExample, DangerExample, InfoExample, WarningExample]
+  examples: [
+    {
+      component: SuccessExample,
+      title: 'Success Alert',
+      getContainerProps
+    },
+    {
+      component: DangerExample,
+      title: 'Danger Alert',
+      getContainerProps
+    },
+    {
+      component: InfoExample,
+      title: 'Info Alert',
+      getContainerProps
+    },
+    {
+      component: WarningExample,
+      title: 'Warning Alert',
+      getContainerProps
+    }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/DangerAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/DangerAlert.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Alert, Button } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class DangerAlert extends React.Component {
-  static title = 'Danger Alert';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/InfoAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/InfoAlert.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Alert, Button } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class InfoAlert extends React.Component {
-  static title = 'Info Alert';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/SuccessAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/SuccessAlert.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Alert, Button } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SuccessAlert extends React.Component {
-  static title = 'Success Alert';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/WarningAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/WarningAlert.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Alert, Button } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class WarningAlert extends React.Component {
-  static title = 'Warning Alert';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Avatar/Avatar.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Avatar/Avatar.docs.js
@@ -6,5 +6,11 @@ export default {
   components: {
     Avatar
   },
-  examples: [Simple]
+  examples: [
+    {
+      component: Simple,
+      displayName: 'SimpleAvatar',
+      title: 'Simple Avatar'
+    }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/Avatar/examples/SimpleAvatar.js
+++ b/packages/patternfly-4/react-core/src/components/Avatar/examples/SimpleAvatar.js
@@ -3,11 +3,10 @@ import { Avatar } from '@patternfly/react-core';
 import avatarImg from './img_avatar.png';
 
 class SimpleAvatar extends React.Component {
-  static title = 'Simple Avatar';
-
   render() {
     return <Avatar src={avatarImg} alt="avatar" />;
   }
+
 }
 
 export default SimpleAvatar;

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.docs.js
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.docs.js
@@ -9,6 +9,6 @@ export default {
   enumValues: {
     'Object.values(BackgroundImageSrc)': Object.values(BackgroundImageSrc)
   },
-  examples: [SimpleBackgroundImage],
+  examples: [{ component: SimpleBackgroundImage, title: 'Simple Background Image' }],
   fullPageOnly: true
 };

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/examples/SimpleBackgroundImage.js
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/examples/SimpleBackgroundImage.js
@@ -17,8 +17,6 @@ const images = {
 };
 
 class SimpleBackgroundImage extends React.Component {
-  static title = 'Simple Background Image';
-
   render() {
     return <BackgroundImage src={images} />;
   }

--- a/packages/patternfly-4/react-core/src/components/Badge/Badge.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Badge/Badge.docs.js
@@ -1,11 +1,23 @@
 import { Badge } from '@patternfly/react-core';
 import Read from './examples/ReadBadge';
 import Unread from './examples/UnreadBadge';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Badge',
   components: {
     Badge
   },
-  examples: [Unread, Read]
+  examples: [
+    {
+      component: Unread,
+      title: 'Unread Badge',
+      getContainerProps
+    },
+    {
+      component: Read,
+      title: 'Read Badge',
+      getContainerProps
+    }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/Badge/examples/ReadBadge.js
+++ b/packages/patternfly-4/react-core/src/components/Badge/examples/ReadBadge.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Badge } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class ReadBadge extends React.Component {
-  static title = 'Read Badge';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Badge/examples/UnreadBadge.js
+++ b/packages/patternfly-4/react-core/src/components/Badge/examples/UnreadBadge.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Badge } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class UnreadBadge extends React.Component {
-  static title = 'Unread Badge';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Brand/Brand.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Brand/Brand.docs.js
@@ -6,5 +6,5 @@ export default {
   components: {
     Brand
   },
-  examples: [Simple]
+  examples: [{ component: Simple, title: 'Simple Brand' }]
 };

--- a/packages/patternfly-4/react-core/src/components/Brand/examples/SimpleBrand.js
+++ b/packages/patternfly-4/react-core/src/components/Brand/examples/SimpleBrand.js
@@ -3,8 +3,6 @@ import { Brand } from '@patternfly/react-core';
 import brandImg from './pf_logo.svg';
 
 class SimpleBrand extends React.Component {
-  static title = 'Simple Brand';
-
   render() {
     return <Brand src={brandImg} alt="Brand Image" />;
   }

--- a/packages/patternfly-4/react-core/src/components/Button/Button.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Button/Button.docs.js
@@ -2,6 +2,7 @@ import { Button, ButtonVariant, ButtonType } from '@patternfly/react-core';
 import VariantsExample from './examples/ButtonVariants';
 import BlockExample from './examples/BlockButton';
 import LinkExample from './examples/LinkButton';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Button',
@@ -12,5 +13,14 @@ export default {
     'Object.values(ButtonVariant)': Object.values(ButtonVariant),
     'Object.values(ButtonType)': Object.values(ButtonType)
   },
-  examples: [VariantsExample, BlockExample, LinkExample]
+  examples: [
+    { component: VariantsExample, getContainerProps, title: 'Button Variants' },
+    { component: BlockExample, title: 'Block Button' },
+    {
+      component: LinkExample,
+      getContainerProps,
+      title: 'Links',
+      description: `Links with button styling. Semantic buttons and links are important for usability as well as accessibility. Using an "a" instead of a "button" element to perform user initiated actions should be avoided, unless absolutely necessary.`
+    }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/Button/examples/BlockButton.js
+++ b/packages/patternfly-4/react-core/src/components/Button/examples/BlockButton.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Button } from '@patternfly/react-core';
 
 class BlockButton extends React.Component {
-  static title = 'Block Button';
-
   render() {
     return <Button isBlock>Block Button</Button>;
   }

--- a/packages/patternfly-4/react-core/src/components/Button/examples/ButtonVariants.js
+++ b/packages/patternfly-4/react-core/src/components/Button/examples/ButtonVariants.js
@@ -1,12 +1,8 @@
 import React from 'react';
 import { Button } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
-import getContainerProps from './common/getContainerProps';
 
 class ButtonVariants extends React.Component {
-  static title = 'Button Variants';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Button/examples/LinkButton.js
+++ b/packages/patternfly-4/react-core/src/components/Button/examples/LinkButton.js
@@ -1,12 +1,7 @@
 import React from 'react';
 import { Button } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class LinkButton extends React.Component {
-  static title = 'Links';
-  static description = `Links with button styling. Semantic buttons and links are important for usability as well as accessibility. Using an "a" instead of a "button" element to perform user initiated actions should be avoided, unless absolutely necessary.`;
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Card/Card.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Card/Card.docs.js
@@ -9,5 +9,5 @@ export default {
     CardBody,
     CardFooter
   },
-  examples: [Simple]
+  examples: [{ component: Simple, title: 'Simple Card' }]
 };

--- a/packages/patternfly-4/react-core/src/components/Card/examples/SimpleCard.js
+++ b/packages/patternfly-4/react-core/src/components/Card/examples/SimpleCard.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Card, CardHeader, CardBody, CardFooter } from '@patternfly/react-core';
 
 class SimpleCard extends React.Component {
-  static title = 'Simple Card';
-
   render() {
     return (
       <Card>

--- a/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.docs.js
@@ -9,5 +9,10 @@ export default {
   components: {
     Checkbox
   },
-  examples: [Controlled, Uncontrolled, Disabled, Custom]
+  examples: [
+    { component: Controlled, title: 'Controlled Checkbox' },
+    { component: Uncontrolled, title: 'Uncontrolled Checkbox' },
+    { component: Disabled, title: 'Disabled Checkbox' },
+    { component: Custom, title: 'Custom label Checkbox' }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/Checkbox/examples/ControlledCheckbox.js
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/examples/ControlledCheckbox.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Checkbox } from '@patternfly/react-core';
 
 class ControlledCheckbox extends React.Component {
-  static title = 'Controlled Checkbox';
-
   state = {
     checked: false
   };

--- a/packages/patternfly-4/react-core/src/components/Checkbox/examples/CustomLabelCheckbox.js
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/examples/CustomLabelCheckbox.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { Checkbox, Badge } from '@patternfly/react-core';
 
 class CustomLabelCheckbox extends React.Component {
-  static title = 'Custom label Checkbox';
   render() {
     return <Checkbox label={<Badge>Badge here!</Badge>} aria-label="uncontrolled checkbox example" id="check-5" />;
   }

--- a/packages/patternfly-4/react-core/src/components/Checkbox/examples/DisabledCheckbox.js
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/examples/DisabledCheckbox.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { Checkbox } from '@patternfly/react-core';
 
 class DisabledCheckbox extends React.Component {
-  static title = 'Disabled Checkbox';
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Checkbox/examples/UncontrolledCheckbox.js
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/examples/UncontrolledCheckbox.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { Checkbox } from '@patternfly/react-core';
 
 class UncontrolledCheckbox extends React.Component {
-  static title = 'Uncontrolled Checkbox';
   render() {
     return <Checkbox label="Uncontrolled CheckBox" aria-label="uncontrolled checkbox example" id="check-2" />;
   }

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.docs.js
@@ -14,5 +14,11 @@ export default {
     DropdownSeparator,
     DropdownToggle
   },
-  examples: [Basic, Simple, PositionRight, DirectionUp, Kebab]
+  examples: [
+    { component: Basic, title: 'Basic dropdown' },
+    { component: Simple, title: 'Simple dropdown' },
+    { component: PositionRight, title: 'Dropdown - position right' },
+    { component: DirectionUp, title: 'Dropdown - direction up' },
+    { component: Kebab, title: 'Kebab' }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/Dropdown/examples/BasicDropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/examples/BasicDropdown.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 import { Dropdown, DropdownToggle } from '@patternfly/react-core';
 
 export default class BasicDropdown extends Component {
-  static title = 'Basic dropdown';
-
   constructor(props) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-core/src/components/Dropdown/examples/DirectionUpDropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/examples/DirectionUpDropdown.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownDirection } from '@patternfly/react-core';
 
 export default class DirectionUpDropdown extends Component {
-  static title = 'Dropdown - direction up';
-
   constructor(props) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-core/src/components/Dropdown/examples/KebabDropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/examples/KebabDropdown.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 import { Dropdown, KebabToggle, DropdownItem, DropdownSeparator } from '@patternfly/react-core';
 
 export default class KebabDropdown extends Component {
-  static title = 'Kebab';
-
   constructor(props) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-core/src/components/Dropdown/examples/PositionRightDropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/examples/PositionRightDropdown.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownPosition } from '@patternfly/react-core';
 
 export default class PositionRightDropdown extends Component {
-  static title = 'Dropdown - position right';
-
   constructor(props) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-core/src/components/Dropdown/examples/SimpleDropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/examples/SimpleDropdown.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator } from '@patternfly/react-core';
 
 export default class SimpleDropdown extends Component {
-  static title = 'Simple dropdown';
-
   constructor(props) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-core/src/components/Form/Form.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Form/Form.docs.js
@@ -3,7 +3,6 @@ import Horizontal from './examples/HorizontalForm';
 import Various from './examples/VariousLabelsForm';
 import Alternative from './examples/AlternativeForm';
 import Invalid from './examples/InvalidForm';
-import PropTypes from 'prop-types';
 import { Form, FormGroup, ActionGroup } from '@patternfly/react-core';
 
 export default {
@@ -13,5 +12,15 @@ export default {
     FormGroup,
     ActionGroup
   },
-  examples: [Simple, Horizontal, Alternative, Invalid, Various]
+  examples: [
+    { component: Simple, title: 'Simple Form' },
+    { component: Horizontal, title: 'Horizontal form' },
+    { component: Alternative, title: 'Alternative Form' },
+    { component: Invalid, title: 'Invalid form' },
+    {
+      component: Various,
+      title: 'Various labels and helper text',
+      description: 'Label and helperText can be a string, a function or a node.'
+    }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/Form/examples/AlternativeForm.js
+++ b/packages/patternfly-4/react-core/src/components/Form/examples/AlternativeForm.js
@@ -1,10 +1,17 @@
 import React from 'react';
-import { Form, FormGroup, TextInput, Checkbox, ActionGroup, Toolbar } from '@patternfly/react-core';
-import { ToolbarGroup, ToolbarItem, Button } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  Checkbox,
+  ActionGroup,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem,
+  Button
+} from '@patternfly/react-core';
 
 class AlternativeForm extends React.Component {
-  static title = 'Alternative Form';
-
   state = {
     value: '',
     value1: ''

--- a/packages/patternfly-4/react-core/src/components/Form/examples/HorizontalForm.js
+++ b/packages/patternfly-4/react-core/src/components/Form/examples/HorizontalForm.js
@@ -1,10 +1,21 @@
 import React from 'react';
-import { FormGroup, TextInput, TextArea, Form, SelectOption, Select, Radio } from '@patternfly/react-core';
-import { Toolbar, ToolbarItem, ToolbarGroup, Button, ActionGroup, Checkbox } from '@patternfly/react-core';
+import {
+  FormGroup,
+  TextInput,
+  TextArea,
+  Form,
+  SelectOption,
+  Select,
+  Radio,
+  Toolbar,
+  ToolbarItem,
+  ToolbarGroup,
+  Button,
+  ActionGroup,
+  Checkbox
+} from '@patternfly/react-core';
 
 class HorizontalForm extends React.Component {
-  static title = 'Horizontal form';
-
   state = {
     value: 'please choose',
     value1: '',

--- a/packages/patternfly-4/react-core/src/components/Form/examples/InvalidForm.js
+++ b/packages/patternfly-4/react-core/src/components/Form/examples/InvalidForm.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Form, FormGroup, TextInput } from '@patternfly/react-core';
 
 class InvalidForm extends React.Component {
-  static title = 'Invalid form';
-
   render() {
     return (
       <Form>

--- a/packages/patternfly-4/react-core/src/components/Form/examples/SimpleForm.js
+++ b/packages/patternfly-4/react-core/src/components/Form/examples/SimpleForm.js
@@ -1,10 +1,17 @@
 import React from 'react';
-import { Form, FormGroup, TextInput, Checkbox, ActionGroup } from '@patternfly/react-core';
-import { Toolbar, ToolbarGroup, Button, Radio } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  Checkbox,
+  ActionGroup,
+  Toolbar,
+  ToolbarGroup,
+  Button,
+  Radio
+} from '@patternfly/react-core';
 
 class SimpleForm extends React.Component {
-  static title = 'Simple Form';
-
   state = {
     value1: '',
     value2: '',

--- a/packages/patternfly-4/react-core/src/components/Form/examples/VariousLabelsForm.js
+++ b/packages/patternfly-4/react-core/src/components/Form/examples/VariousLabelsForm.js
@@ -2,9 +2,6 @@ import React from 'react';
 import { Form, FormGroup, TextInput, Badge } from '@patternfly/react-core';
 
 class VariousLabelsForm extends React.Component {
-  static description = 'Label and helperText can be a string, a function or a node.';
-  static title = 'Various labels and helper text';
-
   state = {
     value1: '',
     value2: ''

--- a/packages/patternfly-4/react-core/src/components/Label/Label.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Label/Label.docs.js
@@ -6,5 +6,5 @@ export default {
   components: {
     Label
   },
-  examples: [SimpleLabel]
+  examples: [{ component: SimpleLabel, title: 'Labels' }]
 };

--- a/packages/patternfly-4/react-core/src/components/Label/examples/SimpleLabel.js
+++ b/packages/patternfly-4/react-core/src/components/Label/examples/SimpleLabel.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Label } from '@patternfly/react-core';
 
 class SimpleLabel extends React.Component {
-  static title = 'Labels';
-
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/List/List.docs.js
+++ b/packages/patternfly-4/react-core/src/components/List/List.docs.js
@@ -9,5 +9,9 @@ export default {
     List,
     ListItem
   },
-  examples: [Simple, Inline, Grid]
+  examples: [
+    { component: Simple, title: 'Simple List' },
+    { component: Inline, title: 'Inline List' },
+    { component: Grid, title: 'Grid List' }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/List/examples/GridList.js
+++ b/packages/patternfly-4/react-core/src/components/List/examples/GridList.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { List, ListItem } from '@patternfly/react-core';
 
 class GridList extends React.Component {
-  static title = 'Grid List';
-
   render() {
     return (
       <List variant="grid">

--- a/packages/patternfly-4/react-core/src/components/List/examples/InlineList.js
+++ b/packages/patternfly-4/react-core/src/components/List/examples/InlineList.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { List, ListItem } from '@patternfly/react-core';
 
 class InlineList extends React.Component {
-  static title = 'Inline List';
-
   render() {
     return (
       <List variant="inline">

--- a/packages/patternfly-4/react-core/src/components/List/examples/SimpleList.js
+++ b/packages/patternfly-4/react-core/src/components/List/examples/SimpleList.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { List, ListItem } from '@patternfly/react-core';
 
 class SimpleList extends React.Component {
-  static title = 'Simple List';
-
   render() {
     return (
       <List>

--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginPage.docs.js
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginPage.docs.js
@@ -7,6 +7,6 @@ export default {
     LoginPage,
     LoginForm
   },
-  examples: [SimpleLoginPage],
+  examples: [{ component: SimpleLoginPage, title: 'Simple LoginPage' }],
   fullPageOnly: true
 };

--- a/packages/patternfly-4/react-core/src/components/LoginPage/examples/SimpleLoginPage.js
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/examples/SimpleLoginPage.js
@@ -27,8 +27,6 @@ const images = {
 };
 
 class SimpleLoginPage extends React.Component {
-  static title = 'Simple LoginPage';
-
   constructor(props) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-core/src/components/Modal/Modal.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/Modal.docs.js
@@ -7,5 +7,5 @@ export default {
   components: {
     Modal
   },
-  examples: [Simple, Large]
+  examples: [{ component: Simple, title: 'Simple Modal' }, { component: Large, title: 'Large Modal' }]
 };

--- a/packages/patternfly-4/react-core/src/components/Modal/examples/LargeModal.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/examples/LargeModal.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Modal, Button } from '@patternfly/react-core';
 
 class LargeModal extends React.Component {
-  static title = 'Large Modal';
-
   state = {
     isModalOpen: false
   };

--- a/packages/patternfly-4/react-core/src/components/Modal/examples/SimpleModal.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/examples/SimpleModal.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Modal, Button } from '@patternfly/react-core';
 
 class SimpleModal extends React.Component {
-  static title = 'Simple Modal';
-
   state = {
     isModalOpen: false
   };

--- a/packages/patternfly-4/react-core/src/components/Nav/Nav.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/Nav.docs.js
@@ -21,13 +21,13 @@ export default {
     'Object.values(NavVariants)': Object.values(NavVariants)
   },
   examples: [
-    SimpleList,
-    GroupedList,
-    DefaultList,
-    ExpandableList,
-    ExpandableTitlesList,
-    MixedList,
-    HorizontalList,
-    TertiaryList
+    { component: SimpleList, title: 'Simple Nav' },
+    { component: GroupedList, title: 'Grouped Nav' },
+    { component: DefaultList, title: 'Default Nav' },
+    { component: ExpandableList, title: 'Expandable Nav' },
+    { component: ExpandableTitlesList, title: 'Expandable Nav (w/subnav titles)' },
+    { component: MixedList, title: 'Nav Mixed' },
+    { component: HorizontalList, title: 'Horizontal List' },
+    { component: TertiaryList, title: 'Tertiary List' }
   ]
 };

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavDefaultList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavDefaultList.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Nav, NavList, NavItem } from '@patternfly/react-core';
 
 class NavDefaultList extends React.Component {
-  static title = 'Default Nav';
-
   state = {
     activeItem: 0
   };

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavExpandableList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavExpandableList.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Nav, NavList, NavExpandable, NavItem } from '@patternfly/react-core';
 
 class NavExpandableList extends React.Component {
-  static title = 'Expandable Nav';
-
   state = {
     activeGroup: 'grp-1',
     activeItem: 'grp-1_itm-1'

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavExpandableTitlesList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavExpandableTitlesList.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Nav, NavList, NavExpandable, NavItem } from '@patternfly/react-core';
 
 class NavExpandableTitlesList extends React.Component {
-  static title = 'Expandable Nav (w/subnav titles)';
-
   state = {
     activeGroup: 'grp-1',
     activeItem: 'grp-1_itm-1'

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavGroupedList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavGroupedList.js
@@ -1,9 +1,7 @@
 import React from 'react';
-import { Nav, NavList, NavGroup, NavItem } from '@patternfly/react-core';
+import { Nav, NavGroup, NavItem } from '@patternfly/react-core';
 
 class NavGroupedList extends React.Component {
-  static title = 'Grouped Nav';
-
   state = {
     activeItem: 'grp-1_itm-1'
   };

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavHorizontalList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavHorizontalList.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Nav, NavList, NavItem, NavVariants } from '@patternfly/react-core';
 
 class NavHorizontalList extends React.Component {
-  static title = 'Horizontal List';
-
   state = {
     activeItem: 0
   };

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavMixedList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavMixedList.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Nav, NavList, NavExpandable, NavItem } from '@patternfly/react-core';
 
 class NavMixedList extends React.Component {
-  static title = 'Nav Mixed';
-
   state = {
     activeGroup: '',
     activeItem: 'itm-1'

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavSimpleList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavSimpleList.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Nav, NavList, NavItem, NavVariants } from '@patternfly/react-core';
 
 class NavSimpleList extends React.Component {
-  static title = 'Simple Nav';
-
   state = {
     activeItem: 0
   };

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavTertiaryList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavTertiaryList.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Nav, NavList, NavItem, NavVariants } from '@patternfly/react-core';
 
 class NavTertiaryList extends React.Component {
-  static title = 'Tertiary List';
-
   state = {
     activeItem: 0
   };

--- a/packages/patternfly-4/react-core/src/components/Progress/Progress.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/Progress.docs.js
@@ -24,18 +24,18 @@ export default {
     'Object.values(ProgressMeasureLocation)': Object.values(ProgressMeasureLocation)
   },
   examples: [
-    Simple,
-    LabeledProgress,
-    SmallProgress,
-    LargeProgress,
-    ProgressOutside,
-    ProgressInside,
-    ProgressSuccess,
-    ProgressFailure,
-    ProgressInsideSuccess,
-    ProgressOutsideFailure,
-    ProgressWithoutMeasure,
-    ProgressFailureWithoutMeasure,
-    ProgressWithDynamicDescription
+    { component: Simple, title: 'Simple Progress' },
+    { component: LabeledProgress, title: 'Progress with additional label' },
+    { component: SmallProgress, title: 'Progress Small' },
+    { component: LargeProgress, title: 'Progress Large' },
+    { component: ProgressOutside, title: 'Progress Outside' },
+    { component: ProgressInside, title: 'Progress Inside' },
+    { component: ProgressSuccess, title: 'Progress Success' },
+    { component: ProgressFailure, title: 'Progress Failure' },
+    { component: ProgressInsideSuccess, title: 'Progress Inside Success' },
+    { component: ProgressOutsideFailure, title: 'Progress Outside Failure' },
+    { component: ProgressWithoutMeasure, title: 'Progress Without Measure' },
+    { component: ProgressFailureWithoutMeasure, title: 'Progress Failure Without Measure' },
+    { component: ProgressWithDynamicDescription, title: 'Progress with Dynamic Description' }
   ]
 };

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/LabeledProgress.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/LabeledProgress.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress, ProgressMeasureLocation } from '@patternfly/react-core';
 
 class LabeledProgress extends React.Component {
-  static title = 'Progress with additional label';
-
   render() {
     return <Progress value={33} title="Descriptive text here" measureLocation={ProgressMeasureLocation.top} label="Some label" />;
   }

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/LargeProgress.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/LargeProgress.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress, ProgressSize } from '@patternfly/react-core';
 
 class LargeProgress extends React.Component {
-  static title = 'Progress Large';
-
   render() {
     return <Progress value={33} title="Descriptive text here" size={ProgressSize.lg} />;
   }

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressFailure.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressFailure.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress, ProgressVariant } from '@patternfly/react-core';
 
 class ProgressFailure extends React.Component {
-  static title = 'Progress Failure';
-
   render() {
     return <Progress value={33} title="Failure due to an error" variant={ProgressVariant.danger} />;
   }

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressFailureWithoutMeasure.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressFailureWithoutMeasure.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress, ProgressMeasureLocation, ProgressVariant } from '@patternfly/react-core';
 
 class ProgressFailureWithoutMeasure extends React.Component {
-  static title = 'Progress Failure Without Measure';
-
   render() {
     return (
       <Progress

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressInside.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressInside.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress, ProgressMeasureLocation } from '@patternfly/react-core';
 
 class ProgressInside extends React.Component {
-  static title = 'Progress Inside';
-
   render() {
     return <Progress value={33} title="Descriptive text here" measureLocation={ProgressMeasureLocation.inside} />;
   }

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressInsideSuccess.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressInsideSuccess.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress, ProgressMeasureLocation, ProgressVariant } from '@patternfly/react-core';
 
 class ProgressInsideSuccess extends React.Component {
-  static title = 'Progress Inside Success';
-
   render() {
     return (
       <Progress

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressOutside.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressOutside.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress, ProgressMeasureLocation } from '@patternfly/react-core';
 
 class ProgressOutside extends React.Component {
-  static title = 'Progress Outside';
-
   render() {
     return <Progress value={33} title="Descriptive text here" measureLocation={ProgressMeasureLocation.outside} />;
   }

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressOutsideFailure.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressOutsideFailure.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress, ProgressMeasureLocation, ProgressVariant } from '@patternfly/react-core';
 
 class ProgressOutsideFailure extends React.Component {
-  static title = 'Progress Outside Failure';
-
   render() {
     return (
       <Progress

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressSuccess.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressSuccess.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress, ProgressVariant } from '@patternfly/react-core';
 
 class ProgressSuccess extends React.Component {
-  static title = 'Progress Success';
-
   render() {
     return <Progress value={33} title="Success" variant={ProgressVariant.success} />;
   }

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressWithDynamicDescription.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressWithDynamicDescription.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress } from '@patternfly/react-core';
 
 class ProgressWithDynamicDescription extends React.Component {
-  static title = 'Progress with Dynamic Description';
-
   render() {
     return <Progress value={33} title="Descriptive text here" valueText="Descriptive text here" />;
   }

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressWithoutMeasure.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/ProgressWithoutMeasure.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress, ProgressMeasureLocation } from '@patternfly/react-core';
 
 class ProgressWithoutMeasure extends React.Component {
-  static title = 'Progress Without Measure';
-
   render() {
     return <Progress value={33} title="Descriptive text here" measureLocation={ProgressMeasureLocation.none} />;
   }

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/SimpleProgress.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/SimpleProgress.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress } from '@patternfly/react-core';
 
 class SimpleProgress extends React.Component {
-  static title = 'Simple Progress';
-
   render() {
     return <Progress value={33} title="Descriptive text here" />;
   }

--- a/packages/patternfly-4/react-core/src/components/Progress/examples/SmallProgress.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/examples/SmallProgress.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Progress, ProgressSize } from '@patternfly/react-core';
 
 class SmallProgress extends React.Component {
-  static title = 'Progress Small';
-
   render() {
     return <Progress value={33} title="Descriptive text here" size={ProgressSize.sm} />;
   }

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.docs.js
@@ -3,11 +3,17 @@ import Uncontrolled from './examples/UncontrolledRadio';
 import Disabled from './examples/DisabledRadio';
 import Custom from './examples/CustomLabelRadio';
 import { Radio } from '@patternfly/react-core';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Radio',
   components: {
     Radio
   },
-  examples: [Controlled, Uncontrolled, Disabled, Custom]
+  examples: [
+    { component: Controlled, title: 'Controlled Radio' },
+    { component: Uncontrolled, title: 'Uncontrolled Radio' },
+    { component: Disabled, title: 'Disabled Radio' },
+    { component: Custom, title: 'Custom label Radio', getContainerProps }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/Radio/examples/ControlledRadio.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/examples/ControlledRadio.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Radio } from '@patternfly/react-core';
 
 class ControlledRadio extends React.Component {
-  static title = 'Controlled Radio';
-
   state = {
     value: '4'
   };

--- a/packages/patternfly-4/react-core/src/components/Radio/examples/CustomLabelRadio.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/examples/CustomLabelRadio.js
@@ -1,11 +1,7 @@
 import React from 'react';
-import getContainerProps from './common/getContainerProps';
 import { Radio, Badge } from '@patternfly/react-core';
 
 class CustomLabelRadio extends React.Component {
-  static title = 'Custom label Radio';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Radio/examples/DisabledRadio.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/examples/DisabledRadio.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Radio } from '@patternfly/react-core';
 
 class DisabledRadio extends React.Component {
-  static title = 'Disabled Radio';
-
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Radio/examples/UncontrolledRadio.js
+++ b/packages/patternfly-4/react-core/src/components/Radio/examples/UncontrolledRadio.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Radio } from '@patternfly/react-core';
 
 class UncontrolledRadio extends React.Component {
-  static title = 'Uncontrolled Radio';
-
   render() {
     return (
       <Radio label="Uncontrolled radio example" id="radio-4" name="radio-4" aria-label="uncontrolled radio example" />

--- a/packages/patternfly-4/react-core/src/components/Select/Select.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.docs.js
@@ -10,5 +10,9 @@ export default {
     SelectOption,
     SelectOptionGroup
   },
-  examples: [SelectInput, SelectInputGrouped, SelectInputDisabled]
+  examples: [
+    { component: SelectInput, title: 'Select Input' },
+    { component: SelectInputGrouped, title: 'Select Input with grouping' },
+    { component: SelectInputDisabled, title: 'Select Input Disabled' }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/Select/examples/SelectInput.js
+++ b/packages/patternfly-4/react-core/src/components/Select/examples/SelectInput.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Select, SelectOption } from '@patternfly/react-core';
 
 class SelectInput extends React.Component {
-  static title = 'Select Input';
-
   state = {
     value: 'mrs'
   };

--- a/packages/patternfly-4/react-core/src/components/Select/examples/SelectInputDisabled.js
+++ b/packages/patternfly-4/react-core/src/components/Select/examples/SelectInputDisabled.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Select, SelectOption } from '@patternfly/react-core';
 
 class SelectInputDisabled extends React.Component {
-  static title = 'Select Input Disabled';
-
   state = {
     value: '1'
   };

--- a/packages/patternfly-4/react-core/src/components/Select/examples/SelectInputGrouped.js
+++ b/packages/patternfly-4/react-core/src/components/Select/examples/SelectInputGrouped.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Select, SelectOption, SelectOptionGroup } from '@patternfly/react-core';
 
 class SelectInputGrouped extends React.Component {
-  static title = 'Select Input with grouping';
-
   state = {
     value: '2'
   };

--- a/packages/patternfly-4/react-core/src/components/Text/Text.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Text/Text.docs.js
@@ -26,5 +26,15 @@ export default {
     'Object.values(TextListVariants)': Object.values(TextListVariants),
     'Object.values(TextListItemVariants)': Object.values(TextListItemVariants)
   },
-  examples: [Headings, BodyText, UnorderedList, OrderedList, DataList]
+  examples: [
+    { component: Headings, title: 'Headings Example' },
+    { component: BodyText, title: 'Body text examples' },
+    {
+      component: UnorderedList,
+      title: 'Unordered list example',
+      description: 'Text components such as Text, TextList, TextListItem need to be placed within a TextContent'
+    },
+    { component: OrderedList, title: 'Ordered list Example' },
+    { component: DataList, title: 'Data list example' }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/Text/examples/BodyText.js
+++ b/packages/patternfly-4/react-core/src/components/Text/examples/BodyText.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { TextContent, Text, TextVariants } from '@patternfly/react-core';
 
 class BodyText extends React.Component {
-  static title = 'Body text examples';
-
   render() {
     return (
       <TextContent>

--- a/packages/patternfly-4/react-core/src/components/Text/examples/DataList.js
+++ b/packages/patternfly-4/react-core/src/components/Text/examples/DataList.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { TextContent, TextList, TextListVariants, TextListItem, TextListItemVariants } from '@patternfly/react-core';
 
 class DataList extends React.Component {
-  static title = 'Data list example';
-
   render() {
     return (
       <TextContent>

--- a/packages/patternfly-4/react-core/src/components/Text/examples/Headings.js
+++ b/packages/patternfly-4/react-core/src/components/Text/examples/Headings.js
@@ -1,9 +1,7 @@
 import React from 'react';
-import { TextContent, Text, TextVariants, TextList, TextListVariants, TextListItem, TextListItemVariants } from '@patternfly/react-core';
+import { TextContent, Text, TextVariants } from '@patternfly/react-core';
 
 class Headings extends React.Component {
-  static title = 'Headings Example';
-
   render() {
     return (
       <TextContent>

--- a/packages/patternfly-4/react-core/src/components/Text/examples/OrderedList.js
+++ b/packages/patternfly-4/react-core/src/components/Text/examples/OrderedList.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { TextContent, TextList, TextListVariants, TextListItem } from '@patternfly/react-core';
 
 class OrderedList extends React.Component {
-  static title = 'Ordered list Example';
-
   render() {
     return (
       <TextContent>

--- a/packages/patternfly-4/react-core/src/components/Text/examples/UnorderedList.js
+++ b/packages/patternfly-4/react-core/src/components/Text/examples/UnorderedList.js
@@ -2,9 +2,6 @@ import React from 'react';
 import { TextContent, TextList, TextListItem } from '@patternfly/react-core';
 
 class UnorderedList extends React.Component {
-  static title = 'Unordered list example';
-  static description = 'Text components such as Text, TextList, TextListItem need to be placed within a TextContent';
-
   render() {
     return (
       <TextContent>

--- a/packages/patternfly-4/react-core/src/components/TextArea/TextArea.docs.js
+++ b/packages/patternfly-4/react-core/src/components/TextArea/TextArea.docs.js
@@ -7,5 +7,5 @@ export default {
   components: {
     TextArea
   },
-  examples: [Simple, Invalid]
+  examples: [{ component: Simple, title: 'Simple TextArea' }, { component: Invalid, title: 'Invalid TextArea' }]
 };

--- a/packages/patternfly-4/react-core/src/components/TextArea/examples/InvalidTextArea.js
+++ b/packages/patternfly-4/react-core/src/components/TextArea/examples/InvalidTextArea.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { TextArea } from '@patternfly/react-core';
 
 class InvalidTextArea extends React.Component {
-  static title = 'Invalid TextArea';
-
   state = {
     value: ''
   };

--- a/packages/patternfly-4/react-core/src/components/TextArea/examples/SimpleTextArea.js
+++ b/packages/patternfly-4/react-core/src/components/TextArea/examples/SimpleTextArea.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { TextArea } from '@patternfly/react-core';
 
 class SimpleTextArea extends React.Component {
-  static title = 'Simple TextArea';
-
   state = {
     value: ''
   };

--- a/packages/patternfly-4/react-core/src/components/TextInput/TextInput.docs.js
+++ b/packages/patternfly-4/react-core/src/components/TextInput/TextInput.docs.js
@@ -10,5 +10,11 @@ export default {
   components: {
     TextInput
   },
-  examples: [Simple, Disabled, ReadOnly, Invalid, Alt]
+  examples: [
+    { component: Simple, title: 'Simple TextInput' },
+    { component: Disabled, title: 'Disabled TextInput' },
+    { component: ReadOnly, title: 'ReadOnly TextInput' },
+    { component: Invalid, title: 'Invalid TextInput' },
+    { component: Alt, title: 'Alternative TextInput' }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/TextInput/examples/AltTextInput.js
+++ b/packages/patternfly-4/react-core/src/components/TextInput/examples/AltTextInput.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { TextInput } from '@patternfly/react-core';
 
 class AltTextInput extends React.Component {
-  static title = 'Alternative TextInput';
-
   state = {
     value: ''
   };

--- a/packages/patternfly-4/react-core/src/components/TextInput/examples/DisabledTextInput.js
+++ b/packages/patternfly-4/react-core/src/components/TextInput/examples/DisabledTextInput.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { TextInput } from '@patternfly/react-core';
 
 class DisabledTextInput extends React.Component {
-  static title = 'Disabled TextInput';
-
   state = {
     value: ''
   };

--- a/packages/patternfly-4/react-core/src/components/TextInput/examples/InvalidTextInput.js
+++ b/packages/patternfly-4/react-core/src/components/TextInput/examples/InvalidTextInput.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { TextInput } from '@patternfly/react-core';
 
 class InvalidTextInput extends React.Component {
-  static title = 'Invalid TextInput';
-
   state = {
     value: ''
   };

--- a/packages/patternfly-4/react-core/src/components/TextInput/examples/ReadOnlyTextInput.js
+++ b/packages/patternfly-4/react-core/src/components/TextInput/examples/ReadOnlyTextInput.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { TextInput } from '@patternfly/react-core';
 
 class ReadOnlyTextInput extends React.Component {
-  static title = 'ReadOnly TextInput';
-
   state = {
     readOnly: 'read only text input example'
   };

--- a/packages/patternfly-4/react-core/src/components/TextInput/examples/SimpleTextInput.js
+++ b/packages/patternfly-4/react-core/src/components/TextInput/examples/SimpleTextInput.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { TextInput } from '@patternfly/react-core';
 
 class SimpleTextInput extends React.Component {
-  static title = 'Simple TextInput';
-
   state = {
     value: ''
   };

--- a/packages/patternfly-4/react-core/src/components/Title/Title.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Title/Title.docs.js
@@ -9,5 +9,5 @@ export default {
   enumValues: {
     'Object.values(TitleSize)': Object.values(TitleSize)
   },
-  examples: [TitleSizes]
+  examples: [{ component: TitleSizes, title: 'Title Sizes' }]
 };

--- a/packages/patternfly-4/react-core/src/components/Title/examples/TitleSizes.js
+++ b/packages/patternfly-4/react-core/src/components/Title/examples/TitleSizes.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { Title } from '@patternfly/react-core';
 
 class TitleSizes extends React.Component {
-  static title = 'Title Sizes';
-
   render() {
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/PageLayoutDemo.docs.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/PageLayoutDemo.docs.js
@@ -9,13 +9,13 @@ import PageLayoutHorizontalNavCondensed from './examples/PageLayoutHorizontalNav
 export default {
   title: 'Page Layout Demos',
   examples: [
-    PageLayoutDefaultNav,
-    PageLayoutExpandableNav,
-    PageLayoutGroupsNav,
-    PageLayoutHorizontalNav,
-    PageLayoutSimpleNav,
-    PageLayoutVerticalNavCondensed,
-    PageLayoutHorizontalNavCondensed
+    { component: PageLayoutDefaultNav, title: 'Using default navigation' },
+    { component: PageLayoutExpandableNav, title: 'Using expandable navigation' },
+    { component: PageLayoutGroupsNav, title: 'Using grouped navigation' },
+    { component: PageLayoutHorizontalNav, title: 'Using horizontal navigation' },
+    { component: PageLayoutSimpleNav, title: 'Using simple navigation' },
+    { component: PageLayoutVerticalNavCondensed, title: 'Using vertical navigation with condensed header' },
+    { component: PageLayoutHorizontalNavCondensed, title: 'Using horizontal navigation with condensed header' }
   ],
   fullPageOnly: true
 };

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.js
@@ -38,8 +38,6 @@ import brandImg from './l_pf-reverse-164x11.png';
 import avatarImg from './img_avatar.png';
 
 class PageLayoutDefaultNav extends React.Component {
-  static title = 'Using default navigation';
-
   constructor(props) {
     super(props);
     // Set initial isNavOpen state based on window width

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.js
@@ -39,8 +39,6 @@ import brandImg from './l_pf-reverse-164x11.png';
 import avatarImg from './img_avatar.png';
 
 class PageLayoutExpandableNav extends React.Component {
-  static title = 'Using expandable navigation';
-
   constructor(props) {
     super(props);
     // Set initial isNavOpen state based on window width

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.js
@@ -34,8 +34,6 @@ import brandImg from './l_pf-reverse-164x11.png';
 import avatarImg from './img_avatar.png';
 
 class PageLayoutGroupsNav extends React.Component {
-  static title = 'Using grouped navigation';
-
   constructor(props) {
     super(props);
     // Set initial isNavOpen state based on window width

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.js
@@ -38,8 +38,6 @@ import brandImg from './l_pf-reverse-164x11.png';
 import avatarImg from './img_avatar.png';
 
 class PageLayoutHorizontalNav extends React.Component {
-  static title = 'Using horizontal navigation';
-
   constructor(props) {
     super(props);
     // Set initial isNavOpen state based on window width

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNavCondensed.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNavCondensed.js
@@ -38,8 +38,6 @@ import brandImg from './l_pf-reverse-164x11.png';
 import avatarImg from './img_avatar.png';
 
 class PageLayoutHorizontalNavCondensed extends React.Component {
-  static title = 'Using horizontal navigation with condensed header';
-
   constructor(props) {
     super(props);
     // Set initial isNavOpen state based on window width

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.js
@@ -39,8 +39,6 @@ import brandImg from './l_pf-reverse-164x11.png';
 import avatarImg from './img_avatar.png';
 
 class PageLayoutSimpleNav extends React.Component {
-  static title = 'Using simple navigation';
-
   constructor(props) {
     super(props);
     // Set initial isNavOpen state based on window width

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutVerticalNavCondensed.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutVerticalNavCondensed.js
@@ -39,8 +39,6 @@ import brandImg from './l_pf-reverse-164x11.png';
 import avatarImg from './img_avatar.png';
 
 class PageLayoutVerticalNavCondensed extends React.Component {
-  static title = 'Using vertical navigation with condensed header';
-
   constructor(props) {
     super(props);
     // Set initial isNavOpen state based on window width

--- a/packages/patternfly-4/react-core/src/demos/Toolbar/ToolbarDemo.docs.js
+++ b/packages/patternfly-4/react-core/src/demos/Toolbar/ToolbarDemo.docs.js
@@ -1,7 +1,12 @@
 import SimpleToolbarDemo from './examples/SimpleToolbarDemo';
 import ComplexToolbarDemo from './examples/ComplexToolbarDemo';
+import flexStyles from '@patternfly/patternfly-next/utilities/Flex/flex.css';
+import spacingStyles from '@patternfly/patternfly-next/utilities/Spacing/spacing.css';
 
 export default {
   title: 'Toolbar Demo',
-  examples: [SimpleToolbarDemo, ComplexToolbarDemo]
+  examples: [
+    { component: SimpleToolbarDemo, title: 'Toolbar Simple Example', liveScope: { flexStyles, spacingStyles } },
+    { component: ComplexToolbarDemo, title: 'Toolbar Complex Example', liveScope: { flexStyles, spacingStyles } }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/demos/Toolbar/examples/ComplexToolbarDemo.js
+++ b/packages/patternfly-4/react-core/src/demos/Toolbar/examples/ComplexToolbarDemo.js
@@ -18,9 +18,6 @@ import spacingStyles from '@patternfly/patternfly-next/utilities/Spacing/spacing
 import { ListUlIcon, SortAlphaDownIcon, TableIcon } from '@patternfly/react-icons';
 
 class ComplexToolbarDemo extends React.Component {
-  static title = 'Toolbar Complex Example';
-  static liveScope = { flexStyles, spacingStyles };
-
   constructor(props) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-core/src/demos/Toolbar/examples/SimpleToolbarDemo.js
+++ b/packages/patternfly-4/react-core/src/demos/Toolbar/examples/SimpleToolbarDemo.js
@@ -17,9 +17,6 @@ import spacingStyles from '@patternfly/patternfly-next/utilities/Spacing/spacing
 import { ListUlIcon, SortAlphaDownIcon, TableIcon } from '@patternfly/react-icons';
 
 class SimpleToolbarDemo extends React.Component {
-  static title = 'Toolbar Simple Example';
-  static liveScope = { flexStyles, spacingStyles };
-
   constructor(props) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-core/src/layouts/Bullseye/Bullseye.docs.js
+++ b/packages/patternfly-4/react-core/src/layouts/Bullseye/Bullseye.docs.js
@@ -1,5 +1,6 @@
 import { Bullseye } from '@patternfly/react-core';
 import Simple from './examples/SimpleBullseye';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Bullseye',
@@ -7,5 +8,5 @@ export default {
   components: {
     Bullseye
   },
-  examples: [Simple]
+  examples: [{ component: Simple, title: 'Simple Bullseye Layout', getContainerProps }]
 };

--- a/packages/patternfly-4/react-core/src/layouts/Bullseye/examples/SimpleBullseye.js
+++ b/packages/patternfly-4/react-core/src/layouts/Bullseye/examples/SimpleBullseye.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Bullseye } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleBullseye extends React.Component {
-  static title = 'Simple Bullseye Layout';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Bullseye>

--- a/packages/patternfly-4/react-core/src/layouts/Gallery/Gallery.docs.js
+++ b/packages/patternfly-4/react-core/src/layouts/Gallery/Gallery.docs.js
@@ -1,6 +1,7 @@
 import { Gallery, GalleryItem } from '@patternfly/react-core';
 import SimpleGallery from './examples/SimpleGallery';
 import GalleryWithGutters from './examples/GalleryWithGutters';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Gallery',
@@ -10,5 +11,8 @@ export default {
     Gallery,
     GalleryItem
   },
-  examples: [SimpleGallery, GalleryWithGutters]
+  examples: [
+    { component: SimpleGallery, title: 'Simple Gallery Layout', getContainerProps },
+    { component: GalleryWithGutters, title: 'Gallery With Gutters', getContainerProps }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/layouts/Gallery/examples/GalleryWithGutters.js
+++ b/packages/patternfly-4/react-core/src/layouts/Gallery/examples/GalleryWithGutters.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class GalleryWithGutters extends React.Component {
-  static title = 'Gallery With Gutters';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Gallery gutter="md">

--- a/packages/patternfly-4/react-core/src/layouts/Gallery/examples/SimpleGallery.js
+++ b/packages/patternfly-4/react-core/src/layouts/Gallery/examples/SimpleGallery.js
@@ -1,12 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleGallery extends React.Component {
-  static title = 'Simple Gallery Layout';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Gallery>

--- a/packages/patternfly-4/react-core/src/layouts/Grid/Grid.docs.js
+++ b/packages/patternfly-4/react-core/src/layouts/Grid/Grid.docs.js
@@ -3,6 +3,7 @@ import GridPlayground from './examples/GridPlayground';
 import Simple from './examples/SimpleGrid';
 import WithGutters from './examples/GridWithGutters';
 import Overrides from './examples/GridOverrides';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Grid',
@@ -14,5 +15,10 @@ export default {
   enumValues: {
     gridSpans: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
   },
-  examples: [Simple, WithGutters, Overrides, GridPlayground]
+  examples: [
+    { component: Simple, title: 'Simple Grid', getContainerProps },
+    { component: WithGutters, title: 'Grid with gutters', getContainerProps },
+    { component: Overrides, title: 'Grid With Overrides', getContainerProps },
+    { component: GridPlayground, title: 'Grid Playground', live: false }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/layouts/Grid/examples/GridOverrides.js
+++ b/packages/patternfly-4/react-core/src/layouts/Grid/examples/GridOverrides.js
@@ -1,12 +1,8 @@
 import React from 'react';
 import Grid from '../Grid';
 import GridItem from '../GridItem';
-import getContainerProps from './common/getContainerProps';
 
 class GridOverrides extends React.Component {
-  static title = 'Grid With Overrides';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Grid sm={6} md={4} lg={3}>

--- a/packages/patternfly-4/react-core/src/layouts/Grid/examples/GridPlayground.js
+++ b/packages/patternfly-4/react-core/src/layouts/Grid/examples/GridPlayground.js
@@ -16,9 +16,6 @@ function createGridItem() {
 }
 
 class GridPlayground extends React.Component {
-  static title = 'Grid Playground';
-  static live = false;
-
   state = {
     gridItems: [createGridItem(), createGridItem(), createGridItem(), createGridItem()]
   };

--- a/packages/patternfly-4/react-core/src/layouts/Grid/examples/GridWithGutters.js
+++ b/packages/patternfly-4/react-core/src/layouts/Grid/examples/GridWithGutters.js
@@ -1,12 +1,8 @@
 import React from 'react';
 import Grid from '../Grid';
 import GridItem from '../GridItem';
-import getContainerProps from './common/getContainerProps';
 
 class GridWithGutters extends React.Component {
-  static title = 'Grid with gutters';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Grid gutter="md">

--- a/packages/patternfly-4/react-core/src/layouts/Grid/examples/SimpleGrid.js
+++ b/packages/patternfly-4/react-core/src/layouts/Grid/examples/SimpleGrid.js
@@ -1,12 +1,8 @@
 import React from 'react';
 import Grid from '../Grid';
 import GridItem from '../GridItem';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleGrid extends React.Component {
-  static title = 'Simple Grid';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Grid>

--- a/packages/patternfly-4/react-core/src/layouts/Level/Level.docs.js
+++ b/packages/patternfly-4/react-core/src/layouts/Level/Level.docs.js
@@ -1,6 +1,7 @@
 import { Level, LevelItem } from '@patternfly/react-core';
 import Simple from './examples/SimpleLevel';
 import WithGutters from './examples/LevelWithGutters';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Level',
@@ -9,5 +10,8 @@ export default {
     Level,
     LevelItem
   },
-  examples: [Simple, WithGutters]
+  examples: [
+    { component: Simple, title: 'Simple Level Layout', getContainerProps },
+    { component: WithGutters, title: 'Level With Gutters', getContainerProps }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/layouts/Level/examples/LevelWithGutters.js
+++ b/packages/patternfly-4/react-core/src/layouts/Level/examples/LevelWithGutters.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Level, LevelItem } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class LevelWithGutters extends React.Component {
-  static title = 'Level With Gutters';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Level gutter="md">

--- a/packages/patternfly-4/react-core/src/layouts/Level/examples/SimpleLevel.js
+++ b/packages/patternfly-4/react-core/src/layouts/Level/examples/SimpleLevel.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Level, LevelItem } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleLevel extends React.Component {
-  static title = 'Simple Level Layout';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Level>

--- a/packages/patternfly-4/react-core/src/layouts/Page/Page.docs.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/Page.docs.js
@@ -1,6 +1,7 @@
 import { Page, PageHeader, PageSidebar, PageSection, PageSectionVariants } from '@patternfly/react-core';
 import VerticalPage from './examples/VerticalPage';
 import HorizontalPage from './examples/HorizontalPage';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Page',
@@ -13,5 +14,8 @@ export default {
   enumValues: {
     'Object.values(PageSectionVariants)': Object.values(PageSectionVariants)
   },
-  examples: [VerticalPage, HorizontalPage]
+  examples: [
+    { component: VerticalPage, title: 'Vertical Page Layout', getContainerProps },
+    { component: HorizontalPage, title: 'Horizontal Page Layout', getContainerProps }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/layouts/Page/examples/HorizontalPage.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/examples/HorizontalPage.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Page, PageHeader, PageSection, PageSectionVariants } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class HorizontalPage extends React.Component {
-  static title = 'Horizontal Page Layout';
-  static getContainerProps = getContainerProps;
-
   render() {
     const logoProps = {
       href: 'https://patternfly.org',

--- a/packages/patternfly-4/react-core/src/layouts/Page/examples/VerticalPage.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/examples/VerticalPage.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Page, PageHeader, PageSidebar, PageSection, PageSectionVariants } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class VerticalPage extends React.Component {
-  static title = 'Vertical Page Layout';
-  static getContainerProps = getContainerProps;
-
   constructor(props) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-core/src/layouts/Split/Split.docs.js
+++ b/packages/patternfly-4/react-core/src/layouts/Split/Split.docs.js
@@ -1,6 +1,7 @@
 import { Split, SplitItem, GutterSize } from '@patternfly/react-core';
 import Simple from './examples/SimpleSplit';
 import WithGutter from './examples/SplitWithGutter';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Split',
@@ -11,5 +12,8 @@ export default {
   enumValues: {
     'Object.keys(GutterSize)': Object.keys(GutterSize)
   },
-  examples: [Simple, WithGutter]
+  examples: [
+    { component: Simple, title: 'Simple Split Layout', getContainerProps },
+    { component: WithGutter, title: 'Split Layout With Gutter', getContainerProps }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/layouts/Split/examples/SimpleSplit.js
+++ b/packages/patternfly-4/react-core/src/layouts/Split/examples/SimpleSplit.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Split, SplitItem } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleSplit extends React.Component {
-  static title = 'Simple Split Layout';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Split>

--- a/packages/patternfly-4/react-core/src/layouts/Split/examples/SplitWithGutter.js
+++ b/packages/patternfly-4/react-core/src/layouts/Split/examples/SplitWithGutter.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Split, SplitItem } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SplitWithGutter extends React.Component {
-  static title = 'Split Layout With Gutter';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Split gutter="md">

--- a/packages/patternfly-4/react-core/src/layouts/Stack/Stack.docs.js
+++ b/packages/patternfly-4/react-core/src/layouts/Stack/Stack.docs.js
@@ -1,6 +1,7 @@
 import { Stack, StackItem, GutterSize } from '@patternfly/react-core';
 import Simple from './examples/SimpleStack';
 import StackWithGutter from './examples/StackWithGutter';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Stack',
@@ -11,5 +12,8 @@ export default {
   enumValues: {
     'Object.keys(GutterSize)': Object.keys(GutterSize)
   },
-  examples: [Simple, StackWithGutter]
+  examples: [
+    { component: Simple, title: 'Simple Stack Layout', getContainerProps },
+    { component: StackWithGutter, title: 'Stack Layout With Gutter', getContainerProps }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/layouts/Stack/examples/SimpleStack.js
+++ b/packages/patternfly-4/react-core/src/layouts/Stack/examples/SimpleStack.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Stack, StackItem } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleStack extends React.Component {
-  static title = 'Simple Stack Layout';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Stack>

--- a/packages/patternfly-4/react-core/src/layouts/Stack/examples/StackWithGutter.js
+++ b/packages/patternfly-4/react-core/src/layouts/Stack/examples/StackWithGutter.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Stack, StackItem } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class StackWithGutter extends React.Component {
-  static title = 'Stack Layout With Gutter';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Stack gutter="md">

--- a/packages/patternfly-4/react-core/src/layouts/Toolbar/Toolbar.docs.js
+++ b/packages/patternfly-4/react-core/src/layouts/Toolbar/Toolbar.docs.js
@@ -1,6 +1,7 @@
 import { Toolbar, ToolbarGroup, ToolbarItem, ToolbarSection } from '@patternfly/react-core';
 import SimpleToolbar from './examples/SimpleToolbar';
 import SimpleToolbarSection from './examples/SimpleToolbarSection';
+import getContainerProps from './examples/common/getContainerProps';
 
 export default {
   title: 'Toolbar',
@@ -10,5 +11,8 @@ export default {
     ToolbarItem,
     ToolbarSection
   },
-  examples: [SimpleToolbar, SimpleToolbarSection]
+  examples: [
+    { component: SimpleToolbar, title: 'Simple Toolbar Layout', getContainerProps },
+    { component: SimpleToolbarSection, title: 'Toolbar with sections', getContainerProps }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/layouts/Toolbar/examples/SimpleToolbar.js
+++ b/packages/patternfly-4/react-core/src/layouts/Toolbar/examples/SimpleToolbar.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleToolbar extends React.Component {
-  static title = 'Simple Toolbar Layout';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Toolbar>

--- a/packages/patternfly-4/react-core/src/layouts/Toolbar/examples/SimpleToolbarSection.js
+++ b/packages/patternfly-4/react-core/src/layouts/Toolbar/examples/SimpleToolbarSection.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Toolbar, ToolbarGroup, ToolbarSection, ToolbarItem } from '@patternfly/react-core';
-import getContainerProps from './common/getContainerProps';
 
 class SimpleToolbarSection extends React.Component {
-  static title = 'Toolbar with sections';
-  static getContainerProps = getContainerProps;
-
   render() {
     return (
       <Toolbar>

--- a/packages/patternfly-4/react-docs/src/components/componentDocs/componentDocs.js
+++ b/packages/patternfly-4/react-docs/src/components/componentDocs/componentDocs.js
@@ -11,7 +11,17 @@ import Section from '../section';
 const propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
-  examples: PropTypes.arrayOf(PropTypes.func),
+  examples: PropTypes.arrayOf(
+    PropTypes.shape({
+      component: PropTypes.func,
+      title: PropTypes.string,
+      description: PropTypes.string,
+      getContainerProps: PropTypes.func,
+      displayName: PropTypes.string,
+      live: PropTypes.bool,
+      liveScope: PropTypes.object
+    })
+  ),
   components: PropTypes.objectOf(PropTypes.func),
   enumValues: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.any)),
   rawExamples: PropTypes.array,
@@ -40,22 +50,25 @@ class ComponentDocs extends React.PureComponent {
           <p className={css(styles.description)} dangerouslySetInnerHTML={makeDescription(description)} />
         )}
         <Section title="Examples">
-          {examples.map((ComponentExample, i) => {
+          {examples.map((exampleObj, i) => {
+            const ComponentExample = exampleObj.component;
             const { __docgenInfo: componentDocs } = ComponentExample;
-            const rawExample = rawExamples.find(example => example.name === componentDocs.displayName);
+            const rawExample = rawExamples.find(
+              example => example.name === componentDocs.displayName || exampleObj.displayName
+            );
             return (
               <Example
                 key={i}
-                title={ComponentExample.title}
-                description={ComponentExample.description}
+                title={exampleObj.title}
+                description={exampleObj.description}
                 raw={rawExample.file}
                 path={rawExample.path}
                 images={images}
                 fullPageOnly={fullPageOnly}
-                live={ComponentExample.live}
-                liveScope={ComponentExample.liveScope}
+                live={exampleObj.live}
+                liveScope={exampleObj.liveScope}
                 name={componentDocs.displayName}
-                {...(ComponentExample.getContainerProps ? ComponentExample.getContainerProps() : {})}
+                {...(exampleObj.getContainerProps ? exampleObj.getContainerProps() : {})}
               >
                 <ComponentExample />
               </Example>

--- a/packages/patternfly-4/react-docs/src/components/example/liveDemo.js
+++ b/packages/patternfly-4/react-docs/src/components/example/liveDemo.js
@@ -40,9 +40,10 @@ const transformCode = code => {
     code = code.replace(/extends Component/gm, 'extends React.Component');
     code = code.replace(/^\s*export.*$/gm, '');
     code = code.replace(/^\s*static(.|\s)*?;$/gm, '');
-    const transformedCode = transform(code, {
+    let transformedCode = transform(code, {
       presets: ['react', 'stage-2']
     }).code;
+    transformedCode = transformedCode.replace(/"use strict";/gm, '');
     return transformedCode;
   } catch (e) {
     console.log(e);

--- a/packages/patternfly-4/react-styled-system/src/components/StyledSystem/StyledSystem.docs.js
+++ b/packages/patternfly-4/react-styled-system/src/components/StyledSystem/StyledSystem.docs.js
@@ -20,17 +20,61 @@ export default {
     StyledText
   },
   examples: [
-    SpaceStyles,
-    WidthStyles,
-    ResponsiveStyles,
-    FlexStyles,
-    FontSizeStyles,
-    ColorStyles,
-    TypographyStyles,
-    BorderStyles,
-    BoxShadowStyles,
-    PositionStyles,
-    OverrideTheme
+    {
+      component: SpaceStyles,
+      title: 'Space',
+      description: `
+    <em>The space utility converts shorthand margin and padding props to margin and padding CSS declarations.<br />
+    Use StyledConstants.space with margin and padding props<br />
+    Negative values from StyledConstants.space (neg_*) can be used for negative margins.<br />
+    String values are passed as raw CSS values.<br />
+    Array values are converted into responsive values.</em>
+    `
+    },
+    {
+      component: WidthStyles,
+      title: 'Width',
+      description: `
+    <em>Numbers from 0-1 are converted to percentage widths.<br />
+    Numbers greater than 1 are converted to pixel values.<br />
+    String values are passed as raw CSS values.<br />
+    Array values are converted into responsive width styles.<br /></em>
+    `
+    },
+    {
+      component: ResponsiveStyles,
+      title: 'Responsive',
+      description:
+        '<em>All props accept arrays as values for responsive styling. You can specify up to 4 array values for each of the breakpoints.</em>'
+    },
+    { component: FlexStyles, title: 'Flex' },
+    {
+      component: FontSizeStyles,
+      title: 'Font Size',
+      description: `
+      <em>Use StyledConstants.fontSizes to set a size.<br />
+      Array values are converted into responsive values.</em>
+    `
+    },
+    {
+      component: ColorStyles,
+      title: 'Colors',
+      description: `
+      <em>Use color or bg (background) props with StyledConstants.colors to set a color.<br />
+      Array values are converted into responsive values.</em>
+    `
+    },
+    { component: TypographyStyles, title: 'Typography' },
+    { component: BorderStyles, title: 'Borders' },
+    { component: BoxShadowStyles, title: 'Box Shadow' },
+    { component: PositionStyles, title: 'Position' },
+    {
+      component: OverrideTheme,
+      title: 'Override Theme',
+      description: `
+    <em><p>You can override the theme by supplying a theme object.</p>
+    <p>If multiple PatternFlyThemeProviders are nested, the theme object of the lower provider will be merged into the ancestor theme.</p></em>`
+    }
   ],
   description: `
     <strong>Warning, the StyledSystem components are experimental and in their own package @patternfly/react-styled-system. Use at your own risk!</strong><br />

--- a/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/BorderStyles.js
+++ b/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/BorderStyles.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { PatternFlyThemeProvider, StyledConstants, StyledBox } from '@patternfly/react-styled-system';
 
 class BorderStyles extends React.Component {
-  static title = 'Borders';
-
   render() {
     const { space, borders, radii, colors } = StyledConstants;
     return (

--- a/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/BoxShadowStyles.js
+++ b/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/BoxShadowStyles.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { PatternFlyThemeProvider, StyledConstants, StyledBox } from '@patternfly/react-styled-system';
 
 class BoxShadowStyles extends React.Component {
-  static title = 'Box Shadow';
-
   render() {
     const { space, borders, radii, colors, shadows } = StyledConstants;
     return (

--- a/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/ColorStyles.js
+++ b/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/ColorStyles.js
@@ -2,12 +2,6 @@ import React from 'react';
 import { PatternFlyThemeProvider, StyledConstants, StyledBox } from '@patternfly/react-styled-system';
 
 class ColorStyles extends React.Component {
-  static title = 'Colors';
-  static description = `
-    <em>Use color or bg (background) props with StyledConstants.colors to set a color.<br />
-    Array values are converted into responsive values.</em>
-  `;
-
   render() {
     const { colors } = StyledConstants;
     return (

--- a/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/FlexStyles.js
+++ b/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/FlexStyles.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { PatternFlyThemeProvider, StyledConstants, StyledBox, StyledFlex, StyledText } from '@patternfly/react-styled-system';
 
 class FlexStyles extends React.Component {
-  static title = 'Flex';
-
   render() {
     const { fonts, space, colors, fontSizes } = StyledConstants;
     return (

--- a/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/FontSizeStyles.js
+++ b/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/FontSizeStyles.js
@@ -2,12 +2,6 @@ import React from 'react';
 import { PatternFlyThemeProvider, StyledConstants, StyledText } from '@patternfly/react-styled-system';
 
 class FontSizeStyles extends React.Component {
-  static title = 'Font Size';
-  static description = `
-    <em>Use StyledConstants.fontSizes to set a size.<br />
-    Array values are converted into responsive values.</em>
-  `;
-
   render() {
     const { fontSizes } = StyledConstants;
     return (

--- a/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/OverrideTheme.js
+++ b/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/OverrideTheme.js
@@ -2,11 +2,6 @@ import React from 'react';
 import { PatternFlyThemeProvider, StyledConstants, StyledBox, StyledText } from '@patternfly/react-styled-system';
 
 class OverrideTheme extends React.Component {
-  static title = 'Override Theme';
-  static description = `
-  <em><p>You can override the theme by supplying a theme object.</p>
-  <p>If multiple PatternFlyThemeProviders are nested, the theme object of the lower provider will be merged into the ancestor theme.</p></em>`;
-
   render() {
     const { colors } = StyledConstants;
     const customTheme = {

--- a/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/PositionStyles.js
+++ b/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/PositionStyles.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { PatternFlyThemeProvider, StyledConstants, StyledBox } from '@patternfly/react-styled-system';
 
 class PositionStyles extends React.Component {
-  static title = 'Position';
-
   render() {
     const { space, borders, zIndices, colors } = StyledConstants;
     return (

--- a/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/ResponsiveStyles.js
+++ b/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/ResponsiveStyles.js
@@ -2,9 +2,6 @@ import React from 'react';
 import { PatternFlyThemeProvider, StyledConstants, StyledBox, StyledText } from '@patternfly/react-styled-system';
 
 class ResponsiveStyles extends React.Component {
-  static title = 'Responsive';
-  static description = '<em>All props accept arrays as values for responsive styling. You can specify up to 4 array values for each of the breakpoints.</em>';
-
   render() {
     const { space, colors, fontSizes, borders } = StyledConstants;
 

--- a/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/SpaceStyles.js
+++ b/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/SpaceStyles.js
@@ -2,15 +2,6 @@ import React from 'react';
 import { PatternFlyThemeProvider, StyledConstants, StyledBox } from '@patternfly/react-styled-system';
 
 class SpaceStyles extends React.Component {
-  static title = 'Space';
-  static description = `
-  <em>The space utility converts shorthand margin and padding props to margin and padding CSS declarations.<br />
-  Use StyledConstants.space with margin and padding props<br />
-  Negative values from StyledConstants.space (neg_*) can be used for negative margins.<br />
-  String values are passed as raw CSS values.<br />
-  Array values are converted into responsive values.</em>
-  `;
-
   render() {
     const { space, borders } = StyledConstants;
     return (

--- a/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/TypographyStyles.js
+++ b/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/TypographyStyles.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { PatternFlyThemeProvider, StyledConstants, StyledText } from '@patternfly/react-styled-system';
 
 class TypographyStyles extends React.Component {
-  static title = 'Typography';
-
   render() {
     const { fonts, lineHeights, fontWeights, fontSizes } = StyledConstants;
     return (

--- a/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/WidthStyles.js
+++ b/packages/patternfly-4/react-styled-system/src/components/StyledSystem/examples/WidthStyles.js
@@ -2,14 +2,6 @@ import React from 'react';
 import { PatternFlyThemeProvider, StyledConstants, StyledBox } from '@patternfly/react-styled-system';
 
 class WidthStyles extends React.Component {
-  static title = 'Width';
-  static description = `
-  <em>Numbers from 0-1 are converted to percentage widths.<br />
-  Numbers greater than 1 are converted to pixel values.<br />
-  String values are passed as raw CSS values.<br />
-  Array values are converted into responsive width styles.<br /></em>
-  `;
-
   render() {
     const { borders, ratio } = StyledConstants;
     return (


### PR DESCRIPTION
**What**:

The static fields shouldn't be in the examples since a consumer copying the example could also pick those up which wouldn't make sense.
The static fields are supporting fields for the workspace documentation, and as such should be in the *.docs.js files instead.

Closes:
#786 