### PR TITLE
fix(Chip): Replace check for length of chip text with refs

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Chip/Chip.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Chip/Chip.d.ts
@@ -3,7 +3,7 @@ import { Omit, OneOf } from '../../typeUtils';
 import { TooltipPosition } from '../Tooltip';
 
 export interface ChipProps extends HTMLProps<HTMLDivElement> {
-  children: string;
+  children?: string;
   closeBtnAriaLabel: string;
   isOverflowChip: boolean;
   tooltipPosition: OneOf<typeof TooltipPosition, keyof typeof TooltipPosition>;

--- a/packages/patternfly-4/react-core/src/components/Chip/Chip.js
+++ b/packages/patternfly-4/react-core/src/components/Chip/Chip.js
@@ -7,6 +7,12 @@ import { TimesCircleIcon } from '@patternfly/react-icons';
 import styles from '@patternfly/patternfly-next/components/Chip/chip.css';
 import GenerateId from '../../internal/GenerateId/GenerateId';
 class Chip extends React.Component {
+  span = React.createRef();
+  state = { isTooltipVisible: false };
+
+  componentDidMount() {
+    this.setState({ isTooltipVisible: this.span.current && this.span.current.offsetWidth < this.span.current.scrollWidth });
+  }
 
   renderOverflowChip = () => {
     const { children, className, onClick } = this.props;
@@ -27,12 +33,11 @@ class Chip extends React.Component {
       className,
       onClick,
     } = this.props;
-    const isTooltipVisible = children.length > 16;
-    if (isTooltipVisible) {
+    if (this.state.isTooltipVisible) {
       return (
         <Tooltip position={tooltipPosition} content={children}>
           <div className={css(styles.chip, className)}>
-            <span className={css(styles.chipText)} id={randomId}>
+            <span ref={this.span} className={css(styles.chipText)} id={randomId}>
               {children}
             </span>
             <ChipButton onClick={onClick} ariaLabel={closeBtnAriaLabel} id={`remove_${randomId}`} aria-labelledby={`remove_${randomId} ${randomId}`}>
@@ -44,7 +49,7 @@ class Chip extends React.Component {
     } else {
       return (
         <div className={css(styles.chip, className)}>
-          <span className={css(styles.chipText)} id={randomId}>
+          <span ref={this.span} className={css(styles.chipText)} id={randomId}>
             {children}
           </span>
           <ChipButton onClick={onClick} ariaLabel={closeBtnAriaLabel} id={`remove_${randomId}`} aria-labelledby={`remove_${randomId} ${randomId}`}>
@@ -74,7 +79,7 @@ class Chip extends React.Component {
 }
 Chip.propTypes = {
   /** Content rendered inside the chip text */
-  children: PropTypes.string.isRequired,
+  children: PropTypes.string,
   /** Aria Label for close button */
   closeBtnAriaLabel: PropTypes.string,
   /** ID of the chip */


### PR DESCRIPTION
Replaced hard-coded check with refs/check for CSS overflow. Also made children optional to allow for empty chips.

Fixes #1197.