### PR TITLE
fix(EmptyState): a typo at the import path in EmptyStateIcon.d.ts

### DIFF
--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateIcon.d.ts
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateIcon.d.ts
@@ -1,5 +1,5 @@
 import { SFC, HTMLProps } from 'react';
-import { OneOf, Omit } from './typeUtils';
+import { OneOf, Omit } from '../../typeUtils';
 
 export const IconSize: {
   sm: 'sm';


### PR DESCRIPTION
There is a typo in `EmptyStateIcon.d.ts` - it imports `OneOf` and `Omit` from `../typeUtils` which doesn't exist. It is supposed to be `../../typeUtils`.

This is on me.