### PR TITLE
chore(react-core): Replace SFC syntax with FunctionComponent

### DIFF
--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface AboutModalProps extends HTMLProps<HTMLDivElement> {
   children: ReactNode;
@@ -14,6 +14,6 @@ export interface AboutModalProps extends HTMLProps<HTMLDivElement> {
   heroImageAlt?: string;
 }
 
-declare const AboutModal: SFC<AboutModalProps>;
+declare const AboutModal: FunctionComponent<AboutModalProps>;
 
 export default AboutModal;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBox.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBox.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface ModalBoxProps extends HTMLProps<HTMLDivElement> {
   children: ReactNode;
@@ -6,6 +6,6 @@ export interface ModalBoxProps extends HTMLProps<HTMLDivElement> {
   ariaDescribedById: string;
 }
 
-declare const ModalBox: SFC<ModalBoxProps>;
+declare const ModalBox: FunctionComponent<ModalBoxProps>;
 
 export default ModalBox;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxBrand.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxBrand.d.ts
@@ -1,8 +1,8 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
-export interface AboutMoalBoxBrandProps extends HTMLProps<HTMLImageElement> {
+export interface AboutModalBoxBrandProps extends HTMLProps<HTMLImageElement> {
   src?: string;
   alt: string;
 }
-declare const AboutMoalBoxBrand: SFC<AboutMoalBoxBrandProps>;
-export default AboutMoalBoxBrand;
+declare const AboutModalBoxBrand: FunctionComponent<AboutModalBoxBrandProps>;
+export default AboutModalBoxBrand;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxCloseButton.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxCloseButton.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface AboutModalBoxCloseButtonProps extends HTMLProps<HTMLDivElement> {
   onClose?: Function;
 }
 
-declare const AboutModalBoxCloseButton: SFC<AboutModalBoxCloseButtonProps>;
+declare const AboutModalBoxCloseButton: FunctionComponent<AboutModalBoxCloseButtonProps>;
 
 export default AboutModalBoxCloseButton;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxContent.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxContent.d.ts
@@ -1,10 +1,10 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface ModalBoxBodyProps extends HTMLProps<HTMLDivElement> {
   children: ReactNode;
   id: string;
 }
 
-declare const ModalBoxBody: SFC<ModalBoxBodyProps>;
+declare const ModalBoxBody: FunctionComponent<ModalBoxBodyProps>;
 
 export default ModalBoxBody;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxHeader.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxHeader.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface AboutModalBoxHeaderProps extends HTMLProps<HTMLDivElement> {
   productName: string;
@@ -6,6 +6,6 @@ export interface AboutModalBoxHeaderProps extends HTMLProps<HTMLDivElement> {
   id: string;
 }
 
-declare const AboutModalBoxHeader: SFC<AboutModalBoxHeaderProps>;
+declare const AboutModalBoxHeader: FunctionComponent<AboutModalBoxHeaderProps>;
 
 export default AboutModalBoxHeader;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxHero.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxHero.d.ts
@@ -1,8 +1,8 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface AboutMoalBoxHeroProps extends HTMLProps<HTMLImageElement> {
   src?: string;
   alt: string;
 }
-declare const AboutMoalBoxHero: SFC<AboutMoalBoxHeroProps>;
+declare const AboutMoalBoxHero: FunctionComponent<AboutMoalBoxHeroProps>;
 export default AboutMoalBoxHero;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalContainer.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalContainer.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface AboutModalContainerProps extends HTMLProps<HTMLDivElement> {
   children: ReactNode;
@@ -16,6 +16,6 @@ export interface AboutModalContainerProps extends HTMLProps<HTMLDivElement> {
   heroImageAlt?: string;
 }
 
-declare const AboutModalContainer: SFC<AboutModalContainerProps>;
+declare const AboutModalContainer: FunctionComponent<AboutModalContainerProps>;
 
 export default AboutModalContainer;

--- a/packages/patternfly-4/react-core/src/components/Alert/Alert.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Alert/Alert.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf, Omit } from '../../typeUtils';
 
 export const AlertVariant: {
@@ -17,6 +17,6 @@ export interface AlertProps extends Omit<HTMLProps<HTMLDivElement>, 'action'> {
   variantLabel?: string;
 }
 
-declare const Alert: SFC<AlertProps>;
+declare const Alert: FunctionComponent<AlertProps>;
 
 export default Alert;

--- a/packages/patternfly-4/react-core/src/components/Alert/AlertActionCloseButton.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Alert/AlertActionCloseButton.d.ts
@@ -1,11 +1,10 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
-import { OneOf, Omit } from '../../typeUtils';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface AlertActionCloseButtonProps extends HTMLProps<HTMLDivElement> {
   onClose?: Function;
   'aria-label'?: string;
 }
 
-declare const AlertActionCloseButton: SFC<AlertActionCloseButtonProps>;
+declare const AlertActionCloseButton: FunctionComponent<AlertActionCloseButtonProps>;
 
 export default AlertActionCloseButton;

--- a/packages/patternfly-4/react-core/src/components/Alert/AlertActionLink.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Alert/AlertActionLink.d.ts
@@ -1,8 +1,7 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
-import { OneOf, Omit } from '../../typeUtils';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface AlertActionLinkProps extends HTMLProps<HTMLDivElement> {}
 
-declare const AlertActionLink: SFC<AlertActionLinkProps>;
+declare const AlertActionLink: FunctionComponent<AlertActionLinkProps>;
 
 export default AlertActionLink;

--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/ApplicationLauncher.d.ts
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/ApplicationLauncher.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactType, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf } from '../../typeUtils';
 import { DropdownPosition, DropdownDirection } from '../Dropdown/dropdownConstants';
 
@@ -11,6 +11,6 @@ export interface ApplicationLauncherProps extends HTMLProps<HTMLDivElement> {
   position?: OneOf<typeof DropdownPosition, keyof typeof DropdownPosition>;
 }
 
-declare const ApplicationLauncher: SFC<ApplicationLauncherProps>;
+declare const ApplicationLauncher: FunctionComponent<ApplicationLauncherProps>;
 
 export default ApplicationLauncher;

--- a/packages/patternfly-4/react-core/src/components/Avatar/Avatar.tsx
+++ b/packages/patternfly-4/react-core/src/components/Avatar/Avatar.tsx
@@ -21,7 +21,7 @@ export interface AvatarProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLIma
   alt: string;
 }
 
-const Avatar:React.SFC<AvatarProps> = (props) => (
+const Avatar:React.FunctionComponent<AvatarProps> = (props) => (
   <img {...props} className={css(styles.avatar, props.className)} />
 );
 

--- a/packages/patternfly-4/react-core/src/components/Backdrop/Backdrop.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Backdrop/Backdrop.d.ts
@@ -1,10 +1,10 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface BackdropProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
   className?: string;
 }
 
-declare const Backdrop: SFC<BackdropProps>;
+declare const Backdrop: FunctionComponent<BackdropProps>;
 
 export default Backdrop;

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.d.ts
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.d.ts
@@ -1,5 +1,5 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
-import { Omit, OneOf } from '../../typeUtils';
+import { FunctionComponent, HTMLProps } from 'react';
+import { Omit } from '../../typeUtils';
 
 export const BackgroundImageSrc: {
   xs: 'xs';
@@ -16,6 +16,6 @@ export interface BackgroundImageProps extends Omit<HTMLProps<HTMLDivElement>, 's
   src: string | BackgroundImageSrcMap;
 }
 
-declare const BackgroundImage: SFC<BackgroundImageProps>;
+declare const BackgroundImage: FunctionComponent<BackgroundImageProps>;
 
 export default BackgroundImage;

--- a/packages/patternfly-4/react-core/src/components/Badge/Badge.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Badge/Badge.d.ts
@@ -1,11 +1,10 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
-import { Omit, OneOf } from '../../typeUtils';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface BadgeProps extends HTMLProps<HTMLSpanElement> {
   isRead?: Boolean;
   children?: ReactNode;
 }
 
-declare const Badge: SFC<BadgeProps>;
+declare const Badge: FunctionComponent<BadgeProps>;
 
 export default Badge;

--- a/packages/patternfly-4/react-core/src/components/Brand/Brand.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Brand/Brand.d.ts
@@ -1,9 +1,8 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
-import { Omit } from '../../typeUtils';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface BrandProps extends HTMLProps<HTMLImageElement> {
   src?: string;
   alt: string;
 }
-declare const Brand: SFC<BrandProps>;
+declare const Brand: FunctionComponent<BrandProps>;
 export default Brand;

--- a/packages/patternfly-4/react-core/src/components/Breadcrumb/Breadcrumb.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Breadcrumb/Breadcrumb.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface BreadcrumbProps extends HTMLProps<HTMLElement> {
     children?: ReactNode;
@@ -6,6 +6,6 @@ export interface BreadcrumbProps extends HTMLProps<HTMLElement> {
     'aria-label'?: string;
 }
 
-declare const Breadcrumb: SFC<BreadcrumbProps>;
+declare const Breadcrumb: FunctionComponent<BreadcrumbProps>;
 
 export default Breadcrumb;

--- a/packages/patternfly-4/react-core/src/components/Breadcrumb/BreadcrumbHeading.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Breadcrumb/BreadcrumbHeading.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode, ReactType } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode, ReactType } from 'react';
 
 export interface BreadcrumbHeadingProps extends HTMLProps<HTMLLIElement> {
     children?: ReactNode;
@@ -8,6 +8,6 @@ export interface BreadcrumbHeadingProps extends HTMLProps<HTMLLIElement> {
     component?: ReactType<BreadcrumbHeadingProps>;
 }
 
-declare const BreeadcrumbHeading: SFC<BreadcrumbHeadingProps>;
+declare const BreeadcrumbHeading: FunctionComponent<BreadcrumbHeadingProps>;
 
 export default BreeadcrumbHeading;

--- a/packages/patternfly-4/react-core/src/components/Breadcrumb/BreadcrumbItem.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Breadcrumb/BreadcrumbItem.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode, ReactType } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode, ReactType } from 'react';
 
 export interface BreadcrumbItemProps extends HTMLProps<HTMLLIElement> {
     children?: ReactNode;
@@ -9,6 +9,6 @@ export interface BreadcrumbItemProps extends HTMLProps<HTMLLIElement> {
     component?: ReactType<BreadcrumbItemProps>;
 }
 
-declare const BreeadcrumbItem: SFC<BreadcrumbItemProps>;
+declare const BreeadcrumbItem: FunctionComponent<BreadcrumbItemProps>;
 
 export default BreeadcrumbItem;

--- a/packages/patternfly-4/react-core/src/components/Button/Button.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Button/Button.d.ts
@@ -1,4 +1,4 @@
-import { HTMLProps, SFC, ReactType, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode, ReactType } from 'react';
 import { OneOf } from '../../typeUtils';
 
 export const ButtonVariant: {
@@ -27,6 +27,6 @@ export interface ButtonProps extends HTMLProps<HTMLButtonElement> {
   type?: OneOf<typeof ButtonType, keyof typeof ButtonType>;
 }
 
-declare const Button: SFC<ButtonProps>;
+declare const Button: FunctionComponent<ButtonProps>;
 
 export default Button;

--- a/packages/patternfly-4/react-core/src/components/Card/Card.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Card/Card.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactType } from 'react';
+import { FunctionComponent, HTMLProps, ReactType } from 'react';
 
 export interface CardProps extends HTMLProps<HTMLDivElement> {
   component?: ReactType<CardProps>;
 }
 
-declare const Card: SFC<CardProps>;
+declare const Card: FunctionComponent<CardProps>;
 
 export default Card;

--- a/packages/patternfly-4/react-core/src/components/Card/CardBody.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Card/CardBody.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactType } from 'react';
+import { FunctionComponent, HTMLProps, ReactType } from 'react';
 
 export interface CardBodyProps extends HTMLProps<HTMLDivElement> {
   component?: ReactType<CardBodyProps>;
 }
 
-declare const CardBody: SFC<CardBodyProps>;
+declare const CardBody: FunctionComponent<CardBodyProps>;
 
 export default CardBody;

--- a/packages/patternfly-4/react-core/src/components/Card/CardFooter.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Card/CardFooter.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactType } from 'react';
+import { FunctionComponent, HTMLProps, ReactType } from 'react';
 
 export interface CardFooterProps extends HTMLProps<HTMLDivElement> {
   component?: ReactType<CardFooterProps>;
 }
 
