### PR TITLE
style(DesktopViewer): use standard button size in DesktopViewer

### DIFF
--- a/packages/patternfly-3/react-console/src/DesktopViewer/ConnectWithRemoteViewer.js
+++ b/packages/patternfly-3/react-console/src/DesktopViewer/ConnectWithRemoteViewer.js
@@ -57,11 +57,11 @@ const ConnectWithRemoteViewer = ({
     <div className="remote-viewer-pf">
       <h2>{textDesktopConnection}</h2>
       <div className="remote-viewer-pf-launch">
-        <Button className="remote-viewer-pf-launch-vv" bsSize="large" onClick={onClickVV} disabled={!console}>
+        <Button className="remote-viewer-pf-launch-vv" onClick={onClickVV} disabled={!console}>
           {textConnectWithRemoteViewer}
         </Button>
         {!!rdp && (
-          <Button bsSize="large" onClick={onClickRDP} className="remote-viewer-pf-launch-rdp">
+          <Button onClick={onClickRDP} className="remote-viewer-pf-launch-rdp">
             {textConnectWithRDP}
           </Button>
         )}

--- a/packages/patternfly-3/react-console/src/DesktopViewer/__snapshots__/DesktopViewer.test.js.snap
+++ b/packages/patternfly-3/react-console/src/DesktopViewer/__snapshots__/DesktopViewer.test.js.snap
@@ -14,7 +14,7 @@ exports[`DesktopViewer custom topClassName 1`] = `
       class="remote-viewer-pf-launch"
     >
       <button
-        class="remote-viewer-pf-launch-vv btn btn-lg btn-default"
+        class="remote-viewer-pf-launch-vv btn btn-default"
         disabled=""
         type="button"
       >
@@ -52,7 +52,7 @@ exports[`DesktopViewer empty 1`] = `
       class="remote-viewer-pf-launch"
     >
       <button
-        class="remote-viewer-pf-launch-vv btn btn-lg btn-default"
+        class="remote-viewer-pf-launch-vv btn btn-default"
         disabled=""
         type="button"
       >
@@ -90,7 +90,7 @@ exports[`DesktopViewer with Spice and VNC 1`] = `
       class="remote-viewer-pf-launch"
     >
       <button
-        class="remote-viewer-pf-launch-vv btn btn-lg btn-default"
+        class="remote-viewer-pf-launch-vv btn btn-default"
         type="button"
       >
         Launch Remote Viewer
@@ -222,13 +222,13 @@ exports[`DesktopViewer with Spice, VNC and RDP (different hostname) 1`] = `
       class="remote-viewer-pf-launch"
     >
       <button
-        class="remote-viewer-pf-launch-vv btn btn-lg btn-default"
+        class="remote-viewer-pf-launch-vv btn btn-default"
         type="button"
       >
         Launch Remote Viewer
       </button>
       <button
-        class="remote-viewer-pf-launch-rdp btn btn-lg btn-default"
+        class="remote-viewer-pf-launch-rdp btn btn-default"
         type="button"
       >
         Launch Remote Desktop
@@ -412,13 +412,13 @@ exports[`DesktopViewer with Spice, VNC and RDP 1`] = `
       class="remote-viewer-pf-launch"
     >
       <button
-        class="remote-viewer-pf-launch-vv btn btn-lg btn-default"
+        class="remote-viewer-pf-launch-vv btn btn-default"
         type="button"
       >
         Launch Remote Viewer
       </button>
       <button
-        class="remote-viewer-pf-launch-rdp btn btn-lg btn-default"
+        class="remote-viewer-pf-launch-rdp btn btn-default"
         type="button"
       >
         Launch Remote Desktop
@@ -666,14 +666,13 @@ exports[`DesktopViewer with custom more-info content 1`] = `
             active={false}
             block={false}
             bsClass="btn"
-            bsSize="large"
             bsStyle="default"
             className="remote-viewer-pf-launch-vv"
             disabled={false}
             onClick={[Function]}
           >
             <button
-              className="remote-viewer-pf-launch-vv btn btn-lg btn-default"
+              className="remote-viewer-pf-launch-vv btn btn-default"
               disabled={false}
               onClick={[Function]}
               type="button"


### PR DESCRIPTION
Prior this fix, the Launch buttons firing file download were "btn-lg".
This looks weird in some use-cases (like OpenShift).

If the button size needs to be biger in rare cases, it can be tweaked via custom styling.

**What**: use standard button size in DesktopViewer

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
