### PR TITLE
feat(Progress): use max parameter to scale value of progress bar

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Progress/Progress.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/Progress.js
@@ -71,9 +71,14 @@ class Progress extends Component {
       ...props,
       ...(valueText ? { 'aria-valuetext': valueText } : { 'aria-describedby': `${this.id}-description` })
     };
-    let limitedValue;
-    limitedValue = value < min ? min : value;
-    limitedValue = limitedValue > max ? max : limitedValue;
+    const scaledValue =
+      max === 100
+        ? value < min
+          ? min
+          : Math.min(value, max)
+        : value < min
+          ? Math.floor(Math.min((min / max) * 100, 100))
+          : Math.floor(Math.min((value / max) * 100, 100));
     return (
       <div
         {...additionalProps}
@@ -87,12 +92,12 @@ class Progress extends Component {
         id={this.id}
         role="progressbar"
         aria-valuemin={min}
-        aria-valuenow={limitedValue}
+        aria-valuenow={scaledValue}
         aria-valuemax={max}
       >
         <ProgressContainer
           parentId={this.id}
-          value={limitedValue}
+          value={scaledValue}
           title={title}
           label={label}
           variant={variant}

--- a/packages/patternfly-4/react-core/src/components/Progress/Progress.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/Progress.js
@@ -71,14 +71,7 @@ class Progress extends Component {
       ...props,
       ...(valueText ? { 'aria-valuetext': valueText } : { 'aria-describedby': `${this.id}-description` })
     };
-    const scaledValue =
-      max === 100
-        ? value < min
-          ? min
-          : Math.min(value, max)
-        : value < min
-          ? Math.floor(Math.min((min / max) * 100, 100))
-          : Math.floor(Math.min((value / max) * 100, 100));
+    const scaledValue = Math.min(100, Math.max(0, Math.floor(((value - min) / (max - min)) * 100)));
     return (
       <div
         {...additionalProps}

--- a/packages/patternfly-4/react-core/src/components/Progress/Progress.test.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/Progress.test.js
@@ -33,6 +33,21 @@ test('value higher than maxValue', () => {
   expect(view).toMatchSnapshot();
 });
 
+test('value scaled with minValue', () => {
+  const view = mount(<Progress min={10} value={50} id="scaled-min-value" />);
+  expect(view).toMatchSnapshot();
+});
+
+test('value scaled with maxValue', () => {
+  const view = mount(<Progress value={50} id="scaled-max-value" max={80} />);
+  expect(view).toMatchSnapshot();
+});
+
+test('value scaled between minValue and maxValue', () => {
+  const view = mount(<Progress min={10} value={50} id="scaled-range-value" max={80} />);
+  expect(view).toMatchSnapshot();
+});
+
 describe('Progress size', () => {
   Object.keys(ProgressSize).forEach(oneSize => {
     test(oneSize, () => {

--- a/packages/patternfly-4/react-core/src/components/Progress/ProgressContainer.js
+++ b/packages/patternfly-4/react-core/src/components/Progress/ProgressContainer.js
@@ -55,12 +55,11 @@ const ProgressContainer = ({ value, title, parentId, label, variant, measureLoca
         {(measureLocation === ProgressMeasureLocation.top || measureLocation === ProgressMeasureLocation.outside) && (
           <span className={css(progressStyle.progressMeasure)}>{label || `${value}%`}</span>
         )}
-        {measureLocation !== ProgressMeasureLocation.none &&
-          variantToIcon.hasOwnProperty(variant) && (
-            <span className={css(progressStyle.progressStatusIcon)}>
-              <StatusIcon />
-            </span>
-          )}
+        {variantToIcon.hasOwnProperty(variant) && (
+          <span className={css(progressStyle.progressStatusIcon)}>
+            <StatusIcon />
+          </span>
+        )}
       </div>
       <ProgressBar value={value}>{measureLocation === ProgressMeasureLocation.inside && `${value}%`}</ProgressBar>
     </Fragment>

--- a/packages/patternfly-4/react-core/src/components/Progress/__snapshots__/Progress.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Progress/__snapshots__/Progress.test.js.snap
@@ -1798,7 +1798,7 @@ exports[`value lower than minValue 1`] = `
     aria-describedby="lower-min-value-description"
     aria-valuemax={100}
     aria-valuemin={40}
-    aria-valuenow={40}
+    aria-valuenow={0}
     className="pf-c-progress"
     id="lower-min-value"
     role="progressbar"
@@ -1807,7 +1807,7 @@ exports[`value lower than minValue 1`] = `
       measureLocation="top"
       parentId="lower-min-value"
       title=""
-      value={40}
+      value={0}
       variant="info"
     >
       <div
@@ -1820,12 +1820,12 @@ exports[`value lower than minValue 1`] = `
         <span
           className="pf-c-progress__measure"
         >
-          40%
+          0%
         </span>
       </div>
       <ProgressBar
         className=""
-        value={40}
+        value={0}
       >
         <div
           className="pf-c-progress__bar"
@@ -1834,7 +1834,325 @@ exports[`value lower than minValue 1`] = `
             className="pf-c-progress__indicator"
             style={
               Object {
-                "width": "40%",
+                "width": "0%",
+              }
+            }
+          >
+            <span
+              className="pf-c-progress__measure"
+            />
+          </div>
+        </div>
+      </ProgressBar>
+    </ProgressContainer>
+  </div>
+</Progress>
+`;
+
+exports[`value scaled between minValue and maxValue 1`] = `
+.pf-c-progress__description {
+  display: block;
+  grid-column: 1 / 2;
+}
+.pf-c-progress__measure {
+  display: block;
+}
+.pf-c-progress__status {
+  display: block;
+  grid-column: 2 / 3;
+  grid-row: 1 / 2;
+}
+.pf-c-progress__measure {
+  display: block;
+}
+.pf-c-progress__indicator {
+  display: block;
+  position: absolute;
+  grid-column: 1 / 3;
+  grid-row: 2 / 3;
+  height: 0.5rem;
+  background-color: #cc0000;
+}
+.pf-c-progress__bar {
+  display: block;
+  position: relative;
+  grid-column: 1 / 3;
+  grid-row: 2 / 3;
+  height: 0.5rem;
+  background-color: #ffffff;
+}
+.pf-c-progress {
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: 1fr auto;
+}
+
+<Progress
+  className=""
+  id="scaled-range-value"
+  max={80}
+  measureLocation="top"
+  min={10}
+  size={null}
+  title=""
+  value={50}
+  valueText={null}
+  variant="info"
+>
+  <div
+    aria-describedby="scaled-range-value-description"
+    aria-valuemax={80}
+    aria-valuemin={10}
+    aria-valuenow={57}
+    className="pf-c-progress"
+    id="scaled-range-value"
+    role="progressbar"
+  >
+    <ProgressContainer
+      measureLocation="top"
+      parentId="scaled-range-value"
+      title=""
+      value={57}
+      variant="info"
+    >
+      <div
+        className="pf-c-progress__description"
+        id="scaled-range-value-description"
+      />
+      <div
+        className="pf-c-progress__status"
+      >
+        <span
+          className="pf-c-progress__measure"
+        >
+          57%
+        </span>
+      </div>
+      <ProgressBar
+        className=""
+        value={57}
+      >
+        <div
+          className="pf-c-progress__bar"
+        >
+          <div
+            className="pf-c-progress__indicator"
+            style={
+              Object {
+                "width": "57%",
+              }
+            }
+          >
+            <span
+              className="pf-c-progress__measure"
+            />
+          </div>
+        </div>
+      </ProgressBar>
+    </ProgressContainer>
+  </div>
+</Progress>
+`;
+
+exports[`value scaled with maxValue 1`] = `
+.pf-c-progress__description {
+  display: block;
+  grid-column: 1 / 2;
+}
+.pf-c-progress__measure {
+  display: block;
+}
+.pf-c-progress__status {
+  display: block;
+  grid-column: 2 / 3;
+  grid-row: 1 / 2;
+}
+.pf-c-progress__measure {
+  display: block;
+}
+.pf-c-progress__indicator {
+  display: block;
+  position: absolute;
+  grid-column: 1 / 3;
+  grid-row: 2 / 3;
+  height: 0.5rem;
+  background-color: #cc0000;
+}
+.pf-c-progress__bar {
+  display: block;
+  position: relative;
+  grid-column: 1 / 3;
+  grid-row: 2 / 3;
+  height: 0.5rem;
+  background-color: #ffffff;
+}
+.pf-c-progress {
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: 1fr auto;
+}
+
+<Progress
+  className=""
+  id="scaled-max-value"
+  max={80}
+  measureLocation="top"
+  min={0}
+  size={null}
+  title=""
+  value={50}
+  valueText={null}
+  variant="info"
+>
+  <div
+    aria-describedby="scaled-max-value-description"
+    aria-valuemax={80}
+    aria-valuemin={0}
+    aria-valuenow={62}
+    className="pf-c-progress"
+    id="scaled-max-value"
+    role="progressbar"
+  >
+    <ProgressContainer
+      measureLocation="top"
+      parentId="scaled-max-value"
+      title=""
+      value={62}
+      variant="info"
+    >
+      <div
+        className="pf-c-progress__description"
+        id="scaled-max-value-description"
+      />
+      <div
+        className="pf-c-progress__status"
+      >
+        <span
+          className="pf-c-progress__measure"
+        >
+          62%
+        </span>
+      </div>
+      <ProgressBar
+        className=""
+        value={62}
+      >
+        <div
+          className="pf-c-progress__bar"
+        >
+          <div
+            className="pf-c-progress__indicator"
+            style={
+              Object {
+                "width": "62%",
+              }
+            }
+          >
+            <span
+              className="pf-c-progress__measure"
+            />
+          </div>
+        </div>
+      </ProgressBar>
+    </ProgressContainer>
+  </div>
+</Progress>
+`;
+
+exports[`value scaled with minValue 1`] = `
+.pf-c-progress__description {
+  display: block;
+  grid-column: 1 / 2;
+}
+.pf-c-progress__measure {
+  display: block;
+}
+.pf-c-progress__status {
+  display: block;
+  grid-column: 2 / 3;
+  grid-row: 1 / 2;
+}
+.pf-c-progress__measure {
+  display: block;
+}
+.pf-c-progress__indicator {
+  display: block;
+  position: absolute;
+  grid-column: 1 / 3;
+  grid-row: 2 / 3;
+  height: 0.5rem;
+  background-color: #cc0000;
+}
+.pf-c-progress__bar {
+  display: block;
+  position: relative;
+  grid-column: 1 / 3;
+  grid-row: 2 / 3;
+  height: 0.5rem;
+  background-color: #ffffff;
+}
+.pf-c-progress {
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: 1fr auto;
+}
+
+<Progress
+  className=""
+  id="scaled-min-value"
+  max={100}
+  measureLocation="top"
+  min={10}
+  size={null}
+  title=""
+  value={50}
+  valueText={null}
+  variant="info"
+>
+  <div
+    aria-describedby="scaled-min-value-description"
+    aria-valuemax={100}
+    aria-valuemin={10}
+    aria-valuenow={44}
+    className="pf-c-progress"
+    id="scaled-min-value"
+    role="progressbar"
+  >
+    <ProgressContainer
+      measureLocation="top"
+      parentId="scaled-min-value"
+      title=""
+      value={44}
+      variant="info"
+    >
+      <div
+        className="pf-c-progress__description"
+        id="scaled-min-value-description"
+      />
+      <div
+        className="pf-c-progress__status"
+      >
+        <span
+          className="pf-c-progress__measure"
+        >
+          44%
+        </span>
+      </div>
+      <ProgressBar
+        className=""
+        value={44}
+      >
+        <div
+          className="pf-c-progress__bar"
+        >
+          <div
+            className="pf-c-progress__indicator"
+            style={
+              Object {
+                "width": "44%",
               }
             }
           >

--- a/packages/patternfly-4/react-core/src/components/Progress/__snapshots__/Progress.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Progress/__snapshots__/Progress.test.js.snap
@@ -1692,7 +1692,7 @@ exports[`value higher than maxValue 1`] = `
     aria-describedby="higher-max-value-description"
     aria-valuemax={60}
     aria-valuemin={0}
-    aria-valuenow={60}
+    aria-valuenow={100}
     className="pf-c-progress"
     id="higher-max-value"
     role="progressbar"
@@ -1701,7 +1701,7 @@ exports[`value higher than maxValue 1`] = `
       measureLocation="top"
       parentId="higher-max-value"
       title=""
-      value={60}
+      value={100}
       variant="info"
     >
       <div
@@ -1714,12 +1714,12 @@ exports[`value higher than maxValue 1`] = `
         <span
           className="pf-c-progress__measure"
         >
-          60%
+          100%
         </span>
       </div>
       <ProgressBar
         className=""
-        value={60}
+        value={100}
       >
         <div
           className="pf-c-progress__bar"
@@ -1728,7 +1728,7 @@ exports[`value higher than maxValue 1`] = `
             className="pf-c-progress__indicator"
             style={
               Object {
-                "width": "60%",
+                "width": "100%",
               }
             }
           >


### PR DESCRIPTION
**What**: Change max parameter to control scaling of progress bar. Previously, it acted as a limit for the progress value.

Addresses issue: #945

Other notes:
- use floor of scaled value to prevent false 100% reports
- change internal variable name to better represent behavior
- update snapshot of Progress tests to reflect new behavior of max