-declare const CardFooter: SFC<CardFooterProps>;
+declare const CardFooter: FunctionComponent<CardFooterProps>;
 
 export default CardFooter;

--- a/packages/patternfly-4/react-core/src/components/Card/CardHeader.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Card/CardHeader.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactType } from 'react';
+import { FunctionComponent, HTMLProps, ReactType } from 'react';
 
 export interface CardHeaderProps extends HTMLProps<HTMLDivElement> {
   component?: ReactType<CardHeaderProps>;
 }
 
-declare const CardHeader: SFC<CardHeaderProps>;
+declare const CardHeader: FunctionComponent<CardHeaderProps>;
 
 export default CardHeader;

--- a/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.d.ts
@@ -1,4 +1,4 @@
-import { HTMLProps, FormEvent, ReactNode } from 'react';
+import { FormEvent, FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface CheckboxProps extends Omit<HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled' | 'label'> {
@@ -11,6 +11,6 @@ export interface CheckboxProps extends Omit<HTMLProps<HTMLInputElement>, 'type' 
   label?: ReactNode;
 }
 
-declare const Checkbox: React.SFC<CheckboxProps>;
+declare const Checkbox: FunctionComponent<CheckboxProps>;
 
 export default Checkbox;

--- a/packages/patternfly-4/react-core/src/components/Chip/Chip.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Chip/Chip.d.ts
@@ -1,5 +1,5 @@
-import { SFC, HTMLProps } from 'react';
-import { Omit, OneOf } from '../../typeUtils';
+import { FunctionComponent, HTMLProps } from 'react';
+import { OneOf } from '../../typeUtils';
 import { TooltipPosition } from '../Tooltip';
 
 export interface ChipProps extends HTMLProps<HTMLDivElement> {
@@ -9,7 +9,7 @@ export interface ChipProps extends HTMLProps<HTMLDivElement> {
   tooltipPosition: OneOf<typeof TooltipPosition, keyof typeof TooltipPosition>;
 }
 
-declare const Chip: SFC<ChipProps>;
+declare const Chip: FunctionComponent<ChipProps>;
 
 export default Chip;
 

--- a/packages/patternfly-4/react-core/src/components/Chip/ChipButton.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Chip/ChipButton.d.ts
@@ -1,7 +1,7 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface ChipButtonProps extends HTMLProps<HTMLButtonElement> {}
 
-declare const ChipButton: SFC<ChipButtonProps>;
+declare const ChipButton: FunctionComponent<ChipButtonProps>;
 
 export default ChipButton;

--- a/packages/patternfly-4/react-core/src/components/DataList/DataList.d.ts
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataList.d.ts
@@ -1,10 +1,10 @@
-import { SFC, HTMLProps } from 'react';
-import {  Omit } from '../../typeUtils';
+import { FunctionComponent, HTMLProps } from 'react';
+import { Omit } from '../../typeUtils';
 
 export interface DataListProps extends Omit<HTMLProps<HTMLUListElement>, 'aria-label'> {
   'aria-label': string;
 }
 
-declare const DataList: SFC<DataListProps>;
+declare const DataList: FunctionComponent<DataListProps>;
 
 export default DataList;

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListAction.d.ts
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListAction.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface DataListActionProps extends HTMLProps<HTMLDivElement> {
   'aria-labelledby': string;
@@ -6,6 +6,6 @@ export interface DataListActionProps extends HTMLProps<HTMLDivElement> {
   id: string;
 }
 
-declare const DataListAction: SFC<DataListActionProps>;
+declare const DataListAction: FunctionComponent<DataListActionProps>;
 
 export default DataListAction;

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListCell.d.ts
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListCell.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface DataListCellProps extends HTMLProps<HTMLDivElement> {
   width: 1 | 2 | 3 | 4 | 5;
 }
 
-declare const DataListCell: SFC<DataListCellProps>;
+declare const DataListCell: FunctionComponent<DataListCellProps>;
 
 export default DataListCell;

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListCheck.d.ts
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListCheck.d.ts
@@ -1,4 +1,4 @@
-import { HTMLProps, FormEvent, ReactNode } from 'react';
+import { FormEvent, FunctionComponent, HTMLProps } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface DataListCheckProps
@@ -10,6 +10,6 @@ export interface DataListCheckProps
   'aria-labelledby': string;
 }
 
-declare const DataListCheck: React.SFC<DataListCheckProps>;
+declare const DataListCheck: FunctionComponent<DataListCheckProps>;
 
 export default DataListCheck;

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListContent.d.ts
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListContent.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface DataListContentProps extends Omit<HTMLProps<HTMLElement>, 'aria-label'> {
@@ -6,6 +6,6 @@ export interface DataListContentProps extends Omit<HTMLProps<HTMLElement>, 'aria
   'aria-label': string;
 }
 
-declare const DataListContent: SFC<DataListContentProps>;
+declare const DataListContent: FunctionComponent<DataListContentProps>;
 
 export default DataListContent;

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListItem.d.ts
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListItem.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface DataListItemProps extends Omit<HTMLProps<HTMLLIElement>, 'aria-label'> {
@@ -6,6 +6,6 @@ export interface DataListItemProps extends Omit<HTMLProps<HTMLLIElement>, 'aria-
   'aria-labelledby': string;
 }
 
-declare const DataListItem: SFC<DataListItemProps>;
+declare const DataListItem: FunctionComponent<DataListItemProps>;
 
 export default DataListItem;

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListToggle.d.ts
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListToggle.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface DataListToggleProps extends Omit<HTMLProps<HTMLDivElement>, 'aria-labelledby' | 'aria-label' | 'id'> {
@@ -8,6 +8,6 @@ export interface DataListToggleProps extends Omit<HTMLProps<HTMLDivElement>, 'ar
   id: string;
 }
 
-declare const DataListToggle: SFC<DataListToggleProps>;
+declare const DataListToggle: FunctionComponent<DataListToggleProps>;
 
 export default DataListToggle;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.d.ts
@@ -1,6 +1,5 @@
-import { SFC, HTMLProps, ReactType, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf } from '../../typeUtils';
-import DropdownToggle from './DropdownToggle';
 import { DropdownPosition, DropdownDirection } from './dropdownConstants';
 
 export interface DropdownProps extends HTMLProps<HTMLDivElement> {
@@ -15,6 +14,6 @@ export interface DropdownProps extends HTMLProps<HTMLDivElement> {
   toggle?: ReactNode;
 }
 
-declare const Dropdown: SFC<DropdownProps>;
+declare const Dropdown: FunctionComponent<DropdownProps>;
 
 export default Dropdown;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactType, ReactNode } from 'react';
+import { HTMLProps, ReactType } from 'react';
 
 export interface DropdownItemProps extends HTMLProps<HTMLAnchorElement> {
   component?: ReactType<DropdownItemProps>;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactType, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode, ReactType } from 'react';
 
 export interface DropdownToggleProps extends HTMLProps<HTMLButtonElement> {
   id?: string;
@@ -13,6 +13,6 @@ export interface DropdownToggleProps extends HTMLProps<HTMLButtonElement> {
   iconComponent?: ReactType;
 }
 
-declare const DropdownToggle: SFC<DropdownToggleProps>;
+declare const DropdownToggle: FunctionComponent<DropdownToggleProps>;
 
 export default DropdownToggle;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Item.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Item.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactType } from 'react';
+import { FunctionComponent } from 'react';
 import { DropdownItemProps } from './DropdownItem';
 
 export interface ItemProps extends DropdownItemProps {
 }
 
-declare const Item: SFC<ItemProps>;
+declare const Item: FunctionComponent<ItemProps>;
 
 export default Item;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/KebabToggle.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/KebabToggle.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactType } from 'react';
