### PR TITLE
feat(Alert): Add optional Close button to Alert via onClose prop

### DIFF
--- a/packages/patternfly-4/react-charts/package.json
+++ b/packages/patternfly-4/react-charts/package.json
@@ -46,7 +46,7 @@
     "victory": "^30.1.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly-next": "1.0.120",
+    "@patternfly/patternfly-next": "1.0.126",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/packages/patternfly-4/react-core/package.json
+++ b/packages/patternfly-4/react-core/package.json
@@ -62,7 +62,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.0.0",
-    "@patternfly/patternfly-next": "1.0.120",
+    "@patternfly/patternfly-next": "1.0.126",
     "@types/enzyme": "^3.1.15",
     "@types/jest": "^23.3.10",
     "@types/prop-types": "^15.5.6",

--- a/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalBox.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalBox.test.js.snap
@@ -9,7 +9,7 @@ exports[`AboutModalBox Test 1`] = `
   overflow-x: hidden;
   overflow-y: auto;
   background-color: #030303;
-  box-shadow: 0 0 100px 0 rgba(255,255,255,0.05);
+  box-shadow: 0 0 100px 0 rgba(255,255,255,.05);
 }
 
 <div

--- a/packages/patternfly-4/react-core/src/components/Alert/Alert.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Alert/Alert.d.ts
@@ -12,6 +12,8 @@ export interface AlertProps extends Omit<HTMLProps<HTMLDivElement>, 'action'> {
   variant: OneOf<typeof AlertVariant, keyof typeof AlertVariant>;
   children?: ReactNode;
   action?: ReactNode;
+  onClose?: Function;
+  closeButtonAriaLabel?: String;
 }
 
 declare const Alert: SFC<AlertProps>;

--- a/packages/patternfly-4/react-core/src/components/Alert/Alert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/Alert.js
@@ -30,6 +30,10 @@ const propTypes = {
   'aria-label': PropTypes.string,
   /** Variant label text for screen readers */
   variantLabel: PropTypes.string,
+  /** A callback for when the close button is clicked (if undefined, no close button is rendered) */
+  onClose: PropTypes.func,
+  /** Allows localization of the accessible label on the close button */
+  closeButtonAriaLabel: PropTypes.string,
   /** Additional props are spread to the container <div>  */
   '': PropTypes.any
 };
@@ -40,7 +44,9 @@ const defaultProps = {
   title: '',
   children: '',
   className: '',
-  variantLabel: null
+  variantLabel: null,
+  onClose: undefined,
+  closeButtonAriaLabel: 'Close'
 };
 
 const getDefaultAriaLabel = variant => `${capitalize(AlertVariant[variant])} Notification`;
@@ -53,6 +59,8 @@ const Alert = ({
   title,
   children,
   className,
+  onClose,
+  closeButtonAriaLabel,
   ...props
 }) => {
   variantLabel = variantLabel || capitalize(AlertVariant[variant]);
@@ -68,7 +76,9 @@ const Alert = ({
   return (
     <div {...props} className={customClassName} aria-label={ariaLabel}>
       <AlertIcon variant={variant} />
-      <AlertBody title={readerTitle}>{children}</AlertBody>
+      <AlertBody title={readerTitle} onClose={onClose} closeButtonAriaLabel={closeButtonAriaLabel}>
+        {children}
+      </AlertBody>
       {action && <AlertAction>{action}</AlertAction>}
     </div>
   );

--- a/packages/patternfly-4/react-core/src/components/Alert/Alert.test.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/Alert.test.js
@@ -37,6 +37,30 @@ Object.keys(AlertVariant).forEach(variant => {
       expect(view).toMatchSnapshot();
     });
 
+    test('Close button', () => {
+      const onClose = jest.fn();
+      const view = mount(
+        <Alert variant={variant} onClose={onClose}>
+          Some alert
+        </Alert>
+      );
+      expect(view).toMatchSnapshot();
+      view.find('button[aria-label="Close"]').simulate('click');
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test('Close button and Title', () => {
+      const onClose = jest.fn();
+      const view = mount(
+        <Alert variant={variant} onClose={onClose} title="Some title">
+          Some alert
+        </Alert>
+      );
+      expect(view).toMatchSnapshot();
+      view.find('button[aria-label="Close"]').simulate('click');
+      expect(onClose).toHaveBeenCalled();
+    });
+
     test('Custom aria label', () => {
       const view = mount(
         <Alert variant={variant} aria-label={`Custom aria label for ${variant}`} action="action" title="Some title">

--- a/packages/patternfly-4/react-core/src/components/Alert/AlertBody.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/AlertBody.js
@@ -2,21 +2,32 @@ import React from 'react';
 import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
 import styles from '@patternfly/patternfly-next/components/Alert/alert.css';
+import { TimesIcon } from '@patternfly/react-icons';
+import { Button, ButtonVariant } from '../Button';
 
 const propTypes = {
   title: PropTypes.node,
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  onClose: PropTypes.func,
+  closeButtonAriaLabel: PropTypes.string
 };
 
 const defaultProps = {
   title: null,
   children: '',
-  className: ''
+  className: '',
+  onClose: undefined,
+  closeButtonAriaLabel: 'Close'
 };
 
-const AlertBody = ({ title, className, children, ...props }) => (
+const AlertBody = ({ title, className, children, onClose, closeButtonAriaLabel, ...props }) => (
   <div {...props} className={css(styles.alertBody, className)}>
+    {onClose && (
+      <Button variant={ButtonVariant.plain} onClick={onClose} aria-label={closeButtonAriaLabel}>
+        <TimesIcon />
+      </Button>
+    )}
     {title && <h4 className={css(styles.alertTitle)}>{title}</h4>}
     {children && <p>{children}</p>}
   </div>

--- a/packages/patternfly-4/react-core/src/components/Alert/AlertBody.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/AlertBody.js
@@ -18,7 +18,7 @@ const defaultProps = {
 const AlertBody = ({ title, className, children, ...props }) => (
   <div {...props} className={css(styles.alertBody, className)}>
     {title && <h4 className={css(styles.alertTitle)}>{title}</h4>}
-    {children}
+    {children && <p>{children}</p>}
   </div>
 );
 

--- a/packages/patternfly-4/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -110,7 +110,9 @@ exports[`Alert - danger Action 1`] = `
             : 
           </span>
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
     <AlertAction
@@ -237,7 +239,9 @@ exports[`Alert - danger Action and Title 1`] = `
           </span>
           Some title
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
     <AlertAction
@@ -359,7 +363,9 @@ exports[`Alert - danger Body 1`] = `
             : 
           </span>
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
   </div>
@@ -478,7 +484,9 @@ exports[`Alert - danger Custom aria label 1`] = `
           </span>
           Some title
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
     <AlertAction
@@ -601,7 +609,9 @@ exports[`Alert - danger Title 1`] = `
           </span>
           Some title
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
   </div>
@@ -718,7 +728,9 @@ exports[`Alert - info Action 1`] = `
             : 
           </span>
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
     <AlertAction
@@ -845,7 +857,9 @@ exports[`Alert - info Action and Title 1`] = `
           </span>
           Some title
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
     <AlertAction
@@ -967,7 +981,9 @@ exports[`Alert - info Body 1`] = `
             : 
           </span>
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
   </div>
@@ -1086,7 +1102,9 @@ exports[`Alert - info Custom aria label 1`] = `
           </span>
           Some title
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
     <AlertAction
