### PR TITLE
fix: Add consistent aria labels for <nav> elements

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Breadcrumb/Breadcrumb.js
+++ b/packages/patternfly-4/react-core/src/components/Breadcrumb/Breadcrumb.js
@@ -17,7 +17,7 @@ const propTypes = {
 const defaultProps = {
   children: null,
   className: '',
-  'aria-label': 'breadcrumb'
+  'aria-label': 'Breadcrumb'
 };
 
 const Breadcrumb = ({ className, children, ...props }) => (

--- a/packages/patternfly-4/react-core/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.js.snap
@@ -31,7 +31,7 @@ exports[`Breadcrumb component should render breadcrumb with children 1`] = `
 }
 
 <nav
-  aria-label="breadcrumb"
+  aria-label="Breadcrumb"
   className="pf-c-breadcrumb"
 >
   <ol
@@ -71,7 +71,7 @@ exports[`Breadcrumb component should render breadcrumb with className 1`] = `
 }
 
 <nav
-  aria-label="breadcrumb"
+  aria-label="Breadcrumb"
   className="pf-c-breadcrumb className"
 >
   <ol
@@ -91,7 +91,7 @@ exports[`Breadcrumb component should render default breadcrumb 1`] = `
 }
 
 <nav
-  aria-label="breadcrumb"
+  aria-label="Breadcrumb"
   className="pf-c-breadcrumb"
 >
   <ol

--- a/packages/patternfly-4/react-core/src/components/Nav/Nav.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Nav/Nav.d.ts
@@ -6,7 +6,7 @@ export interface NavProps extends Omit<HTMLProps<HTMLDivElement>, 'onSelect'> {
   className?: string;
   onSelect?(groupId: number, itemId: number, event: FormEvent<HTMLInputElement>): void;
   onToggle?(groupId: number, expanded: boolean, event: FormEvent<HTMLInputElement>): void;
-  'aria-label': string;
+  'aria-label'?: string;
 }
 
 declare const Nav: FunctionComponent<NavProps>;

--- a/packages/patternfly-4/react-core/src/components/Nav/Nav.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/Nav.js
@@ -49,12 +49,6 @@ class Nav extends React.Component {
     });
   }
 
-  // Determine if it's a tertiary nav or not (tertiary needs a different aria-label)
-  determineLabel() {
-    const isTertiary = React.Children.map(this.props.children, child => child.props.variant === 'tertiary');
-    return isTertiary[0] ? 'Local' : 'Global';
-  }
-
   render() {
     const { 'aria-label': ariaLabel, children, className, ...props } = this.props;
 
@@ -68,7 +62,7 @@ class Nav extends React.Component {
       >
         <nav className={css(styles.nav, className)}
              {...props}
-             aria-label={ariaLabel ? ariaLabel : this.determineLabel()}>
+             aria-label={ariaLabel ? ariaLabel : typeof this.props.children.props !== 'undefined' && this.props.children.props.variant === 'tertiary' ? 'Local' : 'Global'}>
           {children}
         </nav>
       </NavContext.Provider>

--- a/packages/patternfly-4/react-core/src/components/Nav/Nav.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/Nav.js
@@ -19,6 +19,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  'aria-label': '',
   children: null,
   className: '',
   onSelect: () => undefined,
@@ -61,8 +62,8 @@ class Nav extends React.Component {
         }}
       >
         <nav className={css(styles.nav, className)}
-             {...props}
-             aria-label={ariaLabel ? ariaLabel : typeof this.props.children.props !== 'undefined' && this.props.children.props.variant === 'tertiary' ? 'Local' : 'Global'}>
+             aria-label={ariaLabel === '' ? typeof this.props.children.props !== 'undefined' && this.props.children.props.variant === 'tertiary' ? 'Local' : 'Global' : ariaLabel}
+             {...props}>
           {children}
         </nav>
       </NavContext.Provider>

--- a/packages/patternfly-4/react-core/src/components/Nav/Nav.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/Nav.js
@@ -13,7 +13,7 @@ const propTypes = {
   /** Callback for when a list is expanded or collapsed */
   onToggle: PropTypes.func,
   /** Accessibility label */
-  'aria-label': PropTypes.string.isRequired,
+  'aria-label': PropTypes.string,
   /** Additional props are spread to the container <nav> */
   '': PropTypes.any
 };
@@ -49,8 +49,14 @@ class Nav extends React.Component {
     });
   }
 
+  // Determine if it's a tertiary nav or not (tertiary needs a different aria-label)
+  determineLabel() {
+    const isTertiary = React.Children.map(this.props.children, child => child.props.variant === 'tertiary');
+    return isTertiary[0] ? 'Local' : 'Global';
+  }
+
   render() {
-    const { children, className, ...props } = this.props;
+    const { 'aria-label': ariaLabel, children, className, ...props } = this.props;
 
     return (
       <NavContext.Provider
@@ -60,7 +66,9 @@ class Nav extends React.Component {
           onToggle: (event, groupId, expanded) => this.onToggle(event, groupId, expanded)
         }}
       >
-        <nav className={css(styles.nav, className)} {...props}>
+        <nav className={css(styles.nav, className)}
+             {...props}
+             aria-label={ariaLabel ? ariaLabel : this.determineLabel()}>
           {children}
         </nav>
       </NavContext.Provider>

--- a/packages/patternfly-4/react-core/src/components/Nav/Nav.test.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/Nav.test.js
@@ -26,7 +26,7 @@ const context = {
 
 test('Default Nav List', () => {
   const view = mount(
-    <Nav aria-label="Test">
+    <Nav>
       <NavList>
         {props.items.map(item => (
           <NavItem to={item.to} key={item.to}>
@@ -43,7 +43,7 @@ test('Default Nav List', () => {
 test('Default Nav List - Trigger item active update', () => {
   window.location.hash = '#link2';
   const view = mount(
-    <Nav aria-label="Test">
+    <Nav>
       <NavList>
         {props.items.map(item => (
           <NavItem to={item.to} key={item.to}>
@@ -63,7 +63,7 @@ test('Default Nav List - Trigger item active update', () => {
 
 test('Simple Nav List', () => {
   const view = mount(
-    <Nav aria-label="Test">
+    <Nav>
       <NavList variant="simple">
         {props.items.map(item => (
           <NavItem to={item.to} key={item.to}>
@@ -79,7 +79,7 @@ test('Simple Nav List', () => {
 
 test('Expandable Nav List', () => {
   const view = mount(
-    <Nav aria-label="Test">
+    <Nav>
       <NavList>
         <NavExpandable id="grp-1" title="Section 1">
           {props.items.map(item => (
@@ -98,7 +98,7 @@ test('Expandable Nav List', () => {
 test('Expandable Nav List - Trigger toggle', () => {
   window.location.hash = '#link2';
   const view = mount(
-    <Nav aria-label="Test">
+    <Nav>
       <NavList>
         <NavExpandable id="grp-1" title="Section 1" className="expandable-group" isExpanded>
           {props.items.map(item => (
@@ -138,7 +138,7 @@ test('Expandable Nav List with aria label', () => {
 
 test('Nav Grouped List', () => {
   const view = mount(
-    <Nav aria-label="Test">
+    <Nav>
       <NavGroup id="grp-1" title="Section 1">
         <NavList>
           {props.items.map(item => (
@@ -165,7 +165,7 @@ test('Nav Grouped List', () => {
 
 test('Horizontal Nav List', () => {
   const view = mount(
-    <Nav aria-label="Test">
+    <Nav>
       <NavList variant="horizontal">
         {props.items.map(item => (
           <NavItem to={item.to} key={item.to}>
@@ -181,7 +181,7 @@ test('Horizontal Nav List', () => {
 
 test('Tertiary Nav List', () => {
   const view = mount(
-    <Nav aria-label="Test">
+    <Nav>
       <NavList variant="tertiary">
         {props.items.map(item => (
           <NavItem to={item.to} key={item.to}>
@@ -198,7 +198,7 @@ test('Tertiary Nav List', () => {
 test('Nav List with custom item nodes', () => {
   const CustomNode = () => <div>My custom node</div>;
   const view = mount(
-    <Nav aria-label="Test">
+    <Nav>
       <NavList variant="tertiary">
         <NavItem to="/components/nav#link1">
           <CustomNode />

--- a/packages/patternfly-4/react-core/src/components/Nav/__snapshots__/Nav.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Nav/__snapshots__/Nav.test.js.snap
@@ -34,6 +34,7 @@ exports[`Default Nav List - Trigger item active update 1`] = `
 }
 
 <Nav
