### PR TITLE
fix(DualList): fix hidden inputs

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/DualListSelector/DualList.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/DualListSelector/DualList.stories.js
@@ -16,6 +16,7 @@ import {
   DualListFilter,
   DualListFooter,
   DualListHeading,
+  DualListHiddenSelect,
   DualListItem,
   DualListItems,
   DualListMainCheckbox,
@@ -41,9 +42,10 @@ const storyInfo = {
     DualListItem,
     DualListItems,
     DualListMainCheckbox,
-    DualListSort
+    DualListSort,
+    DualListHiddenSelect
   ],
-  propTablesExclude: [DualListControlled, DualListSelector]
+  propTablesExclude: [DualListControlled, DualListSelector, Button]
 };
 
 stories.addDecorator(
@@ -74,7 +76,7 @@ stories.add(
 stories.add(
   'Dual List Selector as a form input',
   withInfo(storyInfo)(() => (
-    <React.Fragment>
+    <div>
       <h3>Please see this short video to understand how to send the form values by network:</h3>
       <iframe
         width="400"
@@ -101,6 +103,6 @@ stories.add(
         />
         <Button type="submit">Submit form</Button>
       </form>
-    </React.Fragment>
+    </div>
   ))
 );

--- a/packages/patternfly-3/patternfly-react/src/components/DualListSelector/components/DualListHiddenSelect.js
+++ b/packages/patternfly-3/patternfly-react/src/components/DualListSelector/components/DualListHiddenSelect.js
@@ -1,19 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getSelectedItems } from '../helpers';
 
 const DualListHiddenSelect = ({ items, ...props }) => {
-  const selectedItems = getSelectedItems(items);
   const selectedValues = [];
   const options = (
     <React.Fragment>
-      {selectedItems ? (
-        selectedItems.map(({ value, children, label }, index) => {
+      {items ? (
+        items.map(({ value, children, label }, index) => {
           if (children) {
             return children.map(({ value: childValue, label: childLabel }, childIndex) => {
               selectedValues.push(childValue);
               return (
-                <option key={`${index}-${childIndex}`} value={childValue} selected>
+                <option key={`${index}-${childIndex}`} value={childValue}>
                   {childLabel}
                 </option>
               );
@@ -21,7 +19,7 @@ const DualListHiddenSelect = ({ items, ...props }) => {
           }
           selectedValues.push(value);
           return (
-            <option key={index} value={value} selected>
+            <option key={index} value={value}>
               {label}
             </option>
           );
@@ -31,7 +29,6 @@ const DualListHiddenSelect = ({ items, ...props }) => {
       )}
     </React.Fragment>
   );
-
   return (
     <select {...props} multiple hidden defaultValue={selectedValues}>
       {options}

--- a/packages/patternfly-3/patternfly-react/src/components/DualListSelector/helpers.js
+++ b/packages/patternfly-3/patternfly-react/src/components/DualListSelector/helpers.js
@@ -257,23 +257,3 @@ export const isItemSelected = item => item.checked;
 export const isItemHidden = item => item.hidden;
 
 export const isItemDisabled = item => item.disabled;
-
-export const getSelectedItems = list => {
-  const selectedItems = [];
-  list.forEach(item => {
-    if (isItemSelected(item)) {
-      selectedItems.push(item);
-    } else if (itemHasChildren(item)) {
-      const selectedChildren = [];
-      item.children.forEach(child => {
-        if (isItemSelected(child)) {
-          selectedChildren.push(child);
-        }
-      });
-      if (selectedChildren.length > 0) {
-        selectedItems.push({ ...item, children: selectedChildren });
-      }
-    }
-  });
-  return selectedItems;
-};


### PR DESCRIPTION
Hidden inputs should reflect the whole list and not just the selected items.
The main idea of the dual list is to mimic the html select behavior into a prettier implementation
and when the consumers will choose that one side is the "selected-side", they will be able to send of all its items on submitting in a form for example.

this PR also fixes a test warning, and storybook error