### PR TITLE
fix(title): allow multiple heading levels for Title

### DIFF
--- a/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalBoxHeader.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalBoxHeader.test.js.snap
@@ -32,6 +32,7 @@ exports[`AboutModalBoxHeader Test 1`] = `
   </div>
   <Title
     className=""
+    headingLevel="h1"
     id="id"
     size="4xl"
   >

--- a/packages/patternfly-4/react-core/src/components/LoginPage/__snapshots__/LoginBoxHeader.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/__snapshots__/LoginBoxHeader.test.js.snap
@@ -21,6 +21,7 @@ exports[`renders with PatternFly Core styles 1`] = `
 >
   <Title
     className="css-tc6z4j"
+    headingLevel="h1"
     size="3xl"
   />
   <div

--- a/packages/patternfly-4/react-core/src/components/Title/Title.js
+++ b/packages/patternfly-4/react-core/src/components/Title/Title.js
@@ -19,18 +19,34 @@ const propTypes = {
   /** content rendered inside the Title */
   children: PropTypes.node,
   /** additional classes added to the Title */
-  className: PropTypes.string
+  className: PropTypes.string,
+  /** the heading level to use */
+  headingLevel: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
 };
 
 const defaultProps = {
   children: '',
-  className: ''
+  className: '',
+  headingLevel: 'h1'
 };
 
