### PR TITLE
fix(LoginPage): remove password's caps lock warning

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/LoginPage.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/LoginPage.stories.js
@@ -81,7 +81,6 @@ const createProps = () => {
           minLength: 8,
           errors: card.passwordField.errors,
           warnings: card.passwordField.warnings,
-          warning: card.passwordField.warnings.capsLock,
           showWarning: true
         },
         additionalFields: null,

--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/LoginPage.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/LoginPage.test.js
@@ -4,7 +4,7 @@ import { DropdownButton } from 'react-bootstrap';
 import englishMessages from './mocks/messages.en';
 import frenchMessages from './mocks/messages.fr';
 import { LoginPage, LoginCardWithValidation } from './index';
-import { KEY_CODES, noop } from '../../common/helpers';
+import { noop } from '../../common/helpers';
 
 const { Input, ForgotPassword, SignUp } = LoginPage.Card;
 const { FooterLinks } = LoginPage;
@@ -60,7 +60,6 @@ const createProps = () => {
           errors: card.passwordField.errors,
           minLength: 8,
           warnings: card.passwordField.warnings,
-          warning: card.passwordField.warnings.capsLock,
           showWarning: true
         },
         rememberMe: {
@@ -114,63 +113,6 @@ test('Dropdown updates succesfully', () => {
       .at(0)
       .props().title
   ).toEqual(frenchMessages.card.header.selectedLanguage);
-});
-
-test('Toggle Caps lock warning in password field by the events: focus, blur and mouseEnter', () => {
-  const component = mount(<LoginPage {...createProps()} />);
-  const passwordElement = component.find('input[type="password"]').at(0);
-
-  passwordElement.simulate('focus').simulate('keypress', { keyCode: KEY_CODES.A, shiftKey: false });
-
-  expect(
-    component
-      .find(Input)
-      .at(1)
-      .props().warning
-  ).toEqual(englishMessages.card.passwordField.warnings.capsLock);
-
-  expect(
-    component
-      .find(Input)
-      .at(1)
-      .props().showWarning
-  ).toEqual(true);
-
-  passwordElement.simulate('blur').simulate('keypress', { keyCode: KEY_CODES.A, shiftKey: false });
-
-  expect(
-    component
-      .find(Input)
-      .at(1)
-      .props().showWarning
-  ).toEqual(false);
-
-  passwordElement.simulate('keypress', { keyCode: KEY_CODES.A, shiftKey: false }).simulate('focus');
-
-  expect(
-    component
-      .find(Input)
-      .at(1)
-      .props().showWarning
-  ).toEqual(true);
-});
-
-test('Toggle CapsLock cause warning to show under password field when focused', () => {
-  const component = mount(<LoginPage {...createProps()} />);
-  component.find('input[type="password"]').simulate('change', { target: { value: 'test' } });
-  component
-    .find(LoginCardWithValidation)
-    .instance()
-    .toggleCapsLock({ key: 'CapsLock' });
-
-  component.find('input[type="password"]').simulate('focus');
-
-  expect(
-    component
-      .find(Input)
-      .at(1)
-      .props().showWarning
-  ).toBeTruthy();
 });
 
 test('Submit while inputs are empty cause specific errors to be shown and onChange they disappear', () => {

--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/SocialLoginPage.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/SocialLoginPage.test.js
@@ -128,7 +128,6 @@ const createProps = () => {
           minLength: 8,
           errors: card.passwordField.errors,
           warnings: card.passwordField.warnings,
-          warning: card.passwordField.warnings.capsLock,
           showWarning: true
         },
         rememberMe: {

--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/components/LoginCardComponents/LoginCardWithValidation.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/components/LoginCardComponents/LoginCardWithValidation.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import LoginCardInput from './LoginCardInput';
-import { KEY_CODES, KEYS } from '../../../../common/helpers';
 
 class LoginCardWithValidation extends React.Component {
   state = {
@@ -18,7 +17,6 @@ class LoginCardWithValidation extends React.Component {
       isFocused: false,
       showError: false
     },
-    isCapsLock: false,
     form: {
       showError: this.props.showError,
       submitError: this.props.submitError,
@@ -26,14 +24,6 @@ class LoginCardWithValidation extends React.Component {
       isSubmitting: this.props.isSubmitting
     }
   };
-
-  componentDidMount() {
-    window.addEventListener('keyup', this.toggleCapsLock);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('keyup', this.toggleCapsLock);
-  }
 
   onInputChange = (e, inputType) => {
     this.props[inputType].onChange && this.props[inputType].onChange(e);
@@ -64,14 +54,8 @@ class LoginCardWithValidation extends React.Component {
         ...this.state[inputType],
         isFocused: false,
         showError: false
-      },
-      isCapsLock: false
+      }
     });
-  };
-
-  onKeyPress = (e, inputType) => {
-    this.props[inputType].onMouseEnter && this.props[inputType].onMouseEnter(e);
-    this.handleCapsLock(e);
   };
 
   onSubmit = e => {
@@ -109,14 +93,12 @@ class LoginCardWithValidation extends React.Component {
 
   getModifiedProps = () => {
     const { usernameField, passwordField } = this.props;
-    const passwordFieldWarningType = this.state.isCapsLock ? 'capsLock' : this.state.passwordField.warningType;
     return {
       usernameField: {
         ...usernameField,
         onChange: e => this.onInputChange(e, 'usernameField'),
         onFocus: e => this.onInputFocus(e, 'usernameField'),
         onBlur: e => this.onInputBlur(e, 'usernameField'),
-        onKeyPress: e => this.onKeyPress(e, 'usernameField'),
         error: usernameField.errors[this.state.usernameField.errorType],
         showError: this.state.usernameField.showError
       },
@@ -125,9 +107,8 @@ class LoginCardWithValidation extends React.Component {
         onChange: e => this.onInputChange(e, 'passwordField'),
         onFocus: e => this.onInputFocus(e, 'passwordField'),
         onBlur: e => this.onInputBlur(e, 'passwordField'),
-        onKeyPress: e => this.onKeyPress(e, 'passwordField'),
-        warning: passwordField.warnings[passwordFieldWarningType],
-        showWarning: this.state.passwordField.isFocused && this.state.isCapsLock,
+        warning: this.state.passwordField.warningType,
+        showWarning: this.state.passwordField.isFocused,
         error: passwordField.errors[this.state.passwordField.errorType],
         showError: this.state.passwordField.showError
       },
@@ -210,27 +191,6 @@ class LoginCardWithValidation extends React.Component {
         errorType: 'empty',
         showError: true
       }
-    });
-  };
-
-  toggleCapsLock = e => {
-    if (!this.state.passwordField.value) {
-      return;
-    }
-    e.key === KEYS.CAPSLOCK &&
-      this.setState({
-        isCapsLock: !this.state.isCapsLock
-      });
-  };
-
-  handleCapsLock = e => {
-    const keyCode = e.keyCode ? e.keyCode : e.which;
-    const shiftKey = e.shiftKey ? e.shiftKey : keyCode === KEY_CODES.SHIFT;
-    const isCapsLock =
-      (keyCode >= KEY_CODES.A && keyCode <= KEY_CODES.Z && !shiftKey) ||
-      (keyCode >= KEY_CODES.NUMPAD['0'] && keyCode <= KEY_CODES.F11 && shiftKey);
-    this.setState({
-      isCapsLock
     });
   };
 

--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/mocks/messages.en.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/mocks/messages.en.js
@@ -40,9 +40,6 @@ const passwordField = {
   errors: {
     empty: 'Please enter your password.',
     short: 'Password too short, minimum length is 8 characters'
-  },
-  warnings: {
-    capsLock: 'Caps lock is currently on.'
   }
 };
 

--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/mocks/messages.fr.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/mocks/messages.fr.js
@@ -37,9 +37,6 @@ const passwordField = {
   errors: {
     empty: 'Veuillez entrer votre mot de passe.',
     short: 'Mot de passe trop court, la longueur minimale est de 8 caractères'
-  },
-  warnings: {
-    capsLock: 'Le verrouillage des majuscules est actuellement activé.'
   }
 };
 


### PR DESCRIPTION
Continued to the design refactoring [discussion](https://github.com/patternfly/patternfly-design/issues/671#issuecomment-457323229l)
where we decided to remove the inputs warning,

this is the first step - removing the caps lock warning.
