### PR TITLE
Dropdown interaction issues

### DIFF
--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/__snapshots__/ApplicationLauncher.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/__snapshots__/ApplicationLauncher.test.js.snap
@@ -12,6 +12,7 @@ exports[`ApplicationLauncher dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Link
       </DropdownItem>,
@@ -21,6 +22,7 @@ exports[`ApplicationLauncher dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Action
       </DropdownItem>,
@@ -30,6 +32,7 @@ exports[`ApplicationLauncher dropup + right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -39,6 +42,7 @@ exports[`ApplicationLauncher dropup + right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -55,6 +59,7 @@ exports[`ApplicationLauncher dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -64,6 +69,7 @@ exports[`ApplicationLauncher dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -109,6 +115,7 @@ exports[`ApplicationLauncher dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Link
       </DropdownItem>,
@@ -118,6 +125,7 @@ exports[`ApplicationLauncher dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Action
       </DropdownItem>,
@@ -127,6 +135,7 @@ exports[`ApplicationLauncher dropup 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -136,6 +145,7 @@ exports[`ApplicationLauncher dropup 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -152,6 +162,7 @@ exports[`ApplicationLauncher dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -161,6 +172,7 @@ exports[`ApplicationLauncher dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -206,6 +218,7 @@ exports[`ApplicationLauncher expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Link
       </DropdownItem>,
@@ -215,6 +228,7 @@ exports[`ApplicationLauncher expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Action
       </DropdownItem>,
@@ -224,6 +238,7 @@ exports[`ApplicationLauncher expanded 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -233,6 +248,7 @@ exports[`ApplicationLauncher expanded 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -249,6 +265,7 @@ exports[`ApplicationLauncher expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -258,6 +275,7 @@ exports[`ApplicationLauncher expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -303,6 +321,7 @@ exports[`ApplicationLauncher regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Link
       </DropdownItem>,
@@ -312,6 +331,7 @@ exports[`ApplicationLauncher regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Action
       </DropdownItem>,
@@ -321,6 +341,7 @@ exports[`ApplicationLauncher regular 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -330,6 +351,7 @@ exports[`ApplicationLauncher regular 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -346,6 +368,7 @@ exports[`ApplicationLauncher regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -355,6 +378,7 @@ exports[`ApplicationLauncher regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -400,6 +424,7 @@ exports[`ApplicationLauncher right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Link
       </DropdownItem>,
@@ -409,6 +434,7 @@ exports[`ApplicationLauncher right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Action
       </DropdownItem>,
@@ -418,6 +444,7 @@ exports[`ApplicationLauncher right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -427,6 +454,7 @@ exports[`ApplicationLauncher right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -443,6 +471,7 @@ exports[`ApplicationLauncher right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -452,6 +481,7 @@ exports[`ApplicationLauncher right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
       >
         Separated Action
       </DropdownItem>,

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.js
@@ -93,7 +93,7 @@ class Dropdown extends React.Component {
             isOpen={isOpen}
             position={position}
             aria-labelledby={id}
-            onClick={event => onSelect && onSelect(event)}
+            onSelect={event => onSelect && onSelect(event)}
           >
             {renderedContent}
           </DropdownMenu>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.js
@@ -3,7 +3,7 @@ import styles from '@patternfly/patternfly-next/components/Dropdown/dropdown.css
 import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
 import DropdownMenu from './DropdownMenu';
-import { DropdownPosition, DropdownDirection } from './dropdownConstants';
+import { DropdownPosition, DropdownDirection, DropdownContext } from './dropdownConstants';
 
 // seed for the aria-labelledby ID
 let currentId = 0;
@@ -88,15 +88,11 @@ class Dropdown extends React.Component {
       >
         {Children.map(toggle, oneToggle => cloneElement(oneToggle, { parentRef: this.parentRef, isOpen, id, isPlain }))}
         {isOpen && (
-          <DropdownMenu
-            component={component}
-            isOpen={isOpen}
-            position={position}
-            aria-labelledby={id}
-            onSelect={event => onSelect && onSelect(event)}
-          >
-            {renderedContent}
-          </DropdownMenu>
+          <DropdownContext.Provider value={event => onSelect && onSelect(event)}>
+            <DropdownMenu component={component} isOpen={isOpen} position={position} aria-labelledby={id}>
+              {renderedContent}
+            </DropdownMenu>
+          </DropdownContext.Provider>
         )}
       </div>
     );

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.test.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.test.js
@@ -162,9 +162,8 @@ describe('API', () => {
         toggle={<DropdownToggle id="Dropdown Toggle">Dropdown</DropdownToggle>}
       />
     );
-
     view
-      .find('li')
+      .find('a')
       .first()
       .simulate('click');
     expect(mockToggle.mock.calls).toHaveLength(0);

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.d.ts
@@ -4,4 +4,5 @@ export interface DropdownItemProps extends HTMLProps<HTMLAnchorElement> {
   component?: ReactType<DropdownItemProps>;
   children?: ReactNode;
   isDisabled?: Boolean;
+  onClick?: Function;
 }

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -16,6 +16,7 @@ const propTypes = {
   /** Forces display of the hover state of the element */
   isHovered: PropTypes.bool,
   /** Default hyperlink location */
+<<<<<<< HEAD
   href: PropTypes.string,
 <<<<<<< HEAD
   /** Additional props are spread to the container component */
@@ -24,6 +25,9 @@ const propTypes = {
   /** Function callback called when user selects item */
   onSelect: PropTypes.func
 >>>>>>> feat(Dropdown): disable selection of disabled menu items
+=======
+  href: PropTypes.string
+>>>>>>> feat(Dropdown): improved select event piping, added fix for focus trap toggle
 };
 
 const defaultProps = {
@@ -61,7 +65,7 @@ const DropdownItem = ({ className, children, isHovered, onSelect, component: Com
         <Component
           {...additionalProps}
           className={css(isDisabled && styles.modifiers.disabled, isHovered && styles.modifiers.hover, className)}
-          onClick={!isDisabled ? onSelect : null}
+          onClick={!isDisabled ? onSelect : Function.prototype}
         >
           {children}
         </Component>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -19,8 +19,10 @@ const propTypes = {
   href: PropTypes.string,
   /** Additional props are spread to the container component */
   '': PropTypes.any,
-  /** Function callback called when user selects item */
-  onSelect: PropTypes.func
+  /** Callback for select event */
+  onSelect: PropTypes.func,
+  /** Callback for click event */
+  onClick: PropTypes.func
 };
 
 const defaultProps = {
@@ -30,10 +32,20 @@ const defaultProps = {
   component: 'a',
   isDisabled: false,
   href: '#',
-  onSelect: Function.prototype
+  onSelect: Function.prototype,
+  onClick: Function.prototype
 };
 
-const DropdownItem = ({ className, children, isHovered, onSelect, component: Component, isDisabled, ...props }) => {
+const DropdownItem = ({
+  className,
+  children,
+  isHovered,
+  onSelect,
+  onClick,
+  component: Component,
+  isDisabled,
+  ...props
+}) => {
   const additionalProps = props;
   if (Component === 'a') {
     additionalProps['aria-disabled'] = isDisabled;
@@ -59,8 +71,13 @@ const DropdownItem = ({ className, children, isHovered, onSelect, component: Com
         <Component
           {...additionalProps}
           className={css(isDisabled && styles.modifiers.disabled, isHovered && styles.modifiers.hover, className)}
-          onClick={() => {
-            Component === 'button' ? (props.onClick && props.onClick(), onSelect()) : onSelect();
+          onClick={event => {
+            if (Component === 'button') {
+              onClick && onClick(event);
+              onSelect(event);
+            } else {
+              onSelect(event);
+            }
           }}
         >
           {children}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -20,8 +20,6 @@ const propTypes = {
   href: PropTypes.string,
   /** Additional props are spread to the container component */
   '': PropTypes.any,
-  /** Callback for select event */
-  onSelect: PropTypes.func,
   /** Callback for click event */
   onClick: PropTypes.func
 };
@@ -33,7 +31,6 @@ const defaultProps = {
   component: 'a',
   isDisabled: false,
   href: '#',
-  onSelect: Function.prototype,
   onClick: Function.prototype
 };
 
@@ -77,8 +74,6 @@ class DropdownItem extends React.Component {
                   if (!isDisabled) {
                     if (Component === 'button') onClick && onClick(event);
                     onSelect && onSelect(event);
-                  } else {
-                    Function.prototype;
                   }
                 }}
               >

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -17,8 +17,13 @@ const propTypes = {
   isHovered: PropTypes.bool,
   /** Default hyperlink location */
   href: PropTypes.string,
+<<<<<<< HEAD
   /** Additional props are spread to the container component */
   '': PropTypes.any
+=======
+  /** Function callback called when user selects item */
+  onSelect: PropTypes.func
+>>>>>>> feat(Dropdown): disable selection of disabled menu items
 };
 
 const defaultProps = {
@@ -30,7 +35,7 @@ const defaultProps = {
   href: '#'
 };
 
-const DropdownItem = ({ className, children, isHovered, component: Component, isDisabled, ...props }) => {
+const DropdownItem = ({ className, children, isHovered, onSelect, component: Component, isDisabled, ...props }) => {
   const additionalProps = props;
   if (Component === 'a') {
     additionalProps['aria-disabled'] = isDisabled;
@@ -56,6 +61,7 @@ const DropdownItem = ({ className, children, isHovered, component: Component, is
         <Component
           {...additionalProps}
           className={css(isDisabled && styles.modifiers.disabled, isHovered && styles.modifiers.hover, className)}
+          onClick={!isDisabled ? onSelect : null}
         >
           {children}
         </Component>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -16,18 +16,11 @@ const propTypes = {
   /** Forces display of the hover state of the element */
   isHovered: PropTypes.bool,
   /** Default hyperlink location */
-<<<<<<< HEAD
   href: PropTypes.string,
-<<<<<<< HEAD
   /** Additional props are spread to the container component */
-  '': PropTypes.any
-=======
+  '': PropTypes.any,
   /** Function callback called when user selects item */
   onSelect: PropTypes.func
->>>>>>> feat(Dropdown): disable selection of disabled menu items
-=======
-  href: PropTypes.string
->>>>>>> feat(Dropdown): improved select event piping, added fix for focus trap toggle
 };
 
 const defaultProps = {
@@ -36,7 +29,8 @@ const defaultProps = {
   isHovered: false,
   component: 'a',
   isDisabled: false,
-  href: '#'
+  href: '#',
+  onSelect: Function.prototype
 };
 
 const DropdownItem = ({ className, children, isHovered, onSelect, component: Component, isDisabled, ...props }) => {
@@ -65,7 +59,9 @@ const DropdownItem = ({ className, children, isHovered, onSelect, component: Com
         <Component
           {...additionalProps}
           className={css(isDisabled && styles.modifiers.disabled, isHovered && styles.modifiers.hover, className)}
-          onClick={!isDisabled ? onSelect : Function.prototype}
+          onClick={() => {
+            Component === 'button' ? (props.onClick && props.onClick(), onSelect()) : onSelect();
+          }}
         >
           {children}
         </Component>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -3,6 +3,7 @@ import styles from '@patternfly/patternfly-next/components/Dropdown/dropdown.css
 import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
 import { componentShape } from '../../internal/componentShape';
+import { DropdownContext } from './dropdownConstants';
 
 const propTypes = {
   /** Anything which can be rendered as dropdown item */
@@ -36,56 +37,60 @@ const defaultProps = {
   onClick: Function.prototype
 };
 
-const DropdownItem = ({
-  className,
-  children,
-  isHovered,
-  onSelect,
-  onClick,
-  component: Component,
-  isDisabled,
-  ...props
-}) => {
-  const additionalProps = props;
-  if (Component === 'a') {
-    additionalProps['aria-disabled'] = isDisabled;
-    additionalProps.tabIndex = isDisabled ? -1 : additionalProps.tabIndex;
-  } else if (Component === 'button') {
-    additionalProps.disabled = isDisabled;
-    additionalProps.type = additionalProps.type || 'button';
-  }
+class DropdownItem extends React.Component {
+  render() {
+    const {
+      className,
+      children,
+      isHovered,
+      onClick,
+      component: Component,
+      isDisabled,
+      ...additionalProps
+    } = this.props;
+    if (Component === 'a') {
+      additionalProps['aria-disabled'] = isDisabled;
+      additionalProps.tabIndex = isDisabled ? -1 : additionalProps.tabIndex;
+    } else if (Component === 'button') {
+      additionalProps.disabled = isDisabled;
+    }
 
-  return (
-    <li>
-      {React.isValidElement(children) ? (
-        React.Children.map(children, child =>
-          React.cloneElement(child, {
-            className: `${css(
-              isDisabled && styles.modifiers.disabled,
-              isHovered && styles.modifiers.hover,
-              className
-            )} ${child.props.className}`
-          })
-        )
-      ) : (
-        <Component
-          {...additionalProps}
-          className={css(isDisabled && styles.modifiers.disabled, isHovered && styles.modifiers.hover, className)}
-          onClick={event => {
-            if (Component === 'button') {
-              onClick && onClick(event);
-              onSelect(event);
-            } else {
-              onSelect(event);
-            }
-          }}
-        >
-          {children}
-        </Component>
-      )}
-    </li>
-  );
-};
+    return (
+      <DropdownContext.Consumer>
+        {onSelect => (
+          <li>
+            {React.isValidElement(children) ? (
+              React.Children.map(children, child =>
+                React.cloneElement(child, {
+                  className: `${css(
+                    isDisabled && styles.modifiers.disabled,
+                    isHovered && styles.modifiers.hover,
+                    className
+                  )} ${child.props.className}`
+                })
+              )
+            ) : (
+              <Component
+                {...additionalProps}
+                className={css(isDisabled && styles.modifiers.disabled, isHovered && styles.modifiers.hover, className)}
+                onClick={event => {
+                  if (!isDisabled) {
+                    if (Component === 'button') onClick && onClick(event);
+                    onSelect && onSelect(event);
+                  } else {
+                    Function.prototype;
+                  }
+                }}
+              >
+                {children}
+              </Component>
+            )}
+          </li>
+        )}
+      </DropdownContext.Consumer>
+    );
+  }
+}
 
 DropdownItem.propTypes = propTypes;
 DropdownItem.defaultProps = defaultProps;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
@@ -16,10 +16,14 @@ const propTypes = {
   /** Indicates which component will be used as dropdown menu */
   component: componentShape,
   /** Indicates where menu will be alligned horizontally */
+<<<<<<< HEAD
   position: PropTypes.oneOf(Object.values(DropdownPosition)),
   onSelect: PropTypes.func,
   /** Additional props are spread to the container component */
   '': PropTypes.any
+=======
+  position: PropTypes.oneOf(Object.keys(DropdownPosition))
+>>>>>>> feat(Dropdown): improved select event piping, added fix for focus trap toggle
 };
 
 const defaultProps = {
@@ -32,7 +36,6 @@ const defaultProps = {
 
 const DropdownMenu = ({ className, isOpen, position, children, onSelect, component: Component, ...props }) => {
   let menu = null;
-  if (children) children = React.Children.map(children, child => React.cloneElement(child, { onSelect }));
   if (Component === 'div') {
     menu = (
       <Component
@@ -43,6 +46,7 @@ const DropdownMenu = ({ className, isOpen, position, children, onSelect, compone
           className
         )}
         hidden={!isOpen}
+        onClick={onSelect}
       >
         {children}
       </Component>
@@ -63,7 +67,7 @@ const DropdownMenu = ({ className, isOpen, position, children, onSelect, compone
           )}
           hidden={!isOpen}
         >
-          {children}
+          {children && React.Children.map(children, child => React.cloneElement(child, { onSelect }))}
         </Component>
       </FocusTrap>
     );

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
@@ -16,14 +16,10 @@ const propTypes = {
   /** Indicates which component will be used as dropdown menu */
   component: componentShape,
   /** Indicates where menu will be alligned horizontally */
-<<<<<<< HEAD
   position: PropTypes.oneOf(Object.values(DropdownPosition)),
   onSelect: PropTypes.func,
   /** Additional props are spread to the container component */
   '': PropTypes.any
-=======
-  position: PropTypes.oneOf(Object.keys(DropdownPosition))
->>>>>>> feat(Dropdown): improved select event piping, added fix for focus trap toggle
 };
 
 const defaultProps = {

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
@@ -17,6 +17,7 @@ const propTypes = {
   component: componentShape,
   /** Indicates where menu will be alligned horizontally */
   position: PropTypes.oneOf(Object.values(DropdownPosition)),
+  onSelect: PropTypes.func,
   /** Additional props are spread to the container component */
   '': PropTypes.any
 };
@@ -29,8 +30,9 @@ const defaultProps = {
   component: 'ul'
 };
 
-const DropdownMenu = ({ className, isOpen, position, children, component: Component, ...props }) => {
+const DropdownMenu = ({ className, isOpen, position, children, onSelect, component: Component, ...props }) => {
   let menu = null;
+  if (children) children = React.Children.map(children, child => React.cloneElement(child, { onSelect }));
   if (Component === 'div') {
     menu = (
       <Component

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
@@ -17,7 +17,6 @@ const propTypes = {
   component: componentShape,
   /** Indicates where menu will be alligned horizontally */
   position: PropTypes.oneOf(Object.values(DropdownPosition)),
-  onSelect: PropTypes.func,
   /** Additional props are spread to the container component */
   '': PropTypes.any
 };

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
@@ -3,7 +3,7 @@ import styles from '@patternfly/patternfly-next/components/Dropdown/dropdown.css
 import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
 import { componentShape } from '../../internal/componentShape';
-import { DropdownPosition } from './dropdownConstants';
+import { DropdownPosition, DropdownContext } from './dropdownConstants';
 import FocusTrap from 'focus-trap-react';
 
 const propTypes = {
@@ -30,22 +30,26 @@ const defaultProps = {
   component: 'ul'
 };
 
-const DropdownMenu = ({ className, isOpen, position, children, onSelect, component: Component, ...props }) => {
+const DropdownMenu = ({ className, isOpen, position, children, component: Component, ...props }) => {
   let menu = null;
   if (Component === 'div') {
     menu = (
-      <Component
-        {...props}
-        className={css(
-          styles.dropdownMenu,
-          position === DropdownPosition.right && styles.modifiers.alignRight,
-          className
+      <DropdownContext.Consumer>
+        {onSelect => (
+          <Component
+            {...props}
+            className={css(
+              styles.dropdownMenu,
+              position === DropdownPosition.right && styles.modifiers.alignRight,
+              className
+            )}
+            hidden={!isOpen}
+            onClick={event => onSelect && onSelect(event)}
+          >
+            {children}
+          </Component>
         )}
-        hidden={!isOpen}
-        onClick={onSelect}
-      >
-        {children}
-      </Component>
+      </DropdownContext.Consumer>
     );
   } else if (Component === 'ul') {
     menu = (
@@ -63,7 +67,7 @@ const DropdownMenu = ({ className, isOpen, position, children, onSelect, compone
           )}
           hidden={!isOpen}
         >
-          {children && React.Children.map(children, child => React.cloneElement(child, { onSelect }))}
+          {children}
         </Component>
       </FocusTrap>
     );

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -171,6 +171,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -180,6 +181,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -189,6 +191,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -198,6 +201,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -214,6 +218,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -223,6 +228,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -346,6 +352,7 @@ exports[`KebabToggle dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -355,6 +362,7 @@ exports[`KebabToggle dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -364,6 +372,7 @@ exports[`KebabToggle dropup 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -373,6 +382,7 @@ exports[`KebabToggle dropup 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -389,6 +399,7 @@ exports[`KebabToggle dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -398,6 +409,7 @@ exports[`KebabToggle dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -549,6 +561,7 @@ exports[`KebabToggle expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -558,6 +571,7 @@ exports[`KebabToggle expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -567,6 +581,7 @@ exports[`KebabToggle expanded 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -576,6 +591,7 @@ exports[`KebabToggle expanded 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -592,6 +608,7 @@ exports[`KebabToggle expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -601,6 +618,7 @@ exports[`KebabToggle expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -914,6 +932,7 @@ exports[`KebabToggle plain 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -923,6 +942,7 @@ exports[`KebabToggle plain 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -932,6 +952,7 @@ exports[`KebabToggle plain 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -941,6 +962,7 @@ exports[`KebabToggle plain 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -957,6 +979,7 @@ exports[`KebabToggle plain 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -966,6 +989,7 @@ exports[`KebabToggle plain 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -1089,6 +1113,7 @@ exports[`KebabToggle regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -1098,6 +1123,7 @@ exports[`KebabToggle regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -1107,6 +1133,7 @@ exports[`KebabToggle regular 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -1116,6 +1143,7 @@ exports[`KebabToggle regular 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -1132,6 +1160,7 @@ exports[`KebabToggle regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -1141,6 +1170,7 @@ exports[`KebabToggle regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -1264,6 +1294,7 @@ exports[`KebabToggle right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -1273,6 +1304,7 @@ exports[`KebabToggle right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -1282,6 +1314,7 @@ exports[`KebabToggle right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -1291,6 +1324,7 @@ exports[`KebabToggle right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -1307,6 +1341,7 @@ exports[`KebabToggle right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -1316,6 +1351,7 @@ exports[`KebabToggle right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -1594,6 +1630,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -1603,6 +1640,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -1612,6 +1650,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -1621,6 +1660,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -1637,6 +1677,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -1646,6 +1687,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -1778,6 +1820,7 @@ exports[`dropdown dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -1787,6 +1830,7 @@ exports[`dropdown dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -1796,6 +1840,7 @@ exports[`dropdown dropup 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -1805,6 +1850,7 @@ exports[`dropdown dropup 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -1821,6 +1867,7 @@ exports[`dropdown dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -1830,6 +1877,7 @@ exports[`dropdown dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -1990,6 +2038,7 @@ exports[`dropdown expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -1999,6 +2048,7 @@ exports[`dropdown expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -2008,6 +2058,7 @@ exports[`dropdown expanded 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -2017,6 +2068,7 @@ exports[`dropdown expanded 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -2033,6 +2085,7 @@ exports[`dropdown expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -2042,6 +2095,7 @@ exports[`dropdown expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -2364,6 +2418,7 @@ exports[`dropdown regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -2373,6 +2428,7 @@ exports[`dropdown regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -2382,6 +2438,7 @@ exports[`dropdown regular 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -2391,6 +2448,7 @@ exports[`dropdown regular 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -2407,6 +2465,7 @@ exports[`dropdown regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -2416,6 +2475,7 @@ exports[`dropdown regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -2548,6 +2608,7 @@ exports[`dropdown right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -2557,6 +2618,7 @@ exports[`dropdown right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -2566,6 +2628,7 @@ exports[`dropdown right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -2575,6 +2638,7 @@ exports[`dropdown right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -2591,6 +2655,7 @@ exports[`dropdown right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -2600,6 +2665,7 @@ exports[`dropdown right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -171,6 +171,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Link
@@ -181,6 +182,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Action
@@ -191,6 +193,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Link
@@ -201,6 +204,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Action
@@ -218,6 +222,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Link
@@ -228,6 +233,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Action
@@ -352,6 +358,7 @@ exports[`KebabToggle dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Link
@@ -362,6 +369,7 @@ exports[`KebabToggle dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Action
@@ -372,6 +380,7 @@ exports[`KebabToggle dropup 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Link
@@ -382,6 +391,7 @@ exports[`KebabToggle dropup 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Action
@@ -399,6 +409,7 @@ exports[`KebabToggle dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Link
@@ -409,6 +420,7 @@ exports[`KebabToggle dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Action
@@ -561,6 +573,7 @@ exports[`KebabToggle expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Link
@@ -571,6 +584,7 @@ exports[`KebabToggle expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Action
@@ -581,6 +595,7 @@ exports[`KebabToggle expanded 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Link
@@ -591,6 +606,7 @@ exports[`KebabToggle expanded 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Action
@@ -608,6 +624,7 @@ exports[`KebabToggle expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Link
@@ -618,6 +635,7 @@ exports[`KebabToggle expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Action
@@ -739,6 +757,7 @@ exports[`KebabToggle expanded 1`] = `
               isDisabled={false}
               isHovered={false}
               key=".$link"
+              onClick={[Function]}
               onSelect={[Function]}
             >
               <li>
@@ -759,6 +778,7 @@ exports[`KebabToggle expanded 1`] = `
               isDisabled={false}
               isHovered={false}
               key=".$action"
+              onClick={[Function]}
               onSelect={[Function]}
             >
               <li>
@@ -783,6 +803,7 @@ exports[`KebabToggle expanded 1`] = `
               isDisabled={true}
               isHovered={false}
               key=".$disabled link"
+              onClick={[Function]}
               onSelect={[Function]}
             >
               <li>
@@ -804,6 +825,7 @@ exports[`KebabToggle expanded 1`] = `
               isDisabled={true}
               isHovered={false}
               key=".$disabled action"
+              onClick={[Function]}
               onSelect={[Function]}
             >
               <li>
@@ -836,6 +858,7 @@ exports[`KebabToggle expanded 1`] = `
                 href="#"
                 isDisabled={false}
                 isHovered={false}
+                onClick={[Function]}
                 onSelect={[Function]}
                 role="separator"
               >
@@ -856,6 +879,7 @@ exports[`KebabToggle expanded 1`] = `
               isDisabled={false}
               isHovered={false}
               key=".$separated link"
+              onClick={[Function]}
               onSelect={[Function]}
             >
               <li>
@@ -876,6 +900,7 @@ exports[`KebabToggle expanded 1`] = `
               isDisabled={false}
               isHovered={false}
               key=".$separated action"
+              onClick={[Function]}
               onSelect={[Function]}
             >
               <li>
@@ -932,6 +957,7 @@ exports[`KebabToggle plain 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Link
@@ -942,6 +968,7 @@ exports[`KebabToggle plain 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Action
@@ -952,6 +979,7 @@ exports[`KebabToggle plain 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Link
@@ -962,6 +990,7 @@ exports[`KebabToggle plain 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Action
@@ -979,6 +1008,7 @@ exports[`KebabToggle plain 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Link
@@ -989,6 +1019,7 @@ exports[`KebabToggle plain 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Action
@@ -1113,6 +1144,7 @@ exports[`KebabToggle regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Link
@@ -1123,6 +1155,7 @@ exports[`KebabToggle regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Action
@@ -1133,6 +1166,7 @@ exports[`KebabToggle regular 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Link
@@ -1143,6 +1177,7 @@ exports[`KebabToggle regular 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Action
@@ -1160,6 +1195,7 @@ exports[`KebabToggle regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Link
@@ -1170,6 +1206,7 @@ exports[`KebabToggle regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Action
@@ -1294,6 +1331,7 @@ exports[`KebabToggle right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Link
@@ -1304,6 +1342,7 @@ exports[`KebabToggle right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Action
@@ -1314,6 +1353,7 @@ exports[`KebabToggle right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Link
@@ -1324,6 +1364,7 @@ exports[`KebabToggle right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Action
@@ -1341,6 +1382,7 @@ exports[`KebabToggle right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Link
@@ -1351,6 +1393,7 @@ exports[`KebabToggle right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Action
@@ -1630,6 +1673,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Link
@@ -1640,6 +1684,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Action
@@ -1650,6 +1695,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Link
@@ -1660,6 +1706,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Action
@@ -1677,6 +1724,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Link
@@ -1687,6 +1735,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Action
@@ -1820,6 +1869,7 @@ exports[`dropdown dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Link
@@ -1830,6 +1880,7 @@ exports[`dropdown dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Action
@@ -1840,6 +1891,7 @@ exports[`dropdown dropup 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Link
@@ -1850,6 +1902,7 @@ exports[`dropdown dropup 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Action
@@ -1867,6 +1920,7 @@ exports[`dropdown dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Link
@@ -1877,6 +1931,7 @@ exports[`dropdown dropup 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Action
@@ -2038,6 +2093,7 @@ exports[`dropdown expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Link
@@ -2048,6 +2104,7 @@ exports[`dropdown expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Action
@@ -2058,6 +2115,7 @@ exports[`dropdown expanded 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Link
@@ -2068,6 +2126,7 @@ exports[`dropdown expanded 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Action
@@ -2085,6 +2144,7 @@ exports[`dropdown expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Link
@@ -2095,6 +2155,7 @@ exports[`dropdown expanded 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Action
@@ -2219,6 +2280,7 @@ exports[`dropdown expanded 1`] = `
               isDisabled={false}
               isHovered={false}
               key=".$link"
+              onClick={[Function]}
               onSelect={[Function]}
             >
               <li>
@@ -2239,6 +2301,7 @@ exports[`dropdown expanded 1`] = `
               isDisabled={false}
               isHovered={false}
               key=".$action"
+              onClick={[Function]}
               onSelect={[Function]}
             >
               <li>
@@ -2263,6 +2326,7 @@ exports[`dropdown expanded 1`] = `
               isDisabled={true}
               isHovered={false}
               key=".$disabled link"
+              onClick={[Function]}
               onSelect={[Function]}
             >
               <li>
@@ -2284,6 +2348,7 @@ exports[`dropdown expanded 1`] = `
               isDisabled={true}
               isHovered={false}
               key=".$disabled action"
+              onClick={[Function]}
               onSelect={[Function]}
             >
               <li>
@@ -2316,6 +2381,7 @@ exports[`dropdown expanded 1`] = `
                 href="#"
                 isDisabled={false}
                 isHovered={false}
+                onClick={[Function]}
                 onSelect={[Function]}
                 role="separator"
               >
@@ -2336,6 +2402,7 @@ exports[`dropdown expanded 1`] = `
               isDisabled={false}
               isHovered={false}
               key=".$separated link"
+              onClick={[Function]}
               onSelect={[Function]}
             >
               <li>
@@ -2356,6 +2423,7 @@ exports[`dropdown expanded 1`] = `
               isDisabled={false}
               isHovered={false}
               key=".$separated action"
+              onClick={[Function]}
               onSelect={[Function]}
             >
               <li>
@@ -2418,6 +2486,7 @@ exports[`dropdown regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Link
@@ -2428,6 +2497,7 @@ exports[`dropdown regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Action
@@ -2438,6 +2508,7 @@ exports[`dropdown regular 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Link
@@ -2448,6 +2519,7 @@ exports[`dropdown regular 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Action
@@ -2465,6 +2537,7 @@ exports[`dropdown regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Link
@@ -2475,6 +2548,7 @@ exports[`dropdown regular 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Action
@@ -2608,6 +2682,7 @@ exports[`dropdown right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Link
@@ -2618,6 +2693,7 @@ exports[`dropdown right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Action
@@ -2628,6 +2704,7 @@ exports[`dropdown right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Link
@@ -2638,6 +2715,7 @@ exports[`dropdown right aligned 1`] = `
         href="#"
         isDisabled={true}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Disabled Action
@@ -2655,6 +2733,7 @@ exports[`dropdown right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Link
@@ -2665,6 +2744,7 @@ exports[`dropdown right aligned 1`] = `
         href="#"
         isDisabled={false}
         isHovered={false}
+        onClick={[Function]}
         onSelect={[Function]}
       >
         Separated Action

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -124,7 +124,6 @@ exports[`KebabToggle basic 1`] = `
       className=""
       component="div"
       isOpen={true}
-      onSelect={[Function]}
       position="left"
     >
       <div
@@ -730,7 +729,6 @@ exports[`KebabToggle expanded 1`] = `
       className=""
       component="ul"
       isOpen={true}
-      onSelect={[Function]}
       position="left"
     >
       <FocusTrap
@@ -756,7 +754,7 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key=".$link"
+              key="link"
               onClick={[Function]}
               onSelect={[Function]}
             >
@@ -766,6 +764,7 @@ exports[`KebabToggle expanded 1`] = `
                   className=""
                   href="#"
                   onClick={[Function]}
+                  onSelect={[Function]}
                 >
                   Link
                 </a>
@@ -777,7 +776,7 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key=".$action"
+              key="action"
               onClick={[Function]}
               onSelect={[Function]}
             >
@@ -790,7 +789,11 @@ exports[`KebabToggle expanded 1`] = `
                   type="button"
 =======
                   onClick={[Function]}
+<<<<<<< HEAD
 >>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
+=======
+                  onSelect={[Function]}
+>>>>>>> feat(Dropdown): use Context to pass onSelect handlers
                 >
                   Action
                 </button>
@@ -802,7 +805,7 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={true}
               isHovered={false}
-              key=".$disabled link"
+              key="disabled link"
               onClick={[Function]}
               onSelect={[Function]}
             >
@@ -812,6 +815,7 @@ exports[`KebabToggle expanded 1`] = `
                   className="pf-m-disabled"
                   href="#"
                   onClick={[Function]}
+                  onSelect={[Function]}
                   tabIndex={-1}
                 >
                   Disabled Link
@@ -824,7 +828,7 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={true}
               isHovered={false}
-              key=".$disabled action"
+              key="disabled action"
               onClick={[Function]}
               onSelect={[Function]}
             >
@@ -837,7 +841,11 @@ exports[`KebabToggle expanded 1`] = `
                   type="button"
 =======
                   onClick={[Function]}
+<<<<<<< HEAD
 >>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
+=======
+                  onSelect={[Function]}
+>>>>>>> feat(Dropdown): use Context to pass onSelect handlers
                 >
                   Disabled Action
                 </button>
@@ -849,8 +857,7 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key=".$separator"
-              onSelect={[Function]}
+              key="separator"
             >
               <DropdownItem
                 className="pf-c-dropdown__separator"
@@ -867,6 +874,7 @@ exports[`KebabToggle expanded 1`] = `
                     className="pf-c-dropdown__separator"
                     href="#"
                     onClick={[Function]}
+                    onSelect={[Function]}
                     role="separator"
                   />
                 </li>
@@ -878,7 +886,7 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key=".$separated link"
+              key="separated link"
               onClick={[Function]}
               onSelect={[Function]}
             >
@@ -888,6 +896,7 @@ exports[`KebabToggle expanded 1`] = `
                   className=""
                   href="#"
                   onClick={[Function]}
+                  onSelect={[Function]}
                 >
                   Separated Link
                 </a>
@@ -899,7 +908,7 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key=".$separated action"
+              key="separated action"
               onClick={[Function]}
               onSelect={[Function]}
             >
@@ -912,7 +921,11 @@ exports[`KebabToggle expanded 1`] = `
                   type="button"
 =======
                   onClick={[Function]}
+<<<<<<< HEAD
 >>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
+=======
+                  onSelect={[Function]}
+>>>>>>> feat(Dropdown): use Context to pass onSelect handlers
                 >
                   Separated Action
                 </button>
@@ -1620,7 +1633,6 @@ exports[`dropdown basic 1`] = `
       className=""
       component="div"
       isOpen={true}
-      onSelect={[Function]}
       position="left"
     >
       <div
@@ -2253,7 +2265,6 @@ exports[`dropdown expanded 1`] = `
       className=""
       component="ul"
       isOpen={true}
-      onSelect={[Function]}
       position="left"
     >
       <FocusTrap
@@ -2279,7 +2290,7 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key=".$link"
+              key="link"
               onClick={[Function]}
               onSelect={[Function]}
             >
@@ -2289,6 +2300,7 @@ exports[`dropdown expanded 1`] = `
                   className=""
                   href="#"
                   onClick={[Function]}
+                  onSelect={[Function]}
                 >
                   Link
                 </a>
@@ -2300,7 +2312,7 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key=".$action"
+              key="action"
               onClick={[Function]}
               onSelect={[Function]}
             >
@@ -2313,7 +2325,11 @@ exports[`dropdown expanded 1`] = `
                   type="button"
 =======
                   onClick={[Function]}
+<<<<<<< HEAD
 >>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
+=======
+                  onSelect={[Function]}
+>>>>>>> feat(Dropdown): use Context to pass onSelect handlers
                 >
                   Action
                 </button>
@@ -2325,7 +2341,7 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={true}
               isHovered={false}
-              key=".$disabled link"
+              key="disabled link"
               onClick={[Function]}
               onSelect={[Function]}
             >
@@ -2335,6 +2351,7 @@ exports[`dropdown expanded 1`] = `
                   className="pf-m-disabled"
                   href="#"
                   onClick={[Function]}
+                  onSelect={[Function]}
                   tabIndex={-1}
                 >
                   Disabled Link
@@ -2347,7 +2364,7 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={true}
               isHovered={false}
-              key=".$disabled action"
+              key="disabled action"
               onClick={[Function]}
               onSelect={[Function]}
             >
@@ -2360,7 +2377,11 @@ exports[`dropdown expanded 1`] = `
                   type="button"
 =======
                   onClick={[Function]}
+<<<<<<< HEAD
 >>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
+=======
+                  onSelect={[Function]}
+>>>>>>> feat(Dropdown): use Context to pass onSelect handlers
                 >
                   Disabled Action
                 </button>
@@ -2372,8 +2393,7 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key=".$separator"
-              onSelect={[Function]}
+              key="separator"
             >
               <DropdownItem
                 className="pf-c-dropdown__separator"
@@ -2390,6 +2410,7 @@ exports[`dropdown expanded 1`] = `
                     className="pf-c-dropdown__separator"
                     href="#"
                     onClick={[Function]}
+                    onSelect={[Function]}
                     role="separator"
                   />
                 </li>
@@ -2401,7 +2422,7 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key=".$separated link"
+              key="separated link"
               onClick={[Function]}
               onSelect={[Function]}
             >
@@ -2411,6 +2432,7 @@ exports[`dropdown expanded 1`] = `
                   className=""
                   href="#"
                   onClick={[Function]}
+                  onSelect={[Function]}
                 >
                   Separated Link
                 </a>
@@ -2422,7 +2444,7 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key=".$separated action"
+              key="separated action"
               onClick={[Function]}
               onSelect={[Function]}
             >
@@ -2435,7 +2457,11 @@ exports[`dropdown expanded 1`] = `
                   type="button"
 =======
                   onClick={[Function]}
+<<<<<<< HEAD
 >>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
+=======
+                  onSelect={[Function]}
+>>>>>>> feat(Dropdown): use Context to pass onSelect handlers
                 >
                   Separated Action
                 </button>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -171,7 +171,6 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -182,7 +181,6 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -193,7 +191,6 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -204,7 +201,6 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -222,7 +218,6 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -233,7 +228,6 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -358,7 +352,6 @@ exports[`KebabToggle dropup 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -369,7 +362,6 @@ exports[`KebabToggle dropup 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -380,7 +372,6 @@ exports[`KebabToggle dropup 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -391,7 +382,6 @@ exports[`KebabToggle dropup 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -409,7 +399,6 @@ exports[`KebabToggle dropup 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -420,7 +409,6 @@ exports[`KebabToggle dropup 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -573,7 +561,6 @@ exports[`KebabToggle expanded 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -584,7 +571,6 @@ exports[`KebabToggle expanded 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -595,7 +581,6 @@ exports[`KebabToggle expanded 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -606,7 +591,6 @@ exports[`KebabToggle expanded 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -624,7 +608,6 @@ exports[`KebabToggle expanded 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -635,7 +618,6 @@ exports[`KebabToggle expanded 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -756,7 +738,6 @@ exports[`KebabToggle expanded 1`] = `
               isHovered={false}
               key="link"
               onClick={[Function]}
-              onSelect={[Function]}
             >
               <li>
                 <a
@@ -764,7 +745,6 @@ exports[`KebabToggle expanded 1`] = `
                   className=""
                   href="#"
                   onClick={[Function]}
-                  onSelect={[Function]}
                 >
                   Link
                 </a>
@@ -778,7 +758,6 @@ exports[`KebabToggle expanded 1`] = `
               isHovered={false}
               key="action"
               onClick={[Function]}
-              onSelect={[Function]}
             >
               <li>
                 <button
@@ -790,10 +769,13 @@ exports[`KebabToggle expanded 1`] = `
 =======
                   onClick={[Function]}
 <<<<<<< HEAD
+<<<<<<< HEAD
 >>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
 =======
                   onSelect={[Function]}
 >>>>>>> feat(Dropdown): use Context to pass onSelect handlers
+=======
+>>>>>>> feat(Dropdown): remove onSelect default
                 >
                   Action
                 </button>
@@ -807,7 +789,6 @@ exports[`KebabToggle expanded 1`] = `
               isHovered={false}
               key="disabled link"
               onClick={[Function]}
-              onSelect={[Function]}
             >
               <li>
                 <a
@@ -815,7 +796,6 @@ exports[`KebabToggle expanded 1`] = `
                   className="pf-m-disabled"
                   href="#"
                   onClick={[Function]}
-                  onSelect={[Function]}
                   tabIndex={-1}
                 >
                   Disabled Link
@@ -830,7 +810,6 @@ exports[`KebabToggle expanded 1`] = `
               isHovered={false}
               key="disabled action"
               onClick={[Function]}
-              onSelect={[Function]}
             >
               <li>
                 <button
@@ -842,10 +821,13 @@ exports[`KebabToggle expanded 1`] = `
 =======
                   onClick={[Function]}
 <<<<<<< HEAD
+<<<<<<< HEAD
 >>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
 =======
                   onSelect={[Function]}
 >>>>>>> feat(Dropdown): use Context to pass onSelect handlers
+=======
+>>>>>>> feat(Dropdown): remove onSelect default
                 >
                   Disabled Action
                 </button>
@@ -866,7 +848,6 @@ exports[`KebabToggle expanded 1`] = `
                 isDisabled={false}
                 isHovered={false}
                 onClick={[Function]}
-                onSelect={[Function]}
                 role="separator"
               >
                 <li>
@@ -874,7 +855,6 @@ exports[`KebabToggle expanded 1`] = `
                     className="pf-c-dropdown__separator"
                     href="#"
                     onClick={[Function]}
-                    onSelect={[Function]}
                     role="separator"
                   />
                 </li>
@@ -888,7 +868,6 @@ exports[`KebabToggle expanded 1`] = `
               isHovered={false}
               key="separated link"
               onClick={[Function]}
-              onSelect={[Function]}
             >
               <li>
                 <a
@@ -896,7 +875,6 @@ exports[`KebabToggle expanded 1`] = `
                   className=""
                   href="#"
                   onClick={[Function]}
-                  onSelect={[Function]}
                 >
                   Separated Link
                 </a>
@@ -910,7 +888,6 @@ exports[`KebabToggle expanded 1`] = `
               isHovered={false}
               key="separated action"
               onClick={[Function]}
-              onSelect={[Function]}
             >
               <li>
                 <button
@@ -922,10 +899,13 @@ exports[`KebabToggle expanded 1`] = `
 =======
                   onClick={[Function]}
 <<<<<<< HEAD
+<<<<<<< HEAD
 >>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
 =======
                   onSelect={[Function]}
 >>>>>>> feat(Dropdown): use Context to pass onSelect handlers
+=======
+>>>>>>> feat(Dropdown): remove onSelect default
                 >
                   Separated Action
                 </button>
@@ -971,7 +951,6 @@ exports[`KebabToggle plain 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -982,7 +961,6 @@ exports[`KebabToggle plain 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -993,7 +971,6 @@ exports[`KebabToggle plain 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -1004,7 +981,6 @@ exports[`KebabToggle plain 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -1022,7 +998,6 @@ exports[`KebabToggle plain 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -1033,7 +1008,6 @@ exports[`KebabToggle plain 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -1158,7 +1132,6 @@ exports[`KebabToggle regular 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -1169,7 +1142,6 @@ exports[`KebabToggle regular 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -1180,7 +1152,6 @@ exports[`KebabToggle regular 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -1191,7 +1162,6 @@ exports[`KebabToggle regular 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -1209,7 +1179,6 @@ exports[`KebabToggle regular 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -1220,7 +1189,6 @@ exports[`KebabToggle regular 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -1345,7 +1313,6 @@ exports[`KebabToggle right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -1356,7 +1323,6 @@ exports[`KebabToggle right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -1367,7 +1333,6 @@ exports[`KebabToggle right aligned 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -1378,7 +1343,6 @@ exports[`KebabToggle right aligned 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -1396,7 +1360,6 @@ exports[`KebabToggle right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -1407,7 +1370,6 @@ exports[`KebabToggle right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -1686,7 +1648,6 @@ exports[`dropdown dropup + right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -1697,7 +1658,6 @@ exports[`dropdown dropup + right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -1708,7 +1668,6 @@ exports[`dropdown dropup + right aligned 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -1719,7 +1678,6 @@ exports[`dropdown dropup + right aligned 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -1737,7 +1695,6 @@ exports[`dropdown dropup + right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -1748,7 +1705,6 @@ exports[`dropdown dropup + right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -1882,7 +1838,6 @@ exports[`dropdown dropup 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -1893,7 +1848,6 @@ exports[`dropdown dropup 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -1904,7 +1858,6 @@ exports[`dropdown dropup 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -1915,7 +1868,6 @@ exports[`dropdown dropup 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -1933,7 +1885,6 @@ exports[`dropdown dropup 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -1944,7 +1895,6 @@ exports[`dropdown dropup 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -2106,7 +2056,6 @@ exports[`dropdown expanded 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -2117,7 +2066,6 @@ exports[`dropdown expanded 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -2128,7 +2076,6 @@ exports[`dropdown expanded 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -2139,7 +2086,6 @@ exports[`dropdown expanded 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -2157,7 +2103,6 @@ exports[`dropdown expanded 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -2168,7 +2113,6 @@ exports[`dropdown expanded 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -2292,7 +2236,6 @@ exports[`dropdown expanded 1`] = `
               isHovered={false}
               key="link"
               onClick={[Function]}
-              onSelect={[Function]}
             >
               <li>
                 <a
@@ -2300,7 +2243,6 @@ exports[`dropdown expanded 1`] = `
                   className=""
                   href="#"
                   onClick={[Function]}
-                  onSelect={[Function]}
                 >
                   Link
                 </a>
@@ -2314,7 +2256,6 @@ exports[`dropdown expanded 1`] = `
               isHovered={false}
               key="action"
               onClick={[Function]}
-              onSelect={[Function]}
             >
               <li>
                 <button
@@ -2326,10 +2267,13 @@ exports[`dropdown expanded 1`] = `
 =======
                   onClick={[Function]}
 <<<<<<< HEAD
+<<<<<<< HEAD
 >>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
 =======
                   onSelect={[Function]}
 >>>>>>> feat(Dropdown): use Context to pass onSelect handlers
+=======
+>>>>>>> feat(Dropdown): remove onSelect default
                 >
                   Action
                 </button>
@@ -2343,7 +2287,6 @@ exports[`dropdown expanded 1`] = `
               isHovered={false}
               key="disabled link"
               onClick={[Function]}
-              onSelect={[Function]}
             >
               <li>
                 <a
@@ -2351,7 +2294,6 @@ exports[`dropdown expanded 1`] = `
                   className="pf-m-disabled"
                   href="#"
                   onClick={[Function]}
-                  onSelect={[Function]}
                   tabIndex={-1}
                 >
                   Disabled Link
@@ -2366,7 +2308,6 @@ exports[`dropdown expanded 1`] = `
               isHovered={false}
               key="disabled action"
               onClick={[Function]}
-              onSelect={[Function]}
             >
               <li>
                 <button
@@ -2378,10 +2319,13 @@ exports[`dropdown expanded 1`] = `
 =======
                   onClick={[Function]}
 <<<<<<< HEAD
+<<<<<<< HEAD
 >>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
 =======
                   onSelect={[Function]}
 >>>>>>> feat(Dropdown): use Context to pass onSelect handlers
+=======
+>>>>>>> feat(Dropdown): remove onSelect default
                 >
                   Disabled Action
                 </button>
@@ -2402,7 +2346,6 @@ exports[`dropdown expanded 1`] = `
                 isDisabled={false}
                 isHovered={false}
                 onClick={[Function]}
-                onSelect={[Function]}
                 role="separator"
               >
                 <li>
@@ -2410,7 +2353,6 @@ exports[`dropdown expanded 1`] = `
                     className="pf-c-dropdown__separator"
                     href="#"
                     onClick={[Function]}
-                    onSelect={[Function]}
                     role="separator"
                   />
                 </li>
@@ -2424,7 +2366,6 @@ exports[`dropdown expanded 1`] = `
               isHovered={false}
               key="separated link"
               onClick={[Function]}
-              onSelect={[Function]}
             >
               <li>
                 <a
@@ -2432,7 +2373,6 @@ exports[`dropdown expanded 1`] = `
                   className=""
                   href="#"
                   onClick={[Function]}
-                  onSelect={[Function]}
                 >
                   Separated Link
                 </a>
@@ -2446,7 +2386,6 @@ exports[`dropdown expanded 1`] = `
               isHovered={false}
               key="separated action"
               onClick={[Function]}
-              onSelect={[Function]}
             >
               <li>
                 <button
@@ -2458,10 +2397,13 @@ exports[`dropdown expanded 1`] = `
 =======
                   onClick={[Function]}
 <<<<<<< HEAD
+<<<<<<< HEAD
 >>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
 =======
                   onSelect={[Function]}
 >>>>>>> feat(Dropdown): use Context to pass onSelect handlers
+=======
+>>>>>>> feat(Dropdown): remove onSelect default
                 >
                   Separated Action
                 </button>
@@ -2513,7 +2455,6 @@ exports[`dropdown regular 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -2524,7 +2465,6 @@ exports[`dropdown regular 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -2535,7 +2475,6 @@ exports[`dropdown regular 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -2546,7 +2485,6 @@ exports[`dropdown regular 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -2564,7 +2502,6 @@ exports[`dropdown regular 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -2575,7 +2512,6 @@ exports[`dropdown regular 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,
@@ -2709,7 +2645,6 @@ exports[`dropdown right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Link
       </DropdownItem>,
@@ -2720,7 +2655,6 @@ exports[`dropdown right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Action
       </DropdownItem>,
@@ -2731,7 +2665,6 @@ exports[`dropdown right aligned 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Link
       </DropdownItem>,
@@ -2742,7 +2675,6 @@ exports[`dropdown right aligned 1`] = `
         isDisabled={true}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Disabled Action
       </DropdownItem>,
@@ -2760,7 +2692,6 @@ exports[`dropdown right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Link
       </DropdownItem>,
@@ -2771,7 +2702,6 @@ exports[`dropdown right aligned 1`] = `
         isDisabled={false}
         isHovered={false}
         onClick={[Function]}
-        onSelect={[Function]}
       >
         Separated Action
       </DropdownItem>,

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -764,18 +764,7 @@ exports[`KebabToggle expanded 1`] = `
                   className=""
                   disabled={false}
                   href="#"
-<<<<<<< HEAD
-                  type="button"
-=======
                   onClick={[Function]}
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
-=======
-                  onSelect={[Function]}
->>>>>>> feat(Dropdown): use Context to pass onSelect handlers
-=======
->>>>>>> feat(Dropdown): remove onSelect default
                 >
                   Action
                 </button>
@@ -816,18 +805,7 @@ exports[`KebabToggle expanded 1`] = `
                   className="pf-m-disabled"
                   disabled={true}
                   href="#"
-<<<<<<< HEAD
-                  type="button"
-=======
                   onClick={[Function]}
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
-=======
-                  onSelect={[Function]}
->>>>>>> feat(Dropdown): use Context to pass onSelect handlers
-=======
->>>>>>> feat(Dropdown): remove onSelect default
                 >
                   Disabled Action
                 </button>
@@ -894,18 +872,7 @@ exports[`KebabToggle expanded 1`] = `
                   className=""
                   disabled={false}
                   href="#"
-<<<<<<< HEAD
-                  type="button"
-=======
                   onClick={[Function]}
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
-=======
-                  onSelect={[Function]}
->>>>>>> feat(Dropdown): use Context to pass onSelect handlers
-=======
->>>>>>> feat(Dropdown): remove onSelect default
                 >
                   Separated Action
                 </button>
@@ -2262,18 +2229,7 @@ exports[`dropdown expanded 1`] = `
                   className=""
                   disabled={false}
                   href="#"
-<<<<<<< HEAD
-                  type="button"
-=======
                   onClick={[Function]}
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
-=======
-                  onSelect={[Function]}
->>>>>>> feat(Dropdown): use Context to pass onSelect handlers
-=======
->>>>>>> feat(Dropdown): remove onSelect default
                 >
                   Action
                 </button>
@@ -2314,18 +2270,7 @@ exports[`dropdown expanded 1`] = `
                   className="pf-m-disabled"
                   disabled={true}
                   href="#"
-<<<<<<< HEAD
-                  type="button"
-=======
                   onClick={[Function]}
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
-=======
-                  onSelect={[Function]}
->>>>>>> feat(Dropdown): use Context to pass onSelect handlers
-=======
->>>>>>> feat(Dropdown): remove onSelect default
                 >
                   Disabled Action
                 </button>
@@ -2392,18 +2337,7 @@ exports[`dropdown expanded 1`] = `
                   className=""
                   disabled={false}
                   href="#"
-<<<<<<< HEAD
-                  type="button"
-=======
                   onClick={[Function]}
-<<<<<<< HEAD
-<<<<<<< HEAD
->>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
-=======
-                  onSelect={[Function]}
->>>>>>> feat(Dropdown): use Context to pass onSelect handlers
-=======
->>>>>>> feat(Dropdown): remove onSelect default
                 >
                   Separated Action
                 </button>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -124,7 +124,7 @@ exports[`KebabToggle basic 1`] = `
       className=""
       component="div"
       isOpen={true}
-      onClick={[Function]}
+      onSelect={[Function]}
       position="left"
     >
       <div
@@ -694,7 +694,7 @@ exports[`KebabToggle expanded 1`] = `
       className=""
       component="ul"
       isOpen={true}
-      onClick={[Function]}
+      onSelect={[Function]}
       position="left"
     >
       <FocusTrap
@@ -713,7 +713,6 @@ exports[`KebabToggle expanded 1`] = `
             aria-labelledby="Dropdown Toggle"
             className="pf-c-dropdown__menu"
             hidden={false}
-            onClick={[Function]}
           >
             <DropdownItem
               className=""
@@ -721,13 +720,15 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key="link"
+              key=".$link"
+              onSelect={[Function]}
             >
               <li>
                 <a
                   aria-disabled={false}
                   className=""
                   href="#"
+                  onClick={[Function]}
                 >
                   Link
                 </a>
@@ -739,14 +740,19 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key="action"
+              key=".$action"
+              onSelect={[Function]}
             >
               <li>
                 <button
                   className=""
                   disabled={false}
                   href="#"
+<<<<<<< HEAD
                   type="button"
+=======
+                  onClick={[Function]}
+>>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
                 >
                   Action
                 </button>
@@ -758,13 +764,15 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={true}
               isHovered={false}
-              key="disabled link"
+              key=".$disabled link"
+              onSelect={[Function]}
             >
               <li>
                 <a
                   aria-disabled={true}
                   className="pf-m-disabled"
                   href="#"
+                  onClick={[Function]}
                   tabIndex={-1}
                 >
                   Disabled Link
@@ -777,14 +785,19 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={true}
               isHovered={false}
-              key="disabled action"
+              key=".$disabled action"
+              onSelect={[Function]}
             >
               <li>
                 <button
                   className="pf-m-disabled"
                   disabled={true}
                   href="#"
+<<<<<<< HEAD
                   type="button"
+=======
+                  onClick={[Function]}
+>>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
                 >
                   Disabled Action
                 </button>
@@ -796,7 +809,8 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key="separator"
+              key=".$separator"
+              onSelect={[Function]}
             >
               <DropdownItem
                 className="pf-c-dropdown__separator"
@@ -804,12 +818,14 @@ exports[`KebabToggle expanded 1`] = `
                 href="#"
                 isDisabled={false}
                 isHovered={false}
+                onSelect={[Function]}
                 role="separator"
               >
                 <li>
                   <div
                     className="pf-c-dropdown__separator"
                     href="#"
+                    onClick={[Function]}
                     role="separator"
                   />
                 </li>
@@ -821,13 +837,15 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key="separated link"
+              key=".$separated link"
+              onSelect={[Function]}
             >
               <li>
                 <a
                   aria-disabled={false}
                   className=""
                   href="#"
+                  onClick={[Function]}
                 >
                   Separated Link
                 </a>
@@ -839,14 +857,19 @@ exports[`KebabToggle expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key="separated action"
+              key=".$separated action"
+              onSelect={[Function]}
             >
               <li>
                 <button
                   className=""
                   disabled={false}
                   href="#"
+<<<<<<< HEAD
                   type="button"
+=======
+                  onClick={[Function]}
+>>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
                 >
                   Separated Action
                 </button>
@@ -1518,7 +1541,7 @@ exports[`dropdown basic 1`] = `
       className=""
       component="div"
       isOpen={true}
-      onClick={[Function]}
+      onSelect={[Function]}
       position="left"
     >
       <div
@@ -2115,7 +2138,7 @@ exports[`dropdown expanded 1`] = `
       className=""
       component="ul"
       isOpen={true}
-      onClick={[Function]}
+      onSelect={[Function]}
       position="left"
     >
       <FocusTrap
@@ -2134,7 +2157,6 @@ exports[`dropdown expanded 1`] = `
             aria-labelledby="Dropdown Toggle"
             className="pf-c-dropdown__menu"
             hidden={false}
-            onClick={[Function]}
           >
             <DropdownItem
               className=""
@@ -2142,13 +2164,15 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key="link"
+              key=".$link"
+              onSelect={[Function]}
             >
               <li>
                 <a
                   aria-disabled={false}
                   className=""
                   href="#"
+                  onClick={[Function]}
                 >
                   Link
                 </a>
@@ -2160,14 +2184,19 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key="action"
+              key=".$action"
+              onSelect={[Function]}
             >
               <li>
                 <button
                   className=""
                   disabled={false}
                   href="#"
+<<<<<<< HEAD
                   type="button"
+=======
+                  onClick={[Function]}
+>>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
                 >
                   Action
                 </button>
@@ -2179,13 +2208,15 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={true}
               isHovered={false}
-              key="disabled link"
+              key=".$disabled link"
+              onSelect={[Function]}
             >
               <li>
                 <a
                   aria-disabled={true}
                   className="pf-m-disabled"
                   href="#"
+                  onClick={[Function]}
                   tabIndex={-1}
                 >
                   Disabled Link
@@ -2198,14 +2229,19 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={true}
               isHovered={false}
-              key="disabled action"
+              key=".$disabled action"
+              onSelect={[Function]}
             >
               <li>
                 <button
                   className="pf-m-disabled"
                   disabled={true}
                   href="#"
+<<<<<<< HEAD
                   type="button"
+=======
+                  onClick={[Function]}
+>>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
                 >
                   Disabled Action
                 </button>
@@ -2217,7 +2253,8 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key="separator"
+              key=".$separator"
+              onSelect={[Function]}
             >
               <DropdownItem
                 className="pf-c-dropdown__separator"
@@ -2225,12 +2262,14 @@ exports[`dropdown expanded 1`] = `
                 href="#"
                 isDisabled={false}
                 isHovered={false}
+                onSelect={[Function]}
                 role="separator"
               >
                 <li>
                   <div
                     className="pf-c-dropdown__separator"
                     href="#"
+                    onClick={[Function]}
                     role="separator"
                   />
                 </li>
@@ -2242,13 +2281,15 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key="separated link"
+              key=".$separated link"
+              onSelect={[Function]}
             >
               <li>
                 <a
                   aria-disabled={false}
                   className=""
                   href="#"
+                  onClick={[Function]}
                 >
                   Separated Link
                 </a>
@@ -2260,14 +2301,19 @@ exports[`dropdown expanded 1`] = `
               href="#"
               isDisabled={false}
               isHovered={false}
-              key="separated action"
+              key=".$separated action"
+              onSelect={[Function]}
             >
               <li>
                 <button
                   className=""
                   disabled={false}
                   href="#"
+<<<<<<< HEAD
                   type="button"
+=======
+                  onClick={[Function]}
+>>>>>>> feat(Dropdown): assign onClick to disabled items, update tests
                 >
                   Separated Action
                 </button>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownItem.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownItem.test.js.snap
@@ -26,7 +26,6 @@ exports[`dropdown items separator 1`] = `
   isDisabled={false}
   isHovered={false}
   onClick={[Function]}
-  onSelect={[Function]}
   role="separator"
 />
 `;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownItem.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownItem.test.js.snap
@@ -1,102 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`dropdown items a 1`] = `
-<li>
-  <a
-    aria-disabled={false}
-    className=""
-    href="#"
-    onClick={[Function]}
-  >
-    Something
-  </a>
-</li>
-`;
+exports[`dropdown items a 1`] = `<[object Object] />`;
 
-exports[`dropdown items button 1`] = `
-<li>
-  <button
-    className=""
-    disabled={false}
-    href="#"
-    type="button"
-    onClick={[Function]}
-  >
-    Something
-  </button>
-</li>
-`;
+exports[`dropdown items button 1`] = `<[object Object] />`;
 
-exports[`dropdown items disabled a 1`] = `
-.pf-m-disabled {
-  display: block;
-}
+exports[`dropdown items disabled a 1`] = `<[object Object] />`;
 
-<li>
-  <a
-    aria-disabled={true}
-    className="pf-m-disabled"
-    href="#"
-    onClick={[Function]}
-    tabIndex={-1}
-  >
-    Something
-  </a>
-</li>
-`;
+exports[`dropdown items disabled button 1`] = `<[object Object] />`;
 
-exports[`dropdown items disabled button 1`] = `
-.pf-m-disabled {
-  display: block;
-}
+exports[`dropdown items hover a 1`] = `<[object Object] />`;
 
-<li>
-  <button
-    className="pf-m-disabled"
-    disabled={true}
-    href="#"
-    type="button"
-    onClick={[Function]}
-  >
-    Something
-  </button>
-</li>
-`;
-
-exports[`dropdown items hover a 1`] = `
-.pf-m-hover {
-  display: block;
-}
-
-<li>
-  <a
-    aria-disabled={false}
-    className="pf-m-hover"
-    href="#"
-    onClick={[Function]}
-  >
-    Something
-  </a>
-</li>
-`;
-
-exports[`dropdown items hover button 1`] = `
-.pf-m-hover {
-  display: block;
-}
-
-<li>
-  <button
-    className="pf-m-hover"
-    disabled={false}
-    href="#"
-    type="button"
-    onClick={[Function]}
-  >
-    Something
-  </button>
-</li>
-`;
+exports[`dropdown items hover button 1`] = `<[object Object] />`;
 
 exports[`dropdown items separator 1`] = `
 .pf-c-dropdown__separator {

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownItem.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownItem.test.js.snap
@@ -111,6 +111,7 @@ exports[`dropdown items separator 1`] = `
   href="#"
   isDisabled={false}
   isHovered={false}
+  onClick={[Function]}
   onSelect={[Function]}
   role="separator"
 />

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownItem.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownItem.test.js.snap
@@ -6,6 +6,7 @@ exports[`dropdown items a 1`] = `
     aria-disabled={false}
     className=""
     href="#"
+    onClick={[Function]}
   >
     Something
   </a>
@@ -19,6 +20,7 @@ exports[`dropdown items button 1`] = `
     disabled={false}
     href="#"
     type="button"
+    onClick={[Function]}
   >
     Something
   </button>
@@ -35,6 +37,7 @@ exports[`dropdown items disabled a 1`] = `
     aria-disabled={true}
     className="pf-m-disabled"
     href="#"
+    onClick={[Function]}
     tabIndex={-1}
   >
     Something
@@ -53,6 +56,7 @@ exports[`dropdown items disabled button 1`] = `
     disabled={true}
     href="#"
     type="button"
+    onClick={[Function]}
   >
     Something
   </button>
@@ -69,6 +73,7 @@ exports[`dropdown items hover a 1`] = `
     aria-disabled={false}
     className="pf-m-hover"
     href="#"
+    onClick={[Function]}
   >
     Something
   </a>
@@ -86,6 +91,7 @@ exports[`dropdown items hover button 1`] = `
     disabled={false}
     href="#"
     type="button"
+    onClick={[Function]}
   >
     Something
   </button>
@@ -105,6 +111,7 @@ exports[`dropdown items separator 1`] = `
   href="#"
   isDisabled={false}
   isHovered={false}
+  onSelect={[Function]}
   role="separator"
 />
 `;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/dropdownConstants.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/dropdownConstants.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export const DropdownPosition = {
   right: 'right',
   left: 'left'
@@ -7,3 +9,7 @@ export const DropdownDirection = {
   up: 'up',
   down: 'down'
 };
+
+export const DropdownContext = React.createContext({
+  onSelect: () => {}
+});


### PR DESCRIPTION
Issue reference: #984 

**What**: Fix focus trap disabling the dropdown toggle function. Pipe onSelect event to DropdownItem, allowing its disabled property to control if the event is fired. In our example docs, this means that clicking a disabled link will not close the dropdown.