### PR TITLE
BulletChartAxisTic: Fixed text property for custom axis tic mark

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Chart/BulletChart/BulletChartAxisTic.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Chart/BulletChart/BulletChartAxisTic.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const BulletChartAxisTic = ({ className, vertical, value, ...props }) => {
+const BulletChartAxisTic = ({ className, text, vertical, value, ...props }) => {
   const bulletChartAxisTicClass = classNames('bullet-chart-pf-axis-tic', className);
 
   let ticStyle;
@@ -14,7 +14,7 @@ const BulletChartAxisTic = ({ className, vertical, value, ...props }) => {
 
   return (
     <span className={bulletChartAxisTicClass} style={ticStyle}>
-      {value}
+      {text || value}
     </span>
   );
 };

--- a/packages/patternfly-3/patternfly-react/src/components/Chart/BulletChart/__snapshots__/BulletChart.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/Chart/BulletChart/__snapshots__/BulletChart.test.js.snap
@@ -3137,7 +3137,7 @@ exports[`BulletChartAxisTic renders text properly 1`] = `
     }
   }
 >
-  25
+  my-bullet-axis-tic-text
 </span>
 `;
 


### PR DESCRIPTION
This PR fixes an issue with the `text` property of BulletChartAxisTic. 

The `text` property is documented, but never used in the code. It allows users to apply a custom label to the x-axis, while the given `value` property used by default.

Fixes https://github.com/patternfly/patternfly-react/issues/1028