+import { FunctionComponent } from 'react';
 import { DropdownToggleProps } from './DropdownToggle';
 
 export interface KebabProps extends DropdownToggleProps {
 }
 
-declare const Kebab: SFC<KebabProps>;
+declare const Kebab: FunctionComponent<KebabProps>;
 
 export default Kebab;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Separator.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Separator.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactType } from 'react';
+import { FunctionComponent } from 'react';
 import { DropdownItemProps } from './DropdownItem';
 
 export interface SeparatorProps extends DropdownItemProps {
 }
 
-declare const Separator: SFC<SeparatorProps>;
+declare const Separator: FunctionComponent<SeparatorProps>;
 
 export default Separator;

--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.d.ts
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.d.ts
@@ -1,10 +1,10 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface EmptyStateProps extends Omit<HTMLProps<HTMLDivElement>, 'children'> {
   children: ReactNode;
 }
 
-declare const EmptyState: SFC<EmptyStateProps>;
+declare const EmptyState: FunctionComponent<EmptyStateProps>;
 
 export default EmptyState;

--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateBody.d.ts
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateBody.d.ts
@@ -1,7 +1,7 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface EmptyStateBodyProps extends HTMLProps<HTMLParagraphElement> {}
 
-declare const EmptyStateBody: SFC<EmptyStateBodyProps>;
+declare const EmptyStateBody: FunctionComponent<EmptyStateBodyProps>;
 
 export default EmptyStateBody;

