### PR TITLE
docs(Text): remove pre Text example

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Text/examples/BodyText.js
+++ b/packages/patternfly-4/react-core/src/components/Text/examples/BodyText.js
@@ -17,9 +17,6 @@ class BodyText extends React.Component {
           </Text>
           . Phasellus lacus ex, semper ac tortor nec, fringilla condimentum orci. Fusce eu rutrum tellus.
         </Text>
-        <Text component={TextVariants.pre}>
-          Aliquam sagittis rhoncus vulputate. Cras non luctus sem, sed tincidunt ligula.
-        </Text>
         <Text component={TextVariants.blockquote}>
           Ut venenatis, nisl scelerisque sollicitudin fermentum, quam libero hendrerit ipsum, ut blandit est tellus sit
           amet turpis.


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Removing pre Text example, but leaving pre in TextVariants for now due to its usage in livedemo

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Refer to issue**: #1023

<!-- feel free to add additional comments -->
