### PR TITLE
PF4: fix(LoginForm): LoginForm.d.ts fix typo passwordValue

### DIFF
--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginForm.d.ts
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginForm.d.ts
@@ -9,7 +9,7 @@ export interface LoginFormProps extends HTMLProps<HTMLFormElement> {
   usernameHelperTextInvalid?: string;
   isValidUsername?: boolean;
   passwordLabel?: string;
-  PasswordValue?: string;
+  passwordValue?: string;
   onChangePassword?: Function;
   passwordHelperText?: string;
   passwordHelperTextInvalid?: string;


### PR DESCRIPTION

fix #1062

Change a typo error in LoginForm component.


**What**:

Change passwordValue by passwordValue, we can't use the password field when you import this component