--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateIcon.d.ts
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateIcon.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 import { OneOf, Omit } from '../../typeUtils';
 
 export const IconSize: {
@@ -15,9 +15,9 @@ export interface IconProps extends Omit<HTMLProps<SVGElement>, 'size'> {
 }
 
 export interface EmptyStateIconProps extends IconProps {
-  icon: string | SFC<IconProps>,
+  icon: string | FunctionComponent<IconProps>,
 }
 
-declare const EmptyStateIcon: SFC<EmptyStateIconProps>;
+declare const EmptyStateIcon: FunctionComponent<EmptyStateIconProps>;
 
 export default EmptyStateIcon;

--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateSecondaryActions.d.ts
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateSecondaryActions.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface EmptyStateSecondaryActionsProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
 }
 
-declare const EmptyStateSecondaryActions: SFC<EmptyStateSecondaryActionsrops>;
+declare const EmptyStateSecondaryActions: FunctionComponent<EmptyStateSecondaryActionsProps>;
 
 export default EmptyStateSecondaryActions;

--- a/packages/patternfly-4/react-core/src/components/Form/ActionGroup.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Form/ActionGroup.d.ts
@@ -1,7 +1,7 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface ActionGroupProps extends HTMLProps<HTMLDivElement> { }
 
-declare const ActionGroup: SFC<ActionGroupProps>;
+declare const ActionGroup: FunctionComponent<ActionGroupProps>;
 
 export default ActionGroup;

--- a/packages/patternfly-4/react-core/src/components/Form/Form.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Form/Form.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface FormProps extends HTMLProps<HTMLFormElement> {
     isHorizontal?: boolean;
 }
 
-declare const Form: SFC<FormProps>;
+declare const Form: FunctionComponent<FormProps>;
 
 export default Form;

--- a/packages/patternfly-4/react-core/src/components/Form/FormGroup.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Form/FormGroup.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { Omit } from '../../typeUtils'
 
 export interface FormGroupProps extends Omit<HTMLProps<HTMLDivElement>, 'label'> {
@@ -11,6 +11,6 @@ export interface FormGroupProps extends Omit<HTMLProps<HTMLDivElement>, 'label'>
   isInline?: boolean;
 }
 
-declare const FormGroup: SFC<FormGroupProps>;
+declare const FormGroup: FunctionComponent<FormGroupProps>;
 
 export default FormGroup;

--- a/packages/patternfly-4/react-core/src/components/FormSelect/FormSelect.d.ts
+++ b/packages/patternfly-4/react-core/src/components/FormSelect/FormSelect.d.ts
@@ -1,4 +1,4 @@
-import { HTMLProps, FormEvent } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface FormSelectProps
@@ -11,6 +11,6 @@ export interface FormSelectProps
   onChange?(event: React.FormEvent<HTMLSelectElement>): void;
 }
 
-declare const FormSelect: React.SFC<FormSelectProps>;
+declare const FormSelect: FunctionComponent<FormSelectProps>;
 
 export default FormSelect;

--- a/packages/patternfly-4/react-core/src/components/FormSelect/FormSelectOption.d.ts
+++ b/packages/patternfly-4/react-core/src/components/FormSelect/FormSelectOption.d.ts
@@ -1,4 +1,4 @@
-import { HTMLProps, FormEvent } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface FormSelectOptionProps extends Omit<HTMLProps<HTMLOptionElement>, 'disabled'> {
@@ -8,6 +8,6 @@ export interface FormSelectOptionProps extends Omit<HTMLProps<HTMLOptionElement>
   isDisabled?: boolean;
 }
 
-declare const FormSelectOption: React.SFC<FormSelectOptionProps>;
+declare const FormSelectOption: FunctionComponent<FormSelectOptionProps>;
 
 export default FormSelectOption;

--- a/packages/patternfly-4/react-core/src/components/FormSelect/FormSelectOptionGroup.d.ts
+++ b/packages/patternfly-4/react-core/src/components/FormSelect/FormSelectOptionGroup.d.ts
@@ -1,4 +1,4 @@
-import { HTMLProps, FormEvent } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface FormSelectOptionGroupProps extends Omit<HTMLProps<HTMLOptGroupElement>, 'disabled'> {
@@ -6,6 +6,6 @@ export interface FormSelectOptionGroupProps extends Omit<HTMLProps<HTMLOptGroupE
   isDisabled?: boolean;
 }
 
-declare const FormSelectOptionGroup: React.SFC<FormSelectOptionGroupProps>;
+declare const FormSelectOptionGroup: FunctionComponent<FormSelectOptionGroupProps>;
 
 export default FormSelectOptionGroup;

--- a/packages/patternfly-4/react-core/src/components/Label/Label.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Label/Label.d.ts
@@ -1,10 +1,10 @@
-import { HTMLProps, SFC, ReactType, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface LabelProps extends HTMLProps<HTMLSpanElement> {
   children: ReactNode;
   isCompact?: boolean;
 }
 
-declare const Label: SFC<LabelProps>;
+declare const Label: FunctionComponent<LabelProps>;
 
 export default Label;

--- a/packages/patternfly-4/react-core/src/components/List/List.d.ts
+++ b/packages/patternfly-4/react-core/src/components/List/List.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf } from '../../typeUtils';
 
 export const ListVariant: {
@@ -11,6 +11,6 @@ export interface ListProps extends HTMLProps<HTMLUListElement> {
   variant?: OneOf<typeof ListVariant, keyof typeof ListVariant>;
 }
 
-declare const List: SFC<ListProps>;
+declare const List: FunctionComponent<ListProps>;
 
 export default List;

--- a/packages/patternfly-4/react-core/src/components/List/ListItem.d.ts
+++ b/packages/patternfly-4/react-core/src/components/List/ListItem.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface ListItemProps extends HTMLProps<HTMLLIElement> {
   children?: ReactNode;
 }
 
-declare const ListItem: SFC<ListItemProps>;
+declare const ListItem: FunctionComponent<ListItemProps>;
 
 export default ListItem;

--- a/packages/patternfly-4/react-core/src/components/LoginPage/Login.d.ts
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/Login.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface LoginProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
@@ -7,6 +7,6 @@ export interface LoginProps extends HTMLProps<HTMLDivElement> {
   header?: ReactNode;
 }
 
-declare const Login: SFC<LoginProps>;
+declare const Login: FunctionComponent<LoginProps>;
 
 export default Login;

--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginFooter.d.ts
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginFooter.d.ts
@@ -1,10 +1,10 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface LoginFooterProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
   className?: string;
 }
 
-declare const LoginFooter: SFC<LoginFooterProps>;
+declare const LoginFooter: FunctionComponent<LoginFooterProps>;
 
 export default LoginFooter;

--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginFooterItem.d.ts
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginFooterItem.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface LoginFooterItemProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
@@ -7,6 +7,6 @@ export interface LoginFooterItemProps extends HTMLProps<HTMLDivElement> {
   target?: string;
 }
 
