### PR TITLE
[WIP] fix(Page): Remove `pf-m-expanded` and `pf-m-collapsed` modifiers from sidebar on resize

### DIFF
--- a/packages/patternfly-4/react-core/src/internal/util.js
+++ b/packages/patternfly-4/react-core/src/internal/util.js
@@ -1,3 +1,5 @@
+import { global_breakpoint_md as breakpointMd } from '@patternfly/react-tokens';
+
 export function capitalize(input) {
   return input[0].toUpperCase() + input.substring(1);
 }
@@ -17,4 +19,8 @@ export function debounce(func, wait) {
     clearTimeout(timeout);
     timeout = setTimeout(() => func.apply(this, args), wait);
   };
+}
+
+export function isDesktop() {
+  return !!window && window.innerWidth >= parseInt(breakpointMd.value, 10);
 }

--- a/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/PageHeader.js
@@ -64,7 +64,10 @@ const PageHeader = ({
               <div className={css(styles.pageHeaderBrandToggle)}>
                 <Button
                   id="nav-toggle"
-                  onClick={onNavToggle}
+                  onClick={e => {
+                    context.onNavToggle(e);
+                    onNavToggle(e);
+                  }}
                   aria-label="Toggle primary navigation"
                   variant={ButtonVariant.plain}
                 >

--- a/packages/patternfly-4/react-core/src/layouts/Page/PageSidebar.js
+++ b/packages/patternfly-4/react-core/src/layouts/Page/PageSidebar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styles from '@patternfly/patternfly-next/layouts/Page/page.css';
 import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
+import { PageContext } from './Page';
 
 const propTypes = {
   /** Additional classes added to the page sidebar */
@@ -19,17 +20,21 @@ const defaultProps = {
 };
 
 const PageSidebar = ({ className, nav, isNavOpen, ...props }) => (
-  <aside
-    className={css(
-      styles.pageSidebar,
-      isNavOpen && styles.modifiers.expanded,
-      !isNavOpen && styles.modifiers.collapsed,
-      className
+  <PageContext.Consumer>
+    {context => (
+      <aside
+        className={css(
+          styles.pageSidebar,
+          context.navHasToggled && isNavOpen && styles.modifiers.expanded,
+          context.navHasToggled && !isNavOpen && styles.modifiers.collapsed,
+          className
+        )}
+        {...props}
+      >
+        {nav}
+      </aside>
     )}
-    {...props}
-  >
-    {nav}
-  </aside>
+  </PageContext.Consumer>
 );
 
 PageSidebar.propTypes = propTypes;

--- a/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/Page.test.js.snap
+++ b/packages/patternfly-4/react-core/src/layouts/Page/__snapshots__/Page.test.js.snap
@@ -25,7 +25,7 @@ exports[`Check page condensed header example against snapshot 1`] = `
   max-width: 100%;
   min-height: 6.875rem;
 }
-.pf-l-page__sidebar.pf-m-expanded {
+.pf-l-page__sidebar {
   display: block;
   grid-area: 2 / 1;
   z-index: 200;
@@ -35,8 +35,7 @@ exports[`Check page condensed header example against snapshot 1`] = `
   overflow-x: hidden;
   overflow-y: auto;
   background-color: #ffffff;
-  transform: translate3d(0,0,0);
-  box-shadow: 0.75rem 0 0.625rem -0.25rem rgba(3, 3, 3, 0.07);
+  transform: translate3d(-100%,0,0);
 }
 .pf-l-page__main-section {
   display: block;
@@ -146,7 +145,7 @@ exports[`Check page condensed header example against snapshot 1`] = `
       nav="Navigation"
     >
       <aside
-        className="pf-l-page__sidebar pf-m-expanded"
+        className="pf-l-page__sidebar"
       >
         Navigation
       </aside>
@@ -225,7 +224,7 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
   max-width: 100%;
   min-height: 0;
 }
-.pf-l-page__sidebar.pf-m-expanded {
+.pf-l-page__sidebar {
   display: block;
   grid-area: 2 / 1;
   z-index: 200;
@@ -235,8 +234,7 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
   overflow-x: hidden;
   overflow-y: auto;
   background-color: #ffffff;
-  transform: translate3d(0,0,0);
-  box-shadow: 0.75rem 0 0.625rem -0.25rem rgba(3, 3, 3, 0.07);
+  transform: translate3d(-100%,0,0);
 }
 .pf-l-page__main-section {
   display: block;
@@ -351,7 +349,7 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
       nav={null}
     >
       <aside
-        className="pf-l-page__sidebar pf-m-expanded"
+        className="pf-l-page__sidebar"
       />
     </PageSidebar>
     <main
@@ -428,7 +426,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
   max-width: 100%;
   min-height: 0;
 }
-.pf-l-page__sidebar.pf-m-expanded {
+.pf-l-page__sidebar {
   display: block;
   grid-area: 2 / 1;
   z-index: 200;
@@ -438,8 +436,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
   overflow-x: hidden;
   overflow-y: auto;
   background-color: #ffffff;
-  transform: translate3d(0,0,0);
-  box-shadow: 0.75rem 0 0.625rem -0.25rem rgba(3, 3, 3, 0.07);
+  transform: translate3d(-100%,0,0);
 }
 .pf-l-page__main-section {
   display: block;
@@ -549,7 +546,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
       nav="Navigation"
     >
       <aside
-        className="pf-l-page__sidebar pf-m-expanded"
+        className="pf-l-page__sidebar"
       >
         Navigation
       </aside>


### PR DESCRIPTION
These modifiers override the default responsive CSS styles. Changed the behavior so that the modifiers are only added on toggle, and are removed on resize.