### PR TITLE
fix(Avatar): Correctly export Avatar component typings

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Avatar/index.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Avatar/index.d.ts
@@ -1,0 +1,1 @@
+export { default as Avatar, AvatarProps } from './Avatar';

--- a/packages/patternfly-4/react-core/src/components/Avatar/index.ts
+++ b/packages/patternfly-4/react-core/src/components/Avatar/index.ts
@@ -1,1 +1,1 @@
-export { default as Avatar, AvatarProps } from './Avatar';
+export { default as Avatar } from './Avatar';


### PR DESCRIPTION
**What**:
Fixes #1133 

_TL/DR:_ The index.ts file for the PF4 Avatar component currently exports both the component itself and the component's props interface. It looks like the interface is compiled away, which leads to an import error when compiling apps depending on it.

```
./node_modules/@patternfly/react-core/dist/esm/components/Avatar/index.js
  Attempted import error: 'AvatarProps' is not exported from './Avatar'.
```

**How:**
Splitting up the index.ts file into an index.ts and an index.d.ts file resolves the issue, while still keeping the TypeScript support. That's the approach to this that other components take as well.

**Additional Comments:**
If I missed any conventions or requirements, please let me know! 🙂 