-const Title = ({ size, className, children, ...props }) => (
-  <h1 {...props} className={css(styles.title, getModifier(styles, size), className)}>
-    {children}
-  </h1>
+const getTitleElement = (level, children, ...props) => {
+  return React.createElement(level, ...props, children);
+};
+
+const Title = ({ size, className, children, headingLevel, ...props }) => (
+  <React.Fragment>
+    {
+      getTitleElement(
+        headingLevel,
+        children,
+        {
+          ...props,
+          className: css(styles.title, getModifier(styles, size), className)
+        }
+      )
+    }
+  </React.Fragment>
 );
 
 Title.propTypes = propTypes;

--- a/packages/patternfly-4/react-core/src/components/Title/Title.js
+++ b/packages/patternfly-4/react-core/src/components/Title/Title.js
@@ -30,8 +30,7 @@ const defaultProps = {
   headingLevel: 'h1'
 };
 
-const Title = ({ size, className, children, headingLevel, ...props }) => {
-  const HeadingLevel = headingLevel;
+const Title = ({ size, className, children, headingLevel: HeadingLevel, ...props }) => {
   return (
     <HeadingLevel {...props} className={css(styles.title, getModifier(styles, size), className)}>
       {children}

--- a/packages/patternfly-4/react-core/src/components/Title/Title.js
+++ b/packages/patternfly-4/react-core/src/components/Title/Title.js
@@ -30,14 +30,14 @@ const defaultProps = {
   headingLevel: 'h1'
 };
 
-const Title = ({ size, className, children, headingLevel, ...props }) => React.createElement(
-  headingLevel,
-  {
-    ...props,
-    className: css(styles.title, getModifier(styles, size), className)
-  },
-  children
-);
+const Title = ({ size, className, children, headingLevel, ...props }) => {
+  const HeadingLevel = headingLevel;
+  return (
+    <HeadingLevel {...props} className={css(styles.title, getModifier(styles, size), className)}>
+      {children}
+    </HeadingLevel>
+  );
+};
 
 Title.propTypes = propTypes;
 Title.defaultProps = defaultProps;

--- a/packages/patternfly-4/react-core/src/components/Title/Title.js
+++ b/packages/patternfly-4/react-core/src/components/Title/Title.js
@@ -30,23 +30,13 @@ const defaultProps = {
   headingLevel: 'h1'
 };
 
-const getTitleElement = (level, children, ...props) => {
-  return React.createElement(level, ...props, children);
-};
-
-const Title = ({ size, className, children, headingLevel, ...props }) => (
-  <React.Fragment>
-    {
-      getTitleElement(
-        headingLevel,
-        children,
-        {
-          ...props,
-          className: css(styles.title, getModifier(styles, size), className)
-        }
-      )
-    }
-  </React.Fragment>
+const Title = ({ size, className, children, headingLevel, ...props }) => React.createElement(
+  headingLevel,
+  {
+    ...props,
+    className: css(styles.title, getModifier(styles, size), className)
+  },
+  children
 );
 
 Title.propTypes = propTypes;

--- a/packages/patternfly-4/react-core/src/components/Title/Title.test.js
+++ b/packages/patternfly-4/react-core/src/components/Title/Title.test.js
@@ -8,3 +8,17 @@ Object.values(TitleSize).forEach(size => {
     expect(view).toMatchSnapshot();
   });
 });
+
+test('Heading level defaults to h1', () => {
+  const view = shallow(<Title size='lg'>Default H1 heading</Title>);
+  const isH1 = view.find('h1').length === 1;
+  expect(isH1).toBe(true);
+});
+
+test('Heading level can be set to h3', () => {
+  const view = shallow(<Title size='lg' headingLevel="h3">H3 Heading</Title>);
+  const isH3 = view.find('h3').length === 1;
+  const isH1 = view.find('h1').length === 1;
+  expect(isH1).toBe(false);
+  expect(isH3).toBe(true);
+});

--- a/packages/patternfly-4/react-core/src/components/Title/__snapshots__/Title.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Title/__snapshots__/Title.test.js.snap
@@ -8,14 +8,12 @@ exports[`2xl Title 1`] = `
   line-height: 1.3;
 }
 
-<React.Fragment>
-  <h1
-    className="pf-c-title pf-m-2xl"
-  >
-    2xl
-     Title
-  </h1>
-</React.Fragment>
+<h1
+  className="pf-c-title pf-m-2xl"
+>
+  2xl
+   Title
+</h1>
 `;
 
 exports[`3xl Title 1`] = `
@@ -26,14 +24,12 @@ exports[`3xl Title 1`] = `
   line-height: 1.3;
 }
 
-<React.Fragment>
-  <h1
-    className="pf-c-title pf-m-3xl"
-  >
-    3xl
-     Title
-  </h1>
-</React.Fragment>
+<h1
+  className="pf-c-title pf-m-3xl"
+>
+  3xl
+   Title
+</h1>
 `;
 
 exports[`4xl Title 1`] = `
@@ -44,14 +40,12 @@ exports[`4xl Title 1`] = `
   line-height: 1.3;
 }
 
-<React.Fragment>
-  <h1
-    className="pf-c-title pf-m-4xl"
-  >
-    4xl
-     Title
-  </h1>
-</React.Fragment>
+<h1
+  className="pf-c-title pf-m-4xl"
+>
+  4xl
+   Title
+</h1>
 `;
 
 exports[`lg Title 1`] = `
@@ -62,14 +56,12 @@ exports[`lg Title 1`] = `
   line-height: 1.5;
 }
 
-<React.Fragment>
-  <h1
-    className="pf-c-title pf-m-lg"
-  >
-    lg
-     Title
-  </h1>
-</React.Fragment>
+<h1
+  className="pf-c-title pf-m-lg"
+>
+  lg
+   Title
+</h1>
 `;
 
 exports[`md Title 1`] = `
@@ -80,14 +72,12 @@ exports[`md Title 1`] = `
   line-height: 1.5;
 }
 
-<React.Fragment>
-  <h1
-    className="pf-c-title pf-m-md"
-  >
-    md
-     Title
-  </h1>
-</React.Fragment>
+<h1
+  className="pf-c-title pf-m-md"
+>
+  md
+   Title
+</h1>
 `;
 
 exports[`xl Title 1`] = `
@@ -98,12 +88,10 @@ exports[`xl Title 1`] = `
   line-height: 1.5;
 }
 
-<React.Fragment>
-  <h1
-    className="pf-c-title pf-m-xl"
-  >
-    xl
-     Title
-  </h1>
-</React.Fragment>
+<h1
+  className="pf-c-title pf-m-xl"
+>
+  xl
+   Title
+</h1>
 `;

--- a/packages/patternfly-4/react-core/src/components/Title/__snapshots__/Title.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Title/__snapshots__/Title.test.js.snap
@@ -8,12 +8,14 @@ exports[`2xl Title 1`] = `
   line-height: 1.3;
 }
 
-<h1
-  className="pf-c-title pf-m-2xl"
->
-  2xl
-   Title
-</h1>
+<React.Fragment>
+  <h1
+    className="pf-c-title pf-m-2xl"
+  >
+    2xl
+     Title
+  </h1>
+</React.Fragment>
 `;
 
 exports[`3xl Title 1`] = `