+  aria-label=""
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
@@ -187,6 +188,7 @@ exports[`Default Nav List 1`] = `
 }
 
 <Nav
+  aria-label=""
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
@@ -366,6 +368,7 @@ exports[`Expandable Nav List - Trigger toggle 1`] = `
 }
 
 <Nav
+  aria-label=""
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
@@ -617,6 +620,7 @@ exports[`Expandable Nav List 1`] = `
 }
 
 <Nav
+  aria-label=""
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
@@ -1108,6 +1112,7 @@ exports[`Horizontal Nav List 1`] = `
 }
 
 <Nav
+  aria-label=""
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
@@ -1314,6 +1319,7 @@ exports[`Nav Grouped List 1`] = `
 }
 
 <Nav
+  aria-label=""
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
@@ -1596,6 +1602,7 @@ exports[`Nav List with custom item nodes 1`] = `
 }
 
 <Nav
+  aria-label=""
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
@@ -1677,6 +1684,7 @@ exports[`Simple Nav List 1`] = `
 }
 
 <Nav
+  aria-label=""
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
@@ -1830,6 +1838,7 @@ exports[`Tertiary Nav List 1`] = `
 }
 
 <Nav
+  aria-label=""
   className=""
   onSelect={[Function]}
   onToggle={[Function]}

