### PR TITLE
fix(DualList): Adding debounce for filter changes

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/DualListSelector/DualList.js
+++ b/packages/patternfly-3/patternfly-react/src/components/DualListSelector/DualList.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import cloneDeep from 'lodash/cloneDeep';
 import DualListArrows from './components/DualListArrows';
 import DualListSelector from './components/DualListSelector';
-import { noop } from '../../common/helpers';
+import { noop, debounce } from '../../common/helpers';
 import {
   arrangeArray,
   isAllChildrenChecked,
@@ -25,6 +25,10 @@ import {
 } from './helpers';
 
 class DualList extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onFilterChangeDebounced = debounce(this.emitFilterChange, 200);
+  }
   onItemChange = ({
     target: {
       checked,
@@ -107,7 +111,13 @@ class DualList extends React.Component {
     });
   };
 
-  onFilterChange = ({
+  onFilterChange = event => {
+    /** https://reactjs.org/docs/events.html#event-pooling */
+    event.persist();
+    this.onFilterChangeDebounced(event);
+  };
+
+  emitFilterChange = ({
     target: {
       value,
       dataset: { side }

--- a/packages/patternfly-3/patternfly-react/src/components/DualListSelector/DualList.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/DualListSelector/DualList.test.js
@@ -3,6 +3,20 @@ import { mount, shallow } from 'enzyme';
 import { DualListControlled } from './index';
 import { getCounterMessage as counterMessage, getFilterredItemsLength } from './helpers';
 
+jest.mock('../../common/helpers', () => {
+  const selectKeys = (obj, keys, fn = val => val) =>
+    keys.reduce((values, key) => ({ ...values, [key]: fn(obj[key]) }), {});
+
+  /** Returns a subset of the given object with a validator function applied to its keys. */
+  const filterKeys = (obj, validator) => selectKeys(obj, Object.keys(obj).filter(validator));
+
+  return {
+    debounce: fn => fn,
+    noop: Function.prototype,
+    excludeKeys: (obj, keys) => filterKeys(obj, key => !keys.includes(key))
+  };
+});
+
 const getProps = () => ({
   left: {
     items: [


### PR DESCRIPTION
Reduce the events fired on filter change.

Called twice:
![selection_110](https://user-images.githubusercontent.com/26363699/50148300-d3afc900-02c0-11e9-8a01-532a85e36613.png)
Instead of 6 times:
![selection_111](https://user-images.githubusercontent.com/26363699/50148302-d6aab980-02c0-11e9-8a5b-59a9fabac99e.png)
