### PR TITLE
Add desktop viewer to access consoles

### DIFF
--- a/packages/patternfly-3/react-console/less/access-consoles.less
+++ b/packages/patternfly-3/react-console/less/access-consoles.less
@@ -1,0 +1,5 @@
+.access-consoles-pf {
+  .desktop-viewer-pf {
+    margin-top: 3em;
+  }
+}

--- a/packages/patternfly-3/react-console/less/console.less
+++ b/packages/patternfly-3/react-console/less/console.less
@@ -1,5 +1,6 @@
 @import 'variables';
 
+@import 'access-consoles';
 @import 'serial-console';
 @import 'vnc-console';
 @import 'console-selector';

--- a/packages/patternfly-3/react-console/sass/_access-consoles.scss
+++ b/packages/patternfly-3/react-console/sass/_access-consoles.scss
@@ -1,0 +1,5 @@
+.access-consoles-pf {
+  .desktop-viewer-pf {
+    margin-top: 3em;
+  }
+}

--- a/packages/patternfly-3/react-console/sass/console.scss
+++ b/packages/patternfly-3/react-console/sass/console.scss
@@ -9,6 +9,7 @@
 
 // Console StyleSheets
 @import "variables";
+@import "access-consoles";
 @import "serial-console";
 @import "vnc-console";
 @import "console-selector";

--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
@@ -5,7 +5,7 @@ import { Grid, Form, Dropdown, MenuItem } from 'patternfly-react';
 
 import constants from '../common/constants';
 
-const { NONE_TYPE, SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE } = constants;
+const { NONE_TYPE, SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE, DESKTOP_VIEWER_CONSOLE_TYPE } = constants;
 const { Row, Col } = Grid;
 const { Checkbox, FormGroup } = Form;
 
