### PR TITLE
Removed Props from avatar

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Avatar/Avatar.tsx
+++ b/packages/patternfly-4/react-core/src/components/Avatar/Avatar.tsx
@@ -1,20 +1,10 @@
 import React, { DetailedHTMLProps, ImgHTMLAttributes } from 'react';
 import styles from '@patternfly/patternfly-next/components/Avatar/avatar.css';
 import { css } from '@patternfly/react-styles';
-import PropTypes from 'prop-types';
 
 const defaultProps = {
   className: '',
   src: ''
-};
-
-const propTypes = {
-  /** Additional classes added to the Avatar. */
-  className: PropTypes.string,
-  /** Attribute that specifies the URL of the image for the Avatar. */
-  src: PropTypes.string,
-  /** Attribute that specifies the alt text of the image for the Avatar. */
-  alt: PropTypes.string.isRequired
 };
 
 /**


### PR DESCRIPTION

**What**:
Updated to remove Proptypes from Avatar since we have interface for tsx

**Additional issues**:

Built locally and it worked without proptypes for Jest tests.