@@ -1209,7 +1227,9 @@ exports[`Alert - info Title 1`] = `
           </span>
           Some title
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
   </div>
@@ -1326,7 +1346,9 @@ exports[`Alert - success Action 1`] = `
             : 
           </span>
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
     <AlertAction
@@ -1453,7 +1475,9 @@ exports[`Alert - success Action and Title 1`] = `
           </span>
           Some title
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
     <AlertAction
@@ -1575,7 +1599,9 @@ exports[`Alert - success Body 1`] = `
             : 
           </span>
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
   </div>
@@ -1694,7 +1720,9 @@ exports[`Alert - success Custom aria label 1`] = `
           </span>
           Some title
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
     <AlertAction
@@ -1817,7 +1845,9 @@ exports[`Alert - success Title 1`] = `
           </span>
           Some title
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
   </div>
@@ -1934,7 +1964,9 @@ exports[`Alert - warning Action 1`] = `
             : 
           </span>
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
     <AlertAction
@@ -2061,7 +2093,9 @@ exports[`Alert - warning Action and Title 1`] = `
           </span>
           Some title
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
     <AlertAction
@@ -2183,7 +2217,9 @@ exports[`Alert - warning Body 1`] = `
             : 
           </span>
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
   </div>
@@ -2302,7 +2338,9 @@ exports[`Alert - warning Custom aria label 1`] = `
           </span>
           Some title
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
     <AlertAction
