### PR TITLE
fix(LoginPage): Fix background-image style

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/LoginPage.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/LoginPage.test.js
@@ -14,6 +14,7 @@ const createProps = () => {
   const { header, card } = englishMessages;
   return {
     container: {
+      backgroundUrl: '/some-background',
       translations: { en: englishMessages, fr: frenchMessages },
       alert: {
         message: header.alert,

--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/SocialLoginPage.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/SocialLoginPage.test.js
@@ -71,6 +71,7 @@ const createProps = () => {
   const { header, footerLinks, card } = englishMessages;
   return {
     container: {
+      backgroundUrl: '/some-background',
       translations: { en: englishMessages, fr: frenchMessages },
       className: '',
       alert: {

--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/__snapshots__/LoginPage.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/__snapshots__/LoginPage.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Component matches snapshot 1`] = `
 <div
   class="login-pf"
-  style="background-image: url(null);"
+  style="background-image: url(/some-background);"
 >
   <div
     class="login-pf-page "

--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/__snapshots__/SocialLoginPage.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/__snapshots__/SocialLoginPage.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Component matches snapshot 1`] = `
 <div
   class="login-pf"
-  style="background-image: url(null);"
+  style="background-image: url(/some-background);"
 >
   <div
     class="login-pf-page  login-pf-page-accounts"

--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/components/LoginPageComponents/LoginPageContainer.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/components/LoginPageComponents/LoginPageContainer.js
@@ -2,9 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const LoginPageContainer = ({ backgroundUrl, className, children }) => {
-  const style = {
-    backgroundImage: `url(${backgroundUrl})`
-  };
+  const style = backgroundUrl ? { backgroundImage: `url(${backgroundUrl})` } : {};
 
   return (
     <div className="login-pf" style={style}>


### PR DESCRIPTION
As part of the [LoginPage implementation in Foreman](https://github.com/theforeman/foreman/pull/6234) 
I found that when no background URL is provided, an error will be raised.