### PR TITLE
fix(build): Support running npm scripts under Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react": "^16.3.0",
     "react-dev-utils": "^5.0.0",
     "react-dom": "^16.3.0",
+    "shx": "^0.3.2",
     "travis-deploy-once": "^4.4.1",
     "ts-jest": "^23.10.5"
   },
@@ -73,7 +74,7 @@
     "build:typecheck": "lerna run build:typecheck --scope=@patternfly/react-core --stream",
     "build:prdocs": "lerna run pr-build --scope=@patternfly/react-docs --stream",
     "clean": "yarn clean:build",
-    "clean:build": "rm -rf packages/*/dist && rm -rf packages/patternfly-?/*/dist",
+    "clean:build": "shx rm -rf packages/*/dist && shx rm -rf packages/patternfly-?/*/dist",
     "commit": "git-cz",
     "commitmsg": "commitlint -e",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "clean:build": "shx rm -rf packages/*/dist && shx rm -rf packages/patternfly-?/*/dist",
     "commit": "git-cz",
     "commitmsg": "commitlint -e",
-    "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "coveralls": "shx cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "generate": "yarn plop",
     "lerna": "lerna",
     "lerna:publish": "lerna publish --yes",

--- a/packages/patternfly-3/patternfly-react-extensions/package.json
+++ b/packages/patternfly-3/patternfly-react-extensions/package.json
@@ -34,8 +34,8 @@
     "build:babel": "concurrently \"yarn build:babel:cjs\" \"yarn build:babel:esm\"",
     "build:babel:cjs": "cross-env BABEL_ENV=production:cjs babel src --out-dir dist/js",
     "build:babel:esm": "cross-env BABEL_ENV=production:esm babel src --out-dir dist/esm",
-    "build:less": "mkdir -p dist/less && cp -r less/* dist/less",
-    "build:sass": "mkdir -p dist/sass && cp -r sass/patternfly-react-extensions/* dist/sass && node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react-extensions.scss"
+    "build:less": "shx mkdir -p dist/less && shx cp -r less/* dist/less",
+    "build:sass": "shx mkdir -p dist/sass && shx cp -r sass/patternfly-react-extensions/* dist/sass && cross-var node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react-extensions.scss"
   },
   "dependencies": {
     "breakjs": "^1.0.0",
@@ -52,5 +52,8 @@
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2"
+  },
+  "devDependencies": {
+    "cross-var": "^1.1.0"
   }
 }

--- a/packages/patternfly-3/patternfly-react/package.json
+++ b/packages/patternfly-3/patternfly-react/package.json
@@ -62,10 +62,12 @@
     "build:babel": "concurrently \"yarn build:babel:cjs\" \"yarn build:babel:esm\"",
     "build:babel:cjs": "cross-env BABEL_ENV=production:cjs babel src --out-dir dist/js",
     "build:babel:esm": "cross-env BABEL_ENV=production:esm babel src --out-dir dist/esm",
-    "build:less": "mkdir -p dist/less && cp -r less/* dist/less",
-    "build:sass": "mkdir -p dist/sass && cp -r sass/patternfly-react/* dist/sass && node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react.scss"
+    "build:less": "shx mkdir -p dist/less && shx cp -r less/* dist/less",
+    "build:sass": "shx mkdir -p dist/sass && shx cp -r sass/patternfly-react/* dist/sass && cross-var node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react.scss"
   },
   "devDependencies": {
-    "react-axe": "^3.0.2"
+    "cross-var": "^1.1.0",
+    "react-axe": "^3.0.2",
+    "shx": "^0.3.2"
   }
 }

--- a/packages/patternfly-3/react-console/package.json
+++ b/packages/patternfly-3/react-console/package.json
@@ -34,8 +34,8 @@
     "build:babel": "concurrently \"yarn build:babel:cjs\" \"yarn build:babel:esm\"",
     "build:babel:cjs": "cross-env BABEL_ENV=production:cjs babel src --out-dir dist/js",
     "build:babel:esm": "cross-env BABEL_ENV=production:esm babel src --out-dir dist/esm",
