### PR TITLE
fix(BadgedResource): don't restrict resourceName to a string

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/src/components/BadgedResource/BadgedResource.js
+++ b/packages/patternfly-3/patternfly-react-extensions/src/components/BadgedResource/BadgedResource.js
@@ -99,7 +99,7 @@ BadgedResource.propTypes = {
   /** Full name of the resource kind to display in the badge tooltip and for screen readers (defaulted if valid resourceKind is given) */
   kindStr: PropTypes.string,
   /** Name of the resource */
-  resourceName: PropTypes.string,
+  resourceName: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   /** Flag for large version */
   large: PropTypes.bool,
   /** Delay in ms for the tooltip (-1 to use title rather than a tooltip) */


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: A fix following discussion on #1238 

<!-- Are there any upstream issues or separate issues you need to reference? -->

<!-- feel free to add additional comments -->
