### PR TITLE
PF4: Add missing attribute isPlain to Dropdown

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.d.ts
@@ -6,6 +6,7 @@ import { DropdownPosition, DropdownDirection } from './dropdownConstants';
 export interface DropdownProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
   dropdownItems: ReactNode[];
+  isPlain?: boolean;
   isOpen?: boolean;
   isAction?: boolean;
   onSelect(event: React.SyntheticEvent<HTMLDivElement>): void;


### PR DESCRIPTION
Fix https://github.com/patternfly/patternfly-react/issues/1172

Missing attribute isPlain

