### PR TITLE
fix(Dropdown): Pass down ref for dropdown item

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -96,7 +96,8 @@ class DropdownItem extends React.Component {
                     isDisabled && styles.modifiers.disabled,
                     isHovered && styles.modifiers.hover,
                     className
-                  )} ${child.props.className}`
+                  )} ${child.props.className}`,
+                  ref: this.ref
                 })
               )
             ) : (

--- a/packages/patternfly-4/react-core/src/demos/Toolbar/examples/ComplexToolbarDemo.js
+++ b/packages/patternfly-4/react-core/src/demos/Toolbar/examples/ComplexToolbarDemo.js
@@ -69,11 +69,13 @@ class ComplexToolbarDemo extends React.Component {
         position={DropdownPosition.right}
         toggle={<DropdownToggle onToggle={this.onDropDownToggle}>All</DropdownToggle>}
         isOpen={isDropDownOpen}
+        dropdownItems={[
+          <DropdownItem>Item 1</DropdownItem>,
+          <DropdownItem>Item 2</DropdownItem>,
+          <DropdownItem>Item 3</DropdownItem>,
+          <DropdownItem isDisabled>All</DropdownItem>
+        ]}
       >
-        <DropdownItem>Item 1</DropdownItem>
-        <DropdownItem>Item 2</DropdownItem>
-        <DropdownItem>Item 3</DropdownItem>
-        <DropdownItem isDisabled>All</DropdownItem>
       </Dropdown>
     );
   };
@@ -88,13 +90,15 @@ class ComplexToolbarDemo extends React.Component {
         toggle={<KebabToggle onToggle={this.onKebabToggle} />}
         isOpen={isKebabOpen}
         isPlain
-      >
-        <DropdownItem>Link</DropdownItem>
-        <DropdownItem component="button">Action</DropdownItem>
-        <DropdownItem isDisabled>Disabled Link</DropdownItem>
-        <DropdownItem isDisabled component="button">
-          Disabled Action
+        dropdownItems={[
+          <DropdownItem>Link</DropdownItem>,
+          <DropdownItem component="button">Action</DropdownItem>,
+          <DropdownItem isDisabled>Disabled Link</DropdownItem>,
+          <DropdownItem isDisabled component="button">
+            Disabled Action
         </DropdownItem>
+        ]}
+      >
       </Dropdown>
     );
   };

