### PR TITLE
fix(Table): Use direct imports instead of spread

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Body.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Body.js
@@ -54,7 +54,7 @@ class ContextBody extends React.Component {
             })
           },
           { id: oneRowKey }),
-        ...oneRow.parent ? {
+        ...oneRow.parent !== undefined ? {
           isExpanded: this.parentsExpanded(oneRow.parent) && rows[oneRow.parent].isOpen
         } : {},
       }

--- a/packages/patternfly-4/react-table/src/components/Table/ExpandableRowContent.js
+++ b/packages/patternfly-4/react-table/src/components/Table/ExpandableRowContent.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@patternfly/react-styles';
-import { tableExpandableRowContent } from '@patternfly/patternfly-next/components/Table/table.css';
+import styles from '@patternfly/patternfly-next/components/Table/table.css';
 
 const propTypes = {
   children: PropTypes.node
@@ -11,7 +11,7 @@ const defaultProps = {
 };
 
 const ExpandableRowContent = ({ children, className, ...props }) => (
-  <div {...props} className={css(tableExpandableRowContent)}>
+  <div {...props} className={css(styles.tableExpandableRowContent)}>
     {children}
   </div>
 );

--- a/packages/patternfly-4/react-table/src/components/Table/RowWrapper.js
+++ b/packages/patternfly-4/react-table/src/components/Table/RowWrapper.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropsType from 'prop-types';
-import { tableExpandableRow, modifiers } from '@patternfly/patternfly-next/components/Table/table.css';
+import styles from '@patternfly/patternfly-next/components/Table/table.css';
 import { css } from '@patternfly/react-styles';
 
 const RowWrapper = ({ isOpen, isExpanded, ...props }) => {
   return <tr {...props}
-    className={css(isExpanded !== undefined && tableExpandableRow, isExpanded && modifiers.expanded)}
+    className={css(isExpanded !== undefined && styles.tableExpandableRow, isExpanded && styles.modifiers.expanded)}
     hidden={isExpanded !== undefined && !isExpanded}
   />;
 };

--- a/packages/patternfly-4/react-table/src/components/Table/SelectColumn.js
+++ b/packages/patternfly-4/react-table/src/components/Table/SelectColumn.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from '@patternfly/react-styles';
-import { checkInput } from '@patternfly/patternfly-next/components/Check/check.css';
+import styles from '@patternfly/patternfly-next/components/Check/check.css';
 
 const propTypes = {
   children: PropTypes.node,
@@ -16,7 +16,7 @@ const defaultProps = {
 
 const SelectColumn = ({ children, className, onSelect, ...props }) => (
   <React.Fragment>
-    <input {...props} className={css(checkInput)} type="checkbox" onChange={onSelect}></input>
+    <input {...props} className={css(styles.checkInput)} type="checkbox" onChange={onSelect}></input>
     {children}
   </React.Fragment>
 );

--- a/packages/patternfly-4/react-table/src/components/Table/SortColumn.js
+++ b/packages/patternfly-4/react-table/src/components/Table/SortColumn.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { AngleUpIcon, SortIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
-import { tableSortIndicator } from '@patternfly/patternfly-next/components/Table/table.css';
+import styles from '@patternfly/patternfly-next/components/Table/table.css';
 
 const propTypes = {
   children: PropTypes.node,
@@ -27,7 +27,7 @@ const SortColumn = ({ isSortedBy, children, className, onSort, ...props }) => {
   return (
     <button {...props} className={css(className)} onClick={event => onSort && onSort(event)}>
       {children}
-      <span className={css(tableSortIndicator)}>
+      <span className={css(styles.tableSortIndicator)}>
         <SortedByIcon />
       </span>
     </button>

--- a/packages/patternfly-4/react-table/src/components/Table/Table.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.js
@@ -52,6 +52,7 @@ const propTypes = {
       cells: PropTypes.arrayOf(PropTypes.node),
       isOpen: PropTypes.bool,
       parent: PropTypes.number,
+      showSelect: PropTypes.bool,
       props: PropTypes.any
     }),
     PropTypes.arrayOf(PropTypes.oneOfType([

--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
@@ -11636,6 +11636,12 @@ exports[`Collapsible nested table 1`] = `
   border-top-color: transparent;
   border-top-width: 0;
 }
+.pf-c-table__expandable-row {
+  display: block;
+  position: relative;
+  border-bottom: 0 solid transparent;
+  box-shadow: 0 0 0 0 transparent;
+}
 .pf-c-table__toggle {
   display: block;
 }
@@ -12864,6 +12870,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": false,
                   "isOpen": true,
                   "last-commit": Object {
                     "props": undefined,
@@ -13779,6 +13786,7 @@ exports[`Collapsible nested table 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": false,
                       "isOpen": true,
                       "last-commit": Object {
                         "props": undefined,
@@ -13799,12 +13807,13 @@ exports[`Collapsible nested table 1`] = `
                   rowKey="1-row"
                 >
                   <RowWrapper
+                    isExpanded={false}
                     isOpen={true}
                     onClick={[Function]}
                   >
                     <tr
-                      className=""
-                      hidden={false}
+                      className="pf-c-table__expandable-row"
+                      hidden={true}
                       onClick={[Function]}
                     >
                       <BodyCell
@@ -16593,6 +16602,14 @@ exports[`Collapsible table 1`] = `
   border-top-color: transparent;
   border-top-width: 0;
 }
+.pf-c-table__expandable-row.pf-m-expanded {
+  display: block;
+  position: relative;
+  border-bottom: 0 solid transparent;
+  box-shadow: 0 0.0625rem 0.0625rem 0rem rgba(3, 3, 3, 0.05), 0 0.25rem 0.5rem 0.25rem rgba(3, 3, 3, 0.06);
+  border-bottom-color: #ededed;
+  border-bottom-width: 1px;
+}
 .pf-c-table__toggle {
   display: block;
 }
@@ -17804,6 +17821,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": true,
                   "last-commit": Object {
                     "props": undefined,
                     "title": "five",
@@ -18716,6 +18734,7 @@ exports[`Collapsible table 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": true,
                       "last-commit": Object {
                         "props": undefined,
                         "title": "five",
@@ -18735,10 +18754,11 @@ exports[`Collapsible table 1`] = `
                   rowKey="1-row"
                 >
                   <RowWrapper
+                    isExpanded={true}
                     onClick={[Function]}
                   >
                     <tr
-                      className=""
+                      className="pf-c-table__expandable-row pf-m-expanded"
                       hidden={false}
                       onClick={[Function]}
                     >
@@ -21460,6 +21480,12 @@ exports[`Header width table 1`] = `
   border-bottom: 0 solid transparent;
   box-shadow: 0 0 0 0 transparent;
 }
+.pf-c-table__expandable-row {
+  display: block;
+  position: relative;
+  border-bottom: 0 solid transparent;
+  box-shadow: 0 0 0 0 transparent;
+}
 .pf-c-table.pf-m-grid-md {
   display: block;
   width: 100%;
@@ -22434,6 +22460,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": false,
                   "isOpen": true,
                   "last-commit": Object {
                     "props": undefined,
@@ -23190,6 +23217,7 @@ exports[`Header width table 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": false,
                       "isOpen": true,
                       "last-commit": Object {
                         "props": undefined,
@@ -23210,12 +23238,13 @@ exports[`Header width table 1`] = `
                   rowKey="1-row"
                 >
                   <RowWrapper
+                    isExpanded={false}
                     isOpen={true}
                     onClick={[Function]}
                   >
                     <tr
-                      className=""
-                      hidden={false}
+                      className="pf-c-table__expandable-row"
+                      hidden={true}
                       onClick={[Function]}
                     >
                       <BodyCell
@@ -25479,6 +25508,12 @@ exports[`Selectable table 1`] = `
 .pf-c-table__check {
   display: block;
 }
+.pf-c-table__expandable-row {
+  display: block;
+  position: relative;
+  border-bottom: 0 solid transparent;
+  box-shadow: 0 0 0 0 transparent;
+}
 .pf-c-check__input {
   display: block;
   margin-top: -0.1875rem;
@@ -26708,6 +26743,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": false,
                   "isOpen": true,
                   "last-commit": Object {
                     "props": undefined,
@@ -27565,6 +27601,7 @@ exports[`Selectable table 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": false,
                       "isOpen": true,
                       "last-commit": Object {
                         "props": undefined,
@@ -27585,12 +27622,13 @@ exports[`Selectable table 1`] = `
                   rowKey="1-row"
                 >
                   <RowWrapper
+                    isExpanded={false}
                     isOpen={true}
                     onClick={[Function]}
                   >
                     <tr
-                      className=""
-                      hidden={false}
+                      className="pf-c-table__expandable-row"
+                      hidden={true}
                       onClick={[Function]}
                     >
                       <BodyCell

--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
@@ -25497,50 +25497,17 @@ exports[`Selectable table 1`] = `
 .pf-c-table__check {
   display: block;
 }
-.pf-c-check__input {
-  display: block;
-  margin-top: -0.1875rem;
-  cursor: pointer;
-}
-.pf-c-table__check {
-  display: block;
-}
-.pf-c-table__check {
-  display: block;
-}
 .pf-c-table__expandable-row {
   display: block;
   position: relative;
   border-bottom: 0 solid transparent;
   box-shadow: 0 0 0 0 transparent;
 }
-.pf-c-check__input {
-  display: block;
-  margin-top: -0.1875rem;
-  cursor: pointer;
-}
-.pf-c-table__check {
-  display: block;
-}
-.pf-c-table__check {
-  display: block;
-}
 .pf-c-table__expandable-row {
   display: block;
   position: relative;
   border-bottom: 0 solid transparent;
   box-shadow: 0 0 0 0 transparent;
-}
-.pf-c-check__input {
-  display: block;
-  margin-top: -0.1875rem;
-  cursor: pointer;
-}
-.pf-c-table__check {
-  display: block;
-}
-.pf-c-table__check {
-  display: block;
 }
 .pf-c-check__input {
   display: block;
@@ -27632,7 +27599,6 @@ exports[`Selectable table 1`] = `
                       onClick={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__check"
                         component="td"
                         data-key={0}
                         data-label=""
@@ -27640,27 +27606,9 @@ exports[`Selectable table 1`] = `
                         scope=""
                       >
                         <td
-                          className="pf-c-table__check"
                           data-key={0}
                           scope=""
-                        >
-                          <SelectColumn
-                            aria-labelledby="simple-node1"
-                            checked={false}
-                            className=""
-                            name="checkrow1"
-                            onSelect={[Function]}
-                          >
-                            <input
-                              aria-labelledby="simple-node1"
-                              checked={false}
-                              className="pf-c-check__input"
-                              name="checkrow1"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                          </SelectColumn>
-                        </td>
+                        />
                       </BodyCell>
                       <BodyCell
                         component="td"
@@ -28005,7 +27953,6 @@ exports[`Selectable table 1`] = `
                       onClick={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__check"
                         component="td"
                         data-key={0}
                         data-label=""
@@ -28013,27 +27960,9 @@ exports[`Selectable table 1`] = `
                         scope=""
                       >
                         <td
-                          className="pf-c-table__check"
                           data-key={0}
                           scope=""
-                        >
-                          <SelectColumn
-                            aria-labelledby="simple-node2"
-                            checked={false}
-                            className=""
-                            name="checkrow2"
-                            onSelect={[Function]}
-                          >
-                            <input
-                              aria-labelledby="simple-node2"
-                              checked={false}
-                              className="pf-c-check__input"
-                              name="checkrow2"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                          </SelectColumn>
-                        </td>
+                        />
                       </BodyCell>
                       <BodyCell
                         component="td"
@@ -28750,7 +28679,6 @@ exports[`Selectable table 1`] = `
                       onClick={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__check"
                         component="td"
                         data-key={0}
                         data-label=""
@@ -28758,27 +28686,9 @@ exports[`Selectable table 1`] = `
                         scope=""
                       >
                         <td
-                          className="pf-c-table__check"
                           data-key={0}
                           scope=""
-                        >
-                          <SelectColumn
-                            aria-labelledby="simple-node4"
-                            checked={false}
-                            className=""
-                            name="checkrow4"
-                            onSelect={[Function]}
-                          >
-                            <input
-                              aria-labelledby="simple-node4"
-                              checked={false}
-                              className="pf-c-check__input"
-                              name="checkrow4"
-                              onChange={[Function]}
-                              type="checkbox"
-                            />
-                          </SelectColumn>
-                        </td>
+                        />
                       </BodyCell>
                       <BodyCell
                         component="td"

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/cellActions.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/cellActions.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@patternfly/react-styles';
-import { tableAction } from '@patternfly/patternfly-next/components/Table/table.css';
+import styles from '@patternfly/patternfly-next/components/Table/table.css';
 import ActionsColumn from '../../ActionsColumn';
 
 export default (actions) => {
@@ -10,7 +10,7 @@ export default (actions) => {
       extraParams: { dropdownPosition, dropdownDirection }
     }
   }) => ({
-    className: css(tableAction),
+    className: css(styles.tableAction),
     children: <ActionsColumn
       items={actions}
       dropdownPosition={dropdownPosition}

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/collapsible.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/collapsible.js
@@ -1,6 +1,6 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { css } from '@patternfly/react-styles';
-import { tableToggle } from '@patternfly/patternfly-next/components/Table/table.css';
+import styles from '@patternfly/patternfly-next/components/Table/table.css';
 import CollapseColumn from '../../CollapseColumn';
 import ExpandableRowContent from '../../ExpandableRowContent';
 
@@ -20,7 +20,7 @@ export const collapsible = (
     onCollapse && onCollapse(event, rowIndex, rowData && !rowData.isOpen)
   }
   return {
-    className: css(tableToggle),
+    className: css(styles.tableToggle),
     children: <CollapseColumn aria-labelledby={`${rowLabeledBy}${rowIndex} ${expandId}${rowIndex}`}
       onToggle={onToggle}
       id={expandId + rowIndex}

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/selectable.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/selectable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@patternfly/react-styles';
-import { tableCheck } from '@patternfly/patternfly-next/components/Table/table.css';
+import styles from '@patternfly/patternfly-next/components/Table/table.css';
 import SelectColumn from '../../SelectColumn';
 
 export default (label, { column: { extraParams: { onSelect, rowLabeledBy = 'simple-node' } }, rowIndex, rowData }) => {
@@ -19,7 +19,7 @@ export default (label, { column: { extraParams: { onSelect, rowLabeledBy = 'simp
   }
 
   return ({
-    className: css(tableCheck),
+    className: css(styles.tableCheck),
     component: 'td',
     scope: '',
     children: (

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/selectable.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/selectable.js
@@ -4,6 +4,12 @@ import styles from '@patternfly/patternfly-next/components/Table/table.css';
 import SelectColumn from '../../SelectColumn';
 
 export default (label, { column: { extraParams: { onSelect, rowLabeledBy = 'simple-node' } }, rowIndex, rowData }) => {
+  if (rowData && rowData.hasOwnProperty('parent') && !rowData.showSelect) {
+    return {
+      component: 'td',
+      scope: ''
+    }
+  }
   const rowId = rowIndex !== undefined ? rowIndex : -1;
   function selectClick(event) {
     let selected = rowIndex === undefined ? event.target.checked : rowData && !rowData.selected;

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/sortable.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/sortable.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import SortColumn, { SortByDirection } from '../../SortColumn';
 import { css } from '@patternfly/react-styles';
-import { tableSort, modifiers } from '@patternfly/patternfly-next/components/Table/table.css';
+import styles from '@patternfly/patternfly-next/components/Table/table.css';
 
 export default (label, { column: { extraParams: { sortBy, onSort } }, columnIndex }) => {
   const isSortedBy = sortBy && columnIndex === sortBy.index;
-  const direction = sortBy && sortBy.direction === SortByDirection.asc ? modifiers.ascending : modifiers.descending;
+  const direction = sortBy && sortBy.direction === SortByDirection.asc ?
+    styles.modifiers.ascending :
+    styles.modifiers.descending;
   function sortClicked(event) {
     let reversedDirection;
     if (!isSortedBy) {
@@ -17,7 +19,7 @@ export default (label, { column: { extraParams: { sortBy, onSort } }, columnInde
   }
 
   return ({
-    className: css(tableSort, isSortedBy && direction),
+    className: css(styles.tableSort, isSortedBy && direction),
     'aria-sort': isSortedBy ? `${sortBy.direction}ending` : 'none',
     children: (
       <SortColumn isSortedBy={isSortedBy} onSort={sortClicked}>


### PR DESCRIPTION
**What**:
* When using react table there is tons of warnings due to missing exports in patternfly next styles. That is caused by using spread instead of default import. It is much safer (but a bit less readable) to use direct imports.

* Allow first row to be collapsible by checking undefined instead of casting Boolean.

* Do not show select in collapsed child unless show checkbox is engorced on row.