-declare const LoginFooterItem: SFC<LoginFooterItemProps>;
+declare const LoginFooterItem: FunctionComponent<LoginFooterItemProps>;
 
 export default LoginFooterItem;

--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginForm.d.ts
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginForm.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface LoginFormProps extends HTMLProps<HTMLFormElement> {
   children?: ReactNode;
@@ -22,6 +22,6 @@ export interface LoginFormProps extends HTMLProps<HTMLFormElement> {
   rememberMeAriaLabel?: string;
 }
 
-declare const LoginForm: SFC<LoginFormProps>;
+declare const LoginForm: FunctionComponent<LoginFormProps>;
 
 export default LoginForm;

--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginHeader.d.ts
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginHeader.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface LoginHeaderProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
@@ -6,6 +6,6 @@ export interface LoginHeaderProps extends HTMLProps<HTMLDivElement> {
   headerBrand?: ReactNode;
 }
 
-declare const LoginHeader: SFC<LoginHeaderProps>;
+declare const LoginHeader: FunctionComponent<LoginHeaderProps>;
 
 export default LoginHeader;

--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginMainBody.d.ts
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginMainBody.d.ts
@@ -1,10 +1,10 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface LoginMainBodyProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
   className?: string;
 }
 
-declare const LoginMainBody: SFC<LoginMainBodyProps>;
+declare const LoginMainBody: FunctionComponent<LoginMainBodyProps>;
 
 export default LoginMainBody;

--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginMainFooter.d.ts
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginMainFooter.d.ts
@@ -1,10 +1,10 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface LoginMainFooterProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
   className?: string;
 }
 
-declare const LoginMainFooter: SFC<LoginMainFooterProps>;
+declare const LoginMainFooter: FunctionComponent<LoginMainFooterProps>;
 
 export default LoginMainFooter;

--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginMainHeader.d.ts
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginMainHeader.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface LoginMainHeaderProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
@@ -8,6 +8,6 @@ export interface LoginMainHeaderProps extends HTMLProps<HTMLDivElement> {
   subtitle?: string;
 }
 
-declare const LoginMainHeader: SFC<LoginMainHeaderProps>;
+declare const LoginMainHeader: FunctionComponent<LoginMainHeaderProps>;
 
 export default LoginMainHeader;

