### PR TITLE
docs(Stack): increase height of example containers to show flex grow

### DIFF
--- a/packages/patternfly-4/react-core/src/layouts/Stack/examples/common/getContainerProps.js
+++ b/packages/patternfly-4/react-core/src/layouts/Stack/examples/common/getContainerProps.js
@@ -8,6 +8,9 @@ const styles = StyleSheet.create({
       borderWidth: borderWidth.var,
       borderStyle: 'dashed',
       borderColor: borderColor.var
+    },
+    '&': {
+      height: 250
     }
   }
 });


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Flex grow is being applied but example containers are too short to display the growth. Increased example container height.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Refer to issue**: #1025

<!-- feel free to add additional comments -->
