### PR TITLE
fix(ModalContent): Hide footer when no actions

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.js
@@ -43,7 +43,7 @@ const defaultProps = {
 
 const ModalContent = ({ children, className, isOpen, title, hideTitle, actions, onClose, isLarge, id, ...props }) => {
   const modalBoxHeader = title && <ModalBoxHeader> {title} </ModalBoxHeader>;
-  const modalBoxFooter = actions && <ModalBoxFooter> {actions} </ModalBoxFooter>;
+  const modalBoxFooter = actions.length > 0 && <ModalBoxFooter> {actions} </ModalBoxFooter>;
   if (!isOpen) {
     return null;
   }

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.test.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.test.js
@@ -4,7 +4,7 @@ import ModalContent from './ModalContent';
 
 test('Modal Content Test only body', () => {
   const view = shallow(
-    <ModalContent title="Test Modal Content title" id="id">
+    <ModalContent title="Test Modal Content title" id="id" isOpen>
       This is a ModalBox header
     </ModalContent>
   );
@@ -22,7 +22,7 @@ test('Modal Content Test isOpen', () => {
 
 test('Modal Content Test with header', () => {
   const view = shallow(
-    <ModalContent title="Test Modal Content title" id="id" header="Testing">
+    <ModalContent title="Test Modal Content title" id="id" isOpen header="Testing">
       This is a ModalBox header
     </ModalContent>
   );
@@ -31,7 +31,16 @@ test('Modal Content Test with header', () => {
 
 test('Modal Content Test with footer', () => {
   const view = shallow(
-    <ModalContent title="Test Modal Content title" id="id" footer="Testing">
+    <ModalContent title="Test Modal Content title" id="id" isOpen actions={["Testing"]}>
+      This is a ModalBox header
+    </ModalContent>
+  );
+  expect(view).toMatchSnapshot();
+});
+
+test('Modal Content test without footer', () => {
+  const view = shallow(
+    <ModalContent title="Test Modal Content title" id="id" isOpen>
       This is a ModalBox header
     </ModalContent>
   );
@@ -40,22 +49,23 @@ test('Modal Content Test with footer', () => {
 
 test('Modal Content Test with header and footer', () => {
   const view = shallow(
-    <ModalContent title="Test Modal Content title" header="Testing header" footer="Testing footer" id="id">
+    <ModalContent title="Test Modal Content title" header="Testing header" id="id" isOpen actions={["Testing footer"]}>
       This is a ModalBox header
     </ModalContent>
   );
   expect(view).toMatchSnapshot();
 });
 
-test('Modal Content Test with onlose', () => {
+test('Modal Content Test with onclose', () => {
   const view = shallow(
     <ModalContent
       title="Test Modal Content title"
       header="Testing header"
-      footer="Testing footer"
+      actions={["Testing footer"]}
       isLarge
       onclose={() => undefined}
       id="id"
+      isOpen
     >
       This is a ModalBox header
     </ModalContent>

--- a/packages/patternfly-4/react-core/src/components/Modal/__snapshots__/ModalContent.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Modal/__snapshots__/ModalContent.test.js.snap
@@ -42,10 +42,107 @@ exports[`Modal Content Test isOpen 1`] = `
         >
           This is a ModalBox header
         </ModalBoxBody>
+      </ModalBox>
+    </FocusTrap>
+  </Bullseye>
+</Backdrop>
+`;
+
+exports[`Modal Content Test only body 1`] = `
+<Backdrop
+  className=""
+>
+  <Bullseye
+    className=""
+    component="div"
+  >
+    <FocusTrap
+      _createFocusTrap={[Function]}
+      active={true}
+      focusTrapOptions={
+        Object {
+          "clickOutsideDeactivates": true,
+        }
+      }
+      paused={false}
+      tag="div"
+    >
+      <ModalBox
+        className=""
+        id="id"
+        isLarge={false}
+        title="Test Modal Content title"
+      >
+        <ModalBoxCloseButton
+          className=""
+          onClose={[Function]}
+        />
+        <ModalBoxHeader
+          className=""
+        >
+           
+          Test Modal Content title
+           
+        </ModalBoxHeader>
+        <ModalBoxBody
+          className=""
+          id="id"
+        >
+          This is a ModalBox header
+        </ModalBoxBody>
+      </ModalBox>
+    </FocusTrap>
+  </Bullseye>
+</Backdrop>
+`;
+
+exports[`Modal Content Test with footer 1`] = `
+<Backdrop
+  className=""
+>
+  <Bullseye
+    className=""
+    component="div"
+  >
+    <FocusTrap
+      _createFocusTrap={[Function]}
+      active={true}
+      focusTrapOptions={
+        Object {
+          "clickOutsideDeactivates": true,
+        }
+      }
+      paused={false}
+      tag="div"
+    >
+      <ModalBox
+        className=""
+        id="id"
+        isLarge={false}
+        title="Test Modal Content title"
+      >
+        <ModalBoxCloseButton
+          className=""
+          onClose={[Function]}
+        />
+        <ModalBoxHeader
+          className=""
+        >
+           
+          Test Modal Content title
+           
+        </ModalBoxHeader>
+        <ModalBoxBody
+          className=""
+          id="id"
+        >
+          This is a ModalBox header
+        </ModalBoxBody>
         <ModalBoxFooter
           className=""
         >
            
+          Testing
            
         </ModalBoxFooter>
       </ModalBox>
@@ -54,12 +151,212 @@ exports[`Modal Content Test isOpen 1`] = `
 </Backdrop>
 `;
 
-exports[`Modal Content Test only body 1`] = `""`;
+exports[`Modal Content Test with header 1`] = `
+<Backdrop
+  className=""
+>
+  <Bullseye
+    className=""
+    component="div"
+  >
+    <FocusTrap
+      _createFocusTrap={[Function]}
+      active={true}
+      focusTrapOptions={
+        Object {
+          "clickOutsideDeactivates": true,
+        }
+      }
+      paused={false}
+      tag="div"
+    >
+      <ModalBox
+        className=""
+        id="id"
+        isLarge={false}
+        title="Test Modal Content title"
+      >
+        <ModalBoxCloseButton
+          className=""
+          onClose={[Function]}
+        />
+        <ModalBoxHeader
+          className=""
+        >
+           
+          Test Modal Content title
+           
+        </ModalBoxHeader>
+        <ModalBoxBody
+          className=""
+          header="Testing"
+          id="id"
+        >
+          This is a ModalBox header
+        </ModalBoxBody>
+      </ModalBox>
+    </FocusTrap>
+  </Bullseye>
+</Backdrop>
+`;
 
-exports[`Modal Content Test with footer 1`] = `""`;
+exports[`Modal Content Test with header and footer 1`] = `
+<Backdrop
+  className=""
+>
+  <Bullseye
+    className=""
+    component="div"
+  >
+    <FocusTrap
+      _createFocusTrap={[Function]}
+      active={true}
+      focusTrapOptions={
+        Object {
+          "clickOutsideDeactivates": true,
+        }
+      }
+      paused={false}
+      tag="div"
+    >
+      <ModalBox
+        className=""
+        id="id"
+        isLarge={false}
+        title="Test Modal Content title"
+      >
+        <ModalBoxCloseButton
+          className=""
+          onClose={[Function]}
+        />
+        <ModalBoxHeader
+          className=""
+        >
+           
+          Test Modal Content title
+           
+        </ModalBoxHeader>
+        <ModalBoxBody
+          className=""
+          header="Testing header"
+          id="id"
+        >
+          This is a ModalBox header
+        </ModalBoxBody>
+        <ModalBoxFooter
+          className=""
+        >
+           
+          Testing footer
+           
+        </ModalBoxFooter>
+      </ModalBox>
+    </FocusTrap>
+  </Bullseye>
+</Backdrop>
+`;
 
-exports[`Modal Content Test with header 1`] = `""`;
+exports[`Modal Content Test with onclose 1`] = `
+<Backdrop
+  className=""
+>
+  <Bullseye
+    className=""
+    component="div"
+  >
+    <FocusTrap
+      _createFocusTrap={[Function]}
+      active={true}
+      focusTrapOptions={
+        Object {
+          "clickOutsideDeactivates": true,
+        }
+      }
+      paused={false}
+      tag="div"
+    >
+      <ModalBox
+        className=""
+        id="id"
+        isLarge={true}
+        title="Test Modal Content title"
+      >
+        <ModalBoxCloseButton
+          className=""
+          onClose={[Function]}
+        />
+        <ModalBoxHeader
+          className=""
+        >
+           
+          Test Modal Content title
+           
+        </ModalBoxHeader>
+        <ModalBoxBody
+          className=""
+          header="Testing header"
+          id="id"
+          onclose={[Function]}
+        >
+          This is a ModalBox header
+        </ModalBoxBody>
+        <ModalBoxFooter
+          className=""
+        >
+           
+          Testing footer
+           
+        </ModalBoxFooter>
+      </ModalBox>
+    </FocusTrap>
+  </Bullseye>
+</Backdrop>
+`;
 
-exports[`Modal Content Test with header and footer 1`] = `""`;
-
-exports[`Modal Content Test with onlose 1`] = `""`;
+exports[`Modal Content test without footer 1`] = `
+<Backdrop
+  className=""
+>
+  <Bullseye
+    className=""
+    component="div"
+  >
+    <FocusTrap
+      _createFocusTrap={[Function]}
+      active={true}
+      focusTrapOptions={
+        Object {
+          "clickOutsideDeactivates": true,
+        }
+      }
+      paused={false}
+      tag="div"
+    >
+      <ModalBox
+        className=""
+        id="id"
+        isLarge={false}
+        title="Test Modal Content title"
+      >
+        <ModalBoxCloseButton
+          className=""
+          onClose={[Function]}
+        />
+        <ModalBoxHeader
+          className=""
+        >
+           
+          Test Modal Content title
+           
+        </ModalBoxHeader>
+        <ModalBoxBody
+          className=""
+          id="id"
+        >
+          This is a ModalBox header
+        </ModalBoxBody>
+      </ModalBox>
+    </FocusTrap>
+  </Bullseye>
+</Backdrop>
+`;


### PR DESCRIPTION
Adjusted ModalContent so it only shows the footer if the actions array has content. I also made some
adjustments to ModalContent.test.js since some snapshots were blank, one
test had a typo, and some tests used what seems to be a deprecated footer prop.

Fixes #1107.