### PR TITLE
fix(CardDropdownButton): Allow props to be passed

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Cards/CardDropdownButton.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Cards/CardDropdownButton.js
@@ -8,7 +8,7 @@ const CardDropdownButton = ({ id, children, title, className, pullRight, ...prop
   const classes = classNames('card-pf-time-frame-filter', className);
   const CustomButtonGroup = customGroup => <ButtonGroup {...customGroup} bsClass=" " />;
   return (
-    <Dropdown className={classes} id={id} pullRight={pullRight} componentClass={CustomButtonGroup}>
+    <Dropdown className={classes} id={id} pullRight={pullRight} componentClass={CustomButtonGroup} {...props}>
       <Dropdown.Toggle>{title}</Dropdown.Toggle>
       <Dropdown.Menu>{children}</Dropdown.Menu>
     </Dropdown>

--- a/packages/patternfly-3/patternfly-react/src/components/Cards/Cards.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Cards/Cards.test.js
@@ -54,13 +54,17 @@ test('Card Link is working properly', () => {
 });
 
 test('Card Drop Down Button is working properly', () => {
+  const onClick = jest.fn();
   const component = mount(
-    <CardDropdownButton id="cardDropdownButton1" title="Last 30 Days" onClick={jest.fn()}>
+    <CardDropdownButton id="cardDropdownButton1" title="Last 30 Days" onClick={onClick}>
       <MenuItem eventKey="1" active>
         Last 30 Days
       </MenuItem>
     </CardDropdownButton>
   );
 
+  component.find('button').simulate('click');
+
+  expect(onClick).toHaveBeenCalled();
   expect(component.render()).toMatchSnapshot();
 });

--- a/packages/patternfly-3/patternfly-react/src/components/Cards/__snapshots__/Cards.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/Cards/__snapshots__/Cards.test.js.snap
@@ -10,10 +10,10 @@ exports[`Card Body is working properly 1`] = `
 
 exports[`Card Drop Down Button is working properly 1`] = `
 <div
-  class="card-pf-time-frame-filter dropdown "
+  class="card-pf-time-frame-filter dropdown open "
 >
   <button
-    aria-expanded="false"
+    aria-expanded="true"
     aria-haspopup="true"
     class="dropdown-toggle btn btn-default"
     id="cardDropdownButton1"


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

Allow props to be passed through for CardDropdownButton

<!-- Are there any upstream issues or separate issues you need to reference? -->

<!-- **Additional issues**: -->

<!-- feel free to add additional comments -->