--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginPage.d.ts
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginPage.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf } from '../../typeUtils';
 
 export const LoginListVariant: {
@@ -22,6 +22,6 @@ export interface LoginPageProps extends HTMLProps<HTMLElement> {
   socialMediaLoginContent?: ReactNode;
 }
 
-declare const LoginPage: SFC<LoginPageProps>;
+declare const LoginPage: FunctionComponent<LoginPageProps>;
 
 export default LoginPage;

--- a/packages/patternfly-4/react-core/src/components/Modal/Modal.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/Modal.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface ModalProps extends HTMLProps<HTMLDivElement> {
   actions?: any,
@@ -11,6 +11,6 @@ export interface ModalProps extends HTMLProps<HTMLDivElement> {
   title: string;
 }
 
-declare const Modal: SFC<ModalProps>;
+declare const Modal: FunctionComponent<ModalProps>;
 
 export default Modal;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBox.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBox.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface ModalBoxProps extends HTMLProps<HTMLDivElement> {
   children: ReactNode;
@@ -8,6 +8,6 @@ export interface ModalBoxProps extends HTMLProps<HTMLDivElement> {
   title: string;
 }
 
-declare const ModalBox: SFC<ModalBoxProps>;
+declare const ModalBox: FunctionComponent<ModalBoxProps>;
 
 export default ModalBox;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxBody.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxBody.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface ModalBoxBodyProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
@@ -6,6 +6,6 @@ export interface ModalBoxBodyProps extends HTMLProps<HTMLDivElement> {
   id?: string;
 }
 
-declare const ModalBoxBody: SFC<ModalBoxBodyProps>;
+declare const ModalBoxBody: FunctionComponent<ModalBoxBodyProps>;
 
 export default ModalBoxBody;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxCloseButton.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxCloseButton.d.ts
@@ -1,10 +1,10 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface ModalBoxCloseButtonProps extends HTMLProps<HTMLDivElement> {
   className?: string;
   onClose?: Function;
 }
 
-declare const ModalBoxCloseButton: SFC<ModalBoxCloseButtonProps>;
+declare const ModalBoxCloseButton: FunctionComponent<ModalBoxCloseButtonProps>;
 
 export default ModalBoxCloseButton;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxFooter.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxFooter.d.ts
@@ -1,10 +1,10 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface ModalBoxFooterProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
   className?: string;
 }
 
-declare const ModalBoxFooter: SFC<ModalBoxFooterProps>;
+declare const ModalBoxFooter: FunctionComponent<ModalBoxFooterProps>;
 
 export default ModalBoxFooter;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxHeader.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxHeader.d.ts
@@ -1,10 +1,10 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface ModalBoxHeaderProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
   className?: string;
 }
 
-declare const ModalBoxHeader: SFC<ModalBoxHeaderProps>;
+declare const ModalBoxHeader: FunctionComponent<ModalBoxHeaderProps>;
 
 export default ModalBoxHeader;

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface ModalContentProps extends HTMLProps<HTMLDivElement> {
   children: ReactNode;
@@ -12,6 +12,6 @@ export interface ModalContentProps extends HTMLProps<HTMLDivElement> {
   title: string;
 }
 
-declare const ModalContent: SFC<ModalContentProps>;
+declare const ModalContent: FunctionComponent<ModalContentProps>;
 
 export default ModalContent;

--- a/packages/patternfly-4/react-core/src/components/Nav/Nav.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Nav/Nav.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode, FormEvent } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode, FormEvent } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface NavProps extends Omit<HTMLProps<HTMLDivElement>, 'onSelect'> {
@@ -9,6 +9,6 @@ export interface NavProps extends Omit<HTMLProps<HTMLDivElement>, 'onSelect'> {
   'aria-label': string;
 }
 
-declare const Nav: SFC<NavProps>;
+declare const Nav: FunctionComponent<NavProps>;
 
 export default Nav;

--- a/packages/patternfly-4/react-core/src/components/Nav/NavExpandable.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Nav/NavExpandable.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface NavExpandableProps extends HTMLProps<HTMLDivElement> {
   title: string;
@@ -11,6 +11,6 @@ export interface NavExpandableProps extends HTMLProps<HTMLDivElement> {
   id?: string;
 }
 
-declare const NavExpandable: SFC<NavExpandableProps>;
+declare const NavExpandable: FunctionComponent<NavExpandableProps>;
 
 export default NavExpandable;

--- a/packages/patternfly-4/react-core/src/components/Nav/NavGroup.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Nav/NavGroup.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface NavGroupProps extends HTMLProps<HTMLDivElement> {
   title: string;
@@ -7,6 +7,6 @@ export interface NavGroupProps extends HTMLProps<HTMLDivElement> {
   id?: string;
 }
 
-declare const NavGroup: SFC<NavGroupProps>;
+declare const NavGroup: FunctionComponent<NavGroupProps>;
 
 export default NavGroup;

--- a/packages/patternfly-4/react-core/src/components/Nav/NavItem.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Nav/NavItem.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface NavItemProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode | string;
@@ -10,6 +10,6 @@ export interface NavItemProps extends HTMLProps<HTMLDivElement> {
   itemId?: string | number;
 }
 
-declare const NavItem: SFC<NavItemProps>;
+declare const NavItem: FunctionComponent<NavItemProps>;
 
 export default NavItem;

--- a/packages/patternfly-4/react-core/src/components/Nav/NavList.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Nav/NavList.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf } from '../../typeUtils';
 import { NavVariants } from './NavVariants';
 
@@ -15,6 +15,6 @@ export interface NavListProps extends HTMLProps<HTMLDivElement> {
   isActive?: boolean;
 }
 
-declare const NavList: SFC<NavListProps>;
+declare const NavList: FunctionComponent<NavListProps>;
 
 export default NavList;

--- a/packages/patternfly-4/react-core/src/components/Page/Page.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Page/Page.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface PageProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
@@ -9,6 +9,6 @@ export interface PageProps extends HTMLProps<HTMLDivElement> {
   onPageResize?: Function;
 }
 
-declare const Page: SFC<PageProps>;
+declare const Page: FunctionComponent<PageProps>;
 
 export default Page;

--- a/packages/patternfly-4/react-core/src/components/Page/PageHeader.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Page/PageHeader.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface PageHeaderProps extends HTMLProps<HTMLDivElement> {
   className?: string;
@@ -12,6 +12,6 @@ export interface PageHeaderProps extends HTMLProps<HTMLDivElement> {
   onNavToggle?: Function;
 }
 
-declare const PageHeader: SFC<PageHeaderProps>;
+declare const PageHeader: FunctionComponent<PageHeaderProps>;
 
 export default PageHeader;

--- a/packages/patternfly-4/react-core/src/components/Page/PageSection.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Page/PageSection.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf } from '../../typeUtils';
 
 export const PageSectionVariants: {
@@ -14,6 +14,6 @@ export interface PageSectionProps extends HTMLProps<HTMLDivElement> {
   variant?: OneOf<typeof PageSectionVariants, keyof typeof PageSectionVariants>;
 }
 
-declare const PageSection: SFC<PageSectionProps>;
+declare const PageSection: FunctionComponent<PageSectionProps>;
 
 export default PageSection;

--- a/packages/patternfly-4/react-core/src/components/Page/PageSidebar.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Page/PageSidebar.d.ts
@@ -1,5 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
-import { OneOf } from '../../typeUtils';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface PageSidebarProps extends HTMLProps<HTMLDivElement> {
   className?: string;
@@ -7,6 +6,6 @@ export interface PageSidebarProps extends HTMLProps<HTMLDivElement> {
   isNavOpen?: boolean;
 }
 
-declare const PageSidebar: SFC<PageSidebarProps>;
+declare const PageSidebar: FunctionComponent<PageSidebarProps>;
 
 export default PageSidebar;

--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode, ReactElement } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode, ReactElement } from 'react';
 import { Omit } from '../../typeUtils';
 import { Instance, BasicPlacement } from 'tippy.js';
 
@@ -56,6 +56,6 @@ export interface PopoverProps extends Omit<HTMLProps<HTMLDivElement>, 'children'
   size: 'small' | 'regular' | 'large';
 }
 
-declare const Popover: SFC<PopoverProps>;
+declare const Popover: FunctionComponent<PopoverProps>;
 
 export default Popover;

--- a/packages/patternfly-4/react-core/src/components/Popover/PopoverArrow.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Popover/PopoverArrow.d.ts
@@ -1,8 +1,8 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface PopoverArrowProps extends HTMLProps<HTMLDivElement> {
 }
 
-declare const PopoverArrow: SFC<PopoverArrowProps>;
+declare const PopoverArrow: FunctionComponent<PopoverArrowProps>;
 
 export default PopoverArrow;

--- a/packages/patternfly-4/react-core/src/components/Popover/PopoverBody.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Popover/PopoverBody.d.ts
@@ -1,10 +1,10 @@
-import { SFC, ReactNode } from 'react';
+import { FunctionComponent, ReactNode } from 'react';
 
 export interface PopoverBodyProps  {
   id: string
   children: ReactNode;
 }
 
-declare const PopoverBody: SFC<PopoverBodyProps>;
+declare const PopoverBody: FunctionComponent<PopoverBodyProps>;
 
 export default PopoverBody;

--- a/packages/patternfly-4/react-core/src/components/Popover/PopoverCloseButton.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Popover/PopoverCloseButton.d.ts
@@ -1,9 +1,9 @@
-import { SFC } from 'react';
+import { FunctionComponent } from 'react';
 
 export interface PopoverCloseButtonProps {
   onClose(event: React.SyntheticEvent<HTMLButtonElement>): void
 }
 
-declare const PopoverCloseButton : SFC<PopoverCloseButtonProps>;
+declare const PopoverCloseButton : FunctionComponent<PopoverCloseButtonProps>;
 
 export default PopoverCloseButton;

--- a/packages/patternfly-4/react-core/src/components/Popover/PopoverContent.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Popover/PopoverContent.d.ts
@@ -1,8 +1,8 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface PopoverContentProps extends HTMLProps<HTMLDivElement> {
 }
 
-declare const PopoverContent: SFC<PopoverContentProps>;
+declare const PopoverContent: FunctionComponent<PopoverContentProps>;
 
 export default PopoverContent;

--- a/packages/patternfly-4/react-core/src/components/Popover/PopoverFooter.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Popover/PopoverFooter.d.ts
@@ -1,10 +1,10 @@
-import { SFC, ReactNode } from 'react';
+import { FunctionComponent, ReactNode } from 'react';
 
 export interface PopoverHeaderProps  {
   id: string
   children: ReactNode;
 }
 
-declare const PopoverHeader: SFC<PopoverHeaderProps>;
+declare const PopoverHeader: FunctionComponent<PopoverHeaderProps>;
 
 export default PopoverHeader;

--- a/packages/patternfly-4/react-core/src/components/Popover/PopoverHeader.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Popover/PopoverHeader.d.ts
@@ -1,10 +1,10 @@
-import { SFC, ReactNode } from 'react';
+import { FunctionComponent, ReactNode } from 'react';
 
 export interface PopoverHeaderProps  {
   id: string
   children: ReactNode;
 }
 
-declare const PopoverHeader: SFC<PopoverHeaderProps>;
+declare const PopoverHeader: FunctionComponent<PopoverHeaderProps>;
 
 export default PopoverHeader;

--- a/packages/patternfly-4/react-core/src/components/Progress/Progress.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Progress/Progress.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactType, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf, Omit } from '../../typeUtils';
 
 export const ProgressSize: {
@@ -33,6 +33,6 @@ export interface ProgressProps extends Omit<HTMLProps<HTMLDivElement>, 'size'> {
   valueText?: string;
 }
 
-declare const Progress: SFC<ProgressProps>;
+declare const Progress: FunctionComponent<ProgressProps>;
 
 export default Progress;

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.d.ts
@@ -1,4 +1,4 @@
-import { HTMLProps, FormEvent, ReactNode } from 'react';
+import { FormEvent, FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface RadioProps extends Omit<HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled' | 'label'> {
@@ -12,6 +12,6 @@ export interface RadioProps extends Omit<HTMLProps<HTMLInputElement>, 'type' | '
   name: string;
 }
 
-declare const Radio: React.SFC<RadioProps>;
+declare const Radio: FunctionComponent<RadioProps>;
 
 export default Radio;

--- a/packages/patternfly-4/react-core/src/components/Switch/Switch.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Switch/Switch.d.ts
@@ -1,4 +1,4 @@
-import { HTMLProps, FormEvent, ReactNode } from 'react';
+import { FormEvent, FunctionComponent, HTMLProps } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface SwitchProps extends Omit<HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled' | 'label'> {
@@ -11,6 +11,6 @@ export interface SwitchProps extends Omit<HTMLProps<HTMLInputElement>, 'type' | 
   className?: string;
 }
 