--- a/packages/patternfly-4/react-core/src/demos/Toolbar/examples/ComplexToolbarDemo.js
+++ b/packages/patternfly-4/react-core/src/demos/Toolbar/examples/ComplexToolbarDemo.js
@@ -70,10 +70,10 @@ class ComplexToolbarDemo extends React.Component {
         toggle={<DropdownToggle onToggle={this.onDropDownToggle}>All</DropdownToggle>}
         isOpen={isDropDownOpen}
         dropdownItems={[
-          <DropdownItem>Item 1</DropdownItem>,
-          <DropdownItem>Item 2</DropdownItem>,
-          <DropdownItem>Item 3</DropdownItem>,
-          <DropdownItem isDisabled>All</DropdownItem>
+          <DropdownItem key="item-1">Item 1</DropdownItem>,
+          <DropdownItem key="item-2">Item 2</DropdownItem>,
+          <DropdownItem key="item-3">Item 3</DropdownItem>,
+          <DropdownItem isDisabled key="all">All</DropdownItem>
         ]}
       >
       </Dropdown>
@@ -91,10 +91,10 @@ class ComplexToolbarDemo extends React.Component {
         isOpen={isKebabOpen}
         isPlain
         dropdownItems={[
-          <DropdownItem>Link</DropdownItem>,
-          <DropdownItem component="button">Action</DropdownItem>,
-          <DropdownItem isDisabled>Disabled Link</DropdownItem>,
-          <DropdownItem isDisabled component="button">
+          <DropdownItem key="link">Link</DropdownItem>,
+          <DropdownItem component="button" key="action_button">Action</DropdownItem>,
+          <DropdownItem isDisabled key="disabled_link">Disabled Link</DropdownItem>,
+          <DropdownItem isDisabled component="button" key="disabled_button">
             Disabled Action
         </DropdownItem>
         ]}

--- a/packages/patternfly-4/react-core/src/demos/Toolbar/examples/SimpleToolbarDemo.js
+++ b/packages/patternfly-4/react-core/src/demos/Toolbar/examples/SimpleToolbarDemo.js
@@ -68,11 +68,13 @@ class SimpleToolbarDemo extends React.Component {
         position={DropdownPosition.right}
         toggle={<DropdownToggle onToggle={this.onDropDownToggle}>All</DropdownToggle>}
         isOpen={isDropDownOpen}
+        dropdownItems={[
+          <DropdownItem>Item 1</DropdownItem>,
+          <DropdownItem>Item 2</DropdownItem>,
+          <DropdownItem>Item 3</DropdownItem>,
+          <DropdownItem isDisabled>All</DropdownItem>
+        ]}
       >
-        <DropdownItem>Item 1</DropdownItem>
-        <DropdownItem>Item 2</DropdownItem>
-        <DropdownItem>Item 3</DropdownItem>
-        <DropdownItem isDisabled>All</DropdownItem>
       </Dropdown>
     );
   };
@@ -87,13 +89,15 @@ class SimpleToolbarDemo extends React.Component {
         toggle={<KebabToggle onToggle={this.onKebabToggle} />}
         isOpen={isKebabOpen}
         isPlain
+        dropdownItems={[
+          <DropdownItem>Link</DropdownItem>,
+          <DropdownItem component="button">Action</DropdownItem>,
+          <DropdownItem isDisabled>Disabled Link</DropdownItem>,
+          <DropdownItem isDisabled component="button">
+            Disabled Action
+          </DropdownItem>
+        ]}
       >
-        <DropdownItem>Link</DropdownItem>
-        <DropdownItem component="button">Action</DropdownItem>
-        <DropdownItem isDisabled>Disabled Link</DropdownItem>
-        <DropdownItem isDisabled component="button">
-          Disabled Action
-        </DropdownItem>
       </Dropdown>
     );
   };

--- a/packages/patternfly-4/react-core/src/demos/Toolbar/examples/SimpleToolbarDemo.js
+++ b/packages/patternfly-4/react-core/src/demos/Toolbar/examples/SimpleToolbarDemo.js
@@ -69,10 +69,10 @@ class SimpleToolbarDemo extends React.Component {
         toggle={<DropdownToggle onToggle={this.onDropDownToggle}>All</DropdownToggle>}
         isOpen={isDropDownOpen}
         dropdownItems={[
-          <DropdownItem>Item 1</DropdownItem>,
-          <DropdownItem>Item 2</DropdownItem>,
-          <DropdownItem>Item 3</DropdownItem>,
-          <DropdownItem isDisabled>All</DropdownItem>
+          <DropdownItem key="item-1">Item 1</DropdownItem>,
+          <DropdownItem key="item2">Item 2</DropdownItem>,
+          <DropdownItem key="item-3">Item 3</DropdownItem>,
+          <DropdownItem isDisabled key="all">All</DropdownItem>
         ]}
       >
       </Dropdown>
@@ -90,10 +90,10 @@ class SimpleToolbarDemo extends React.Component {
         isOpen={isKebabOpen}
         isPlain
         dropdownItems={[
-          <DropdownItem>Link</DropdownItem>,
-          <DropdownItem component="button">Action</DropdownItem>,
-          <DropdownItem isDisabled>Disabled Link</DropdownItem>,
-          <DropdownItem isDisabled component="button">
+          <DropdownItem key="link">Link</DropdownItem>,
+          <DropdownItem component="button" key="action-button">Action</DropdownItem>,
+          <DropdownItem isDisabled key="disabled-link">Disabled Link</DropdownItem>,
+          <DropdownItem isDisabled component="button" key="disabled-button">
             Disabled Action
           </DropdownItem>
         ]}


### PR DESCRIPTION
**What**:

This PR fixes problems when DropdownItem is React child, without it the ref wouldn't be assigned and was undefined when tried to access it in componentDidmount.

Fixes: #1191 