### PR TITLE
WIP PR for aria testing Modal component

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Modal/Modal.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/Modal.docs.js
@@ -1,11 +1,16 @@
 import { Modal } from '@patternfly/react-core';
 import Simple from './examples/SimpleModal';
 import Large from './examples/LargeModal';
+import AriaLabel from './examples/AriaLabelModal';
 
 export default {
   title: 'Modal',
   components: {
     Modal
   },
-  examples: [{ component: Simple, title: 'Simple Modal' }, { component: Large, title: 'Large Modal' }]
+  examples: [
+    { component: AriaLabel, title: 'Aria Label Modal' },
+    { component: Simple, title: 'Simple Modal' },
+    { component: Large, title: 'Large Modal' }
+  ]
 };

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBox.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBox.js
@@ -22,14 +22,7 @@ const defaultProps = {
 };
 
 const ModalBox = ({ children, className, isLarge, title, id, ...props }) => (
-  <div
-    {...props}
-    role="dialog"
-    aria-label={title}
-    aria-describedby={id}
-    aria-modal="true"
-    className={css(styles.modalBox, className, isLarge && styles.modifiers.lg)}
-  >
+  <div {...props} className={css(styles.modalBox, className, isLarge && styles.modifiers.lg)}>
     {children}
   </div>
 );

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxHeader.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxHeader.js
@@ -17,7 +17,9 @@ const defaultProps = {
 
 const ModalBoxHeader = ({ children, className, ...props }) => (
   <header {...props} className={css(styles.modalBoxHeader, className)}>
-    <h1 className={css(styles.modalBoxHeaderTitle)}>{children}</h1>
+    <h1 className={css(styles.modalBoxHeaderTitle)} id="modal-header-h1">
+      {children}
+    </h1>
   </header>
 );
 

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.js
@@ -49,12 +49,10 @@ const ModalContent = ({ children, className, isOpen, title, hideTitle, actions, 
     <Backdrop>
       <Bullseye>
         <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
-          <ModalBox className={className} isLarge={isLarge} title={title} id={id}>
+          <ModalBox className={className} isLarge={isLarge} title={title} id={id} {...props}>
             <ModalBoxHCloseButton onClose={onClose} />
-            {modalBoxHeader}
-            <ModalBoxBody {...props} id={id}>
-              {children}
-            </ModalBoxBody>
+            {!hideTitle && modalBoxHeader}
+            <ModalBoxBody id={id}>{children}</ModalBoxBody>
             {modalBoxFooter}
           </ModalBox>
         </FocusTrap>

--- a/packages/patternfly-4/react-core/src/components/Modal/__snapshots__/ModalBox.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Modal/__snapshots__/ModalBox.test.js.snap
@@ -15,11 +15,7 @@ exports[`ModalBox Test 1`] = `
 }
 
 <div
-  aria-describedby="id"
-  aria-label="test title"
-  aria-modal="true"
   className="pf-c-modal-box"
-  role="dialog"
 >
   This is a ModalBox
 </div>
@@ -40,11 +36,7 @@ exports[`ModalBox Test isLarge 1`] = `
 }
 
 <div
-  aria-describedby="id"
-  aria-label="Test Modal title"
-  aria-modal="true"
   className="pf-c-modal-box pf-m-lg"
-  role="dialog"
 >
   This is a ModalBox
 </div>
@@ -65,12 +57,8 @@ exports[`ModalBox Test isOpen 1`] = `
 }
 
 <div
-  aria-describedby="id"
-  aria-label="Test Modal title"
-  aria-modal="true"
   className="pf-c-modal-box pf-m-lg"
   isOpen={true}
-  role="dialog"
 >
   This is a ModalBox
 </div>

--- a/packages/patternfly-4/react-core/src/components/Modal/__snapshots__/ModalBoxHeader.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Modal/__snapshots__/ModalBoxHeader.test.js.snap
@@ -17,6 +17,7 @@ exports[`ModalBoxHeader Test 1`] = `
 >
   <h1
     className="pf-c-modal-box__header-title"
+    id="modal-header-h1"
   >
     This is a ModalBox header
   </h1>

--- a/packages/patternfly-4/react-core/src/components/Modal/examples/AriaLabelModal.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/examples/AriaLabelModal.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Modal, Button } from '@patternfly/react-core';
+
+class AriaLabelModal extends React.Component {
+  state = {
+    isModalOpen: false
+  };
+
+  handleModalToggle = () => {
+    this.setState(({ isModalOpen }) => ({
+      isModalOpen: !isModalOpen
+    }));
+  };
+
+  render() {
+    const { isModalOpen } = this.state;
+
+    return (
+      <React.Fragment>
+        <Button variant="primary" onClick={this.handleModalToggle}>
+          Show Modal
+        </Button>
+        <Modal
+          title="Modal Header"
+          role="dialog"
+          aria-label="Modal Header"
+          aria-describedby="description-text"
+          aria-modal="true"
+          hideTitle
+          isOpen={isModalOpen}
+          onClose={this.handleModalToggle}
+          actions={[
+            <Button key="cancel" variant="secondary" onClick={this.handleModalToggle}>
+              Cancel
+            </Button>,
+            <Button key="confirm" variant="primary" onClick={this.handleModalToggle}>
+              Confirm
+            </Button>
+          ]}
+          reactRoot={document.querySelector('#___gatsby')}
+        >
+          <span id="description-text">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+            dolore magna aliqua.
+          </span>
+          Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+          Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </Modal>
+      </React.Fragment>
+    );
+  }
+}
+
+export default AriaLabelModal;


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Changed aria controls to allow customizable example for screen reader testing. It's worth noting that the current implementation had automatically set aria attributes based on other inputs (aria-label was set by the title attribute, and aria-describedby was set to an id of a container that the component automatically wrapped the body text in, while role and aria-modal were manually declared) and any additional props to Modal were passed to the Modal body and not the Modal box.

@jgiardino You should be able to live-edit the code in the aria example with whatever you need.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Refer to issue**: #1044

<!-- feel free to add additional comments -->
