### PR TITLE
fix(CatalogTile): Fix to correctly position fading out of description text

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
@@ -8,7 +8,6 @@
   height: @catalog-tile-pf-height;
   margin: 0 15px @catalog-tile-pf-margin-bottom 0;
   padding: 15px;
-  position: relative;
   width: @catalog-tile-pf-width;
 
   &.featured {
@@ -63,6 +62,7 @@
 
 .catalog-tile-pf-body {
   display: flex;
+  flex: 1;
   flex-direction: column;
   margin-top: 15px;
   min-height: 0;
@@ -83,13 +83,13 @@
     overflow: hidden;
 
     &::after {
-      background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%);
-      bottom: 20px;
-      content: "";
-      height: 25px;
+      background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 75%);
+      bottom: 0;
+      color: transparent;
+      content: ".";
       position: absolute;
-      right: 15px;
-      width: 20%;
+      right: 0;
+      width: 50%;
       text-align: right;
     }
   }

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
@@ -8,7 +8,6 @@
   height: $catalog-tile-pf-height;
   margin: 0 15px $catalog-tile-pf-margin-bottom 0;
   padding: 15px;
-  position: relative;
   width: $catalog-tile-pf-width;
 
   &.featured {
@@ -63,6 +62,7 @@
 
 .catalog-tile-pf-body {
   display: flex;
+  flex: 1;
   flex-direction: column;
   margin-top: 15px;
   min-height: 0;
@@ -81,15 +81,16 @@
     flex: 1;
     margin-top: 15px;
     overflow: hidden;
+    position: relative;
 
     &::after {
-      background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%);
-      bottom: 20px;
-      content: "";
-      height: 25px;
+      background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 75%);
+      bottom: 0;
+      color: transparent;
+      content: ".";
       position: absolute;
-      right: 15px;
-      width: 20%;
+      right: 0;
+      width: 50%;
       text-align: right;
     }
   }

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/__snapshots__/CatalogTile.test.js.snap
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/__snapshots__/CatalogTile.test.js.snap
@@ -31,7 +31,9 @@ exports[`CatalogTile href renders properly 1`] = `
     <div
       class="catalog-tile-pf-description"
     >
-      1234567890123
+      <span>
+        1234567890123
+      </span>
     </div>
   </div>
 </a>
@@ -68,7 +70,9 @@ exports[`CatalogTile onClick behaves properly 1`] = `
     <div
       class="catalog-tile-pf-description"
     >
-      1234567890123
+      <span>
+        1234567890123
+      </span>
     </div>
   </div>
 </a>
@@ -141,7 +145,9 @@ exports[`CatalogTile renders properly 1`] = `
       <div
         class="catalog-tile-pf-description"
       >
-        A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+        <span>
+          A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+        </span>
       </div>
     </div>
   </div>
@@ -208,7 +214,9 @@ exports[`CatalogTile renders properly 1`] = `
       <div
         class="catalog-tile-pf-description"
       >
-        Simple collaboration from your desktop.
+        <span>
+          Simple collaboration from your desktop.
+        </span>
       </div>
     </div>
   </div>
@@ -267,7 +275,9 @@ exports[`CatalogTile renders properly 1`] = `
       <div
         class="catalog-tile-pf-description"
       >
-        This is a very long description that should be truncated after 112 characters. 112 is the default but can be …
+        <span>
+          This is a very long description that should be truncated after 112 characters. 112 is the default but can be …
+        </span>
       </div>
     </div>
   </div>
@@ -317,7 +327,9 @@ exports[`CatalogTile renders properly 1`] = `
       <div
         class="catalog-tile-pf-description"
       >
-        An online community for testing and showcasing user-created HTML, CSS and JavaScript code snippets.
+        <span>
+          An online community for testing and showcasing user-created HTML, CSS and JavaScript code snippets.
+        </span>
       </div>
     </div>
   </div>
@@ -357,7 +369,9 @@ exports[`CatalogTile renders properly 1`] = `
       <div
         class="catalog-tile-pf-description"
       >
-        truncated
+        <span>
+          truncated
+        </span>
       </div>
     </div>
   </div>

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTileView/__snapshots__/CatalogTileView.test.js.snap
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTileView/__snapshots__/CatalogTileView.test.js.snap
@@ -120,7 +120,9 @@ exports[`CatalogTile renders properly 1`] = `
           <div
             class="catalog-tile-pf-description"
           >
-            A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+            <span>
+              A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+            </span>
           </div>
         </div>
       </div>
@@ -182,7 +184,9 @@ exports[`CatalogTile renders properly 1`] = `
           <div
             class="catalog-tile-pf-description"
           >
-            Simple collaboration from your desktop.
+            <span>
+              Simple collaboration from your desktop.
+            </span>
           </div>
         </div>
       </div>
@@ -239,7 +243,9 @@ exports[`CatalogTile renders properly 1`] = `
           <div
             class="catalog-tile-pf-description"
           >
-            A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+            <span>
+              A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+            </span>
           </div>
         </div>
       </div>
@@ -301,7 +307,9 @@ exports[`CatalogTile renders properly 1`] = `
           <div
             class="catalog-tile-pf-description"
           >
-            Simple collaboration from your desktop.
+            <span>
+              Simple collaboration from your desktop.
+            </span>
           </div>
         </div>
       </div>
@@ -376,7 +384,9 @@ exports[`CatalogTile renders properly 1`] = `
           <div
             class="catalog-tile-pf-description"
           >
-            A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+            <span>
+              A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+            </span>
           </div>
         </div>
       </div>
@@ -438,7 +448,9 @@ exports[`CatalogTile renders properly 1`] = `
           <div
             class="catalog-tile-pf-description"
           >
-            Simple collaboration from your desktop.
+            <span>
+              Simple collaboration from your desktop.
+            </span>
           </div>
         </div>
       </div>
@@ -495,7 +507,9 @@ exports[`CatalogTile renders properly 1`] = `
           <div
             class="catalog-tile-pf-description"
           >
-            A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+            <span>
+              A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+            </span>
           </div>
         </div>
       </div>
@@ -590,7 +604,9 @@ exports[`CatalogTile renders wrapped tiles properly 1`] = `
             <div
               class="catalog-tile-pf-description"
             >
-              A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+              <span>
+                A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+              </span>
             </div>
           </div>
         </div>
@@ -657,7 +673,9 @@ exports[`CatalogTile renders wrapped tiles properly 1`] = `
               <div
                 class="catalog-tile-pf-description"
               >
-                Simple collaboration from your desktop.
+                <span>
+                  Simple collaboration from your desktop.
+                </span>
               </div>
             </div>
           </div>
@@ -716,7 +734,9 @@ exports[`CatalogTile renders wrapped tiles properly 1`] = `
           <div
             class="catalog-tile-pf-description"
           >
-            A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+            <span>
+              A community of designers and developers collaborating to build a UI framework for enterprise web applications.
+            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixes an issue with the fading out box not being positioned correctly when provide is multiple line or non-existent. Also prevents partial (height wise) lines of text from being shown. 