### PR TITLE
PF4: feat(LoginForm) let placeholder in username and password input

### DIFF
--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginForm.d.ts
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginForm.d.ts
@@ -5,12 +5,14 @@ export interface LoginFormProps extends HTMLProps<HTMLFormElement> {
   usernameLabel?: string;
   usernameValue?: string;
   onChangeUsername?: Function;
+  usernamePlaceholder?: string;
   usernameHelperText?: string;
   usernameHelperTextInvalid?: string;
   isValidUsername?: boolean;
   passwordLabel?: string;
   PasswordValue?: string;
   onChangePassword?: Function;
+  passwordPlaceholder?: string;
   passwordHelperText?: string;
   passwordHelperTextInvalid?: string;
   isValidPassword?: boolean;

--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginForm.js
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginForm.js
@@ -14,6 +14,8 @@ const propTypes = {
   usernameValue: PropTypes.string,
   /** Function that handles the onChange event for the Username */
   onChangeUsername: PropTypes.func,
+  /** Placeholder for the User Input Field */
+  usernamePlaceholder: PropTypes.string,
   /** Helper Text for the Username Input Field */
   usernameHelperText: PropTypes.string,
   /** Helper Text for the Username Input Field when it is invalid */
@@ -26,6 +28,8 @@ const propTypes = {
   passwordValue: PropTypes.string,
   /** Function that handles the onChange event for the Password */
   onChangePassword: PropTypes.func,
+  /** Placeholder for the Password Input Field */
+  passwordPlaceholder: PropTypes.string,
   /** Helper Text for the Password Input Field */
   passwordHelperText: PropTypes.string,
   /** Helper Text for the Password Input Field when it is invalid */
@@ -58,12 +62,14 @@ const defaultProps = {
   usernameLabel: 'Username',
   usernameValue: '',
   onChangeUsername: () => undefined,
+  usernamePlaceholder: '',
   usernameHelperText: '',
   usernameHelperTextInvalid: '',
   isValidUsername: true,
   passwordLabel: 'Password',
   passwordValue: '',
   onChangePassword: () => undefined,
+  passwordPlaceholder: '',
   passwordHelperText: '',
   passwordHelperTextInvalid: '',
   isValidPassword: true,
@@ -81,12 +87,14 @@ const LoginForm = ({
   usernameLabel,
   usernameValue,
   onChangeUsername,
+  usernamePlaceholder,
   usernameHelperText,
   usernameHelperTextInvalid,
   isValidUsername,
   passwordLabel,
   passwordValue,
   onChangePassword,
+  passwordPlaceholder,
   passwordHelperText,
   passwordHelperTextInvalid,
   isValidPassword,
@@ -111,6 +119,7 @@ const LoginForm = ({
       <TextInput
         id="pf-login-username-id"
         isRequired
+        placeholder={usernamePlaceholder}
         isValid={isValidUsername}
         type="text"
         name="pf-login-username-id"
@@ -131,6 +140,7 @@ const LoginForm = ({
         type="password"
         id="pf-login-password-id"
         name="pf-login-password-id"
+        placeholder={passwordPlaceholder}
         isValid={isValidPassword}
         value={passwordValue}
         onChange={onChangePassword}

--- a/packages/patternfly-4/react-core/src/components/LoginPage/__snapshots__/LoginForm.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/__snapshots__/LoginForm.test.js.snap
@@ -25,6 +25,7 @@ exports[`LoginForm with rememberMeLabel and no rememberMeAriaLabel generates con
       isValid={true}
       name="pf-login-username-id"
       onChange={[Function]}
+      placeholder=""
       type="text"
       value=""
     />
@@ -49,6 +50,7 @@ exports[`LoginForm with rememberMeLabel and no rememberMeAriaLabel generates con
       isValid={true}
       name="pf-login-password-id"
       onChange={[Function]}
+      placeholder=""
       type="password"
       value=""
     />
@@ -111,6 +113,7 @@ exports[`LoginForm with rememberMeLabel and rememberMeAriaLabel does not generat
       isValid={true}
       name="pf-login-username-id"
       onChange={[Function]}
+      placeholder=""
       type="text"
       value=""
     />
@@ -135,6 +138,7 @@ exports[`LoginForm with rememberMeLabel and rememberMeAriaLabel does not generat
       isValid={true}
       name="pf-login-password-id"
       onChange={[Function]}
+      placeholder=""
       type="password"
       value=""
     />
@@ -197,6 +201,7 @@ exports[`should render Login form 1`] = `
       isValid={true}
       name="pf-login-username-id"
       onChange={[Function]}
+      placeholder=""
       type="text"
       value=""
     />
@@ -221,6 +226,7 @@ exports[`should render Login form 1`] = `
       isValid={true}
       name="pf-login-password-id"
       onChange={[Function]}
+      placeholder=""
       type="password"
       value=""
     />

--- a/packages/patternfly-4/react-core/src/components/LoginPage/examples/SimpleLoginPage.js
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/examples/SimpleLoginPage.js
@@ -103,11 +103,13 @@ class SimpleLoginPage extends React.Component {
         usernameValue={this.state.usernameValue}
         onChangeUsername={this.handleUsernameChange}
         usernameHelperTextInvalid="Unknown Username"
+        usernamePlaceholder="Username"
         isValidUsername
         passwordLabel="Password"
         passwordValue={this.state.passwordValue}
         onChangePassword={this.handlePasswordChange}
         passwordHelperTextInvalid="Password Invalid"
+        passwordPlaceholder="Password"
         isValidPassword
         rememberMeLabel="Keep me logged in for 30 days."
         isRememberMeChecked={this.state.isRememberMeChecked}


### PR DESCRIPTION
Require: https://github.com/patternfly/patternfly-react/pull/1066
Fix #1065 


This let to the user set a placeholder in the username and password fields inside the LoginForm

![peek 2018-12-15 16-20](https://user-images.githubusercontent.com/3019213/50044581-f904c300-0085-11e9-9958-e8ba6a7f018f.gif)