@@ -2425,7 +2463,9 @@ exports[`Alert - warning Title 1`] = `
           </span>
           Some title
         </h4>
-        Some alert
+        <p>
+          Some alert
+        </p>
       </div>
     </AlertBody>
   </div>

--- a/packages/patternfly-4/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -18,19 +18,19 @@ exports[`Alert - danger Action 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert__action {
-  display: block;
-  padding: 1rem 1.5rem 1rem 1.5rem;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 .pf-c-alert.pf-m-danger {
   display: flex;
@@ -144,19 +144,19 @@ exports[`Alert - danger Action and Title 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert__action {
-  display: block;
-  padding: 1rem 1.5rem 1rem 1.5rem;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 .pf-c-alert.pf-m-danger {
   display: flex;
@@ -271,13 +271,14 @@ exports[`Alert - danger Body 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert.pf-m-danger {
@@ -383,19 +384,19 @@ exports[`Alert - danger Custom aria label 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert__action {
-  display: block;
-  padding: 1rem 1.5rem 1rem 1.5rem;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 .pf-c-alert.pf-m-danger {
   display: flex;
@@ -511,13 +512,14 @@ exports[`Alert - danger Title 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert.pf-m-danger {
@@ -624,19 +626,19 @@ exports[`Alert - info Action 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert__action {
-  display: block;
-  padding: 1rem 1.5rem 1rem 1.5rem;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 .pf-c-alert.pf-m-info {
   display: flex;
@@ -750,19 +752,19 @@ exports[`Alert - info Action and Title 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert__action {
-  display: block;
-  padding: 1rem 1.5rem 1rem 1.5rem;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 .pf-c-alert.pf-m-info {
   display: flex;
@@ -877,13 +879,14 @@ exports[`Alert - info Body 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert.pf-m-info {
@@ -989,19 +992,19 @@ exports[`Alert - info Custom aria label 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert__action {
-  display: block;
-  padding: 1rem 1.5rem 1rem 1.5rem;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 .pf-c-alert.pf-m-info {
   display: flex;
@@ -1117,13 +1120,14 @@ exports[`Alert - info Title 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert.pf-m-info {
@@ -1230,19 +1234,19 @@ exports[`Alert - success Action 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert__action {
-  display: block;
-  padding: 1rem 1.5rem 1rem 1.5rem;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 .pf-c-alert.pf-m-success {
   display: flex;
@@ -1356,19 +1360,19 @@ exports[`Alert - success Action and Title 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert__action {
-  display: block;
-  padding: 1rem 1.5rem 1rem 1.5rem;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 .pf-c-alert.pf-m-success {
   display: flex;
@@ -1483,13 +1487,14 @@ exports[`Alert - success Body 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert.pf-m-success {
@@ -1595,19 +1600,19 @@ exports[`Alert - success Custom aria label 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert__action {
-  display: block;
-  padding: 1rem 1.5rem 1rem 1.5rem;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 .pf-c-alert.pf-m-success {
   display: flex;
@@ -1723,13 +1728,14 @@ exports[`Alert - success Title 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert.pf-m-success {
@@ -1836,19 +1842,19 @@ exports[`Alert - warning Action 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert__action {
-  display: block;
-  padding: 1rem 1.5rem 1rem 1.5rem;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 .pf-c-alert.pf-m-warning {
   display: flex;
@@ -1962,19 +1968,19 @@ exports[`Alert - warning Action and Title 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert__action {
-  display: block;
-  padding: 1rem 1.5rem 1rem 1.5rem;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 .pf-c-alert.pf-m-warning {
   display: flex;
@@ -2089,13 +2095,14 @@ exports[`Alert - warning Body 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert.pf-m-warning {
@@ -2201,19 +2208,19 @@ exports[`Alert - warning Custom aria label 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert__action {
-  display: block;
-  padding: 1rem 1.5rem 1rem 1.5rem;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
 }
 .pf-c-alert.pf-m-warning {
   display: flex;
@@ -2329,13 +2336,14 @@ exports[`Alert - warning Title 1`] = `
 }
 .pf-c-alert__title {
   display: block;
-  margin-top: 0.25rem;
-  margin-bottom: 0.25rem;
   font-size: 1rem;
   color: #004368;
 }
 .pf-c-alert__body {
-  display: block;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
   padding: 1rem 1rem 1rem 1rem;
 }
 .pf-c-alert.pf-m-warning {

--- a/packages/patternfly-4/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -41,6 +41,7 @@ exports[`Alert - danger Action 1`] = `
 <Alert
   action="action"
   className=""
+  closeButtonAriaLabel="Close"
   title=""
   variant="danger"
   variantLabel={null}
@@ -85,6 +86,7 @@ exports[`Alert - danger Action 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -169,6 +171,7 @@ exports[`Alert - danger Action and Title 1`] = `
 <Alert
   action="action"
   className=""
+  closeButtonAriaLabel="Close"
   title="Some title"
   variant="danger"
   variantLabel={null}
@@ -213,6 +216,7 @@ exports[`Alert - danger Action and Title 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -294,6 +298,7 @@ exports[`Alert - danger Body 1`] = `
 <Alert
   action={null}
   className=""
+  closeButtonAriaLabel="Close"
   title=""
   variant="danger"
   variantLabel={null}
@@ -338,6 +343,7 @@ exports[`Alert - danger Body 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -362,6 +368,371 @@ exports[`Alert - danger Body 1`] = `
             Danger
             : 
           </span>
+        </h4>
+        <p>
+          Some alert
+        </p>
+      </div>
+    </AlertBody>
+  </div>
+</Alert>
+`;
+
+exports[`Alert - danger Close button 1`] = `
+.pf-c-alert__icon {
+  display: flex;
+  padding: 1rem;
+  font-size: 1.5rem;
+  color: #004368;
+  background-color: #39a5dc;
+}
+.pf-c-button.pf-m-plain {
+  display: inline-block;
+  position: relative;
+  padding: 0.375rem 1rem 0.375rem 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+  text-align: center;
+  white-space: nowrap;
+  border: 0px;
+  border-radius: 3px;
+  text-decoration: none;
+  color: #72767b;
+}
+.pf-u-screen-reader {
+  display: block;
+  position: fixed;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
+}
+.pf-c-alert__title {
+  display: block;
+  font-size: 1rem;
+  color: #004368;
+}
+.pf-c-alert__body {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1rem 1rem 1rem 1rem;
+}
+.pf-c-alert.pf-m-danger {
+  display: flex;
+  background-color: #ffffff;
+  box-shadow: 0 0.1875rem 0.4375rem 0.1875rem rgba(3, 3, 3, 0.13), 0 0.6875rem 1.5rem 1rem rgba(3, 3, 3, 0.12);
+}
+
+<Alert
+  action={null}
+  className=""
+  closeButtonAriaLabel="Close"
+  onClose={[MockFunction]}
+  title=""
+  variant="danger"
+  variantLabel={null}
+>
+  <div
+    aria-label="Danger Notification"
+    className="pf-c-alert pf-m-danger"
+  >
+    <AlertIcon
+      className=""
+      variant="danger"
+    >
+      <div
+        className="pf-c-alert__icon"
+      >
+        <ExclamationCircleIcon
+          color="currentColor"
+          size="sm"
+          title={null}
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 512 512"
+            width="1em"
+          >
+            <path
+              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+              transform=""
+            />
+          </svg>
+        </ExclamationCircleIcon>
+      </div>
+    </AlertIcon>
+    <AlertBody
+      className=""
+      closeButtonAriaLabel="Close"
+      onClose={[MockFunction]}
+      title={
+        <React.Fragment>
+          <span
+            className="pf-u-screen-reader"
+          >
+            Danger
+            : 
+          </span>
+          
+        </React.Fragment>
+      }
+    >
+      <div
+        className="pf-c-alert__body"
+      >
+        <Button
+          aria-label="Close"
+          className=""
+          component="button"
+          isActive={false}
+          isBlock={false}
+          isDisabled={false}
+          isFocus={false}
+          isHover={false}
+          onClick={[MockFunction]}
+          type="button"
+          variant="plain"
+        >
+          <button
+            aria-disabled={null}
+            aria-label="Close"
+            className="pf-c-button pf-m-plain"
+            disabled={false}
+            onClick={[MockFunction]}
+            tabIndex={null}
+            type="button"
+          >
+            <TimesIcon
+              color="currentColor"
+              size="sm"
+              title={null}
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  transform=""
+                />
+              </svg>
+            </TimesIcon>
+          </button>
+        </Button>
+        <h4
+          className="pf-c-alert__title"
+        >
+          <span
+            className="pf-u-screen-reader"
+          >
+            Danger
+            : 
+          </span>
+        </h4>
+        <p>
+          Some alert
+        </p>
+      </div>
+    </AlertBody>
+  </div>
+</Alert>
+`;
+
+exports[`Alert - danger Close button and Title 1`] = `
+.pf-c-alert__icon {
+  display: flex;
+  padding: 1rem;
+  font-size: 1.5rem;
+  color: #004368;
+  background-color: #39a5dc;
+}
+.pf-c-button.pf-m-plain {
+  display: inline-block;
+  position: relative;
+  padding: 0.375rem 1rem 0.375rem 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+  text-align: center;
+  white-space: nowrap;
+  border: 0px;
+  border-radius: 3px;
+  text-decoration: none;
+  color: #72767b;
+}
+.pf-u-screen-reader {
+  display: block;
+  position: fixed;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
+}
+.pf-c-alert__title {
+  display: block;
+  font-size: 1rem;
+  color: #004368;
+}
+.pf-c-alert__body {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1rem 1rem 1rem 1rem;
+}
+.pf-c-alert.pf-m-danger {
+  display: flex;
+  background-color: #ffffff;
+  box-shadow: 0 0.1875rem 0.4375rem 0.1875rem rgba(3, 3, 3, 0.13), 0 0.6875rem 1.5rem 1rem rgba(3, 3, 3, 0.12);
+}
+
+<Alert
+  action={null}
+  className=""
+  closeButtonAriaLabel="Close"
+  onClose={[MockFunction]}
+  title="Some title"
+  variant="danger"
+  variantLabel={null}
+>
+  <div
+    aria-label="Danger Notification"
+    className="pf-c-alert pf-m-danger"
+  >
+    <AlertIcon
+      className=""
+      variant="danger"
+    >
+      <div
+        className="pf-c-alert__icon"
+      >
+        <ExclamationCircleIcon
+          color="currentColor"
+          size="sm"
+          title={null}
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 512 512"
+            width="1em"
+          >
+            <path
+              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+              transform=""
+            />
+          </svg>
+        </ExclamationCircleIcon>
+      </div>
+    </AlertIcon>
+    <AlertBody
+      className=""
+      closeButtonAriaLabel="Close"
+      onClose={[MockFunction]}
+      title={
+        <React.Fragment>
+          <span
+            className="pf-u-screen-reader"
+          >
+            Danger
+            : 
+          </span>
+          Some title
+        </React.Fragment>
+      }
+    >
+      <div
+        className="pf-c-alert__body"
+      >
+        <Button
+          aria-label="Close"
+          className=""
+          component="button"
+          isActive={false}
+          isBlock={false}
+          isDisabled={false}
+          isFocus={false}
+          isHover={false}
+          onClick={[MockFunction]}
+          type="button"
+          variant="plain"
+        >
+          <button
+            aria-disabled={null}
+            aria-label="Close"
+            className="pf-c-button pf-m-plain"
+            disabled={false}
+            onClick={[MockFunction]}
+            tabIndex={null}
+            type="button"
+          >
+            <TimesIcon
+              color="currentColor"
+              size="sm"
+              title={null}
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  transform=""
+                />
+              </svg>
+            </TimesIcon>
+          </button>
+        </Button>
+        <h4
+          className="pf-c-alert__title"
+        >
+          <span
+            className="pf-u-screen-reader"
+          >
+            Danger
+            : 
+          </span>
+          Some title
         </h4>
         <p>
           Some alert
@@ -414,6 +785,7 @@ exports[`Alert - danger Custom aria label 1`] = `
   action="action"
   aria-label="Custom aria label for danger"
   className=""
+  closeButtonAriaLabel="Close"
   title="Some title"
   variant="danger"
   variantLabel={null}
@@ -458,6 +830,7 @@ exports[`Alert - danger Custom aria label 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -539,6 +912,7 @@ exports[`Alert - danger Title 1`] = `
 <Alert
   action={null}
   className=""
+  closeButtonAriaLabel="Close"
   title="Some title"
   variant="danger"
   variantLabel={null}
@@ -583,6 +957,7 @@ exports[`Alert - danger Title 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -659,6 +1034,7 @@ exports[`Alert - info Action 1`] = `
 <Alert
   action="action"
   className=""
+  closeButtonAriaLabel="Close"
   title=""
   variant="info"
   variantLabel={null}
@@ -703,6 +1079,7 @@ exports[`Alert - info Action 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -787,6 +1164,7 @@ exports[`Alert - info Action and Title 1`] = `
 <Alert
   action="action"
   className=""
+  closeButtonAriaLabel="Close"
   title="Some title"
   variant="info"
   variantLabel={null}
@@ -831,6 +1209,7 @@ exports[`Alert - info Action and Title 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -912,6 +1291,7 @@ exports[`Alert - info Body 1`] = `
 <Alert
   action={null}
   className=""
+  closeButtonAriaLabel="Close"
   title=""
   variant="info"
   variantLabel={null}
@@ -956,6 +1336,7 @@ exports[`Alert - info Body 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -980,6 +1361,371 @@ exports[`Alert - info Body 1`] = `
             Info
             : 
           </span>
+        </h4>
+        <p>
+          Some alert
+        </p>
+      </div>
+    </AlertBody>
+  </div>
+</Alert>
+`;
+
+exports[`Alert - info Close button 1`] = `
+.pf-c-alert__icon {
+  display: flex;
+  padding: 1rem;
+  font-size: 1.5rem;
+  color: #004368;
+  background-color: #39a5dc;
+}
+.pf-c-button.pf-m-plain {
+  display: inline-block;
+  position: relative;
+  padding: 0.375rem 1rem 0.375rem 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+  text-align: center;
+  white-space: nowrap;
+  border: 0px;
+  border-radius: 3px;
+  text-decoration: none;
+  color: #72767b;
+}
+.pf-u-screen-reader {
+  display: block;
+  position: fixed;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
+}
+.pf-c-alert__title {
+  display: block;
+  font-size: 1rem;
+  color: #004368;
+}
+.pf-c-alert__body {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1rem 1rem 1rem 1rem;
+}
+.pf-c-alert.pf-m-info {
+  display: flex;
+  background-color: #ffffff;
+  box-shadow: 0 0.1875rem 0.4375rem 0.1875rem rgba(3, 3, 3, 0.13), 0 0.6875rem 1.5rem 1rem rgba(3, 3, 3, 0.12);
+}
+
+<Alert
+  action={null}
+  className=""
+  closeButtonAriaLabel="Close"
+  onClose={[MockFunction]}
+  title=""
+  variant="info"
+  variantLabel={null}
+>
+  <div
+    aria-label="Info Notification"
+    className="pf-c-alert pf-m-info"
+  >
+    <AlertIcon
+      className=""
+      variant="info"
+    >
+      <div
+        className="pf-c-alert__icon"
+      >
+        <InfoCircleIcon
+          color="currentColor"
+          size="sm"
+          title={null}
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 512 512"
+            width="1em"
+          >
+            <path
+              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+              transform=""
+            />
+          </svg>
+        </InfoCircleIcon>
+      </div>
+    </AlertIcon>
+    <AlertBody
+      className=""
+      closeButtonAriaLabel="Close"
+      onClose={[MockFunction]}
+      title={
+        <React.Fragment>
+          <span
+            className="pf-u-screen-reader"
+          >
+            Info
+            : 
+          </span>
+          
+        </React.Fragment>
+      }
+    >
+      <div
+        className="pf-c-alert__body"
+      >
+        <Button
+          aria-label="Close"
+          className=""
+          component="button"
+          isActive={false}
+          isBlock={false}
+          isDisabled={false}
+          isFocus={false}
+          isHover={false}
+          onClick={[MockFunction]}
+          type="button"
+          variant="plain"
+        >
+          <button
+            aria-disabled={null}
+            aria-label="Close"
+            className="pf-c-button pf-m-plain"
+            disabled={false}
+            onClick={[MockFunction]}
+            tabIndex={null}
+            type="button"
+          >
+            <TimesIcon
+              color="currentColor"
+              size="sm"
+              title={null}
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  transform=""
+                />
+              </svg>
+            </TimesIcon>
+          </button>
+        </Button>
+        <h4
+          className="pf-c-alert__title"
+        >
+          <span
+            className="pf-u-screen-reader"
+          >
+            Info
+            : 
+          </span>
+        </h4>
+        <p>
+          Some alert
+        </p>
+      </div>
+    </AlertBody>
+  </div>
+</Alert>
+`;
+
+exports[`Alert - info Close button and Title 1`] = `
+.pf-c-alert__icon {
+  display: flex;
+  padding: 1rem;
+  font-size: 1.5rem;
+  color: #004368;
+  background-color: #39a5dc;
+}
+.pf-c-button.pf-m-plain {
+  display: inline-block;
+  position: relative;
+  padding: 0.375rem 1rem 0.375rem 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+  text-align: center;
+  white-space: nowrap;
+  border: 0px;
+  border-radius: 3px;
+  text-decoration: none;
+  color: #72767b;
+}
+.pf-u-screen-reader {
+  display: block;
+  position: fixed;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
+}
+.pf-c-alert__title {
+  display: block;
+  font-size: 1rem;
+  color: #004368;
+}
+.pf-c-alert__body {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1rem 1rem 1rem 1rem;
+}
+.pf-c-alert.pf-m-info {
+  display: flex;
+  background-color: #ffffff;
+  box-shadow: 0 0.1875rem 0.4375rem 0.1875rem rgba(3, 3, 3, 0.13), 0 0.6875rem 1.5rem 1rem rgba(3, 3, 3, 0.12);
+}
+
+<Alert
+  action={null}
+  className=""
+  closeButtonAriaLabel="Close"
+  onClose={[MockFunction]}
+  title="Some title"
+  variant="info"
+  variantLabel={null}
+>
+  <div
+    aria-label="Info Notification"
+    className="pf-c-alert pf-m-info"
+  >
+    <AlertIcon
+      className=""
+      variant="info"
+    >
+      <div
+        className="pf-c-alert__icon"
+      >
+        <InfoCircleIcon
+          color="currentColor"
+          size="sm"
+          title={null}
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 512 512"
+            width="1em"
+          >
+            <path
+              d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+              transform=""
+            />
+          </svg>
+        </InfoCircleIcon>
+      </div>
+    </AlertIcon>
+    <AlertBody
+      className=""
+      closeButtonAriaLabel="Close"
+      onClose={[MockFunction]}
+      title={
+        <React.Fragment>
+          <span
+            className="pf-u-screen-reader"
+          >
+            Info
+            : 
+          </span>
+          Some title
+        </React.Fragment>
+      }
+    >
+      <div
+        className="pf-c-alert__body"
+      >
+        <Button
+          aria-label="Close"
+          className=""
+          component="button"
+          isActive={false}
+          isBlock={false}
+          isDisabled={false}
+          isFocus={false}
+          isHover={false}
+          onClick={[MockFunction]}
+          type="button"
+          variant="plain"
+        >
+          <button
+            aria-disabled={null}
+            aria-label="Close"
+            className="pf-c-button pf-m-plain"
+            disabled={false}
+            onClick={[MockFunction]}
+            tabIndex={null}
+            type="button"
+          >
+            <TimesIcon
+              color="currentColor"
+              size="sm"
+              title={null}
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  transform=""
+                />
+              </svg>
+            </TimesIcon>
+          </button>
+        </Button>
+        <h4
+          className="pf-c-alert__title"
+        >
+          <span
+            className="pf-u-screen-reader"
+          >
+            Info
+            : 
+          </span>
+          Some title
         </h4>
         <p>
           Some alert
@@ -1032,6 +1778,7 @@ exports[`Alert - info Custom aria label 1`] = `
   action="action"
   aria-label="Custom aria label for info"
   className=""
+  closeButtonAriaLabel="Close"
   title="Some title"
   variant="info"
   variantLabel={null}
@@ -1076,6 +1823,7 @@ exports[`Alert - info Custom aria label 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -1157,6 +1905,7 @@ exports[`Alert - info Title 1`] = `
 <Alert
   action={null}
   className=""
+  closeButtonAriaLabel="Close"
   title="Some title"
   variant="info"
   variantLabel={null}
@@ -1201,6 +1950,7 @@ exports[`Alert - info Title 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -1277,6 +2027,7 @@ exports[`Alert - success Action 1`] = `
 <Alert
   action="action"
   className=""
+  closeButtonAriaLabel="Close"
   title=""
   variant="success"
   variantLabel={null}
@@ -1321,6 +2072,7 @@ exports[`Alert - success Action 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -1405,6 +2157,7 @@ exports[`Alert - success Action and Title 1`] = `
 <Alert
   action="action"
   className=""
+  closeButtonAriaLabel="Close"
   title="Some title"
   variant="success"
   variantLabel={null}
@@ -1449,6 +2202,7 @@ exports[`Alert - success Action and Title 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -1530,6 +2284,7 @@ exports[`Alert - success Body 1`] = `
 <Alert
   action={null}
   className=""
+  closeButtonAriaLabel="Close"
   title=""
   variant="success"
   variantLabel={null}
@@ -1574,6 +2329,7 @@ exports[`Alert - success Body 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -1598,6 +2354,371 @@ exports[`Alert - success Body 1`] = `
             Success
             : 
           </span>
+        </h4>
+        <p>
+          Some alert
+        </p>
+      </div>
+    </AlertBody>
+  </div>
+</Alert>
+`;
+
+exports[`Alert - success Close button 1`] = `
+.pf-c-alert__icon {
+  display: flex;
+  padding: 1rem;
+  font-size: 1.5rem;
+  color: #004368;
+  background-color: #39a5dc;
+}
+.pf-c-button.pf-m-plain {
+  display: inline-block;
+  position: relative;
+  padding: 0.375rem 1rem 0.375rem 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+  text-align: center;
+  white-space: nowrap;
+  border: 0px;
+  border-radius: 3px;
+  text-decoration: none;
+  color: #72767b;
+}
+.pf-u-screen-reader {
+  display: block;
+  position: fixed;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
+}
+.pf-c-alert__title {
+  display: block;
+  font-size: 1rem;
+  color: #004368;
+}
+.pf-c-alert__body {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1rem 1rem 1rem 1rem;
+}
+.pf-c-alert.pf-m-success {
+  display: flex;
+  background-color: #ffffff;
+  box-shadow: 0 0.1875rem 0.4375rem 0.1875rem rgba(3, 3, 3, 0.13), 0 0.6875rem 1.5rem 1rem rgba(3, 3, 3, 0.12);
+}
+
+<Alert
+  action={null}
+  className=""
+  closeButtonAriaLabel="Close"
+  onClose={[MockFunction]}
+  title=""
+  variant="success"
+  variantLabel={null}
+>
+  <div
+    aria-label="Success Notification"
+    className="pf-c-alert pf-m-success"
+  >
+    <AlertIcon
+      className=""
+      variant="success"
+    >
+      <div
+        className="pf-c-alert__icon"
+      >
+        <CheckCircleIcon
+          color="currentColor"
+          size="sm"
+          title={null}
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 512 512"
+            width="1em"
+          >
+            <path
+              d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+              transform=""
+            />
+          </svg>
+        </CheckCircleIcon>
+      </div>
+    </AlertIcon>
+    <AlertBody
+      className=""
+      closeButtonAriaLabel="Close"
+      onClose={[MockFunction]}
+      title={
+        <React.Fragment>
+          <span
+            className="pf-u-screen-reader"
+          >
+            Success
+            : 
+          </span>
+          
+        </React.Fragment>
+      }
+    >
+      <div
+        className="pf-c-alert__body"
+      >
+        <Button
+          aria-label="Close"
+          className=""
+          component="button"
+          isActive={false}
+          isBlock={false}
+          isDisabled={false}
+          isFocus={false}
+          isHover={false}
+          onClick={[MockFunction]}
+          type="button"
+          variant="plain"
+        >
+          <button
+            aria-disabled={null}
+            aria-label="Close"
+            className="pf-c-button pf-m-plain"
+            disabled={false}
+            onClick={[MockFunction]}
+            tabIndex={null}
+            type="button"
+          >
+            <TimesIcon
+              color="currentColor"
+              size="sm"
+              title={null}
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  transform=""
+                />
+              </svg>
+            </TimesIcon>
+          </button>
+        </Button>
+        <h4
+          className="pf-c-alert__title"
+        >
+          <span
+            className="pf-u-screen-reader"
+          >
+            Success
+            : 
+          </span>
+        </h4>
+        <p>
+          Some alert
+        </p>
+      </div>
+    </AlertBody>
+  </div>
+</Alert>
+`;
+
+exports[`Alert - success Close button and Title 1`] = `
+.pf-c-alert__icon {
+  display: flex;
+  padding: 1rem;
+  font-size: 1.5rem;
+  color: #004368;
+  background-color: #39a5dc;
+}
+.pf-c-button.pf-m-plain {
+  display: inline-block;
+  position: relative;
+  padding: 0.375rem 1rem 0.375rem 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+  text-align: center;
+  white-space: nowrap;
+  border: 0px;
+  border-radius: 3px;
+  text-decoration: none;
+  color: #72767b;
+}
+.pf-u-screen-reader {
+  display: block;
+  position: fixed;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
+}
+.pf-c-alert__title {
+  display: block;
+  font-size: 1rem;
+  color: #004368;
+}
+.pf-c-alert__body {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1rem 1rem 1rem 1rem;
+}
+.pf-c-alert.pf-m-success {
+  display: flex;
+  background-color: #ffffff;
+  box-shadow: 0 0.1875rem 0.4375rem 0.1875rem rgba(3, 3, 3, 0.13), 0 0.6875rem 1.5rem 1rem rgba(3, 3, 3, 0.12);
+}
+
+<Alert
+  action={null}
+  className=""
+  closeButtonAriaLabel="Close"
+  onClose={[MockFunction]}
+  title="Some title"
+  variant="success"
+  variantLabel={null}
+>
+  <div
+    aria-label="Success Notification"
+    className="pf-c-alert pf-m-success"
+  >
+    <AlertIcon
+      className=""
+      variant="success"
+    >
+      <div
+        className="pf-c-alert__icon"
+      >
+        <CheckCircleIcon
+          color="currentColor"
+          size="sm"
+          title={null}
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 512 512"
+            width="1em"
+          >
+            <path
+              d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
+              transform=""
+            />
+          </svg>
+        </CheckCircleIcon>
+      </div>
+    </AlertIcon>
+    <AlertBody
+      className=""
+      closeButtonAriaLabel="Close"
+      onClose={[MockFunction]}
+      title={
+        <React.Fragment>
+          <span
+            className="pf-u-screen-reader"
+          >
+            Success
+            : 
+          </span>
+          Some title
+        </React.Fragment>
+      }
+    >
+      <div
+        className="pf-c-alert__body"
+      >
+        <Button
+          aria-label="Close"
+          className=""
+          component="button"
+          isActive={false}
+          isBlock={false}
+          isDisabled={false}
+          isFocus={false}
+          isHover={false}
+          onClick={[MockFunction]}
+          type="button"
+          variant="plain"
+        >
+          <button
+            aria-disabled={null}
+            aria-label="Close"
+            className="pf-c-button pf-m-plain"
+            disabled={false}
+            onClick={[MockFunction]}
+            tabIndex={null}
+            type="button"
+          >
+            <TimesIcon
+              color="currentColor"
+              size="sm"
+              title={null}
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  transform=""
+                />
+              </svg>
+            </TimesIcon>
+          </button>
+        </Button>
+        <h4
+          className="pf-c-alert__title"
+        >
+          <span
+            className="pf-u-screen-reader"
+          >
+            Success
+            : 
+          </span>
+          Some title
         </h4>
         <p>
           Some alert
@@ -1650,6 +2771,7 @@ exports[`Alert - success Custom aria label 1`] = `
   action="action"
   aria-label="Custom aria label for success"
   className=""
+  closeButtonAriaLabel="Close"
   title="Some title"
   variant="success"
   variantLabel={null}
@@ -1694,6 +2816,7 @@ exports[`Alert - success Custom aria label 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -1775,6 +2898,7 @@ exports[`Alert - success Title 1`] = `
 <Alert
   action={null}
   className=""
+  closeButtonAriaLabel="Close"
   title="Some title"
   variant="success"
   variantLabel={null}
@@ -1819,6 +2943,7 @@ exports[`Alert - success Title 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -1895,6 +3020,7 @@ exports[`Alert - warning Action 1`] = `
 <Alert
   action="action"
   className=""
+  closeButtonAriaLabel="Close"
   title=""
   variant="warning"
   variantLabel={null}
@@ -1939,6 +3065,7 @@ exports[`Alert - warning Action 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -2023,6 +3150,7 @@ exports[`Alert - warning Action and Title 1`] = `
 <Alert
   action="action"
   className=""
+  closeButtonAriaLabel="Close"
   title="Some title"
   variant="warning"
   variantLabel={null}
@@ -2067,6 +3195,7 @@ exports[`Alert - warning Action and Title 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -2148,6 +3277,7 @@ exports[`Alert - warning Body 1`] = `
 <Alert
   action={null}
   className=""
+  closeButtonAriaLabel="Close"
   title=""
   variant="warning"
   variantLabel={null}
@@ -2192,6 +3322,7 @@ exports[`Alert - warning Body 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -2216,6 +3347,371 @@ exports[`Alert - warning Body 1`] = `
             Warning
             : 
           </span>
+        </h4>
+        <p>
+          Some alert
+        </p>
+      </div>
+    </AlertBody>
+  </div>
+</Alert>
+`;
+
+exports[`Alert - warning Close button 1`] = `
+.pf-c-alert__icon {
+  display: flex;
+  padding: 1rem;
+  font-size: 1.5rem;
+  color: #004368;
+  background-color: #39a5dc;
+}
+.pf-c-button.pf-m-plain {
+  display: inline-block;
+  position: relative;
+  padding: 0.375rem 1rem 0.375rem 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+  text-align: center;
+  white-space: nowrap;
+  border: 0px;
+  border-radius: 3px;
+  text-decoration: none;
+  color: #72767b;
+}
+.pf-u-screen-reader {
+  display: block;
+  position: fixed;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
+}
+.pf-c-alert__title {
+  display: block;
+  font-size: 1rem;
+  color: #004368;
+}
+.pf-c-alert__body {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1rem 1rem 1rem 1rem;
+}
+.pf-c-alert.pf-m-warning {
+  display: flex;
+  background-color: #ffffff;
+  box-shadow: 0 0.1875rem 0.4375rem 0.1875rem rgba(3, 3, 3, 0.13), 0 0.6875rem 1.5rem 1rem rgba(3, 3, 3, 0.12);
+}
+
+<Alert
+  action={null}
+  className=""
+  closeButtonAriaLabel="Close"
+  onClose={[MockFunction]}
+  title=""
+  variant="warning"
+  variantLabel={null}
+>
+  <div
+    aria-label="Warning Notification"
+    className="pf-c-alert pf-m-warning"
+  >
+    <AlertIcon
+      className=""
+      variant="warning"
+    >
+      <div
+        className="pf-c-alert__icon"
+      >
+        <ExclamationTriangleIcon
+          color="currentColor"
+          size="sm"
+          title={null}
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 576 512"
+            width="1em"
+          >
+            <path
+              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+              transform=""
+            />
+          </svg>
+        </ExclamationTriangleIcon>
+      </div>
+    </AlertIcon>
+    <AlertBody
+      className=""
+      closeButtonAriaLabel="Close"
+      onClose={[MockFunction]}
+      title={
+        <React.Fragment>
+          <span
+            className="pf-u-screen-reader"
+          >
+            Warning
+            : 
+          </span>
+          
+        </React.Fragment>
+      }
+    >
+      <div
+        className="pf-c-alert__body"
+      >
+        <Button
+          aria-label="Close"
+          className=""
+          component="button"
+          isActive={false}
+          isBlock={false}
+          isDisabled={false}
+          isFocus={false}
+          isHover={false}
+          onClick={[MockFunction]}
+          type="button"
+          variant="plain"
+        >
+          <button
+            aria-disabled={null}
+            aria-label="Close"
+            className="pf-c-button pf-m-plain"
+            disabled={false}
+            onClick={[MockFunction]}
+            tabIndex={null}
+            type="button"
+          >
+            <TimesIcon
+              color="currentColor"
+              size="sm"
+              title={null}
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  transform=""
+                />
+              </svg>
+            </TimesIcon>
+          </button>
+        </Button>
+        <h4
+          className="pf-c-alert__title"
+        >
+          <span
+            className="pf-u-screen-reader"
+          >
+            Warning
+            : 
+          </span>
+        </h4>
+        <p>
+          Some alert
+        </p>
+      </div>
+    </AlertBody>
+  </div>
+</Alert>
+`;
+
+exports[`Alert - warning Close button and Title 1`] = `
+.pf-c-alert__icon {
+  display: flex;
+  padding: 1rem;
+  font-size: 1.5rem;
+  color: #004368;
+  background-color: #39a5dc;
+}
+.pf-c-button.pf-m-plain {
+  display: inline-block;
+  position: relative;
+  padding: 0.375rem 1rem 0.375rem 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5;
+  text-align: center;
+  white-space: nowrap;
+  border: 0px;
+  border-radius: 3px;
+  text-decoration: none;
+  color: #72767b;
+}
+.pf-u-screen-reader {
+  display: block;
+  position: fixed;
+  overflow: hidden;
+  clip: rect(0px, 0px, 0px, 0px);
+  white-space: nowrap;
+  border: 0px;
+}
+.pf-c-alert__title {
+  display: block;
+  font-size: 1rem;
+  color: #004368;
+}
+.pf-c-alert__body {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1rem 1rem 1rem 1rem;
+}
+.pf-c-alert.pf-m-warning {
+  display: flex;
+  background-color: #ffffff;
+  box-shadow: 0 0.1875rem 0.4375rem 0.1875rem rgba(3, 3, 3, 0.13), 0 0.6875rem 1.5rem 1rem rgba(3, 3, 3, 0.12);
+}
+
+<Alert
+  action={null}
+  className=""
+  closeButtonAriaLabel="Close"
+  onClose={[MockFunction]}
+  title="Some title"
+  variant="warning"
+  variantLabel={null}
+>
+  <div
+    aria-label="Warning Notification"
+    className="pf-c-alert pf-m-warning"
+  >
+    <AlertIcon
+      className=""
+      variant="warning"
+    >
+      <div
+        className="pf-c-alert__icon"
+      >
+        <ExclamationTriangleIcon
+          color="currentColor"
+          size="sm"
+          title={null}
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 576 512"
+            width="1em"
+          >
+            <path
+              d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+              transform=""
+            />
+          </svg>
+        </ExclamationTriangleIcon>
+      </div>
+    </AlertIcon>
+    <AlertBody
+      className=""
+      closeButtonAriaLabel="Close"
+      onClose={[MockFunction]}
+      title={
+        <React.Fragment>
+          <span
+            className="pf-u-screen-reader"
+          >
+            Warning
+            : 
+          </span>
+          Some title
+        </React.Fragment>
+      }
+    >
+      <div
+        className="pf-c-alert__body"
+      >
+        <Button
+          aria-label="Close"
+          className=""
+          component="button"
+          isActive={false}
+          isBlock={false}
+          isDisabled={false}
+          isFocus={false}
+          isHover={false}
+          onClick={[MockFunction]}
+          type="button"
+          variant="plain"
+        >
+          <button
+            aria-disabled={null}
+            aria-label="Close"
+            className="pf-c-button pf-m-plain"
+            disabled={false}
+            onClick={[MockFunction]}
+            tabIndex={null}
+            type="button"
+          >
+            <TimesIcon
+              color="currentColor"
+              size="sm"
+              title={null}
+            >
+              <svg
+                aria-hidden={true}
+                aria-labelledby={null}
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style={
+                  Object {
+                    "verticalAlign": "-0.125em",
+                  }
+                }
+                viewBox="0 0 352 512"
+                width="1em"
+              >
+                <path
+                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                  transform=""
+                />
+              </svg>
+            </TimesIcon>
+          </button>
+        </Button>
+        <h4
+          className="pf-c-alert__title"
+        >
+          <span
+            className="pf-u-screen-reader"
+          >
+            Warning
+            : 
+          </span>
+          Some title
         </h4>
         <p>
           Some alert
@@ -2268,6 +3764,7 @@ exports[`Alert - warning Custom aria label 1`] = `
   action="action"
   aria-label="Custom aria label for warning"
   className=""
+  closeButtonAriaLabel="Close"
   title="Some title"
   variant="warning"
   variantLabel={null}
@@ -2312,6 +3809,7 @@ exports[`Alert - warning Custom aria label 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span
@@ -2393,6 +3891,7 @@ exports[`Alert - warning Title 1`] = `
 <Alert
   action={null}
   className=""
+  closeButtonAriaLabel="Close"
   title="Some title"
   variant="warning"
   variantLabel={null}
@@ -2437,6 +3936,7 @@ exports[`Alert - warning Title 1`] = `
     </AlertIcon>
     <AlertBody
       className=""
+      closeButtonAriaLabel="Close"
       title={
         <React.Fragment>
           <span

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/DangerAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/DangerAlert.js
@@ -2,12 +2,20 @@ import React from 'react';
 import { Alert, Button } from '@patternfly/react-core';
 
 class DangerAlert extends React.Component {
+  state = { alertOneVisible: true, alertTwoVisible: true };
+  hideAlertOne = () => this.setState({ alertOneVisible: false });
+  hideAlertTwo = () => this.setState({ alertTwoVisible: false });
+
   render() {
+    const { alertOneVisible, alertTwoVisible } = this.state;
     return (
       <React.Fragment>
-        <Alert variant="danger" title="Danger notification title">
-          Danger notification description. <a href="#">This is a link.</a>
-        </Alert>
+        {alertOneVisible && (
+          <Alert variant="danger" title="Danger notification title" onClose={this.hideAlertOne}>
+            Danger notification description. <a href="#">This is a link.</a>
+          </Alert>
+        )}
+        {alertTwoVisible && <Alert variant="danger" title="Danger notification title" onClose={this.hideAlertTwo} />}
         <Alert
           variant="danger"
           title="Danger notification title"

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/DangerAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/DangerAlert.js
@@ -11,7 +11,7 @@ class DangerAlert extends React.Component {
         <Alert
           variant="danger"
           title="Danger notification title"
-          action={<Button variant="secondary">Button</Button>}
+          action={<Button variant="link">Action Button</Button>}
         />
         <Alert variant="danger" title="Danger notification title" />
       </React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/InfoAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/InfoAlert.js
@@ -8,7 +8,7 @@ class InfoAlert extends React.Component {
         <Alert variant="info" title="Info notification title">
           Info notification description. <a href="#">This is a link.</a>
         </Alert>
-        <Alert variant="info" title="Info notification title" action={<Button variant="secondary">Button</Button>} />
+        <Alert variant="info" title="Info notification title" action={<Button variant="link">Action Button</Button>} />
         <Alert variant="info" title="Info notification title" />
       </React.Fragment>
     );

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/InfoAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/InfoAlert.js
@@ -2,12 +2,20 @@ import React from 'react';
 import { Alert, Button } from '@patternfly/react-core';
 
 class InfoAlert extends React.Component {
+  state = { alertOneVisible: true, alertTwoVisible: true };
+  hideAlertOne = () => this.setState({ alertOneVisible: false });
+  hideAlertTwo = () => this.setState({ alertTwoVisible: false });
+
   render() {
+    const { alertOneVisible, alertTwoVisible } = this.state;
     return (
       <React.Fragment>
-        <Alert variant="info" title="Info notification title">
-          Info notification description. <a href="#">This is a link.</a>
-        </Alert>
+        {alertOneVisible && (
+          <Alert variant="info" title="Info notification title" onClose={this.hideAlertOne}>
+            Info notification description. <a href="#">This is a link.</a>
+          </Alert>
+        )}
+        {alertTwoVisible && <Alert variant="info" title="Info notification title" onClose={this.hideAlertTwo} />}
         <Alert variant="info" title="Info notification title" action={<Button variant="link">Action Button</Button>} />
         <Alert variant="info" title="Info notification title" />
       </React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/SuccessAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/SuccessAlert.js
@@ -11,7 +11,7 @@ class SuccessAlert extends React.Component {
         <Alert
           variant="success"
           title="Success notification title"
-          action={<Button variant="secondary">Button</Button>}
+          action={<Button variant="link">Action Button</Button>}
         />
         <Alert variant="success" title="Success notification title" />
       </React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/SuccessAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/SuccessAlert.js
@@ -2,12 +2,20 @@ import React from 'react';
 import { Alert, Button } from '@patternfly/react-core';
 
 class SuccessAlert extends React.Component {
+  state = { alertOneVisible: true, alertTwoVisible: true };
+  hideAlertOne = () => this.setState({ alertOneVisible: false });
+  hideAlertTwo = () => this.setState({ alertTwoVisible: false });
+
   render() {
+    const { alertOneVisible, alertTwoVisible } = this.state;
     return (
       <React.Fragment>
-        <Alert variant="success" title="Success notification title">
-          Success notification description. <a href="#">This is a link.</a>
-        </Alert>
+        {alertOneVisible && (
+          <Alert variant="success" title="Success notification title" onClose={this.hideAlertOne}>
+            Success notification description. <a href="#">This is a link.</a>
+          </Alert>
+        )}
+        {alertTwoVisible && <Alert variant="success" title="Success notification title" onClose={this.hideAlertTwo} />}
         <Alert
           variant="success"
           title="Success notification title"

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/WarningAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/WarningAlert.js
@@ -2,12 +2,20 @@ import React from 'react';
 import { Alert, Button } from '@patternfly/react-core';
 
 class WarningAlert extends React.Component {
+  state = { alertOneVisible: true, alertTwoVisible: true };
+  hideAlertOne = () => this.setState({ alertOneVisible: false });
+  hideAlertTwo = () => this.setState({ alertTwoVisible: false });
+
   render() {
+    const { alertOneVisible, alertTwoVisible } = this.state;
     return (
       <React.Fragment>
-        <Alert variant="warning" title="Warning notification title">
-          Warning notification description. <a href="#">This is a link.</a>
-        </Alert>
+        {alertOneVisible && (
+          <Alert variant="warning" title="Warning notification title" onClose={this.hideAlertOne}>
+            Warning notification description. <a href="#">This is a link.</a>
+          </Alert>
+        )}
+        {alertTwoVisible && <Alert variant="warning" title="Warning notification title" onClose={this.hideAlertTwo} />}
         <Alert
           variant="warning"
           title="Warning notification title"

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/WarningAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/WarningAlert.js
@@ -11,7 +11,7 @@ class WarningAlert extends React.Component {
         <Alert
           variant="warning"
           title="Warning notification title"
-          action={<Button variant="secondary">Button</Button>}
+          action={<Button variant="link">Action Button</Button>}
         />
         <Alert variant="warning" title="Warning notification title" />
       </React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -1130,6 +1130,7 @@ exports[`KebabToggle plain 1`] = `
   font-weight: 400;
   line-height: 1.5;
   background-color: transparent;
+  color: #72767b;
 }
 .pf-c-dropdown {
   display: inline-block;

--- a/packages/patternfly-4/react-styled-system/package.json
+++ b/packages/patternfly-4/react-styled-system/package.json
@@ -43,7 +43,7 @@
     "react": "^16.4.0"
   },
   "devDependencies": {
-    "@patternfly/patternfly-next": "1.0.120",
+    "@patternfly/patternfly-next": "1.0.126",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/packages/patternfly-4/react-table/package.json
+++ b/packages/patternfly-4/react-table/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/patternfly-4/react-table#readme",
   "dependencies": {
-    "@patternfly/patternfly-next": "1.0.120",
+    "@patternfly/patternfly-next": "1.0.126",
     "@patternfly/react-core": "^1.48.0",
     "@patternfly/react-icons": "^2.9.7",
     "@patternfly/react-styles": "^2.3.0",

--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
@@ -26,6 +26,7 @@ exports[`Actions table 1`] = `
   font-weight: 400;
   line-height: 1.5;
   background-color: transparent;
+  color: #72767b;
 }
 .pf-c-dropdown {
   display: inline-block;
@@ -50,6 +51,7 @@ exports[`Actions table 1`] = `
   font-weight: 400;
   line-height: 1.5;
   background-color: transparent;
+  color: #72767b;
 }
 .pf-c-dropdown {
   display: inline-block;
@@ -74,6 +76,7 @@ exports[`Actions table 1`] = `
   font-weight: 400;
   line-height: 1.5;
   background-color: transparent;
+  color: #72767b;
 }
 .pf-c-dropdown {
   display: inline-block;
@@ -98,6 +101,7 @@ exports[`Actions table 1`] = `
   font-weight: 400;
   line-height: 1.5;
   background-color: transparent;
+  color: #72767b;
 }
 .pf-c-dropdown {
   display: inline-block;
@@ -122,6 +126,7 @@ exports[`Actions table 1`] = `
   font-weight: 400;
   line-height: 1.5;
   background-color: transparent;
+  color: #72767b;
 }
 .pf-c-dropdown {
   display: inline-block;
@@ -146,6 +151,7 @@ exports[`Actions table 1`] = `
   font-weight: 400;
   line-height: 1.5;
   background-color: transparent;
+  color: #72767b;
 }
 .pf-c-dropdown {
   display: inline-block;
@@ -170,6 +176,7 @@ exports[`Actions table 1`] = `
   font-weight: 400;
   line-height: 1.5;
   background-color: transparent;
+  color: #72767b;
 }
 .pf-c-dropdown {
   display: inline-block;
@@ -194,6 +201,7 @@ exports[`Actions table 1`] = `
   font-weight: 400;
   line-height: 1.5;
   background-color: transparent;
+  color: #72767b;
 }
 .pf-c-dropdown {
   display: inline-block;
@@ -218,6 +226,7 @@ exports[`Actions table 1`] = `
   font-weight: 400;
   line-height: 1.5;
   background-color: transparent;
+  color: #72767b;
 }
 .pf-c-dropdown {
   display: inline-block;

--- a/packages/patternfly-4/react-tokens/package.json
+++ b/packages/patternfly-4/react-tokens/package.json
@@ -27,7 +27,7 @@
     "build": "node build/generateTokens.js"
   },
   "devDependencies": {
-    "@patternfly/patternfly-next": "1.0.120",
+    "@patternfly/patternfly-next": "1.0.126",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2"

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.3.1",
-    "@patternfly/patternfly-next": "1.0.120",
+    "@patternfly/patternfly-next": "1.0.126",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",
     "node-plop": "^0.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1528,9 +1528,10 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@novnc/novnc/-/novnc-1.0.0.tgz#76b0e89e6f8738ca8154195baf5b8e6a80bc9105"
 
-"@patternfly/patternfly-next@1.0.120":
-  version "1.0.120"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.120.tgz#2e8e1245b25d0207696c547059c5e8754eff8773"
+"@patternfly/patternfly-next@1.0.126":
+  version "1.0.126"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.126.tgz#cdc2b40927663cca82f072b6b6eee98d244a1898"
+  integrity sha512-4CHCw4Rit6xDpVytx1z0hH4+D9iKL/VJPkQnqkNm5bsKxSHr65boPLNv9IcJJZGb0XFYbJud7+yYxYIKdAJM8A==
 
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

Fixes #1036.

In order to get the CSS for the close button, this PR upgrades `@patternfly/patternfly-next` from 1.0.120 to 1.0.126. This upgrade causes some inconsistencies with spacing in the Alert component, which I fixed by wrapping the alert description (children of `AlertBody`) in a `<p>` tag, which is consistent with the `alert-description.hbs` template in core (https://github.com/patternfly/patternfly-next/blob/master/src/patternfly/components/Alert/alert-description.hbs) and by changing the Action Button variant from "secondary" to "link", which is consistent with the changes to the core examples (https://github.com/patternfly/patternfly-next/pull/1208/files#diff-80f605f510a73d9a008b8bec47b6b75dR42). These fixes are in a separate commit to isolate them from the actual Close button feature changes.

With the CSS upgrade in place but without these fixes (db197e7716b98ec9a5a7bda7e40b2b96e7bc60de), the Alert component was rendering like this (note the line break before the description link, and the lack of margin to the right of the action button):

<img width="1015" alt="screenshot 2019-01-16 10 43 39" src="https://user-images.githubusercontent.com/811963/51272944-81ce9180-1999-11e9-91df-6f251b3d00bb.png">

With the fixes in place (daecc00c28ea0c55344958c26ff7a05501c266c8), the Alert component renders like this:

<img width="1010" alt="screenshot 2019-01-16 14 30 01" src="https://user-images.githubusercontent.com/811963/51273637-39b06e80-199b-11e9-858c-e0c0668a636d.png">

The final commit e5c197a2172b9a7aa4e00a62ae8d416c4721be3d adds an optional `onClose` prop to the Alert component which, when defined, will cause a close button to be rendered.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

As noted by @andybraren in https://github.com/patternfly/patternfly-next/issues/1172, there is currently a lack of support for a secondary action button and a close button to both be rendered on an Alert component next to each other. Because this issue was closed and this design is being reworked, I did not attempt to support using both the `action` and the `onClose` props of Alert at the same time. If a user tries to do this, it will render like this:

<img width="1013" alt="screenshot 2019-01-16 14 24 42" src="https://user-images.githubusercontent.com/811963/51273370-7fb90280-199a-11e9-8949-de678467de69.png">

<!-- feel free to add additional comments -->