-declare const Switch: React.SFC<SwitchProps>;
+declare const Switch: FunctionComponent<SwitchProps>;
 
 export default Switch;

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tab.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tab.d.ts
@@ -1,10 +1,10 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface TabProps extends HTMLProps<HTMLDivElement> {
   title: string;
   eventKey: number;
 }
 
-declare const Tab: SFC<TabProps>;
+declare const Tab: FunctionComponent<TabProps>;
 
 export default Tab;

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tabs.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tabs.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, FormEvent } from 'react';
+import { FunctionComponent, HTMLProps, FormEvent } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface TabsProps extends Omit<HTMLProps<HTMLDivElement>, 'onSelect'> {
@@ -11,6 +11,6 @@ export interface TabsProps extends Omit<HTMLProps<HTMLDivElement>, 'onSelect'> {
   rightScrollAriaLabel?: string;
 }
 
-declare const Tabs: SFC<TabsProps>;
+declare const Tabs: FunctionComponent<TabsProps>;
 
 export default Tabs;

--- a/packages/patternfly-4/react-core/src/components/Text/Text.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Text/Text.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf } from '../../typeUtils';
 
 export const TextVariants: {
@@ -21,6 +21,6 @@ export interface TextProps extends HTMLProps<HTMLDivElement> {
   className?: string;
 }
 
-declare const Text: SFC<TextProps>;
+declare const Text: FunctionComponent<TextProps>;
 
 export default Text;

--- a/packages/patternfly-4/react-core/src/components/Text/TextContent.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Text/TextContent.d.ts
@@ -1,10 +1,10 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
 export interface TextContentProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
   className?: string;
 }
 
-declare const TextContent: SFC<TextContentProps>;
+declare const TextContent: FunctionComponent<TextContentProps>;
 
 export default TextContent;

--- a/packages/patternfly-4/react-core/src/components/Text/TextList.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Text/TextList.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf } from '../../typeUtils';
 
 export const TextListVariants: {
@@ -13,6 +13,6 @@ export interface TextListProps extends HTMLProps<HTMLDivElement> {
   className?: string;
 }
 
-declare const TextList: SFC<TextListProps>;
+declare const TextList: FunctionComponent<TextListProps>;
 
 export default TextList;

--- a/packages/patternfly-4/react-core/src/components/Text/TextListItem.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Text/TextListItem.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf } from '../../typeUtils';
 
 export const TextListItemVariants: {
@@ -13,6 +13,6 @@ export interface TextListItemProps extends HTMLProps<HTMLDivElement> {
   className?: string;
 }
 
-declare const TextListItem: SFC<TextListItemProps>;
+declare const TextListItem: FunctionComponent<TextListItemProps>;
 
 export default TextListItem;

--- a/packages/patternfly-4/react-core/src/components/TextArea/TextArea.d.ts
+++ b/packages/patternfly-4/react-core/src/components/TextArea/TextArea.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, FormEvent } from 'react';
+import { FormEvent, FunctionComponent, HTMLProps } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface TextAreaProps extends Omit<HTMLProps<HTMLInputElement>, 'onChange'> {
@@ -7,6 +7,6 @@ export interface TextAreaProps extends Omit<HTMLProps<HTMLInputElement>, 'onChan
   onChange?(value: string, event: FormEvent<HTMLInputElement>): void;
 }
 
-declare const TextArea: SFC<TextAreaProps>;
+declare const TextArea: FunctionComponent<TextAreaProps>;
 
 export default TextArea;

--- a/packages/patternfly-4/react-core/src/components/TextInput/TextInput.d.ts
+++ b/packages/patternfly-4/react-core/src/components/TextInput/TextInput.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, FormEvent } from 'react';
+import { FormEvent, FunctionComponent, HTMLProps } from 'react';
 import { Omit } from '../../typeUtils';
 
 export interface TextInputProps extends Omit<HTMLProps<HTMLInputElement>, 'onChange' | 'disabled'> {
@@ -9,6 +9,6 @@ export interface TextInputProps extends Omit<HTMLProps<HTMLInputElement>, 'onCha
   isReadOnly?: boolean;
 }
 
-declare const TextInput: SFC<TextInputProps>;
+declare const TextInput: FunctionComponent<TextInputProps>;
 
 export default TextInput;

--- a/packages/patternfly-4/react-core/src/components/Title/Title.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Title/Title.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { Omit, OneOf } from '../../typeUtils';
 import { BaseSizes } from '../../styles/sizes';
 
@@ -13,6 +13,6 @@ export interface TitleProps
   children?: ReactNode;
 }
 
-declare const Title: SFC<TitleProps>;
+declare const Title: FunctionComponent<TitleProps>;
 
 export default Title;

--- a/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.d.ts
@@ -1,6 +1,6 @@
-import { SFC, HTMLProps, ReactNode, ReactElement } from 'react';
+import { FunctionComponent, HTMLProps, ReactElement, ReactNode } from 'react';
 import { Omit } from '../../typeUtils';
-import { Instance, BasicPlacement } from 'tippy.js';
+import { BasicPlacement } from 'tippy.js';
 
 export const TooltipPosition: {
   top: 'top';
@@ -28,6 +28,6 @@ export interface TooltipProps extends Omit<HTMLProps<HTMLDivElement>, 'content' 
   size: 'small' | 'regular' | 'large';
 }
 
-declare const Tooltip: SFC<TooltipProps>;
+declare const Tooltip: FunctionComponent<TooltipProps>;
 
 export default Tooltip;

--- a/packages/patternfly-4/react-core/src/layouts/Bullseye/Bullseye.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Bullseye/Bullseye.d.ts
@@ -1,9 +1,9 @@
-import { HTMLProps, SFC, ReactType } from 'react';
+import { FunctionComponent, HTMLProps, ReactType } from 'react';
 
 export interface BullseyeProps extends HTMLProps<HTMLDivElement> {
   component?: ReactType<BullseyeProps>;
 }
 
-declare const Bullseye: SFC<BullseyeProps>;
+declare const Bullseye: FunctionComponent<BullseyeProps>;
 
 export default Bullseye;

