### PR TITLE
fix(LoginPage): typos

### DIFF
--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginForm.js
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginForm.js
@@ -31,7 +31,7 @@ const propTypes = {
   passwordValue: PropTypes.string,
   /** Function that handles the onChange event for the Password */
   onChangePassword: PropTypes.func,
-  /** Helper Text for the Username Input Field */
+  /** Helper Text for the Password Input Field */
   passwordHelperText: PropTypes.string,
   /** Helper Text for the Password Input Field when it is invalid */
   passwordHelperTextInvalid: PropTypes.string,
@@ -118,7 +118,7 @@ const LoginForm = ({
         isRequired
         isValid={isValidUsername}
         type="text"
-        mame="pf-login-username-id"
+        name="pf-login-username-id"
         value={usernameValue}
         onChange={onChangeUsername}
       />

--- a/packages/patternfly-4/react-core/src/components/LoginPage/__snapshots__/LoginForm.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/__snapshots__/LoginForm.test.js.snap
@@ -43,7 +43,7 @@ exports[`LoginForm with rememberMeLabel and no rememberMeAriaLabel generates con
       isReadOnly={false}
       isRequired={true}
       isValid={true}
-      mame="pf-login-username-id"
+      name="pf-login-username-id"
       onChange={[Function]}
       type="text"
       value=""
@@ -153,7 +153,7 @@ exports[`LoginForm with rememberMeLabel and rememberMeAriaLabel does not generat
       isReadOnly={false}
       isRequired={true}
       isValid={true}
-      mame="pf-login-username-id"
+      name="pf-login-username-id"
       onChange={[Function]}
       type="text"
       value=""
@@ -258,7 +258,7 @@ exports[`should render Login form 1`] = `
       isReadOnly={false}
       isRequired={true}
       isValid={true}
-      mame="pf-login-username-id"
+      name="pf-login-username-id"
       onChange={[Function]}
       type="text"
       value=""


### PR DESCRIPTION
fixes https://github.com/patternfly/patternfly-react/issues/987

**What**:
* attribute in login form is `mame` instead of `name`
* docs for `passwordHelperText` should refer to `Password`, not `Username`