### PR TITLE
fix(Radio.d.ts): Made aria-label required

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.d.ts
@@ -7,7 +7,7 @@ export interface RadioProps extends Omit<HTMLProps<HTMLInputElement>, 'type' | '
   isChecked?: boolean;
   onChange?(checked: boolean, event: FormEvent<HTMLInputElement>): void;
   id: string;
-  'aria-label'?: string;
+  'aria-label': string;
   label?: ReactNode;
   name: string;
 }


### PR DESCRIPTION
Made aria-label required in Radio.d.ts to match the JS error handling. Per @titani, it should be consistent.

Fixes https://github.com/patternfly/patternfly-react/issues/1048.