--- a/packages/patternfly-4/react-core/src/components/Nav/__snapshots__/Nav.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Nav/__snapshots__/Nav.test.js.snap
@@ -34,13 +34,12 @@ exports[`Default Nav List - Trigger item active update 1`] = `
 }
 
 <Nav
-  aria-label="Test"
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
 >
   <nav
-    aria-label="Test"
+    aria-label="Global"
     className="pf-c-nav"
     onSelect={[Function]}
     onToggle={[Function]}
@@ -188,13 +187,12 @@ exports[`Default Nav List 1`] = `
 }
 
 <Nav
-  aria-label="Test"
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
 >
   <nav
-    aria-label="Test"
+    aria-label="Global"
     className="pf-c-nav"
     onSelect={[Function]}
     onToggle={[Function]}
@@ -368,13 +366,12 @@ exports[`Expandable Nav List - Trigger toggle 1`] = `
 }
 
 <Nav
-  aria-label="Test"
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
 >
   <nav
-    aria-label="Test"
+    aria-label="Global"
     className="pf-c-nav"
     onSelect={[Function]}
     onToggle={[Function]}
@@ -620,13 +617,12 @@ exports[`Expandable Nav List 1`] = `
 }
 
 <Nav
-  aria-label="Test"
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
 >
   <nav
-    aria-label="Test"
+    aria-label="Global"
     className="pf-c-nav"
     onSelect={[Function]}
     onToggle={[Function]}
@@ -1112,13 +1108,12 @@ exports[`Horizontal Nav List 1`] = `
 }
 
 <Nav
-  aria-label="Test"
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
 >
   <nav
-    aria-label="Test"
+    aria-label="Global"
     className="pf-c-nav"
     onSelect={[Function]}
     onToggle={[Function]}
@@ -1319,13 +1314,12 @@ exports[`Nav Grouped List 1`] = `
 }
 
 <Nav
-  aria-label="Test"
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
 >
   <nav
-    aria-label="Test"
+    aria-label="Global"
     className="pf-c-nav"
     onSelect={[Function]}
     onToggle={[Function]}
