### PR TITLE
fix(Login Page): fix settings visibility

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/components/LoginCardComponents/LoginCardSettings.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/components/LoginCardComponents/LoginCardSettings.js
@@ -6,12 +6,12 @@ import { FormGroup } from '../../../../index';
 import ForgotPassword from './LoginCardForgotPassword';
 
 const LoginCardSettings = ({ rememberMe, forgotPassword, className, ...props }) =>
-  (rememberMe || forgotPassword) && (
+  rememberMe.label || forgotPassword.label ? (
     <FormGroup {...props} className={classNames('login-pf-settings', className)}>
       <RememberMe {...rememberMe} />
       <ForgotPassword {...forgotPassword} />
     </FormGroup>
-  );
+  ) : null;
 
 LoginCardSettings.propTypes = {
   /** Additional css classes. */


### PR DESCRIPTION
fixed the login card settings visibility,
show only when `rememberMe` / `forgotPassword` labels exists. 