### PR TITLE
fix(DropdownToggle): Listen for touch events on the document to close a Toggle on mobile

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.test.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.test.js
@@ -49,10 +49,29 @@ describe('API', () => {
     expect(mockToggle.mock.calls[0][0]).toBe(false);
   });
 
+  test('touch on document', () => {
+    const map = {};
+    document.addEventListener = jest.fn((event, cb) => {
+      map[event] = cb;
+    });
+    const mockToggle = jest.fn();
+    mount(
+      <DropdownToggle id="Dropdown Toggle" onToggle={mockToggle} isOpen parentRef={document.createElement('div')}>
+        Dropdown
+      </DropdownToggle>
+    );
+
+    map.touchstart({ target: document });
+    expect(mockToggle.mock.calls[0][0]).toBe(false);
+  });
+
   test('on click outside has been removed', () => {
     const map = {};
-    document.removeEventListener = jest.fn((event, cb) => {
+    document.addEventListener = jest.fn((event, cb) => {
       map[event] = cb;
+    });
+    document.removeEventListener = jest.fn((event, cb) => {
+      if (map[event] === cb) map[event] = () => {};
     });
     const mockToggle = jest.fn();
     const view = mount(
@@ -61,11 +80,29 @@ describe('API', () => {
       </DropdownToggle>
     );
     view.unmount();
-    setTimeout(() => {
-      map.mousedown({ target: document });
-      expect(mockToggle.mock.calls).toHaveLength(0);
-      expect(document.removeEventListener.mock.calls).toHaveLength(1);
+    map.mousedown({ target: document });
+    expect(mockToggle.mock.calls).toHaveLength(0);
+    expect(document.removeEventListener).toHaveBeenCalledWith('mousedown', expect.any(Function));
+  });
+
+  test('on touch outside has been removed', () => {
+    const map = {};
+    document.addEventListener = jest.fn((event, cb) => {
+      map[event] = cb;
     });
+    document.removeEventListener = jest.fn((event, cb) => {
+      if (map[event] === cb) map[event] = () => {};
+    });
+    const mockToggle = jest.fn();
+    const view = mount(
+      <DropdownToggle id="Dropdown Toggle" onToggle={mockToggle} isOpen parentRef={document.createElement('div')}>
+        Dropdown
+      </DropdownToggle>
+    );
+    view.unmount();
+    map.touchstart({ target: document });
+    expect(mockToggle.mock.calls).toHaveLength(0);
+    expect(document.removeEventListener).toHaveBeenCalledWith('touchstart', expect.any(Function));
   });
 });
 

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Toggle.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Toggle.js
@@ -44,11 +44,13 @@ const defaultProps = {
 class DropdownToggle extends Component {
   componentDidMount = () => {
     document.addEventListener('mousedown', this.onDocClick);
+    document.addEventListener('touchstart', this.onDocClick);
     document.addEventListener('keydown', this.onEscPress);
   };
 
   componentWillUnmount = () => {
     document.removeEventListener('mousedown', this.onDocClick);
+    document.removeEventListener('touchstart', this.onDocClick);
     document.removeEventListener('keydown', this.onEscPress);
   };
 


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Fixes #1131, correcting dropdown behavior on iOS devices.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:
Also fixes a broken test that was never running assertions due to setTimeout.

<!-- feel free to add additional comments -->
