### PR TITLE
fix(MessageDialog): conflict between footer and primaryAction props

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/MessageDialog/MessageDialog.js
+++ b/packages/patternfly-3/patternfly-react/src/components/MessageDialog/MessageDialog.js
@@ -74,7 +74,17 @@ MessageDialog.propTypes = {
   /** A callback fired when the header closeButton or backdrop is clicked */
   onHide: PropTypes.func.isRequired,
   /** callback to trigger when clicking the default footer primary action button */
-  primaryAction: PropTypes.func.isRequired,
+  primaryAction(props, propName, componentName) {
+    if (props.footer) {
+      return null;
+    }
+    return PropTypes.checkPropTypes(
+      { primaryAction: PropTypes.func.isRequired },
+      { [propName]: props[propName] },
+      propName,
+      componentName
+    );
+  },
   /** callback to trigger when clicking the default footer secondary action button */
   secondaryAction: PropTypes.func,
   /** Bootstrap button style for primary action */
@@ -82,7 +92,17 @@ MessageDialog.propTypes = {
   /** Bootstrap button style for secondary action */
   secondaryActionButtonBsStyle: PropTypes.string,
   /** content for default footer primary action button */
-  primaryActionButtonContent: PropTypes.node.isRequired,
+  primaryActionButtonContent(props, propName, componentName) {
+    if (props.footer) {
+      return null;
+    }
+    return PropTypes.checkPropTypes(
+      { primaryActionButtonContent: PropTypes.node.isRequired },
+      { [propName]: props[propName] },
+      propName,
+      componentName
+    );
+  },
   /** content for default footer secondary action button */
   secondaryActionButtonContent: PropTypes.node,
   /** modal title */
@@ -105,9 +125,11 @@ MessageDialog.propTypes = {
 
 MessageDialog.defaultProps = {
   className: '',
+  primaryAction: null,
   secondaryAction: noop,
   primaryActionButtonBsStyle: 'primary',
   secondaryActionButtonBsStyle: 'default',
+  primaryActionButtonContent: null,
   secondaryActionButtonContent: null,
   title: '',
   icon: null,

--- a/packages/patternfly-3/patternfly-react/src/components/MessageDialog/MessageDialog.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/MessageDialog/MessageDialog.test.js
@@ -75,9 +75,7 @@ describe('rendering with options', () => {
         <Button>Close</Button>
       </React.Fragment>
     );
-    const wrapper = shallow(
-      <MessageDialog {...baseProps} onHide={onHide} primaryAction={primaryAction} footer={footer} />
-    );
+    const wrapper = shallow(<MessageDialog show onHide={onHide} footer={footer} />);
 
     expect(wrapper.contains(footer)).toBe(true);
   });
@@ -118,5 +116,36 @@ describe('button interactions', () => {
       .at(1)
       .simulate('click');
     expect(primaryAction).toHaveBeenCalled();
+  });
+});
+
+describe('test primary action and footer props conflict', () => {
+  const consoleErr = global.console.error;
+
+  beforeEach(() => {
+    global.console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    global.console.error = consoleErr;
+  });
+
+  test('check that props check fails if footer is null and primary action is not set', () => {
+    shallow(<MessageDialog show onHide={jest.fn()} primaryActionButtonContent="OK" />);
+    expect(global.console.error).toBeCalledWith(
+      'Warning: Failed primaryAction type: The primaryAction `primaryAction` is marked as required in `MessageDialog`, but its value is `null`.'
+    );
+  });
+
+  test('check that props check fails if those props are not set', () => {
+    shallow(<MessageDialog show onHide={jest.fn()} />);
+    expect(global.console.error).toBeCalledWith(
+      'Warning: Failed primaryActionButtonContent type: The primaryActionButtonContent `primaryActionButtonContent` is marked as required in `MessageDialog`, but its value is `null`.'
+    );
+  });
+
+  test('check that props check does not fail if footer is not null and primary action props are not set', () => {
+    shallow(<MessageDialog show onHide={jest.fn()} footer={<div>This is my footer</div>} />);
+    expect(global.console.error).not.toBeCalled();
   });
 });


### PR DESCRIPTION
**What**:

fixes #1122 
`primaryAction` and `primaryActionButtonContent` are required unless `footer` is set.
However, currently an error message will be displayed if `footer` is set and not `primaryAction` or `primaryActionButtonContent`.

This commit fixes this conflict by checking if `footer` is set and if it does these props won't be required.

