### PR TITLE
chore(pf3): fix pf3 release versions

### DIFF
--- a/packages/patternfly-3/package.json
+++ b/packages/patternfly-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patternfly3-react-lerna-root",
-  "version": "7.16.0",
+  "version": "7.16.1",
   "private": true,
   "config": {
     "access": "private"

--- a/packages/patternfly-3/patternfly-react-extensions/package.json
+++ b/packages/patternfly-3/patternfly-react-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patternfly-react-extensions",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "private": false,
   "description": "This library provides an extended set of React components for use with the PatternFly reference implementation.",
   "main": "dist/js/index.js",

--- a/packages/patternfly-3/patternfly-react/package.json
+++ b/packages/patternfly-3/patternfly-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patternfly-react",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "private": false,
   "description": "This library provides a set of common React components for use with the PatternFly reference implementation.",
   "main": "dist/js/index.js",

--- a/packages/patternfly-3/react-console/package.json
+++ b/packages/patternfly-3/react-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-console",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "private": false,
   "description": "This library provides a set of Console React components for use with the PatternFly reference implementation.",
   "main": "dist/js/index.js",


### PR DESCRIPTION
Something broke in the pf3 build yesterday preventing the build from updating the package.json files with the correct version numbers.  This sets them back correctly