### PR TITLE
fix(AccessConsoles): Fix child component recognition in production build

### DIFF
--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Grid, Form, Dropdown, MenuItem } from 'patternfly-react';
+import { Grid, Form, Dropdown, MenuItem, helpers } from 'patternfly-react';
 
 import constants from '../common/constants';
 
@@ -9,9 +9,11 @@ const { NONE_TYPE, SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE } = constants;
 const { Row, Col } = Grid;
 const { Checkbox, FormGroup } = Form;
 
-const getChildTypeName = child => (child.props.type ? child.props.type : (child.type && child.type.name) || null);
+const getChildTypeName = child =>
+  child.props.type ? child.props.type : (child.type && child.type.displayName) || null;
 
-const isChildOfType = (child, type) => getChildTypeName(child) === type;
+const isChildOfType = (child, type) =>
+  child.props.type === type || (!child.props.type && helpers.hasDisplayName(child, type));
 
 class AccessConsoles extends React.Component {
   state = {

--- a/packages/patternfly-3/react-console/src/SerialConsole/SerialConsole.js
+++ b/packages/patternfly-3/react-console/src/SerialConsole/SerialConsole.js
@@ -131,6 +131,8 @@ class SerialConsole extends React.Component {
   }
 }
 
+SerialConsole.displayName = 'SerialConsole';
+
 SerialConsole.propTypes = {
   /** Initiate connection to backend. In other words, the calling components manages connection state. */
   onConnect: PropTypes.func.isRequired,

--- a/packages/patternfly-3/react-console/src/VncConsole/VncConsole.js
+++ b/packages/patternfly-3/react-console/src/VncConsole/VncConsole.js
@@ -130,6 +130,8 @@ class VncConsole extends React.Component {
   }
 }
 
+VncConsole.displayName = 'VncConsole';
+
 VncConsole.propTypes = {
   children: PropTypes.node /** Children nodes */,
 


### PR DESCRIPTION
In production build, names/strings are minified causing mismatch of `child.type.name`.
In this fix, the component type matching is fixed by using Ract component's displayName.

**What**: Fix AccessConsoles for child component recognition
