### PR TITLE
fix(Dropdown): pass onClick to any dropdown item if present

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -108,7 +108,7 @@ class DropdownItem extends React.Component {
                 onKeyDown={this.onKeyDown}
                 onClick={event => {
                   if (!isDisabled) {
-                    if (Component === 'button') onClick && onClick(event);
+                    onClick && onClick(event);
                     onSelect && onSelect(event);
                   }
                 }}


### PR DESCRIPTION
previous was only done for button type

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Changed onClick to be passed to any child element if it is defined in the DropdownItem, instead of only to button type elements.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Fixes issue**: #1195

<!-- feel free to add additional comments -->