--- a/packages/patternfly-4/react-core/src/layouts/Gallery/Gallery.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Gallery/Gallery.d.ts
@@ -1,4 +1,4 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 import { OneOf } from '../../typeUtils';
 import { GutterSize } from '../../styles/gutters';
 
@@ -6,6 +6,6 @@ export interface GalleryProps extends HTMLProps<HTMLDivElement> {
   gutter: OneOf<typeof GutterSize, keyof typeof GutterSize>;
 }
 
-declare const Gallery: SFC<GalleryProps>;
+declare const Gallery: FunctionComponent<GalleryProps>;
 
 export default Gallery;

--- a/packages/patternfly-4/react-core/src/layouts/Gallery/GalleryItem.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Gallery/GalleryItem.d.ts
@@ -1,7 +1,7 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface GalleryItemProps extends HTMLProps<HTMLDivElement> {}
 
-declare const GalleryItem: SFC<GalleryItemProps>;
+declare const GalleryItem: FunctionComponent<GalleryItemProps>;
 
 export default GalleryItem;

--- a/packages/patternfly-4/react-core/src/layouts/Grid/GridItem.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Grid/GridItem.d.ts
@@ -1,4 +1,4 @@
-import { HTMLProps, SFC } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 type GridItemSpanValue = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
@@ -20,6 +20,6 @@ export interface GridItemProps extends HTMLProps<HTMLDivElement> {
   xlOffset?: GridItemSpanValue;
 }
 
-declare const GridItem: SFC<GridItemProps>;
+declare const GridItem: FunctionComponent<GridItemProps>;
 
 export default GridItem;

--- a/packages/patternfly-4/react-core/src/layouts/Level/Level.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Level/Level.d.ts
@@ -1,11 +1,11 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
-import { Omit, OneOf } from '../../typeUtils';
+import { FunctionComponent, HTMLProps } from 'react';
+import { OneOf } from '../../typeUtils';
 import { GutterSize } from '../../styles/gutters';
 
 export interface LevelProps extends HTMLProps<HTMLDivElement> {
   gutter: OneOf<typeof GutterSize, keyof typeof GutterSize>;
 }
 
-declare const Level: SFC<LevelProps>;
+declare const Level: FunctionComponent<LevelProps>;
 
 export default Level;

--- a/packages/patternfly-4/react-core/src/layouts/Level/LevelItem.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Level/LevelItem.d.ts
@@ -1,9 +1,8 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
-import { Omit, OneOf } from '../../typeUtils';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface LevelItemProps extends HTMLProps<HTMLDivElement> {
 }
 
-declare const LevelItem: SFC<LevelItemProps>;
+declare const LevelItem: FunctionComponent<LevelItemProps>;
 
 export default LevelItem;

--- a/packages/patternfly-4/react-core/src/layouts/Split/Split.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Split/Split.d.ts
@@ -1,12 +1,12 @@
-import { SFC, HTMLProps, ReactType } from 'react';
+import { FunctionComponent, HTMLProps, ReactType } from 'react';
 import { OneOf } from '../../typeUtils';
-import { GutterSize, getGutterModifier } from '../../styles/gutters';
+import { GutterSize } from '../../styles/gutters';
 
 export interface SplitProps extends HTMLProps<HTMLDivElement> {
   component?: ReactType<SplitProps>;
   gutter?: OneOf<typeof GutterSize, keyof typeof GutterSize>;
 }
 
-declare const Split: SFC<SplitProps>;
+declare const Split: FunctionComponent<SplitProps>;
 
 export default Split;

--- a/packages/patternfly-4/react-core/src/layouts/Split/SplitItem.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Split/SplitItem.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface SplitItemProps extends HTMLProps<HTMLDivElement> {
   isMain: boolean;
 }
 
-declare const SplitItem: SFC<SplitItemProps>;
+declare const SplitItem: FunctionComponent<SplitItemProps>;
 
 export default SplitItem;

--- a/packages/patternfly-4/react-core/src/layouts/Stack/Stack.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Stack/Stack.d.ts
@@ -1,12 +1,12 @@
-import { SFC, HTMLProps, ReactType } from 'react';
+import { FunctionComponent, HTMLProps, ReactType } from 'react';
 import { OneOf } from '../../typeUtils';
-import { GutterSize, getGutterModifier } from '../../styles/gutters';
+import { GutterSize } from '../../styles/gutters';
 
 export interface StackProps extends HTMLProps<HTMLDivElement> {
   component?: ReactType<StackProps>;
   gutter?: OneOf<typeof GutterSize, keyof typeof GutterSize>;
 }
 
-declare const Stack: SFC<StackProps>;
+declare const Stack: FunctionComponent<StackProps>;
 
 export default Stack;

--- a/packages/patternfly-4/react-core/src/layouts/Stack/StackItem.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Stack/StackItem.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface StackItemProps extends HTMLProps<HTMLDivElement> {
   isMain: boolean;
 }
 
-declare const StackItem: SFC<StackItemProps>;
+declare const StackItem: FunctionComponent<StackItemProps>;
 
 export default StackItem;

--- a/packages/patternfly-4/react-core/src/layouts/Toolbar/Toolbar.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Toolbar/Toolbar.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface ToolbarProps extends HTMLProps<HTMLDivElement> {
   children?: React.ReactNode
 }
 
-declare const Toolbar: SFC<ToolbarProps>;
+declare const Toolbar: FunctionComponent<ToolbarProps>;
 
 export default Toolbar;

--- a/packages/patternfly-4/react-core/src/layouts/Toolbar/ToolbarGroup.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Toolbar/ToolbarGroup.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface ToolbarGroupProps extends HTMLProps<HTMLDivElement> {
   children?: React.ReactNode
 }
 
-declare const ToolbarGroup: SFC<ToolbarGroupProps>;
+declare const ToolbarGroup: FunctionComponent<ToolbarGroupProps>;
 
 export default ToolbarGroup;

--- a/packages/patternfly-4/react-core/src/layouts/Toolbar/ToolbarItem.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Toolbar/ToolbarItem.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface ToolbarItemProps extends HTMLProps<HTMLDivElement> {
   children?: React.ReactNode
 }
 
-declare const ToolbarItem: SFC<ToolbarItemProps>;
+declare const ToolbarItem: FunctionComponent<ToolbarItemProps>;
 
 export default ToolbarItem;

--- a/packages/patternfly-4/react-core/src/layouts/Toolbar/ToolbarSection.d.ts
+++ b/packages/patternfly-4/react-core/src/layouts/Toolbar/ToolbarSection.d.ts
@@ -1,9 +1,9 @@
-import { SFC, HTMLProps, ReactNode } from 'react';
+import { FunctionComponent, HTMLProps } from 'react';
 
 export interface ToolbarSectionProps extends HTMLProps<HTMLDivElement> {
   children?: React.ReactNode
 }
 
-declare const ToolbarSection: SFC<ToolbarSectionProps>;
+declare const ToolbarSection: FunctionComponent<ToolbarSectionProps>;
 
 export default ToolbarSection;


### PR DESCRIPTION
The first piece of fixing [issue #1149](https://github.com/patternfly/patternfly-react/issues/1149)

tested using demo-app-ts in react-integration
