### PR TITLE
Fix sub-component references in react-console DesktopViewer

### DIFF
--- a/packages/patternfly-3/react-console/src/DesktopViewer/ManualConnection.js
+++ b/packages/patternfly-3/react-console/src/DesktopViewer/ManualConnection.js
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import consoleDetailPropType from './consoleDetailPropType';
-import { Form, FormGroup, Col } from 'patternfly-react';
+import { Form, Grid } from 'patternfly-react';
+
+const { Col } = Grid;
+const { FormGroup } = Form;
 
 const Detail = ({ title, value }) => (
   <FormGroup>


### PR DESCRIPTION
Follow up for a1e4d4f.

<!-- What changes are being made? (What issue is being addressed here?) -->
a1e4d4f fixed subcomponent references for react-console but there are some leftovers.

