### PR TITLE
fix(Dropdown): set default button type to button

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -35,6 +35,7 @@ const DropdownItem = ({ className, children, isHovered, component: Component, is
     additionalProps.tabIndex = isDisabled ? -1 : additionalProps.tabIndex;
   } else if (Component === 'button') {
     additionalProps.disabled = isDisabled;
+    additionalProps.type = additionalProps.type || 'button';
   }
 
   return (

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Toggle.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Toggle.js
@@ -77,6 +77,7 @@ class DropdownToggle extends Component {
       onToggle,
       parentRef,
       id,
+      type,
       ...props
     } = this.props;
     return (
@@ -94,6 +95,7 @@ class DropdownToggle extends Component {
           isPlain && styles.modifiers.plain,
           className
         )}
+        type={type || 'button'}
         onClick={_event => onToggle && onToggle(!isOpen)}
         aria-expanded={isOpen}
       >

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -89,6 +89,7 @@ exports[`KebabToggle basic 1`] = `
           className="pf-c-dropdown__toggle"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           <EllipsisVIcon
             color="currentColor"
@@ -280,6 +281,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
           className="pf-c-dropdown__toggle"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           <EllipsisVIcon
             color="currentColor"
@@ -454,6 +456,7 @@ exports[`KebabToggle dropup 1`] = `
           className="pf-c-dropdown__toggle"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           <EllipsisVIcon
             color="currentColor"
@@ -656,6 +659,7 @@ exports[`KebabToggle expanded 1`] = `
           className="pf-c-dropdown__toggle"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           <EllipsisVIcon
             color="currentColor"
@@ -742,6 +746,7 @@ exports[`KebabToggle expanded 1`] = `
                   className=""
                   disabled={false}
                   href="#"
+                  type="button"
                 >
                   Action
                 </button>
@@ -779,6 +784,7 @@ exports[`KebabToggle expanded 1`] = `
                   className="pf-m-disabled"
                   disabled={true}
                   href="#"
+                  type="button"
                 >
                   Disabled Action
                 </button>
@@ -840,6 +846,7 @@ exports[`KebabToggle expanded 1`] = `
                   className=""
                   disabled={false}
                   href="#"
+                  type="button"
                 >
                   Separated Action
                 </button>
@@ -994,6 +1001,7 @@ exports[`KebabToggle plain 1`] = `
           className="pf-c-dropdown__toggle pf-m-plain"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           <EllipsisVIcon
             color="currentColor"
@@ -1168,6 +1176,7 @@ exports[`KebabToggle regular 1`] = `
           className="pf-c-dropdown__toggle"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           <EllipsisVIcon
             color="currentColor"
@@ -1342,6 +1351,7 @@ exports[`KebabToggle right aligned 1`] = `
           className="pf-c-dropdown__toggle"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           <EllipsisVIcon
             color="currentColor"
@@ -1470,6 +1480,7 @@ exports[`dropdown basic 1`] = `
           className="pf-c-dropdown__toggle"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           Dropdown
           <CaretDownIcon
@@ -1670,6 +1681,7 @@ exports[`dropdown dropup + right aligned 1`] = `
           className="pf-c-dropdown__toggle"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           Dropdown
           <CaretDownIcon
@@ -1853,6 +1865,7 @@ exports[`dropdown dropup 1`] = `
           className="pf-c-dropdown__toggle"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           Dropdown
           <CaretDownIcon
@@ -2064,6 +2077,7 @@ exports[`dropdown expanded 1`] = `
           className="pf-c-dropdown__toggle"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           Dropdown
           <CaretDownIcon
@@ -2153,6 +2167,7 @@ exports[`dropdown expanded 1`] = `
                   className=""
                   disabled={false}
                   href="#"
+                  type="button"
                 >
                   Action
                 </button>
@@ -2190,6 +2205,7 @@ exports[`dropdown expanded 1`] = `
                   className="pf-m-disabled"
                   disabled={true}
                   href="#"
+                  type="button"
                 >
                   Disabled Action
                 </button>
@@ -2251,6 +2267,7 @@ exports[`dropdown expanded 1`] = `
                   className=""
                   disabled={false}
                   href="#"
+                  type="button"
                 >
                   Separated Action
                 </button>
@@ -2411,6 +2428,7 @@ exports[`dropdown regular 1`] = `
           className="pf-c-dropdown__toggle"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           Dropdown
           <CaretDownIcon
@@ -2594,6 +2612,7 @@ exports[`dropdown right aligned 1`] = `
           className="pf-c-dropdown__toggle"
           id="Dropdown Toggle"
           onClick={[Function]}
+          type="button"
         >
           Dropdown
           <CaretDownIcon

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownItem.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownItem.test.js.snap
@@ -18,6 +18,7 @@ exports[`dropdown items button 1`] = `
     className=""
     disabled={false}
     href="#"
+    type="button"
   >
     Something
   </button>
@@ -51,6 +52,7 @@ exports[`dropdown items disabled button 1`] = `
     className="pf-m-disabled"
     disabled={true}
     href="#"
+    type="button"
   >
     Something
   </button>
@@ -83,6 +85,7 @@ exports[`dropdown items hover button 1`] = `
     className="pf-m-hover"
     disabled={false}
     href="#"
+    type="button"
   >
     Something
   </button>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggle.test.js.snap
@@ -49,6 +49,7 @@ exports[`state active 1`] = `
       className="pf-c-dropdown__toggle pf-m-active"
       id="Dropdown Toggle"
       onClick={[Function]}
+      type="button"
     >
       Dropdown
       <CaretDownIcon
@@ -132,6 +133,7 @@ exports[`state focus 1`] = `
       className="pf-c-dropdown__toggle pf-m-focus"
       id="Dropdown Toggle"
       onClick={[Function]}
+      type="button"
     >
       Dropdown
       <CaretDownIcon
@@ -215,6 +217,7 @@ exports[`state hover 1`] = `
       className="pf-c-dropdown__toggle pf-m-hover"
       id="Dropdown Toggle"
       onClick={[Function]}
+      type="button"
     >
       Dropdown
       <CaretDownIcon

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Toggle.test.js.snap
@@ -49,6 +49,7 @@ exports[`Dropdown toggle 1`] = `
       className="pf-c-dropdown__toggle"
       id="Dropdown Toggle"
       onClick={[Function]}
+      type="button"
     >
       Dropdown
       <CaretDownIcon
@@ -128,6 +129,7 @@ exports[`Kebab toggle 1`] = `
       className="pf-c-dropdown__toggle"
       id="Dropdown Toggle"
       onClick={[Function]}
+      type="button"
     >
       <EllipsisVIcon
         color="currentColor"


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Changed Dropdown button types to default to type='button'. Providing a type manually will overwrite the default.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**References issue**: #1105

<!-- feel free to add additional comments -->
