### PR TITLE
fix(build): Support building Gatsby app under Windows

### DIFF
--- a/packages/patternfly-4/react-docs/gatsby-node.js
+++ b/packages/patternfly-4/react-docs/gatsby-node.js
@@ -2,6 +2,9 @@ const path = require(`path`);
 const fs = require('fs-extra'); //eslint-disable-line
 const packageDirs = ['react-core', 'react-charts', 'react-styled-system', 'react-table'];
 
+// Escape single quotes and backslashes in a file path
+const escapeFilePath = path => path.replace(/[\\']/g, '\\$&');
+
 exports.onCreateWebpackConfig = ({ stage, loaders, actions, plugins, getConfig }) => {
   // Enable hot reloading on source code changes
   const pfStylesTest = /patternfly-next.*(components|layouts|utilities).*\.css$/;
@@ -116,13 +119,20 @@ exports.createPages = async ({ graphql, actions }) => {
 
     const rawExamples = [];
     const packageDir = packageDirs.find(pkg => doc.absolutePath.indexOf(pkg) !== -1);
+
+    // In Windows environments, paths use backslashes to separate directories;
+    // Ensure that forward slashes are used to make it comparable
+    const docIdentifier = doc.relativeDirectory.replace(/\\/g, '/');
+
     examples.edges.forEach(({ node: example }) => {
-      if (
-        example.relativeDirectory
-          .split('/')
-          .slice(0, 2)
-          .join('/') === doc.relativeDirectory
-      ) {
+      // Replace backslashes with forward slashes as for `docIdentifier` above,
+      // and remove `/example` postfix
+      const exampleIdentifier = example.relativeDirectory
+        .split(/[/\\]/)
+        .slice(0, 2)
+        .join('/');
+
+      if (exampleIdentifier === docIdentifier) {
         const examplePath = `../../${packageDir}/src/${example.relativePath}`;
         rawExamples.push(
           `{name: '${example.name}', path: '${examplePath}', file: require('!!raw-loader!${examplePath}')}`
@@ -159,7 +169,7 @@ exports.createPages = async ({ graphql, actions }) => {
     const content = `
     import React from 'react';
     import docs from '${doc.absolutePath}';
-    import ComponentDocs from '${docsComponentPath}';
+    import ComponentDocs from '${escapeFilePath(docsComponentPath)}';
     
     const rawExamples = [${rawExamples}];
     const images = [${allImages}];

--- a/packages/patternfly-4/react-docs/gatsby-node.js
+++ b/packages/patternfly-4/react-docs/gatsby-node.js
@@ -3,7 +3,7 @@ const fs = require('fs-extra'); //eslint-disable-line
 const packageDirs = ['react-core', 'react-charts', 'react-styled-system', 'react-table'];
 
 // Escape single quotes and backslashes in a file path
-const escapeFilePath = path => path.replace(/[\\']/g, '\\$&');
+const escapeFilePath = filePath => filePath.replace(/[\\']/g, '\\$&');
 
 exports.onCreateWebpackConfig = ({ stage, loaders, actions, plugins, getConfig }) => {
   // Enable hot reloading on source code changes

--- a/packages/react-icons/build/generatorConfig.js
+++ b/packages/react-icons/build/generatorConfig.js
@@ -4,6 +4,8 @@ const templatesDir = path.resolve(__dirname, './templates');
 const srcDir = path.resolve(__dirname, '../src');
 const iconsDir = path.join(srcDir, './icons');
 
+const escapeFilePath = filePath => filePath.replace(/\\/g, '\\$&');
+
 module.exports = plop => {
   plop.setGenerator('icons', {
     prompts: [],
@@ -14,7 +16,7 @@ module.exports = plop => {
           type: 'add',
           force: true,
           data: icon,
-          path: path.join(iconsDir, './{{id}}.js'),
+          path: escapeFilePath(path.join(iconsDir, './{{id}}.js')),
           templateFile: path.join(templatesDir, 'iconFile.hbs')
         });
 
@@ -22,7 +24,7 @@ module.exports = plop => {
           type: 'add',
           force: true,
           data: icon,
-          path: path.join(iconsDir, './{{id}}.d.ts'),
+          path: escapeFilePath(path.join(iconsDir, './{{id}}.d.ts')),
           templateFile: path.join(templatesDir, 'iconFileTS.hbs')
         });
       });
@@ -30,14 +32,14 @@ module.exports = plop => {
       actions.push({
         type: 'add',
         force: true,
-        path: path.join(srcDir, './index.js'),
+        path: escapeFilePath(path.join(srcDir, './index.js')),
         templateFile: path.join(templatesDir, 'mainBarrelFile.hbs')
       });
 
       actions.push({
         type: 'add',
         force: true,
-        path: path.join(srcDir, './index.d.ts'),
+        path: escapeFilePath(path.join(srcDir, './index.d.ts')),
         templateFile: path.join(templatesDir, 'mainBarrelFileTS.hbs')
       });
 


### PR DESCRIPTION
**What**:
Fixes #1246.

Windows uses backslashes instead of the Unix style forward slashes to separate file path segments.
This caused problems with the Gatsby build of the PF4 react-docs package.

These changes should resolve this by taking both types of slashes into account in the build scripts.
<!-- Are there any upstream issues or separate issues you need to reference? -->
