### PR TITLE
fix(BackgroundImage): remove old tokens

### DIFF
--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.js
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.js
@@ -7,13 +7,8 @@ import styles from '@patternfly/patternfly-next/components/BackgroundImage/backg
 /* eslint-disable camelcase */
 import {
   c_background_image_BackgroundImage_lg,
-  c_background_image_BackgroundImage_md,
-  c_background_image_BackgroundImage_md_2x,
   c_background_image_BackgroundImage_sm,
   c_background_image_BackgroundImage_sm_2x,
-  c_background_image_BackgroundImage_xl,
-  c_background_image_BackgroundImage_xs,
-  c_background_image_BackgroundImage_xs_2x,
   c_background_image_Filter
 } from '@patternfly/react-tokens';
 
@@ -21,8 +16,6 @@ export const BackgroundImageSrc = {
   lg: 'lg',
   sm: 'sm',
   sm2x: 'sm2x',
-  xs: 'xs',
-  xs2x: 'xs2x',
   filter: 'filter'
 };
 
@@ -30,8 +23,6 @@ const variableMap = {
   [BackgroundImageSrc.lg]: c_background_image_BackgroundImage_lg && c_background_image_BackgroundImage_lg.name,
   [BackgroundImageSrc.sm]: c_background_image_BackgroundImage_sm && c_background_image_BackgroundImage_sm.name,
   [BackgroundImageSrc.sm2x]: c_background_image_BackgroundImage_sm_2x && c_background_image_BackgroundImage_sm_2x.name,
-  [BackgroundImageSrc.xs]: c_background_image_BackgroundImage_xs && c_background_image_BackgroundImage_xs.name,
-  [BackgroundImageSrc.xs2x]: c_background_image_BackgroundImage_xs_2x && c_background_image_BackgroundImage_xs_2x.name,
   [BackgroundImageSrc.filter]: c_background_image_Filter && c_background_image_Filter.name
 };
 
@@ -45,8 +36,6 @@ export const propTypes = {
       lg: PropTypes.string,
       sm: PropTypes.string,
       sm2x: PropTypes.string,
-      xs: PropTypes.string,
-      xs2x: PropTypes.string,
       filter: PropTypes.string
     })
   ]).isRequired

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/__snapshots__/BackgroundImage.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/__snapshots__/BackgroundImage.test.js.snap
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BackgroundImage 1`] = `
-.pf-c-background-image.css-1mxwfbc {
+.pf-c-background-image.css-flp5jq {
   display: block;
 }
 
 <div
-  className="pf-c-background-image css-1mxwfbc"
+  className="pf-c-background-image css-flp5jq"
 />
 `;
 
 exports[`BackgroundImage 2`] = `
-.pf-c-background-image.css-1mxwfbc {
+.pf-c-background-image.css-flp5jq {
   display: block;
 }
 
 <div
-  className="pf-c-background-image css-1mxwfbc"
+  className="pf-c-background-image css-flp5jq"
 />
 `;
 
 exports[`allows passing in a single string as the image src 1`] = `
-.pf-c-background-image.css-i3a8u7 {
+.pf-c-background-image.css-1vzg5gc {
   display: block;
 }
 
 <div
-  className="pf-c-background-image css-i3a8u7"
+  className="pf-c-background-image css-1vzg5gc"
 />
 `;

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/examples/SimpleBackgroundImage.js
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/examples/SimpleBackgroundImage.js
@@ -8,8 +8,6 @@ const images = {
   [BackgroundImageSrc.lg]: '/assets/images/pfbg_1200.jpg',
   [BackgroundImageSrc.sm]: '/assets/images/pfbg_768.jpg',
   [BackgroundImageSrc.sm2x]: '/assets/images/pfbg_768@2x.jpg',
-  [BackgroundImageSrc.xs]: '/assets/images/pfbg_576.jpg',
-  [BackgroundImageSrc.xs2x]: '/assets/images/pfbg_576@2x.jpg',
   [BackgroundImageSrc.filter]: '/assets/images/background-filter.svg#image_overlay'
 };
 


### PR DESCRIPTION
**What**:

`BackgroundImage` is using `c_background_image_BackgroundImage_<size>` tokens from `react-tokens` to set default values to the `src` props.

One of the tokens is `c_background_image_BackgroundImage_xs` which is no longer available from patternfly-next.

This patch fixes this by removing any token that is no longer available in patternfly-next.