@@ -24,12 +26,14 @@ exports[`3xl Title 1`] = `
   line-height: 1.3;
 }
 
-<h1
-  className="pf-c-title pf-m-3xl"
->
-  3xl
-   Title
-</h1>
+<React.Fragment>
+  <h1
+    className="pf-c-title pf-m-3xl"
+  >
+    3xl
+     Title
+  </h1>
+</React.Fragment>
 `;
 
 exports[`4xl Title 1`] = `
@@ -40,12 +44,14 @@ exports[`4xl Title 1`] = `
   line-height: 1.3;
 }
 
-<h1
-  className="pf-c-title pf-m-4xl"
->
-  4xl
-   Title
-</h1>
+<React.Fragment>
+  <h1
+    className="pf-c-title pf-m-4xl"
+  >
+    4xl
+     Title
+  </h1>
+</React.Fragment>
 `;
 
 exports[`lg Title 1`] = `
@@ -56,12 +62,14 @@ exports[`lg Title 1`] = `
   line-height: 1.5;
 }
 
-<h1
-  className="pf-c-title pf-m-lg"
->
-  lg
-   Title
-</h1>
+<React.Fragment>
+  <h1
+    className="pf-c-title pf-m-lg"
+  >
+    lg
+     Title
+  </h1>
+</React.Fragment>
 `;
 
 exports[`md Title 1`] = `
@@ -72,12 +80,14 @@ exports[`md Title 1`] = `
   line-height: 1.5;
 }
 
-<h1
-  className="pf-c-title pf-m-md"
->
-  md
-   Title
-</h1>
+<React.Fragment>
+  <h1
+    className="pf-c-title pf-m-md"
+  >
+    md
+     Title
+  </h1>
+</React.Fragment>
 `;
 
 exports[`xl Title 1`] = `
@@ -88,10 +98,12 @@ exports[`xl Title 1`] = `
   line-height: 1.5;
 }
 
-<h1
-  className="pf-c-title pf-m-xl"
->
-  xl
-   Title
-</h1>
+<React.Fragment>
+  <h1
+    className="pf-c-title pf-m-xl"
+  >
+    xl
+     Title
+  </h1>
+</React.Fragment>
 `;

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.js
@@ -30,6 +30,7 @@ import {
   ToolbarItem
 } from '@patternfly/react-core';
 import { global_breakpoint_md as breakpointMd } from '@patternfly/react-tokens';
+// make sure you've installed @patternfly/patternfly-next
 import accessibleStyles from '@patternfly/patternfly-next/utilities/Accessibility/accessibility.css';
 import spacingStyles from '@patternfly/patternfly-next/utilities/Spacing/spacing.css';
 import { css } from '@patternfly/react-styles';
