### PR TITLE
feat(Tooltip): Add optional delay prop to Tooltip

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.d.ts
@@ -20,6 +20,10 @@ export interface TooltipProps extends Omit<Props, 'content' | 'children'> {
   children: ReactElement<any>;
   /** Tooltip content */
   content: ReactElement<any> | string;
+  /** Delay in ms before a tooltip appears */
+  entryDelay?: number;
+  /** Delay in ms before a tooltip disappears */
+  exitDelay?: number;
   /** The element to append the tooltip to, defaults to body */
   appendTo?: Element | ((ref: Element) => Element);
   /** z-index of the tooltip */

--- a/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.js
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.js
@@ -29,6 +29,10 @@ const propTypes = {
   content: PropTypes.node.isRequired,
   /** The reference element to which the tooltip is relatively placed to */
   children: PropTypes.element.isRequired,
+  /** Delay in ms before the tooltip appears */
+  entryDelay: PropTypes.number,
+  /** Delay in ms before the tooltip disappears */
+  exitDelay: PropTypes.number,
   /** The element to append the tooltip to, defaults to body */
   appendTo: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   /** z-index of the tooltip */
@@ -41,6 +45,8 @@ const defaultProps = {
   position: 'top',
   enableFlip: true,
   className: null,
+  entryDelay: 500,
+  exitDelay: 500,
   appendTo: () => document.body,
   zIndex: 9999,
   maxWidth: tooltipMaxWidth && tooltipMaxWidth.value
@@ -72,6 +78,8 @@ class Tooltip extends React.Component {
       children,
       className,
       content: bodyContent,
+      entryDelay,
+      exitDelay,
       appendTo,
       zIndex,
       maxWidth,
@@ -99,6 +107,7 @@ class Tooltip extends React.Component {
         theme="pf-tippy"
         performance
         placement={position}
+        delay={[entryDelay, exitDelay]}
         distance={15}
         flip={enableFlip}
         popperOptions={{

--- a/packages/patternfly-4/react-core/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
@@ -21,6 +21,12 @@ exports[`tooltip renders 1`] = `
       </TooltipContent>
     </div>
   }
+  delay={
+    Array [
+      500,
+      500,
+    ]
+  }
   distance={15}
   flip={true}
   lazy={true}


### PR DESCRIPTION
I added an optional delay prop to the Tooltip component to specify the entrance delay. The external tooltip library defaults to an entrance delay of 0 ms.

The null in {[delay, null]} gets the external tooltip library to use its default exit delay (20 ms). Controlling the exit delay wasn't mentioned in the issue, so I didn't add a prop for it. Let me know if you want an extra prop for that.

I didn't make any changes to the overrides; my IDE removed the spaces at the ends of the lines. I can set it back the way it was if you want. Let me know.

Fixes #1161.