@@ -1602,13 +1596,12 @@ exports[`Nav List with custom item nodes 1`] = `
 }
 
 <Nav
-  aria-label="Test"
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
 >
   <nav
-    aria-label="Test"
+    aria-label="Local"
     className="pf-c-nav"
     onSelect={[Function]}
     onToggle={[Function]}
@@ -1684,13 +1677,12 @@ exports[`Simple Nav List 1`] = `
 }
 
 <Nav
-  aria-label="Test"
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
 >
   <nav
-    aria-label="Test"
+    aria-label="Global"
     className="pf-c-nav"
     onSelect={[Function]}
     onToggle={[Function]}
@@ -1838,13 +1830,12 @@ exports[`Tertiary Nav List 1`] = `
 }
 
 <Nav
-  aria-label="Test"
   className=""
   onSelect={[Function]}
   onToggle={[Function]}
 >
   <nav
-    aria-label="Test"
+    aria-label="Local"
     className="pf-c-nav"
     onSelect={[Function]}
     onToggle={[Function]}

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavDefaultList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavDefaultList.js
@@ -15,7 +15,7 @@ class NavDefaultList extends React.Component {
   render() {
     const { activeItem } = this.state;
     return (
-      <Nav onSelect={this.onSelect} aria-label="Primary Nav Default Example">
+      <Nav onSelect={this.onSelect}>
         <NavList>
           <NavItem to="#default-link1" itemId={0} isActive={activeItem === 0}>
             Link 1

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavExpandableList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavExpandableList.js
@@ -27,7 +27,7 @@ class NavExpandableList extends React.Component {
   render() {
     const { activeGroup, activeItem } = this.state;
     return (
-      <Nav onSelect={this.onSelect} onToggle={this.onToggle} aria-label="Primary Nav Expandable Example">
+      <Nav onSelect={this.onSelect} onToggle={this.onToggle}>
         <NavList>
           <NavExpandable title="Link 1" groupId="grp-1" isActive={activeGroup === 'grp-1'} isExpanded>
             <NavItem to="#expandable-1" groupId="grp-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavExpandableTitlesList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavExpandableTitlesList.js
@@ -17,7 +17,7 @@ class NavExpandableTitlesList extends React.Component {
   render() {
     const { activeGroup, activeItem } = this.state;
     return (
-      <Nav onSelect={this.onSelect} onToggle={this.onToggle} aria-label="Nav Expandable with screen reader headings">
+      <Nav onSelect={this.onSelect} onToggle={this.onToggle}>
         <NavList>
           <NavExpandable title="Link 1" srText="SR Link" groupId="grp-1" isActive={activeGroup === 'grp-1'} isExpanded>
             <NavItem to="#sr-expandable-1" groupId="grp-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavGroupedList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavGroupedList.js
@@ -15,7 +15,7 @@ class NavGroupedList extends React.Component {
   render() {
     const { activeItem } = this.state;
     return (
-      <Nav onSelect={this.onSelect} aria-label="Primary Nav Grouped Example">
+      <Nav onSelect={this.onSelect}>
         <NavGroup title="Section title 1">
           <NavItem to="#grouped-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
             Link 1

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavHorizontalList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavHorizontalList.js
@@ -16,7 +16,7 @@ class NavHorizontalList extends React.Component {
     const { activeItem } = this.state;
     return (
       <div style={{ backgroundColor: '#292e34', padding: '1rem' }}>
-        <Nav onSelect={this.onSelect} aria-label="Primary Nav Horizontal Example">
+        <Nav onSelect={this.onSelect}>
           <NavList variant={NavVariants.horizontal}>
             <NavItem to="#horizontal-link1" itemId={0} isActive={activeItem === 0}>
               Item 1

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavMixedList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavMixedList.js
@@ -17,7 +17,7 @@ class NavMixedList extends React.Component {
   render() {
     const { activeGroup, activeItem } = this.state;
     return (
-      <Nav onSelect={this.onSelect} aria-label="Primary Nav Mixed Example">
+      <Nav onSelect={this.onSelect}>
         <NavList>
           <NavItem to="#mixed-1" itemId="itm-1" isActive={activeItem === 'itm-1'}>
             Link 1 (not expandable)

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavSimpleList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavSimpleList.js
@@ -15,7 +15,7 @@ class NavSimpleList extends React.Component {
   render() {
     const { activeItem } = this.state;
     return (
-      <Nav onSelect={this.onSelect} id="nav-primary-simple" aria-label="Primary Nav, Simple List Example">
+      <Nav onSelect={this.onSelect} id="nav-primary-simple">
         <NavList variant={NavVariants.simple}>
           <NavItem to="#simple-link1" itemId={0} isActive={activeItem === 0}>
             Link 1

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavTertiaryList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavTertiaryList.js
@@ -15,7 +15,7 @@ class NavTertiaryList extends React.Component {
   render() {
     const { activeItem } = this.state;
     return (
-      <Nav onSelect={this.onSelect} aria-label="Tertiary Example">
+      <Nav onSelect={this.onSelect}>
         <NavList variant={NavVariants.tertiary}>
           <NavItem to="#tertiary-link1" itemId={0} isActive={activeItem === 0}>
             Link 1

--- a/packages/patternfly-4/react-core/src/components/Page/PageHeader.js
+++ b/packages/patternfly-4/react-core/src/components/Page/PageHeader.js
@@ -40,8 +40,7 @@ const defaultProps = {
   showNavToggle: false,
   isNavOpen: true,
   onNavToggle: () => undefined,
-  'aria-label': 'Toggle global navigation',
-  '': ''
+  'aria-label': "Global navigation",
 };
 
 const PageHeader = ({

--- a/packages/patternfly-4/react-core/src/components/Page/__snapshots__/Page.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Page/__snapshots__/Page.test.js.snap
@@ -82,8 +82,7 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
   className="my-page-class"
   header={
     <PageHeader
-      =""
-      aria-label="Toggle global navigation"
+      aria-label="Global navigation"
       avatar=" | Avatar"
       className=""
       isNavOpen={true}
@@ -115,8 +114,7 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
     layout="horizontal"
   >
     <PageHeader
-      =""
-      aria-label="Toggle global navigation"
+      aria-label="Global navigation"
       avatar=" | Avatar"
       className=""
       isNavOpen={true}
@@ -129,7 +127,6 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
       topNav={null}
     >
       <header
-        =""
         className="pf-c-page__header"
         nav="Navigation"
         role="banner"
@@ -292,8 +289,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
   className="my-page-class"
   header={
     <PageHeader
-      =""
-      aria-label="Toggle global navigation"
+      aria-label="Global navigation"
       avatar=" | Avatar"
       className=""
       isNavOpen={true}
@@ -322,8 +318,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
     id="PageId"
   >
     <PageHeader
-      =""
-      aria-label="Toggle global navigation"
+      aria-label="Global navigation"
       avatar=" | Avatar"
       className=""
       isNavOpen={true}
@@ -335,7 +330,6 @@ exports[`Check page vertical layout example against snapshot 1`] = `
       topNav={null}
     >
       <header
-        =""
         className="pf-c-page__header"
         role="banner"
       >

--- a/packages/patternfly-4/react-core/src/components/Page/__snapshots__/PageHeader.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Page/__snapshots__/PageHeader.test.js.snap
@@ -26,8 +26,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
 }
 
 <PageHeader
-  =""
-  aria-label="Toggle global navigation"
+  aria-label="Global navigation"
   avatar=" | Avatar"
   className=""
   isNavOpen={true}
@@ -39,7 +38,6 @@ exports[`Check page vertical layout example against snapshot 1`] = `
   topNav={null}
 >
   <header
-    =""
     className="pf-c-page__header"
     role="banner"
   >


### PR DESCRIPTION
I updated the aria labels for Nav, Breadcrumbs, and PageHeader as requested by @jgiardino. Tabs and Pagination aren't in PF4 yet, so I wasn't able to address those in this PR. (Tabs are being added by Titani in a separate PR.)

I also updated the examples, tests, and snapshots for Nav and Breadcrumbs to reflect the new aria labels.

Fixes #1182.