### PR TITLE
fix(TextInput/Area): update type definitions

### DIFF
--- a/packages/patternfly-4/react-core/src/components/TextArea/TextArea.d.ts
+++ b/packages/patternfly-4/react-core/src/components/TextArea/TextArea.d.ts
@@ -2,12 +2,9 @@ import { SFC, HTMLProps, FormEvent } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface TextAreaProps extends Omit<HTMLProps<HTMLInputElement>, 'onChange'> {
-  className?: string;
   isRequired?: boolean;
   isValid?: boolean;
-  value?: string | number;
-  onChange(checked: boolean, event: FormEvent<HTMLInputElement>): void;
-  'aria-label'?: string;
+  onChange?(value: string, event: FormEvent<HTMLInputElement>): void;
 }
 
 declare const TextArea: SFC<TextAreaProps>;

--- a/packages/patternfly-4/react-core/src/components/TextInput/TextInput.d.ts
+++ b/packages/patternfly-4/react-core/src/components/TextInput/TextInput.d.ts
@@ -1,16 +1,12 @@
 import { SFC, HTMLProps, FormEvent } from 'react';
 import { Omit } from '../../typeUtils';
 
-export interface TextInputProps extends Omit<HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled'> {
-  className?: string;
+export interface TextInputProps extends Omit<HTMLProps<HTMLInputElement>, 'onChange' | 'disabled'> {
   isRequired?: boolean;
-  type?: string;
-  value?: string | number;
   isValid?: boolean;
   isDisabled?: boolean;
-  onChange?(checked: boolean, event: FormEvent<HTMLInputElement>): void;
+  onChange?(value: string, event: FormEvent<HTMLInputElement>): void;
   isReadOnly?: boolean;
-  'aria-label'?: string;
 }
 
 declare const TextInput: SFC<TextInputProps>;


### PR DESCRIPTION
**What**:

`onChange` receives two arguments: `value` and `event`.

According to `TextArea.d.ts` and `TextInput.d.ts` the value is `boolean` while it is `string` because they are text input type.

In addition, `onChange` is optional (but it is mandatory in `TextArea.d.ts`).

This patch fixes these to the correct type.