### PR TITLE
fix(EmptyState): Use IconProps to define EmptyStateIconProps

### DIFF
--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateIcon.d.ts
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateIcon.d.ts
@@ -14,7 +14,7 @@ export interface IconProps extends Omit<HTMLProps<SVGElement>, 'size'> {
   title?: string;
 }
 
-export interface EmptyStateIconProps extends HTMLProps<SVGElement> {
+export interface EmptyStateIconProps extends IconProps {
   icon: string | SFC<IconProps>,
 }
 


### PR DESCRIPTION
**What**:

Since `EmptyStateIcon` takes any props that `Icon` takes extend `EmptyStateIconProps` from` IconProps` rather than `HTMLProps<SVGElement>`.

I realized that setting the icon to `size="lg"` through `EmptyStateIcon` will print error message saying `size` is not a valid prop.

This will fix this.