### PR TITLE
docs(Dropdown): clarify Dropdown example titles

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.docs.js
@@ -1,5 +1,5 @@
 import { Dropdown, KebabToggle, DropdownItem, DropdownSeparator, DropdownToggle } from '@patternfly/react-core';
-import Basic from './examples/BasicDropdown';
+import Panel from './examples/DropdownPanel';
 import Simple from './examples/SimpleDropdown';
 import Kebab from './examples/KebabDropdown';
 import PositionRight from './examples/PositionRightDropdown';
@@ -15,10 +15,14 @@ export default {
     DropdownToggle
   },
   examples: [
-    { component: Basic, title: 'Basic dropdown' },
-    { component: Simple, title: 'Simple dropdown' },
+    { component: Simple, title: 'Dropdown' },
     { component: PositionRight, title: 'Dropdown - position right' },
     { component: DirectionUp, title: 'Dropdown - direction up' },
-    { component: Kebab, title: 'Kebab' }
+    { component: Kebab, title: 'Kebab' },
+    {
+      component: Panel,
+      title: 'Dropdown Panel',
+      description: 'The Basic Dropdown is provided for flexibility in allowing various content within a dropdown.'
+    }
   ]
 };

--- a/packages/patternfly-4/react-core/src/components/Dropdown/examples/DropdownPanel.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/examples/DropdownPanel.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Dropdown, DropdownToggle } from '@patternfly/react-core';
 
-export default class BasicDropdown extends Component {
+export default class DropdownPanel extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -29,7 +29,7 @@ export default class BasicDropdown extends Component {
         toggle={<DropdownToggle onToggle={this.onToggle}>Expanded Dropdown</DropdownToggle>}
         isOpen={isOpen}
       >
-        <div>Expanded Dropdown</div>
+        <div>[Panel contents here]</div>
       </Dropdown>
     );
   }


### PR DESCRIPTION
**What**: Rename dropdown examples to better reflect their intended purpose. Reorganize examples so custom case is at the bottom.

Addresses: #1000 


<!-- What changes are being made? (What issue is being addressed here?) -->
<!-- feel free to add additional comments -->
