### PR TITLE
feat(CatalogTile): Add footer option to tiles

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
+++ b/packages/patternfly-3/patternfly-react-extensions/less/catalog-tile.less
@@ -96,6 +96,12 @@
   }
 }
 
+.catalog-tile-pf-footer {
+  border-top: 1px solid rgba(209, 209, 209, 0.75);
+  margin: 5px -15px -15px;
+  padding: 5px 15px;
+}
+
 .catalog-tile-view-pf-no-categories {
   display: flex;
   flex-wrap: wrap;

--- a/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
+++ b/packages/patternfly-3/patternfly-react-extensions/sass/patternfly-react-extensions/_catalog-tile.scss
@@ -96,6 +96,12 @@
   }
 }
 
+.catalog-tile-pf-footer {
+  border-top: 1px solid rgba(209, 209, 209, 0.75);
+  margin: 5px -15px -15px;
+  padding: 5px 15px;
+}
+
 .catalog-tile-view-pf-no-categories {
   display: flex;
   flex-wrap: wrap;

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.js
@@ -92,6 +92,7 @@ class CatalogTile extends React.Component {
       description,
       truncateDescriptionFn,
       maxDescriptionLength,
+      footer,
       ...otherProps
     } = this.props;
     const { heightStyle } = this.state;
@@ -128,6 +129,7 @@ class CatalogTile extends React.Component {
             </span>
           </div>
         </div>
+        {footer && <div className="catalog-tile-pf-footer">{footer}</div>}
       </OuterComponent>
     );
   }
@@ -159,7 +161,9 @@ CatalogTile.propTypes = {
   /** Max description length before applying truncation (when description is a string), -1 for auto truncate to last visible line */
   maxDescriptionLength: PropTypes.number,
   /** Truncation function(description, max, id) used to truncate description when necessary (defaults to using ellipses) */
-  truncateDescriptionFn: PropTypes.func
+  truncateDescriptionFn: PropTypes.func,
+  /** Footer for the tile */
+  footer: PropTypes.oneOfType([PropTypes.string, PropTypes.node])
 };
 
 CatalogTile.defaultProps = {
@@ -174,7 +178,8 @@ CatalogTile.defaultProps = {
   vendor: null,
   description: null,
   maxDescriptionLength: -1,
-  truncateDescriptionFn: null
+  truncateDescriptionFn: null,
+  footer: null
 };
 
 CatalogTile.displayName = 'CatalogTile';

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.stories.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.stories.js
@@ -45,6 +45,29 @@ stories.add(
         }
       />
       <CatalogTile
+        id="tile-footer-test"
+        featured
+        href="https://github.com/patternfly/patternfly-react"
+        iconImg={pfBrand}
+        badges={[
+          <CatalogTileBadge title="Certified" id="certified">
+            <Icon type="fa" name="cog" />
+          </CatalogTileBadge>
+        ]}
+        title="Patternfly-React"
+        vendor="provided by Red Hat"
+        description={
+          'This is a very long description that should be truncated after 112 characters. ' +
+          '112 is the default but can be overridden if need be. You can also provide a custom truncation function ' +
+          'to truncate the description how you see fit. It will be passed the description, max length, and id.'
+        }
+        footer={
+          <span>
+            <Icon type="pf" name="ok" /> Enabled
+          </span>
+        }
+      />
+      <CatalogTile
         iconImg={ngnix}
         badges={[
           <CatalogTileBadge title="Certified" id="certified">
@@ -54,6 +77,11 @@ stories.add(
         title="Nginx"
         vendor={<span>provided by Nginx</span>}
         description="The open source web server that powers 400 million websites."
+        footer={
+          <span>
+            <Icon type="fa" name="hourglass-half" /> Requested
+          </span>
+        }
       />
       <CatalogTile
         iconClass="fa fa-codepen"

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.test.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/CatalogTile.test.js
@@ -98,6 +98,29 @@ test('CatalogTile renders properly', () => {
         maxDescriptionLength={10}
         truncateDescriptionFn={testTruncationFunction}
       />
+      <CatalogTile
+        id="tile-footer-test"
+        featured
+        href="https://github.com/patternfly/patternfly-react"
+        iconImg={pfBrand}
+        badges={[
+          <CatalogTile.Badge title="Certified" id="certified">
+            <Icon type="fa" name="cog" />
+          </CatalogTile.Badge>
+        ]}
+        title="Patternfly-React"
+        vendor="provided by Red Hat"
+        description={
+          'This is a very long description that should be truncated after 112 characters. ' +
+          '112 is the default but can be overridden if need be. You can also provide a custom truncation function ' +
+          'to truncate the description how you see fit. It will be passed the description, max length, and id.'
+        }
+        footer={
+          <span>
+            <Icon type="pf" name="ok" /> Enabled
+          </span>
+        }
+      />
     </div>
   );
   expect(component.render()).toMatchSnapshot();

--- a/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/__snapshots__/CatalogTile.test.js.snap
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/CatalogTile/__snapshots__/CatalogTile.test.js.snap
@@ -375,5 +375,71 @@ exports[`CatalogTile renders properly 1`] = `
       </div>
     </div>
   </div>
+  <a
+    class="catalog-tile-pf featured"
+    href="https://github.com/patternfly/patternfly-react"
+    id="tile-footer-test"
+  >
+    <div
+      class="catalog-tile-pf-header"
+    >
+      <img
+        alt=""
+        class="catalog-tile-pf-icon"
+        src="<PatternFly Brand Image here>"
+      />
+      <div
+        class="catalog-tile-pf-badge-container"
+      >
+        <span>
+          <span
+            class="catalog-tile-pf-badge"
+          >
+            <span
+              aria-hidden="true"
+              class="fa fa-cog"
+            />
+            <span
+              class="sr-only"
+            >
+              Certified
+            </span>
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      class="catalog-tile-pf-body"
+    >
+      <div
+        class="catalog-tile-pf-title"
+      >
+        Patternfly-React
+      </div>
+      <div
+        class="catalog-tile-pf-subtitle"
+      >
+        provided by Red Hat
+      </div>
+      <div
+        class="catalog-tile-pf-description"
+      >
+        <span>
+          This is a very long description that should be truncated after 112 characters. 112 is the default but can be overridden if need be. You can also provide a custom truncation function to truncate the description how you see fit. It will be passed the description, max length, and id.
+        </span>
+      </div>
+    </div>
+    <div
+      class="catalog-tile-pf-footer"
+    >
+      <span>
+        <span
+          aria-hidden="true"
+          class="pficon pficon-ok"
+        />
+         Enabled
+      </span>
+    </div>
+  </a>
 </div>
 `;


### PR DESCRIPTION
This PR provides the ability to have a footer to the catalog tile content.