### PR TITLE
fix: update alt text in LoginPage

### DIFF
--- a/packages/patternfly-4/react-core/src/components/LoginPage/examples/SimpleLoginPage.js
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/examples/SimpleLoginPage.js
@@ -120,7 +120,7 @@ class SimpleLoginPage extends React.Component {
       <LoginPage
         footerListVariants="inline"
         brandImgSrc={brandImg}
-        brandImgAlt="pf-logo"
+        brandImgAlt="PatternFly logo"
         backgroundImgSrc={images}
         backgroundImgAlt="Images"
         footerListItems={listItem}


### PR DESCRIPTION
Updated the branding alt text in the LoginPage to "Patternfly Logo." Per @jgiardino, it should match the example in core and repeat the text/describe the image.

Fixes [#993](https://github.com/patternfly/patternfly-react/issues/993).