### PR TITLE
@patternfly/react-console: Remove unnecessary peer dependencies

### DIFF
--- a/packages/patternfly-3/react-console/package.json
+++ b/packages/patternfly-3/react-console/package.json
@@ -49,11 +49,9 @@
     "patternfly-react": "^2.25.3"
   },
   "peerDependencies": {
-    "patternfly": "^3.58.0",
     "patternfly-react": "^2.24.0",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
-    "react-bootstrap": "^0.32.1",
     "react-dom": "^16.3.2"
   }
 }


### PR DESCRIPTION
This is a follow-up to [`kubevirt-web-ui-components` issue 136](https://github.com/kubevirt/web-ui-components/issues/136).

Main [`patternfly-react` package](https://github.com/patternfly/patternfly-react/blob/master/packages/patternfly-3/patternfly-react/package.json) declares `patternfly` and `react-bootstrap` as regular dependencies, which pulls them into the consuming application's dependency tree.

However, [`@patternfly/react-console` package](https://github.com/patternfly/patternfly-react/blob/master/packages/patternfly-3/react-console/package.json) declares `patternfly` and `react-bootstrap` as _peer dependencies_ (in addition to having a peer dependency on `patternfly-react`, which in turn pulls these two specific libraries as _regular dependencies_).

Aside from the fact that code in `@patternfly/react-console` package doesn't link to neither `patternfly` nor `react-bootstrap`, this breaks the rule established by main `patternfly-react` package - treating those two specific libraries as regular dependencies, pulled transitively into the consuming application's dependency tree.

Having too many peer dependencies can snowball into tons of warnings in consuming libraries and/or applications. Let's try not to introduce additional peer dependencies unless we have a compelling reason to do so.