@@ -133,12 +134,12 @@ class PageLayoutDefaultNav extends React.Component {
       <Toolbar>
         <ToolbarGroup className={css(accessibleStyles.srOnly, accessibleStyles.visibleOnLg)}>
           <ToolbarItem>
-            <Button id="nav-toggle" aria-label="Overflow actions" variant={ButtonVariant.plain}>
+            <Button id="default-example-uid-01" aria-label="Notifications actions" variant={ButtonVariant.plain}>
               <BellIcon />
             </Button>
           </ToolbarItem>
           <ToolbarItem>
-            <Button id="nav-toggle" aria-label="Overflow actions" variant={ButtonVariant.plain}>
+            <Button id="default-example-uid-02" aria-label="Settings actions" variant={ButtonVariant.plain}>
               <CogIcon />
             </Button>
           </ToolbarItem>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.js
@@ -31,6 +31,7 @@ import {
   ToolbarItem
 } from '@patternfly/react-core';
 import { global_breakpoint_md as breakpointMd } from '@patternfly/react-tokens';
+// make sure you've installed @patternfly/patternfly-next
 import accessibleStyles from '@patternfly/patternfly-next/utilities/Accessibility/accessibility.css';
 import spacingStyles from '@patternfly/patternfly-next/utilities/Spacing/spacing.css';
 import { css } from '@patternfly/react-styles';
@@ -157,12 +158,12 @@ class PageLayoutExpandableNav extends React.Component {
       <Toolbar>
         <ToolbarGroup className={css(accessibleStyles.srOnly, accessibleStyles.visibleOnLg)}>
           <ToolbarItem>
-            <Button id="nav-toggle" aria-label="Overflow actions" variant={ButtonVariant.plain}>
+            <Button id="expanded-example-uid-01" aria-label="Notifications actions" variant={ButtonVariant.plain}>
               <BellIcon />
             </Button>
           </ToolbarItem>
           <ToolbarItem>
-            <Button id="nav-toggle" aria-label="Overflow actions" variant={ButtonVariant.plain}>
+            <Button id="expanded-example-uid-02" aria-label="Settings actions" variant={ButtonVariant.plain}>
               <CogIcon />
             </Button>
           </ToolbarItem>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.js
@@ -26,6 +26,7 @@ import {
   ToolbarItem
 } from '@patternfly/react-core';
 import { global_breakpoint_md as breakpointMd } from '@patternfly/react-tokens';
+// make sure you've installed @patternfly/patternfly-next
 import accessibleStyles from '@patternfly/patternfly-next/utilities/Accessibility/accessibility.css';
 import spacingStyles from '@patternfly/patternfly-next/utilities/Spacing/spacing.css';
 import { css } from '@patternfly/react-styles';
@@ -143,12 +144,12 @@ class PageLayoutGroupsNav extends React.Component {
       <Toolbar>
         <ToolbarGroup className={css(accessibleStyles.srOnly, accessibleStyles.visibleOnLg)}>
           <ToolbarItem>
-            <Button id="nav-toggle" aria-label="Overflow actions" variant={ButtonVariant.plain}>
+            <Button id="groups-example-uid-01" aria-label="Notifications actions" variant={ButtonVariant.plain}>
               <BellIcon />
             </Button>
           </ToolbarItem>
           <ToolbarItem>
-            <Button id="nav-toggle" aria-label="Overflow actions" variant={ButtonVariant.plain}>
+            <Button id="groups-example-uid-02" aria-label="Setings actions" variant={ButtonVariant.plain}>
               <CogIcon />
             </Button>
           </ToolbarItem>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.js
@@ -30,6 +30,7 @@ import {
   ToolbarItem
 } from '@patternfly/react-core';
 import { global_breakpoint_md as breakpointMd } from '@patternfly/react-tokens';
+// make sure you've installed @patternfly/patternfly-next
 import accessibleStyles from '@patternfly/patternfly-next/utilities/Accessibility/accessibility.css';
 import spacingStyles from '@patternfly/patternfly-next/utilities/Spacing/spacing.css';
 import { css } from '@patternfly/react-styles';
@@ -133,12 +134,12 @@ class PageLayoutHorizontalNav extends React.Component {
       <Toolbar>
         <ToolbarGroup className={css(accessibleStyles.srOnly, accessibleStyles.visibleOnLg)}>
           <ToolbarItem>
-            <Button id="nav-toggle" aria-label="Overflow actions" variant={ButtonVariant.plain}>
+            <Button id="horizontal-example-uid-01" aria-label="Notifications actions" variant={ButtonVariant.plain}>
               <BellIcon />
             </Button>
           </ToolbarItem>
           <ToolbarItem>
-            <Button id="nav-toggle" aria-label="Overflow actions" variant={ButtonVariant.plain}>
+            <Button id="horizontal-example-uid-02" aria-label="Settings actions" variant={ButtonVariant.plain}>
               <CogIcon />
             </Button>
           </ToolbarItem>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.js
@@ -31,6 +31,7 @@ import {
   ToolbarItem
 } from '@patternfly/react-core';
 import { global_breakpoint_md as breakpointMd } from '@patternfly/react-tokens';
+// make sure you've installed @patternfly/patternfly-next
 import accessibleStyles from '@patternfly/patternfly-next/utilities/Accessibility/accessibility.css';
 import spacingStyles from '@patternfly/patternfly-next/utilities/Spacing/spacing.css';
 import { css } from '@patternfly/react-styles';
@@ -134,12 +135,12 @@ class PageLayoutSimpleNav extends React.Component {
       <Toolbar>
         <ToolbarGroup className={css(accessibleStyles.srOnly, accessibleStyles.visibleOnLg)}>
           <ToolbarItem>
-            <Button id="nav-toggle" aria-label="Overflow actions" variant={ButtonVariant.plain}>
+            <Button id="simple-example-uid-01" aria-label="Notifications actions" variant={ButtonVariant.plain}>
               <BellIcon />
             </Button>
           </ToolbarItem>
           <ToolbarItem>
-            <Button id="nav-toggle" aria-label="Overflow actions" variant={ButtonVariant.plain}>
+            <Button id="simple-example-uid-02" aria-label="Settings actions" variant={ButtonVariant.plain}>
               <CogIcon />
             </Button>
           </ToolbarItem>

--- a/packages/patternfly-4/react-docs/src/components/componentDocs/componentDocs.js
+++ b/packages/patternfly-4/react-docs/src/components/componentDocs/componentDocs.js
@@ -49,7 +49,7 @@ class ComponentDocs extends React.PureComponent {
         {Boolean(description) && (
           <p className={css(styles.description)} dangerouslySetInnerHTML={makeDescription(description)} />
         )}
-        <Section title="Examples">
+        <Section title="Examples" headingLevel="h2">
           {examples.map((exampleObj, i) => {
             const ComponentExample = exampleObj.component;
             const { __docgenInfo: componentDocs } = ComponentExample;

--- a/packages/patternfly-4/react-docs/src/components/example/example.js
+++ b/packages/patternfly-4/react-docs/src/components/example/example.js
@@ -108,7 +108,7 @@ const Example = ({
           </div>
           <LiveDemo raw={raw.trim()} path={examplePath} live={false} />
         </React.Fragment>
-        )}
+      )}
     </div>
   );
 };

--- a/packages/patternfly-4/react-docs/src/components/example/example.js
+++ b/packages/patternfly-4/react-docs/src/components/example/example.js
@@ -66,7 +66,7 @@ const Example = ({
     const path = `/${pathStart}/examples/${exampleName}`;
     return (
       <Section>
-        <Title size="lg">{title}</Title>
+        <Title size="lg" headingLevel="h3">{title}</Title>
         <div className={css(className, styles.example)} {...props}>
           This example can only be accessed in&nbsp;
           <Link target="_blank" to={path}>
@@ -102,13 +102,13 @@ const Example = ({
           />
         </React.Fragment>
       ) : (
-        <React.Fragment>
-          <div className={css(className, styles.example)} {...props}>
-            {children}
-          </div>
-          <LiveDemo raw={raw.trim()} path={examplePath} live={false} />
-        </React.Fragment>
-      )}
+          <React.Fragment>
+            <div className={css(className, styles.example)} {...props}>
+              {children}
+            </div>
+            <LiveDemo raw={raw.trim()} path={examplePath} live={false} />
+          </React.Fragment>
+        )}
     </div>
   );
 };

--- a/packages/patternfly-4/react-docs/src/components/example/example.js
+++ b/packages/patternfly-4/react-docs/src/components/example/example.js
@@ -102,12 +102,12 @@ const Example = ({
           />
         </React.Fragment>
       ) : (
-          <React.Fragment>
-            <div className={css(className, styles.example)} {...props}>
-              {children}
-            </div>
-            <LiveDemo raw={raw.trim()} path={examplePath} live={false} />
-          </React.Fragment>
+        <React.Fragment>
+          <div className={css(className, styles.example)} {...props}>
+            {children}
+          </div>
+          <LiveDemo raw={raw.trim()} path={examplePath} live={false} />
+        </React.Fragment>
         )}
     </div>
   );

--- a/packages/patternfly-4/react-docs/src/components/section/section.js
+++ b/packages/patternfly-4/react-docs/src/components/section/section.js
@@ -5,29 +5,30 @@ import styles from './section.styles';
 import { Title } from '@patternfly/react-core';
 
 const propTypes = {
-  name: PropTypes.string,
-  title: PropTypes.string,
-  description: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
-  preface: PropTypes.string
+  description: PropTypes.string,
+  headingLevel: PropTypes.string,
+  name: PropTypes.string,
+  preface: PropTypes.string,
+  title: PropTypes.string
 };
 
 const defaultProps = {
-  name: '',
   children: null,
   className: '',
-  title: '',
   description: '',
-  preface: ''
+  name: '',
+  preface: '',
+  title: ''
 };
 
-const Section = ({ name, children, className, title, description, preface, ...props }) => (
+const Section = ({ children, className, description, headingLevel, name, preface, title, ...props }) => (
   <section className={css(styles.section, className)}>
     {Boolean(title || description) && (
       <header className={css(styles.header)}>
         {Boolean(title) && (
-          <Title size="lg" id={name}>
+          <Title size="lg" id={name} headingLevel={headingLevel}>
             {title}
           </Title>
         )}


### PR DESCRIPTION
<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: This PR enhances the Title component to allow for multiple heading levels, previously an h1 was assumed. It also tweaks some of the page layout examples to include hints about what packages need to be installed (this information isn't provided elsewhere) and cleans up some duplicate ID's.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: https://github.com/patternfly/patternfly-react/issues/1004

<!-- feel free to add additional comments -->
add a headingLevel prop to the title component
use heading level passed in, or h1 as default
defined unique id's for example components
add instruction where first time users may stumble with copy/paste