### PR TITLE
feat(Overlay): Export the Overlay component from react-bootstrap

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Overlay/Overlay.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Overlay/Overlay.js
@@ -1,0 +1,3 @@
+import { Overlay } from 'react-bootstrap';
+
+export default Overlay;

--- a/packages/patternfly-3/patternfly-react/src/components/Overlay/Overlay.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Overlay/Overlay.stories.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { withKnobs, select } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+import { defaultTemplate } from 'storybook/decorators/storyTemplates';
+import { storybookPackageName, DOCUMENTATION_URL, STORYBOOK_CATEGORY } from 'storybook/constants/siteConstants';
+import { name } from '../../../package.json';
+import { MockOverlayManager, basicExampleSource } from './__mocks__/mockOverlayManager';
+import { Overlay } from './index';
+
+const stories = storiesOf(`${storybookPackageName(name)}/${STORYBOOK_CATEGORY.WIDGETS}/Overlay`, module);
+stories.addDecorator(withKnobs);
+stories.addDecorator(
+  defaultTemplate({
+    title: 'Overlay',
+    reactBootstrapDocumentationLink: `${DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT}overlays`
+  })
+);
+
+stories.add(
+  'Overlay',
+  withInfo({
+    source: false,
+    propTables: [Overlay],
+    propTablesExclude: [MockOverlayManager],
+    text: (
+      <div>
+        <h1>Story Source</h1>
+        <pre>{basicExampleSource}</pre>
+      </div>
+    )
+  })(() => (
+    <MockOverlayManager
+      placement={select('Placement', { top: 'Top', bottom: 'Bottom', right: 'Right', left: 'Left' }, 'top')}
+    />
+  ))
+);

--- a/packages/patternfly-3/patternfly-react/src/components/Overlay/__mocks__/mockOverlayManager.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Overlay/__mocks__/mockOverlayManager.js
@@ -1,0 +1,91 @@
+/* eslint-disable react/no-find-dom-node */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '../../Button';
+import { Popover } from '../../Popover';
+import { Overlay } from '../index';
+
+export class MockOverlayManager extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.buttonRef = React.createRef();
+    this.state = { showOverlay: false };
+  }
+  toggleOverlay = () => {
+    const { showOverlay } = this.state;
+    this.setState({ showOverlay: !showOverlay });
+  };
+  render() {
+    const { placement } = this.props;
+    const { showOverlay } = this.state;
+
+    return (
+      <React.Fragment>
+        <Button bsStyle="primary" bsSize="large" onClick={this.toggleOverlay} ref={this.buttonRef}>
+          Click Here
+        </Button>
+        <Overlay target={this.buttonRef.current} container={this} show={showOverlay} placement={placement}>
+          <Popover id="my-overlay">
+            <strong>Holy guacamole!</strong> Check this info.
+          </Popover>
+        </Overlay>
+      </React.Fragment>
+    );
+  }
+}
+
+MockOverlayManager.propTypes = {
+  placement: PropTypes.oneOf(['top', 'bottom', 'right', 'left'])
+};
+
+MockOverlayManager.defaultProps = {
+  placement: 'top'
+};
+
+export const basicExampleSource = `
+/* eslint-disable react/no-find-dom-node */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '../../Button';
+import { Popover } from '../../Popover';
+import { Overlay } from '../index';
+
+export class MockOverlayManager extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.buttonRef = React.createRef();
+    this.state = { showOverlay: false };
+  }
+  toggleOverlay = () => {
+    const { showOverlay } = this.state;
+    this.setState({ showOverlay: !showOverlay });
+  };
+  render() {
+    const { placement } = this.props;
+    const { showOverlay } = this.state;
+
+    return (
+      <React.Fragment>
+        <Button bsStyle="primary" bsSize="large" onClick={this.toggleOverlay} ref={this.buttonRef}>
+          Click Here
+        </Button>
+        <Overlay target={this.buttonRef.current} container={this} show={showOverlay} placement={placement}>
+          <Popover id="my-overlay">
+            <strong>Holy guacamole!</strong> Check this info.
+          </Popover>
+        </Overlay>
+      </React.Fragment>
+    );
+  }
+}
+
+MockOverlayManager.propTypes = {
+  placement: PropTypes.oneOf(['top', 'bottom', 'right', 'left'])
+};
+
+MockOverlayManager.defaultProps = {
+  placement: 'top'
+};
+`;

--- a/packages/patternfly-3/patternfly-react/src/components/Overlay/index.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Overlay/index.js
@@ -1,0 +1,1 @@
+export { default as Overlay } from './Overlay';

--- a/packages/patternfly-3/patternfly-react/src/index.js
+++ b/packages/patternfly-3/patternfly-react/src/index.js
@@ -54,3 +54,4 @@ export * from './components/VerticalNav';
 export * from './components/Wizard';
 export { patternfly, layout } from './common/patternfly';
 export * from './components/ExpandCollapse';
+export * from './components/Overlay';


### PR DESCRIPTION
**What**:
The `OverlayTrigger` component is great for most use cases, but as a higher level abstraction it can
lack the flexibility needed to build more nuanced or custom behaviors into your `Overlay`
components. For these cases it can be helpful to forgo the trigger and use the `Overlay` component
directly.

**Storybook**
https://rawgit.com/sharvit/patternfly-react/storybook/feature/overlay/index.html?knob-Placement=top&selectedKind=patternfly-react%2FWidgets%2FOverlay&selectedStory=Overlay%20story&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs
