### PR TITLE
feat(KebabToggle): Customizable icon.

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/KebabToggle.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/KebabToggle.js
@@ -5,17 +5,15 @@ import Toggle from './Toggle';
 
 const defaultAriaLabel = 'Actions';
 
-const Kebab = ({ ...props }) => (
+const Kebab = ({icon,  ...props }) => (
   <Toggle {...props}>
-    <EllipsisVIcon />
+    {icon ? icon : <EllipsisVIcon />}
   </Toggle>
 );
 
 Kebab.propTypes = {
   /** HTML ID of dropdown toggle */
   id: PropTypes.string,
-  /** Anything which can be rendered as dropdown toggle */
-  children: PropTypes.node,
   /** Classess applied to root element of dropdown toggle */
   className: PropTypes.string,
   /** Flag to indicate if menu is opened */
@@ -33,11 +31,12 @@ Kebab.propTypes = {
   /** Forces active state */
   isActive: PropTypes.bool,
   /** Display the toggle with no border or background */
-  isPlain: PropTypes.bool
+  isPlain: PropTypes.bool,
+  /** Anything that can be displayed instead of the default EllipsisVIcon as a dropdown toggle **/
+  icon: PropTypes.node
 };
 Kebab.defaultProps = {
   id: '',
-  children: null,
   className: '',
   isOpen: false,
   'aria-label': defaultAriaLabel,
@@ -46,7 +45,8 @@ Kebab.defaultProps = {
   isHovered: false,
   isActive: false,
   isPlain: false,
-  onToggle: Function.prototype
+  onToggle: Function.prototype,
+  icon: null
 };
 
 export default Kebab;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -44,6 +44,7 @@ exports[`KebabToggle basic 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -61,6 +62,7 @@ exports[`KebabToggle basic 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -235,6 +237,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -252,6 +255,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -409,6 +413,7 @@ exports[`KebabToggle dropup 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -426,6 +431,7 @@ exports[`KebabToggle dropup 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -611,6 +617,7 @@ exports[`KebabToggle expanded 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -628,6 +635,7 @@ exports[`KebabToggle expanded 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -945,6 +953,7 @@ exports[`KebabToggle plain 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -962,6 +971,7 @@ exports[`KebabToggle plain 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -1119,6 +1129,7 @@ exports[`KebabToggle regular 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -1136,6 +1147,7 @@ exports[`KebabToggle regular 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -1293,6 +1305,7 @@ exports[`KebabToggle right aligned 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}
@@ -1310,6 +1323,7 @@ exports[`KebabToggle right aligned 1`] = `
     <Kebab
       aria-label="Actions"
       className=""
+      icon={null}
       id="Dropdown Toggle"
       isActive={false}
       isFocused={false}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
@@ -101,6 +101,7 @@ exports[`Kebab toggle 1`] = `
 <Kebab
   aria-label="Actions"
   className=""
+  icon={null}
   id="Dropdown Toggle"
   isActive={false}
   isFocused={false}


### PR DESCRIPTION
 * Allow passing in alternative content for the drop-down symbol.
 * Remove unused children property.

Note: the `children` property may have been originally intended for this purposo but based on discussion with @karelhala I added a new property.

Needed by: https://github.com/RedHatInsights/insights-chrome/pull/90