### PR TITLE
Toolbar: added 'preventSubmit' prop. to allow prevention of internal form submission

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Toolbar/Toolbar.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Toolbar/Toolbar.js
@@ -10,7 +10,7 @@ import ToolbarViewSelector from './ToolbarViewSelector';
 
 import { toolbarContextTypes, getToolbarContext, ToolbarContextProvider } from './ToolbarConstants';
 
-const ContextualToolbar = ({ children, className, ...props }) => {
+const ContextualToolbar = ({ children, className, preventSubmit, ...props }) => {
   const toolbarChildren = filterChildren(children, child => !hasDisplayName(child, ToolbarResults.displayName));
   const resultsChildren = filterChildren(children, child => hasDisplayName(child, ToolbarResults.displayName));
 
@@ -19,7 +19,16 @@ const ContextualToolbar = ({ children, className, ...props }) => {
       <Grid fluid className={className}>
         <Grid.Row className="toolbar-pf">
           <Grid.Col sm={12}>
-            <form className="toolbar-pf-actions">{toolbarChildren}</form>
+            <form
+              className="toolbar-pf-actions"
+              onSubmit={e => {
+                if (preventSubmit) {
+                  e.preventDefault();
+                }
+              }}
+            >
+              {toolbarChildren}
+            </form>
             {resultsChildren}
           </Grid.Col>
         </Grid.Row>
@@ -32,12 +41,15 @@ ContextualToolbar.propTypes = {
   /** Children nodes */
   children: PropTypes.node,
   /** Additional css classes */
-  className: PropTypes.string
+  className: PropTypes.string,
+  /** Prevent submission of toolbar children internal form */
+  preventSubmit: PropTypes.bool
 };
 
 ContextualToolbar.defaultProps = {
   children: null,
-  className: ''
+  className: '',
+  preventSubmit: false
 };
 
 const Toolbar = withContext(toolbarContextTypes, getToolbarContext)(ContextualToolbar);


### PR DESCRIPTION
<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Toolbar has an internal `<form .../>` which will be submitted (causing a screen refresh) upon Enter key press.  This PR adds a `preventSubmit` prop. which when set to `true` will prevent form submission.  Default is `false`.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

Addresses OpenShift Issue: 
https://bugzilla.redhat.com/show_bug.cgi?id=1661141

Fixes #1104 