### PR TITLE
fix(AccessConsoles): fix propTypes checking for "null" child

### DIFF
--- a/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/AccessConsoles.js
@@ -10,10 +10,10 @@ const { Row, Col } = Grid;
 const { Checkbox, FormGroup } = Form;
 
 const getChildTypeName = child =>
-  child.props.type ? child.props.type : (child.type && child.type.displayName) || null;
+  child && child.props && child.props.type ? child.props.type : (child && child.type && child.type.displayName) || null;
 
 const isChildOfType = (child, type) =>
-  child.props.type === type || (!child.props.type && helpers.hasDisplayName(child, type));
+  helpers.hasDisplayName(child, type) || (child && child.props && child.props.type === type);
 
 class AccessConsoles extends React.Component {
   state = {
@@ -134,6 +134,8 @@ const childElementValidator = propValue => {
     if (
       !children.every(
         child =>
+          child === undefined ||
+          child == null ||
           (child.type && validChildrenTypes.indexOf(child.type.displayName) >= 0) ||
           (child.props && validChildrenTypes.indexOf(child.props.type) >= 0)
       )


### PR DESCRIPTION
With this fix, AccessConsole's children of "undefined" or "null" values are handled
correctly by propTypes checking.

Needed for conditionally-rendered children within the higher-level calling code.
**What**: fix propTypes checking for "null" child

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