-    "build:less": "mkdir -p dist/less && cp -r less/* dist/less",
-    "build:sass": "mkdir -p dist/sass && cp -r sass/* dist/sass && node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/console.scss"
+    "build:less": "shx mkdir -p dist/less && shx cp -r less/* dist/less",
+    "build:sass": "shx mkdir -p dist/sass && shx cp -r sass/* dist/sass && cross-var node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/console.scss"
   },
   "dependencies": {
     "@novnc/novnc": "^1.0.0",
@@ -45,6 +45,7 @@
     "xterm": "^3.3.0"
   },
   "devDependencies": {
+    "cross-var": "^1.1.0",
     "patternfly": "^3.58.0",
     "patternfly-react": "^2.29.8"
   },

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "scripts": {
     "prebuild": "node ./build/generateIcons.js",
-    "build": "yarn build:babel; yarn build:ts",
+    "build": "yarn build:babel && yarn build:ts",
     "build:babel": "concurrently \"yarn build:babel:cjs\" \"yarn build:babel:esm\"",
     "build:babel:cjs": "cross-env BABEL_ENV=production:cjs babel src --out-dir dist/js",
     "build:babel:esm": "cross-env BABEL_ENV=production:esm babel src --out-dir dist/esm",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6690,7 +6690,7 @@ cross-spawn@^3.0.0:
 
 cross-var@^1.1.0:
   version "1.1.0"
-  resolved "http://ny-s-nexus:8081/nexus/content/groups/npm-all/cross-var/-/cross-var-1.1.0.tgz#f0f0d4bb235d95138d1a539842d290f00db71cd6"
+  resolved "https://registry.yarnpkg.com/cross-var/-/cross-var-1.1.0.tgz#f0f0d4bb235d95138d1a539842d290f00db71cd6"
   integrity sha1-8PDUuyNdlRONGlOYQtKQ8A23HNY=
   dependencies:
     babel-preset-es2015 "^6.18.0"
@@ -7012,7 +7012,7 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
-cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@^0.3.4:
+cssom@0.3.4, cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
 
@@ -8061,7 +8061,7 @@ es6-map@^0.1.3:
 
 es6-object-assign@^1.0.3:
   version "1.1.0"
-  resolved "http://ny-s-nexus:8081/nexus/content/groups/npm-all/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
 es6-promise@^4.0.3:
@@ -18294,7 +18294,7 @@ shellwords@^0.1.1:
 
 shx@^0.3.2:
   version "0.3.2"
-  resolved "http://ny-s-nexus:8081/nexus/content/groups/npm-all/shx/-/shx-0.3.2.tgz#40501ce14eb5e0cbcac7ddbd4b325563aad8c123"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.2.tgz#40501ce14eb5e0cbcac7ddbd4b325563aad8c123"
   integrity sha512-aS0mWtW3T2sHAenrSrip2XGv39O9dXIFUqxAEWHEOS1ePtGIBavdPJY1kE2IHl14V/4iCbUiNDPGdyYTtmhSoA==
   dependencies:
     es6-object-assign "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4379,7 +4379,7 @@ babel-preset-env@^1.6.1:
     invariant "^2.2.2"
     semver "^5.3.0"
 
-babel-preset-es2015@^6.9.0:
+babel-preset-es2015@^6.18.0, babel-preset-es2015@^6.9.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:
@@ -4528,7 +4528,7 @@ babel-preset-react@^6.24.1:
     babel-plugin-transform-react-jsx-source "^6.22.0"
     babel-preset-flow "^6.23.0"
 
-babel-preset-stage-0@^6.24.1:
+babel-preset-stage-0@^6.16.0, babel-preset-stage-0@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz#5642d15042f91384d7e5af8bc88b1db95b039e6a"
   dependencies:
@@ -4563,7 +4563,7 @@ babel-preset-stage-3@^6.24.1:
     babel-plugin-transform-exponentiation-operator "^6.24.1"
     babel-plugin-transform-object-rest-spread "^6.22.0"
 
-babel-register@^6.26.0, babel-register@^6.9.0:
+babel-register@^6.18.0, babel-register@^6.26.0, babel-register@^6.9.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
   dependencies:
@@ -6688,6 +6688,17 @@ cross-spawn@^3.0.0:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
+cross-var@^1.1.0:
+  version "1.1.0"
+  resolved "http://ny-s-nexus:8081/nexus/content/groups/npm-all/cross-var/-/cross-var-1.1.0.tgz#f0f0d4bb235d95138d1a539842d290f00db71cd6"
+  integrity sha1-8PDUuyNdlRONGlOYQtKQ8A23HNY=
+  dependencies:
+    babel-preset-es2015 "^6.18.0"
+    babel-preset-stage-0 "^6.16.0"
+    babel-register "^6.18.0"
+    cross-spawn "^5.0.1"
+    exit "^0.1.2"
+
 crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
@@ -7001,7 +7012,7 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
-cssom@0.3.4, cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@^0.3.4:
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0", cssom@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
 
@@ -8047,6 +8058,11 @@ es6-map@^0.1.3:
     es6-set "~0.1.5"
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
+
+es6-object-assign@^1.0.3:
+  version "1.1.0"
+  resolved "http://ny-s-nexus:8081/nexus/content/groups/npm-all/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
 es6-promise@^4.0.3:
   version "4.2.4"
@@ -18275,6 +18291,15 @@ shelljs@^0.8.1:
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+
+shx@^0.3.2:
+  version "0.3.2"
+  resolved "http://ny-s-nexus:8081/nexus/content/groups/npm-all/shx/-/shx-0.3.2.tgz#40501ce14eb5e0cbcac7ddbd4b325563aad8c123"
+  integrity sha512-aS0mWtW3T2sHAenrSrip2XGv39O9dXIFUqxAEWHEOS1ePtGIBavdPJY1kE2IHl14V/4iCbUiNDPGdyYTtmhSoA==
+  dependencies:
+    es6-object-assign "^1.0.3"
+    minimist "^1.2.0"
+    shelljs "^0.8.1"
 
 sift@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
### What:
With the current setup, Patternfly's npm scripts cannot be executed in a Windows environment.

The changes proposed by this PR should make all npm scripts platform independent and runnable on both Windows and Linux/OS X environments.

### How:
- **Use  `shx` to make Unix specific commands platform independent**: Commands like `rm`, `cp` etc. that are used in PF's npm scripts are not supported by Windows command lines. The [`shx` command line tool](https://www.npmjs.com/package/shx) provides a layer of abstraction that makes basic unix commands work cross-platform with the established Unix syntax.
- **Use `cross-var` to make Unix specific command line variable syntax platform independent**: The PF3 packages use Unix style variables `$variableName` to refer to environment variables in their npm scripts to build SASS style sheets. Under Windows, a different syntax must be used to make those variables work. The [`cross-var` command line tool](https://www.npmjs.com/package/cross-var) provides a layer of abstraction that makes Unix style variables work cross-platform.

### Open Points/Concerns:
- ~**The `coveralls` script in the root package.json**: It uses a pipe operator, which isn't supported on Windows as-is.~ _PowerShell supports Unix style pipe operations ` | `, only cmd does not. Go Powershell!_ 💪 
- ~**Performance**: The additional layer of abstraction for some scripts might cause some additional runtime overhead during the build process. Compare avg. Jenkins build runtimes before and after the change to get an idea of the impact?~ _Comparing the [Travis build time including the changes](https://travis-ci.org/patternfly/patternfly-react/builds/484459161) with similar recent PR builds ([one](https://travis-ci.org/patternfly/patternfly-react/builds/484375459), and [another one](https://travis-ci.org/patternfly/patternfly-react/builds/483547928)) shows no significant preformance degradations. All are around the 25 to 30 minute mark._
- ~**Executing Test suite under Windows environment**: While the build works fine, running the Jest test suite under Windows currently produces a whole bunch of errors that do not show up on the Travis build. Investigating and resolving this should probably be done in a separate PR.~ _Resolved with #1255._
- **Test changes under Unix environment**: I currently only have access to a Windows environment. While it _should_ work just fine under a Unix one, this needs to be verifed.