### PR TITLE
Icon alignment

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -63,6 +63,11 @@ exports[`Alert - danger Action 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -180,6 +185,11 @@ exports[`Alert - danger Action and Title 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -293,6 +303,11 @@ exports[`Alert - danger Body 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -402,6 +417,11 @@ exports[`Alert - danger Custom aria label 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -515,6 +535,11 @@ exports[`Alert - danger Title 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -624,6 +649,11 @@ exports[`Alert - info Action 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -741,6 +771,11 @@ exports[`Alert - info Action and Title 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -854,6 +889,11 @@ exports[`Alert - info Body 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -963,6 +1003,11 @@ exports[`Alert - info Custom aria label 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -1076,6 +1121,11 @@ exports[`Alert - info Title 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -1185,6 +1235,11 @@ exports[`Alert - success Action 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -1302,6 +1357,11 @@ exports[`Alert - success Action and Title 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -1415,6 +1475,11 @@ exports[`Alert - success Body 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -1524,6 +1589,11 @@ exports[`Alert - success Custom aria label 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -1637,6 +1707,11 @@ exports[`Alert - success Title 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 512 512"
             width="1em"
           >
@@ -1746,6 +1821,11 @@ exports[`Alert - warning Action 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 576 512"
             width="1em"
           >
@@ -1863,6 +1943,11 @@ exports[`Alert - warning Action and Title 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 576 512"
             width="1em"
           >
@@ -1976,6 +2061,11 @@ exports[`Alert - warning Body 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 576 512"
             width="1em"
           >
@@ -2085,6 +2175,11 @@ exports[`Alert - warning Custom aria label 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 576 512"
             width="1em"
           >
@@ -2198,6 +2293,11 @@ exports[`Alert - warning Title 1`] = `
             fill="currentColor"
             height="1em"
             role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
             viewBox="0 0 576 512"
             width="1em"
           >

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -96,6 +96,11 @@ exports[`KebabToggle basic 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 192 512"
               width="1em"
             >
@@ -277,6 +282,11 @@ exports[`KebabToggle dropup + right aligned 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 192 512"
               width="1em"
             >
@@ -441,6 +451,11 @@ exports[`KebabToggle dropup 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 192 512"
               width="1em"
             >
@@ -633,6 +648,11 @@ exports[`KebabToggle expanded 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 192 512"
               width="1em"
             >
@@ -957,6 +977,11 @@ exports[`KebabToggle plain 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 192 512"
               width="1em"
             >
@@ -1121,6 +1146,11 @@ exports[`KebabToggle regular 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 192 512"
               width="1em"
             >
@@ -1285,6 +1315,11 @@ exports[`KebabToggle right aligned 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 192 512"
               width="1em"
             >
@@ -1406,6 +1441,11 @@ exports[`dropdown basic 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 320 512"
               width="1em"
             >
@@ -1596,6 +1636,11 @@ exports[`dropdown dropup + right aligned 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 320 512"
               width="1em"
             >
@@ -1769,6 +1814,11 @@ exports[`dropdown dropup 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 320 512"
               width="1em"
             >
@@ -1970,6 +2020,11 @@ exports[`dropdown expanded 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 320 512"
               width="1em"
             >
@@ -2303,6 +2358,11 @@ exports[`dropdown regular 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 320 512"
               width="1em"
             >
@@ -2476,6 +2536,11 @@ exports[`dropdown right aligned 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 320 512"
               width="1em"
             >

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
@@ -61,6 +61,11 @@ exports[`state active 1`] = `
           fill="currentColor"
           height="1em"
           role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
           viewBox="0 0 320 512"
           width="1em"
         >
@@ -136,6 +141,11 @@ exports[`state focus 1`] = `
           fill="currentColor"
           height="1em"
           role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
           viewBox="0 0 320 512"
           width="1em"
         >
@@ -211,6 +221,11 @@ exports[`state hover 1`] = `
           fill="currentColor"
           height="1em"
           role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
           viewBox="0 0 320 512"
           width="1em"
         >

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
@@ -61,6 +61,11 @@ exports[`Dropdown toggle 1`] = `
           fill="currentColor"
           height="1em"
           role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
           viewBox="0 0 320 512"
           width="1em"
         >
@@ -129,6 +134,11 @@ exports[`Kebab toggle 1`] = `
           fill="currentColor"
           height="1em"
           role="img"
+          style={
+            Object {
+              "verticalAlign": "-0.125em",
+            }
+          }
           viewBox="0 0 192 512"
           width="1em"
         >

--- a/packages/patternfly-4/react-core/src/components/Nav/__snapshots__/Nav.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Nav/__snapshots__/Nav.test.js.snap
@@ -424,6 +424,11 @@ exports[`Expandable Nav List - Trigger toggle 1`] = `
                       fill="currentColor"
                       height="1em"
                       role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
                       viewBox="0 0 256 512"
                       width="1em"
                     >
@@ -668,6 +673,11 @@ exports[`Expandable Nav List 1`] = `
                       fill="currentColor"
                       height="1em"
                       role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
                       viewBox="0 0 256 512"
                       width="1em"
                     >
@@ -920,6 +930,11 @@ exports[`Expandable Nav List with aria label 1`] = `
                       fill="currentColor"
                       height="1em"
                       role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
                       viewBox="0 0 256 512"
                       width="1em"
                     >

--- a/packages/patternfly-4/react-core/src/components/Popover/__snapshots__/Popover.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Popover/__snapshots__/Popover.test.js.snap
@@ -126,6 +126,11 @@ exports[`popover renders close-button, header and body 1`] = `
                       fill="currentColor"
                       height="1em"
                       role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
                       viewBox="0 0 352 512"
                       width="1em"
                     >

--- a/packages/patternfly-4/react-core/src/components/Progress/__snapshots__/Progress.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Progress/__snapshots__/Progress.test.js.snap
@@ -923,6 +923,11 @@ exports[`Progress variant danger 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 512 512"
               width="1em"
             >
@@ -1164,6 +1169,11 @@ exports[`Progress variant success 1`] = `
               fill="currentColor"
               height="1em"
               role="img"
+              style={
+                Object {
+                  "verticalAlign": "-0.125em",
+                }
+              }
               viewBox="0 0 512 512"
               width="1em"
             >

--- a/packages/patternfly-4/react-docs/src/components/example/liveDemo.js
+++ b/packages/patternfly-4/react-docs/src/components/example/liveDemo.js
@@ -124,7 +124,7 @@ class LiveDemo extends React.Component {
                 title="View on GitHub"
                 aria-label="View on GitHub"
               >
-                <i className={css('fab fa-github', styles.icon)} />
+                <i className={css('fab fa-github')} />
               </CoreComponents.Button>
             </a>
             <CoreComponents.TextContent className={css(styles.message, showCopyMessage && styles.messageShow)}>

--- a/packages/patternfly-4/react-docs/src/components/example/liveDemo.styles.js
+++ b/packages/patternfly-4/react-docs/src/components/example/liveDemo.styles.js
@@ -29,8 +29,5 @@ export default StyleSheet.create({
   messageShow: {
     opacity: 1,
     height: 'initial'
-  },
-  icon: {
-    'vertical-align': '10%'
   }
 });

--- a/packages/react-icons/src/__snapshots__/createIcon.test.js.snap
+++ b/packages/react-icons/src/__snapshots__/createIcon.test.js.snap
@@ -8,6 +8,11 @@ exports[`additional props should be spread to the root svg element 1`] = `
   fill="currentColor"
   height="1em"
   role="img"
+  style={
+    Object {
+      "verticalAlign": "-0.125em",
+    }
+  }
   viewBox="0 0 10 20"
   width="1em"
 >

--- a/packages/react-icons/src/createIcon.js
+++ b/packages/react-icons/src/createIcon.js
@@ -18,9 +18,11 @@ const createIcon = iconDefinition => {
 
       const hasTitle = Boolean(title);
       const heightWidth = getSize(size);
+      const baseAlign = -.125 * Number.parseFloat(heightWidth);
 
       return (
         <svg
+          style={{ verticalAlign: `${baseAlign}em` }}
           fill={color}
           height={heightWidth}
           width={heightWidth}


### PR DESCRIPTION
Fix vertical icon placement

I took a look at font awesome and they also have examples of vertical alignment at -.125em for a height of 1em
https://fontawesome.com/how-to-use/on-the-web/advanced/svg-symbols

Seems to fix the vertical alignment issues we were seeing. This value is also being scaled according to icon size.

Closes: #961 #960 

Some comparisons (Before/After):

<img width="212" alt="screen shot 2018-11-27 at 3 03 17 pm" src="https://user-images.githubusercontent.com/869106/49108590-8fe41980-f256-11e8-831c-207df8a5198a.png">
<img width="208" alt="screen shot 2018-11-27 at 3 03 26 pm" src="https://user-images.githubusercontent.com/869106/49108593-92df0a00-f256-11e8-8de7-e4576fcdbefb.png">
<img width="183" alt="screen shot 2018-11-27 at 3 04 46 pm" src="https://user-images.githubusercontent.com/869106/49108600-98d4eb00-f256-11e8-956e-2e64283e1bb6.png">
<img width="184" alt="screen shot 2018-11-27 at 3 05 01 pm" src="https://user-images.githubusercontent.com/869106/49108606-9c687200-f256-11e8-9331-159501486fa4.png">
<img width="826" alt="screen shot 2018-11-27 at 3 05 39 pm" src="https://user-images.githubusercontent.com/869106/49108611-9ffbf900-f256-11e8-8baf-4e34fd8a27af.png">
<img width="818" alt="screen shot 2018-11-27 at 3 05 54 pm" src="https://user-images.githubusercontent.com/869106/49108615-a1c5bc80-f256-11e8-8437-e4ce4a9c4df9.png">
<img width="311" alt="screen shot 2018-11-27 at 3 07 39 pm" src="https://user-images.githubusercontent.com/869106/49108623-a4c0ad00-f256-11e8-82e0-cb02ba552338.png">
<img width="313" alt="screen shot 2018-11-27 at 3 07 49 pm" src="https://user-images.githubusercontent.com/869106/49108629-a7230700-f256-11e8-9481-97c18f05db6d.png">
