### PR TITLE
fix(DropdownItem): wrap DropdownItem in div when child is a Link node

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.docs.js
@@ -4,6 +4,7 @@ import Simple from './examples/SimpleDropdown';
 import Kebab from './examples/KebabDropdown';
 import PositionRight from './examples/PositionRightDropdown';
 import DirectionUp from './examples/DirectionUpDropdown';
+import ReactLinkDropdown from './examples/ReactLinkDropdown';
 
 export default {
   title: 'Dropdown',
@@ -19,6 +20,12 @@ export default {
     { component: PositionRight, title: 'Dropdown - position right' },
     { component: DirectionUp, title: 'Dropdown - direction up' },
     { component: Kebab, title: 'Kebab' },
+    {
+      component: ReactLinkDropdown,
+      title: 'React Router Link usage',
+      description: 'A react-router Link may be wrapped by DropdownItem or used directly within Dropdown.',
+      live: false
+    },
     {
       component: Panel,
       title: 'Dropdown Panel',

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -30,10 +30,7 @@ const defaultProps = {
 
 const DropdownItem = ({ className, children, isHovered, component: Component, isDisabled, ...props }) => {
   const additionalProps = props;
-  if (children && children.type && children.type.name === 'Link') {
-    Component = 'div';
-    additionalProps.href = null;
-  } else if (Component === 'a') {
+  if (Component === 'a') {
     additionalProps['aria-disabled'] = isDisabled;
     additionalProps.tabIndex = isDisabled ? -1 : additionalProps.tabIndex;
   } else if (Component === 'button') {
@@ -42,12 +39,16 @@ const DropdownItem = ({ className, children, isHovered, component: Component, is
 
   return (
     <li>
-      <Component
-        {...additionalProps}
-        className={css(isDisabled && styles.modifiers.disabled, isHovered && styles.modifiers.hover, className)}
-      >
-        {children}
-      </Component>
+      {React.isValidElement(children) ? (
+        React.Children.map(children, child => React.cloneElement(child, { className }))
+      ) : (
+        <Component
+          {...additionalProps}
+          className={css(isDisabled && styles.modifiers.disabled, isHovered && styles.modifiers.hover, className)}
+        >
+          {children}
+        </Component>
+      )}
     </li>
   );
 };

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -40,7 +40,9 @@ const DropdownItem = ({ className, children, isHovered, component: Component, is
   return (
     <li>
       {React.isValidElement(children) ? (
-        children
+        React.Children.map(children, child =>
+          React.cloneElement(child, { className: `${className} ${child.props.className}` })
+        )
       ) : (
         <Component
           {...additionalProps}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -40,7 +40,7 @@ const DropdownItem = ({ className, children, isHovered, component: Component, is
   return (
     <li>
       {React.isValidElement(children) ? (
-        React.Children.map(children, child => React.cloneElement(child, { className }))
+        children
       ) : (
         <Component
           {...additionalProps}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -41,7 +41,13 @@ const DropdownItem = ({ className, children, isHovered, component: Component, is
     <li>
       {React.isValidElement(children) ? (
         React.Children.map(children, child =>
-          React.cloneElement(child, { className: `${className} ${child.props.className}` })
+          React.cloneElement(child, {
+            className: `${css(
+              isDisabled && styles.modifiers.disabled,
+              isHovered && styles.modifiers.hover,
+              className
+            )} ${child.props.className}`
+          })
         )
       ) : (
         <Component

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -30,12 +30,16 @@ const defaultProps = {
 
 const DropdownItem = ({ className, children, isHovered, component: Component, isDisabled, ...props }) => {
   const additionalProps = props;
-  if (Component === 'a') {
+  if (children && children.type && children.type.name === 'Link') {
+    Component = 'div';
+    additionalProps.href = null;
+  } else if (Component === 'a') {
     additionalProps['aria-disabled'] = isDisabled;
     additionalProps.tabIndex = isDisabled ? -1 : additionalProps.tabIndex;
   } else if (Component === 'button') {
     additionalProps.disabled = isDisabled;
   }
+
   return (
     <li>
       <Component

--- a/packages/patternfly-4/react-core/src/components/Dropdown/examples/ReactLinkDropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/examples/ReactLinkDropdown.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react';
+
+export default class ReactLinkDropdown extends Component {
+  render() {
+    return (
+      <pre>
+        {`
+  /** Wrapped Link for DropdownItem list **/
+  <DropdownItem key="link">
+    <Link to={'/'}>Link</Link>
+  </DropdownItem>
+
+  /** Direct child of Dropdown **/
+  <Dropdown
+    onSelect={this.onSelect}
+    toggle={
+      <DropdownToggle onToggle={this.onToggle}>
+        Expanded Dropdown
+      </DropdownToggle>
+    }
+    isOpen={isOpen}
+  >
+    <Link to={'/'}>Link</Link>
+  </Dropdown>
+        `}
+      </pre>
+    );
+  }
+}


### PR DESCRIPTION
Prevents nesting anchor tags.

**What**: If child element of DropdownItem is a react-router Link, wrapper should be a div.

Still need to add to documentation, potentially an example as well.