### PR TITLE
feat(umd modules): adds babel-transform-es2015-modules-umd 

### DIFF
--- a/packages/patternfly-4/react-core/package.json
+++ b/packages/patternfly-4/react-core/package.json
@@ -39,10 +39,11 @@
     "react-dom": "^15.6.2 || ^16.4.0"
   },
   "scripts": {
-    "build": "yarn build:babel && yarn build:generate:dts && yarn build:tsd:copy",
+    "build": "yarn build:babel && yarn build:generate:dts && yarn build:tsd:copy && yarn build:umd",
     "build:babel": "concurrently \"yarn build:babel:cjs\" \"yarn build:babel:esm\"",
     "build:babel:cjs": "cross-env BABEL_ENV=production:cjs babel src --out-dir dist/js --extensions \".css,.js,jsx,.ts,.tsx\"",
     "build:babel:esm": "cross-env BABEL_ENV=production:esm babel src --out-dir dist/esm --extensions \".css,.js,jsx,.ts,.tsx\"",
+    "build:umd": "cross-env BABEL_ENV=production:umd babel dist/esm --out-dir dist/umd --plugins transform-es2015-modules-umd --extensions \".css,.js,jsx,.ts,.tsx\"",
     "build:generate:dts": "tsc -p src/tsconfig.dts.json",
     "build:typecheck": "tsc",
     "build:tsd:copy": "node ./scripts/copyTS.js",
@@ -71,6 +72,7 @@
     "@types/react": "^16.7.13",
     "babel-eslint": "^9.0.0",
     "babel-jest": "^22.4.3",
+    "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-plugin-transform-imports": "^1.5.0",
     "babel-plugin-typescript-to-proptypes": "^0.13.0",
     "css": "^2.2.3",


### PR DESCRIPTION
adds babel-transform-es2015-modules-umd for umd module support

fixes: #1142 
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Docs for [transform-es2015-modules-umd](https://babeljs.io/docs/en/babel-plugin-transform-es2015-modules-umd)

This will convert es2015/esm modules to umd modules so that we can support umd module consumers.

In the future, we may consider rollup-plugin-babel or rollup-plugin-typescript for further support, but this should be the shortest path to support UMD modules today. The hope is to further support teams using RequireJS/CommonJS/SystemJS build systems.


<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
