### PR TITLE
fix(Dropdown): Do not focus Dropdown if menu is not opened

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/Toggle.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Toggle.js
@@ -55,7 +55,7 @@ class DropdownToggle extends Component {
   };
 
   onDocClick = event => {
-    if (this.props.parentRef && !this.props.parentRef.contains(event.target)) {
+    if (this.props.isOpen && this.props.parentRef && !this.props.parentRef.contains(event.target)) {
       this.props.onToggle && this.props.onToggle(false);
       this.toggle.focus();
     }
@@ -64,7 +64,7 @@ class DropdownToggle extends Component {
   onEscPress = event => {
     const { parentRef } = this.props;
     const keyCode = event.keyCode || event.which;
-    if ((keyCode === KEY_CODES.ESCAPE_KEY || event.key === 'Tab') && parentRef && parentRef.contains(event.target)) {
+    if (this.props.isOpen && (keyCode === KEY_CODES.ESCAPE_KEY || event.key === 'Tab') && parentRef && parentRef.contains(event.target)) {
       this.props.onToggle && this.props.onToggle(false);
       this.toggle.focus();
     }


### PR DESCRIPTION
**What**:
If user clicks anywhere on screen and dropdown is present it will automatically scroll to such dropdown even if it's not opened.

**Additional issues**:
https://github.com/RedHatInsights/insights-frontend-components/issues/222