@@ -72,11 +72,12 @@ class AccessConsoles extends React.Component {
     const items = {
       [NONE_TYPE]: this.props.textSelectConsoleType,
       [SERIAL_CONSOLE_TYPE]: this.props.textSerialConsole,
-      [VNC_CONSOLE_TYPE]: this.props.textVncConsole
+      [VNC_CONSOLE_TYPE]: this.props.textVncConsole,
+      [DESKTOP_VIEWER_CONSOLE_TYPE]: this.props.textDesktopViewerConsole
     };
 
     return (
-      <Grid fluid>
+      <Grid fluid className="access-consoles-pf">
         <Form horizontal>
           <FormGroup controlId="console-type" className="console-selector-pf">
             <Col>
@@ -85,28 +86,34 @@ class AccessConsoles extends React.Component {
                   {this.props.children ? items[this.state.type] : this.props.textEmptyConsoleList}
                 </Dropdown.Toggle>
                 <Dropdown.Menu>
+                  {this.isChildOfTypePresent(VNC_CONSOLE_TYPE) && (
+                    <MenuItem eventKey="1" onClick={() => this.onTypeChange(VNC_CONSOLE_TYPE)}>
+                      {items[VNC_CONSOLE_TYPE]}
+                    </MenuItem>
+                  )}
                   {this.isChildOfTypePresent(SERIAL_CONSOLE_TYPE) && (
-                    <MenuItem eventKey="1" onClick={() => this.onTypeChange(SERIAL_CONSOLE_TYPE)}>
+                    <MenuItem eventKey="2" onClick={() => this.onTypeChange(SERIAL_CONSOLE_TYPE)}>
                       {items[SERIAL_CONSOLE_TYPE]}
                     </MenuItem>
                   )}
-                  {this.isChildOfTypePresent(VNC_CONSOLE_TYPE) && (
-                    <MenuItem eventKey="2" onClick={() => this.onTypeChange(VNC_CONSOLE_TYPE)}>
-                      {items[VNC_CONSOLE_TYPE]}
+                  {this.isChildOfTypePresent(DESKTOP_VIEWER_CONSOLE_TYPE) && (
+                    <MenuItem eventKey="3" onClick={() => this.onTypeChange(DESKTOP_VIEWER_CONSOLE_TYPE)}>
+                      {items[DESKTOP_VIEWER_CONSOLE_TYPE]}
                     </MenuItem>
                   )}
                 </Dropdown.Menu>
               </Dropdown>
-              {this.state.type !== NONE_TYPE && (
-                <Checkbox
-                  className="console-selector-pf-disconnect-switch"
-                  inline
-                  defaultChecked={this.props.disconnectByChange}
-                  onChange={e => this.onChangeDisconnectBySwitchClick(e.target)}
-                >
-                  {this.props.textDisconnectByChange}
-                </Checkbox>
-              )}
+              {this.state.type !== NONE_TYPE &&
+                this.state.type !== DESKTOP_VIEWER_CONSOLE_TYPE && (
+                  <Checkbox
+                    className="console-selector-pf-disconnect-switch"
+                    inline
+                    defaultChecked={this.props.disconnectByChange}
+                    onChange={e => this.onChangeDisconnectBySwitchClick(e.target)}
+                  >
+                    {this.props.textDisconnectByChange}
+                  </Checkbox>
+                )}
             </Col>
           </FormGroup>
         </Form>
@@ -118,14 +125,14 @@ class AccessConsoles extends React.Component {
   }
 }
 
-const validChildrenTypes = [SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE];
+const validChildrenTypes = [SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE, DESKTOP_VIEWER_CONSOLE_TYPE];
 const childElementValidator = propValue => {
   if (propValue) {
     const children = Array.isArray(propValue) ? propValue : [propValue];
     if (
       !children.every(
         child =>
-          (child.type && validChildrenTypes.indexOf(child.type.name) >= 0) ||
+          (child.type && validChildrenTypes.indexOf(child.type.displayName) >= 0) ||
           (child.props && validChildrenTypes.indexOf(child.props.type) >= 0)
       )
     ) {
@@ -138,7 +145,7 @@ const childElementValidator = propValue => {
 AccessConsoles.propTypes = {
   /**
    * Child element can be either
-   *   - <SerialConsole> or <VncConsole>
+   *   - <SerialConsole>, <VncConsole> or <DesktopViewer>
    *   - or has a property "type" of value either SERIAL_CONSOLE_TYPE or VNC_CONSOLE_TYPE (useful when wrapping (composing) basic console components
    */
   children: PropTypes.oneOfType([PropTypes.objectOf(childElementValidator), PropTypes.arrayOf(childElementValidator)]),
@@ -146,13 +153,15 @@ AccessConsoles.propTypes = {
   textSelectConsoleType: PropTypes.string /** Internationalization */,
   textSerialConsole: PropTypes.string /** Internationalization */,
   textVncConsole: PropTypes.string /** Internationalization */,
+  textDesktopViewerConsole: PropTypes.string /** Internationalization */,
   textDisconnectByChange: PropTypes.string /** Internationalization */,
   textEmptyConsoleList: PropTypes.string /** Internationalization */,
 
   preselectedType: PropTypes.oneOf([
     NONE_TYPE,
     SERIAL_CONSOLE_TYPE,
-    VNC_CONSOLE_TYPE
+    VNC_CONSOLE_TYPE,
+    DESKTOP_VIEWER_CONSOLE_TYPE
   ]) /** Initial selection of the dropdown */,
   disconnectByChange:
     PropTypes.bool /** Initial value of "Disconnect before switching" checkbox, "false" to disconnect when console type changed */
@@ -164,6 +173,7 @@ AccessConsoles.defaultProps = {
   textSelectConsoleType: 'Select Console Type',
   textSerialConsole: 'Serial Console',
   textVncConsole: 'VNC Console',
+  textDesktopViewerConsole: 'Desktop Viewer',
   textDisconnectByChange: 'Disconnect before switching',
   textEmptyConsoleList: 'No console available',
 

--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.test.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.test.js
@@ -5,11 +5,18 @@ import { noop } from 'patternfly-react';
 import { AccessConsoles } from './index';
 import { SerialConsole } from '../SerialConsole';
 import { VncConsole } from '../VncConsole';
+import { DesktopViewer } from '../DesktopViewer';
 import constants from '../common/constants';
 
 const { SERIAL_CONSOLE_TYPE, VNC_CONSOLE_TYPE, LOADING } = constants;
 
 const MyVncConsoleTestWrapper = () => <p>This can be VncConsole component or a wrapper</p>;
+
+const vnc = {
+  address: 'my.host.com',
+  port: 5902,
+  tlsPort: '5903'
+};
 
 test('AccessConsoles with SerialConsole as a single child', () => {
   const view = shallow(
@@ -89,7 +96,7 @@ test('AccessConsoles switching SerialConsole and VncConsole', () => {
   let consoleItems = wrapper.find('ul li');
   expect(consoleItems).toHaveLength(2);
   consoleItems
-    .first()
+    .at(1)
     .find('a')
     .simulate('click');
   expect(consoleItems).toMatchSnapshot();
@@ -99,7 +106,7 @@ test('AccessConsoles switching SerialConsole and VncConsole', () => {
   consoleItems = wrapper.find('ul li');
   expect(consoleItems).toHaveLength(2);
   consoleItems
-    .at(1)
+    .at(0)
     .find('a')
     .simulate('click');
   expect(consoleItems).toMatchSnapshot();
@@ -146,7 +153,7 @@ test('AccessConsoles disconnects when switching types', () => {
   wrapper.find('button #console-type-selector').simulate('click');
   wrapper
     .find('ul li')
-    .first()
+    .at(1)
     .find('a')
     .simulate('click'); // Select SerialConsole
 
@@ -156,7 +163,7 @@ test('AccessConsoles disconnects when switching types', () => {
   wrapper.find('button #console-type-selector').simulate('click');
   wrapper
     .find('ul li')
-    .at(1)
+    .at(0)
     .find('a')
     .simulate('click'); // Select VncConsole
 
@@ -178,7 +185,7 @@ test('AccessConsoles keeps connection when switching types', () => {
   wrapper.find('button #console-type-selector').simulate('click');
   wrapper
     .find('ul li')
-    .first()
+    .at(1)
     .find('a')
     .simulate('click'); // Select SerialConsole
 
@@ -188,7 +195,7 @@ test('AccessConsoles keeps connection when switching types', () => {
   wrapper.find('button #console-type-selector').simulate('click');
   wrapper
     .find('ul li')
-    .at(1)
+    .at(0)
     .find('a')
     .simulate('click'); // Select VncConsole
 
@@ -201,5 +208,14 @@ test('AccessConsoles keeps connection when switching types', () => {
 
 test('Empty AccessConsoles', () => {
   const view = render(<AccessConsoles />);
+  expect(view).toMatchSnapshot();
+});
+
+test('AccessConsoles with DesktopViewer', () => {
+  const view = render(
+    <AccessConsoles>
+      <DesktopViewer vnc={vnc} />
+    </AccessConsoles>
+  );
   expect(view).toMatchSnapshot();
 });

--- a/packages/patternfly-3/react-console/src/AccessConsoles/__snapshots__/AccessConsoles.test.js.snap
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/__snapshots__/AccessConsoles.test.js.snap
@@ -4,6 +4,7 @@ exports[`AccessConsoles keeps connection when switching types 1`] = `
 <AccessConsoles
   disconnectByChange={false}
   preselectedType="_none_"
+  textDesktopViewerConsole="Desktop Viewer"
   textDisconnectByChange="Disconnect before switching"
   textEmptyConsoleList="No console available"
   textSelectConsoleType="Select Console Type"
@@ -12,11 +13,12 @@ exports[`AccessConsoles keeps connection when switching types 1`] = `
 >
   <Grid
     bsClass="container"
+    className="access-consoles-pf"
     componentClass="div"
     fluid={true}
   >
     <div
-      className="container-fluid"
+      className="access-consoles-pf container-fluid"
     >
       <Form
         bsClass="form"
@@ -157,7 +159,7 @@ exports[`AccessConsoles keeps connection when switching types 1`] = `
                                         role="menuitem"
                                         tabIndex="-1"
                                       >
-                                        Serial Console
+                                        VNC Console
                                       </a>
                                     </SafeAnchor>
                                   </li>
@@ -191,7 +193,7 @@ exports[`AccessConsoles keeps connection when switching types 1`] = `
                                         role="menuitem"
                                         tabIndex="-1"
                                       >
-                                        VNC Console
+                                        Serial Console
                                       </a>
                                     </SafeAnchor>
                                   </li>
@@ -364,6 +366,7 @@ exports[`AccessConsoles switching SerialConsole and VncConsole 1`] = `
 <AccessConsoles
   disconnectByChange={true}
   preselectedType="_none_"
+  textDesktopViewerConsole="Desktop Viewer"
   textDisconnectByChange="Disconnect before switching"
   textEmptyConsoleList="No console available"
   textSelectConsoleType="Select Console Type"
@@ -372,11 +375,12 @@ exports[`AccessConsoles switching SerialConsole and VncConsole 1`] = `
 >
   <Grid
     bsClass="container"
+    className="access-consoles-pf"
     componentClass="div"
     fluid={true}
   >
     <div
-      className="container-fluid"
+      className="access-consoles-pf container-fluid"
     >
       <Form
         bsClass="form"
@@ -515,7 +519,7 @@ exports[`AccessConsoles switching SerialConsole and VncConsole 1`] = `
                                         role="menuitem"
                                         tabIndex="-1"
                                       >
-                                        Serial Console
+                                        VNC Console
                                       </a>
                                     </SafeAnchor>
                                   </li>
@@ -549,7 +553,7 @@ exports[`AccessConsoles switching SerialConsole and VncConsole 1`] = `
                                         role="menuitem"
                                         tabIndex="-1"
                                       >
-                                        VNC Console
+                                        Serial Console
                                       </a>
                                     </SafeAnchor>
                                   </li>
@@ -609,7 +613,7 @@ Array [
         role="menuitem"
         tabIndex="-1"
       >
-        Serial Console
+        VNC Console
       </a>
     </SafeAnchor>
   </li>,
@@ -631,7 +635,7 @@ Array [
         role="menuitem"
         tabIndex="-1"
       >
-        VNC Console
+        Serial Console
       </a>
     </SafeAnchor>
   </li>,
@@ -658,7 +662,7 @@ Array [
         role="menuitem"
         tabIndex="-1"
       >
-        Serial Console
+        VNC Console
       </a>
     </SafeAnchor>
   </li>,
@@ -680,16 +684,78 @@ Array [
         role="menuitem"
         tabIndex="-1"
       >
-        VNC Console
+        Serial Console
       </a>
     </SafeAnchor>
   </li>,
 ]
 `;
 
+exports[`AccessConsoles with DesktopViewer 1`] = `
+<div
+  class="access-consoles-pf container-fluid"
+>
+  <form
+    class="form-horizontal"
+  >
+    <div
+      class="console-selector-pf form-group"
+    >
+      <div
+        class=""
+      >
+        <div
+          class="dropdown btn-group"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="true"
+            class="dropdown-toggle btn btn-default"
+            id="console-type-selector"
+            role="button"
+            type="button"
+          >
+            Select Console Type 
+            <span
+              class="caret"
+            />
+          </button>
+          <ul
+            aria-labelledby="console-type-selector"
+            class="dropdown-menu"
+            role="menu"
+          >
+            <li
+              class=""
+              role="presentation"
+            >
+              <a
+                href="#"
+                role="menuitem"
+                tabindex="-1"
+              >
+                Desktop Viewer
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </form>
+  <div
+    class="row"
+  >
+    <div
+      class=""
+    />
+  </div>
+</div>
+`;
+
 exports[`AccessConsoles with SerialConsole and VncConsole as children 1`] = `
 <Grid
   bsClass="container"
+  className="access-consoles-pf"
   componentClass="div"
   fluid={true}
 >
@@ -733,7 +799,7 @@ exports[`AccessConsoles with SerialConsole and VncConsole as children 1`] = `
               header={false}
               onClick={[Function]}
             >
-              Serial Console
+              VNC Console
             </MenuItem>
             <MenuItem
               bsClass="dropdown"
@@ -743,7 +809,7 @@ exports[`AccessConsoles with SerialConsole and VncConsole as children 1`] = `
               header={false}
               onClick={[Function]}
             >
-              VNC Console
+              Serial Console
             </MenuItem>
           </DropdownMenu>
         </Uncontrolled(Dropdown)>
@@ -765,6 +831,7 @@ exports[`AccessConsoles with SerialConsole and VncConsole as children 1`] = `
 exports[`AccessConsoles with SerialConsole as a single child 1`] = `
 <Grid
   bsClass="container"
+  className="access-consoles-pf"
   componentClass="div"
   fluid={true}
 >
@@ -804,7 +871,7 @@ exports[`AccessConsoles with SerialConsole as a single child 1`] = `
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="1"
+              eventKey="2"
               header={false}
               onClick={[Function]}
             >
@@ -830,6 +897,7 @@ exports[`AccessConsoles with SerialConsole as a single child 1`] = `
 exports[`AccessConsoles with VncConsole as a single child 1`] = `
 <Grid
   bsClass="container"
+  className="access-consoles-pf"
   componentClass="div"
   fluid={true}
 >
@@ -869,7 +937,7 @@ exports[`AccessConsoles with VncConsole as a single child 1`] = `
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="2"
+              eventKey="1"
               header={false}
               onClick={[Function]}
             >
@@ -896,6 +964,7 @@ exports[`AccessConsoles with preselected SerialConsole 1`] = `
 <AccessConsoles
   disconnectByChange={true}
   preselectedType="SerialConsole"
+  textDesktopViewerConsole="Desktop Viewer"
   textDisconnectByChange="Disconnect before switching"
   textEmptyConsoleList="No console available"
   textSelectConsoleType="Select Console Type"
@@ -904,11 +973,12 @@ exports[`AccessConsoles with preselected SerialConsole 1`] = `
 >
   <Grid
     bsClass="container"
+    className="access-consoles-pf"
     componentClass="div"
     fluid={true}
   >
     <div
-      className="container-fluid"
+      className="access-consoles-pf container-fluid"
     >
       <Form
         bsClass="form"
@@ -1022,9 +1092,9 @@ exports[`AccessConsoles with preselected SerialConsole 1`] = `
                                   bsClass="dropdown"
                                   disabled={false}
                                   divider={false}
-                                  eventKey="1"
+                                  eventKey="2"
                                   header={false}
-                                  key=".0"
+                                  key=".1"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   onSelect={[Function]}
@@ -1129,6 +1199,7 @@ exports[`AccessConsoles with preselected SerialConsole 1`] = `
 exports[`AccessConsoles with wrapped SerialConsole as a child 1`] = `
 <Grid
   bsClass="container"
+  className="access-consoles-pf"
   componentClass="div"
   fluid={true}
 >
@@ -1168,7 +1239,7 @@ exports[`AccessConsoles with wrapped SerialConsole as a child 1`] = `
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="1"
+              eventKey="2"
               header={false}
               onClick={[Function]}
             >
@@ -1193,7 +1264,7 @@ exports[`AccessConsoles with wrapped SerialConsole as a child 1`] = `
 
 exports[`Empty AccessConsoles 1`] = `
 <div
-  class="container-fluid"
+  class="access-consoles-pf container-fluid"
 >
   <form
     class="form-horizontal"

--- a/packages/patternfly-3/react-console/src/DesktopViewer/DesktopViewer.js
+++ b/packages/patternfly-3/react-console/src/DesktopViewer/DesktopViewer.js
@@ -57,6 +57,8 @@ DesktopViewer.propTypes = {
   textMoreRDPInfo: PropTypes.string /** Internationalization */
 };
 
+DesktopViewer.displayName = 'DesktopViewer';
+
 DesktopViewer.defaultProps = {
   children: null /** Custom content of more-info section  */,
   topClassName: '' /** Custom class name to be added to the root element. */,

--- a/packages/patternfly-3/react-console/src/common/constants.js
+++ b/packages/patternfly-3/react-console/src/common/constants.js
@@ -3,6 +3,7 @@ const SERIAL_CONSOLE_TYPE = 'SerialConsole';
 const SPICE_CONSOLE_TYPE = 'SpiceConsole';
 const VNC_CONSOLE_TYPE = 'VncConsole';
 const RDP_CONSOLE_TYPE = 'RdpConsole';
+const DESKTOP_VIEWER_CONSOLE_TYPE = 'DesktopViewer';
 
 const CONNECTING = 'connecting';
 const CONNECTED = 'connected';
@@ -21,6 +22,7 @@ const constants = {
   SPICE_CONSOLE_TYPE,
   VNC_CONSOLE_TYPE,
   RDP_CONSOLE_TYPE,
+  DESKTOP_VIEWER_CONSOLE_TYPE,
 
   CONNECTING,
   CONNECTED,


### PR DESCRIPTION
**What**: Add desktop viewer to access consoles

With this patch, the DesktopViewer can be a child component of the AccessConsoles.