### PR TITLE
docs(LoadingState): Add state loading with delay to storybook

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/LoadingState/LoadingState.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoadingState/LoadingState.stories.js
@@ -1,35 +1,59 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, boolean, select } from '@storybook/addon-knobs';
+import { withKnobs, boolean, select, number } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 import { inlineTemplate } from 'storybook/decorators/storyTemplates';
 import { storybookPackageName, DOCUMENTATION_URL, STORYBOOK_CATEGORY } from 'storybook/constants/siteConstants';
 
-import { LoadingState } from './index';
-
+import LoadableState, { LoadableStateSource } from './Stories/LoadableState';
+import LoadingState from './LoadingState';
 import { name } from '../../../package.json';
 
 const stories = storiesOf(`${storybookPackageName(name)}/${STORYBOOK_CATEGORY.COMMUNICATION}/Loading State`, module);
 
 stories.addDecorator(withKnobs);
 
-stories.add(
-  'Loading State',
-  withInfo('Loading State shows centered spinner when loading')(() => {
-    const loading = boolean('Loading', true);
+stories
+  .add(
+    'Loading State',
+    withInfo('Loading State shows centered spinner when loading')(() => {
+      const loading = boolean('Loading', true);
 
-    const size = select('Size', ['lg', 'md', 'sm', 'xs'], 'lg');
+      const size = select('Size', ['lg', 'md', 'sm', 'xs'], 'lg');
 
-    const story = (
-      <LoadingState loading={loading} size={size}>
-        <div>Look at me! I am loaded content!</div>
-      </LoadingState>
-    );
+      const story = (
+        <LoadingState loading={loading} size={size}>
+          <div>Look at me! I am loaded content!</div>
+        </LoadingState>
+      );
 
-    return inlineTemplate({
-      title: 'Loading State',
-      documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_COMMUNICATION}loading-state/`,
-      story
-    });
-  })
-);
+      return inlineTemplate({
+        title: 'Loading State',
+        documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_COMMUNICATION}loading-state/`,
+        story
+      });
+    })
+  )
+  .add(
+    'Loading State with Delay',
+    withInfo({
+      source: false,
+      propTables: [LoadingState],
+      propTablesExclude: [LoadableState],
+      text: (
+        <div>
+          <h1>Story Source</h1>
+          <pre>{LoadableStateSource}</pre>
+        </div>
+      )
+    })(() => {
+      const story = (
+        <LoadableState timeout={number('server response time', 3000)} delay={number('spinner delay', 150)} />
+      );
+      return inlineTemplate({
+        title: 'Loading State with Delay',
+        documentationLink: `${DOCUMENTATION_URL.PATTERNFLY_ORG_COMMUNICATION}loading-state/`,
+        story
+      });
+    })
+  );

--- a/packages/patternfly-3/patternfly-react/src/components/LoadingState/Stories/LoadableState.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoadingState/Stories/LoadableState.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import LoadingState from '../LoadingState';
+import { Button } from '../../Button';
+
+class LoadableState extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      message: 'Pre-Loaded state',
+      loading: false
+    };
+  }
+  render() {
+    const { loading, message } = this.state;
+    const { timeout, delay } = this.props;
+    return (
+      <div>
+        <div>
+          <Button
+            bsStyle="primary"
+            onClick={() => {
+              this.setState({ loading: true });
+              const timer = setTimeout(() => {
+                this.setState({ loading: false, message: 'New Loaded State' });
+                clearTimeout(timer);
+              }, timeout);
+            }}
+          >
+            Fetch data
+          </Button>
+        </div>
+        <div>
+          <LoadingState loading={loading} timeout={delay}>
+            {message}
+          </LoadingState>
+        </div>
+      </div>
+    );
+  }
+}
+
+LoadableState.propTypes = {
+  timeout: PropTypes.number,
+  delay: PropTypes.number
+};
+
+LoadableState.defaultProps = {
+  timeout: 3000,
+  delay: 1000
+};
+
+export const LoadableStateSource = `
+  import React from 'react';
+  import { number } from '@storybook/addon-knobs';
+  import LoadingState from '../LoadingState';
+  import { Button } from '../../Button';
+
+  class LoadableState extends React.Component {
+      state = {
+          message: 'Pre-Loaded state',
+          loading: false
+      };
+      render() {
+          const { loading, message } = this.state;
+          const timeout = number('server response time', 3000);
+          const delay = number('spinner delay', 1000);
+          return (
+              <div>
+                  <div>
+                      <Button
+                          bsStyle="primary"
+                          onClick={() => {
+                              this.setState({ loading: true });
+                              const timer = setTimeout(() => {
+                                  this.setState({ loading: false, message: 'New Loaded State' });
+                                  clearTimeout(timer);
+                              }, timeout);
+                          }}
+                      >
+                          Fetch data
+                  </Button>
+                  </div>
+                  <div>
+                      <LoadingState loading={loading} timeout={delay}>
+                          {message}
+                      </LoadingState>
+                  </div>
+              </div>
+          );
+      }
+  }
+`;
+
+export default LoadableState;


### PR DESCRIPTION
Currently there is only one story in LoadingState which demonstrates its props.
However, it's missing an example of setting a delay and waiting for data to be sent by the server.