### PR TITLE
fix(Button): make aria-label optional prop

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Button/Button.js
+++ b/packages/patternfly-4/react-core/src/components/Button/Button.js
@@ -39,13 +39,8 @@ const propTypes = {
   type: PropTypes.oneOf(Object.values(ButtonType)),
   /** Adds button variant styles */
   variant: PropTypes.oneOf(Object.values(ButtonVariant)),
-  /** Adds accessible text to the button. Required for plain buttons */
-  'aria-label': props => {
-    if (props.variant === ButtonVariant.plain && !props['aria-label']) {
-      return new Error('aria-label is required for Buttons with the plain variant');
-    }
-    return null;
-  },
+  /** Adds accessible text to the button. */
+  'aria-label': PropTypes.string,
   /** Additional props are spread to the container <button> */
   '': PropTypes.any
 };


### PR DESCRIPTION
#1184

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What** :Button should not require and aria-label for pf-m-plain modifier 

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
