### PR TITLE
fix(Table): Do not return value if table is not collapsed

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
@@ -13462,12 +13462,10 @@ exports[`Collapsible nested table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>
@@ -14651,12 +14649,10 @@ exports[`Collapsible nested table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>
@@ -15370,12 +15366,10 @@ exports[`Collapsible nested table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>
@@ -15735,12 +15729,10 @@ exports[`Collapsible nested table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>
@@ -16100,12 +16092,10 @@ exports[`Collapsible nested table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>
@@ -16465,12 +16455,10 @@ exports[`Collapsible nested table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>
@@ -18399,12 +18387,10 @@ exports[`Collapsible table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>
@@ -19116,12 +19102,10 @@ exports[`Collapsible table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>
@@ -19540,12 +19524,10 @@ exports[`Collapsible table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>
@@ -20259,12 +20241,10 @@ exports[`Collapsible table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>
@@ -20624,12 +20604,10 @@ exports[`Collapsible table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>
@@ -20989,12 +20967,10 @@ exports[`Collapsible table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>
@@ -21354,12 +21330,10 @@ exports[`Collapsible table 1`] = `
                         data-key={1}
                         data-label="Header cell"
                         key="1-cell"
-                        title="one"
                       >
                         <td
                           data-key={1}
                           data-label="Header cell"
-                          title="one"
                         >
                           one
                         </td>

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/collapsible.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/collapsible.js
@@ -33,12 +33,10 @@ export const collapsible = (
 
 export const expandedRow = (colSpan) => {
   const expandedRowFormatter = (value, { rowIndex, rowData, column: { extraParams: { contentId = 'expanded-content' } } }) => {
-    return {
-      ...rowData.hasOwnProperty('parent') ? {
+    return rowData.hasOwnProperty('parent') && {
         colSpan: colSpan,
         children: <ExpandableRowContent id={contentId + rowIndex}>{value.title || value}</ExpandableRowContent>
-      } : value
-    };
-  }
+      }
+  };
   return expandedRowFormatter;
 }

--- a/packages/patternfly-4/react-table/src/components/Table/utils/transformers.test.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/transformers.test.js
@@ -138,7 +138,7 @@ describe('Transformer functions', () => {
     test('no parent', () => {
       expect(
         expandedRow(5)({ title: 'test' }, { rowData: {}, column: { extraParams: {} } })
-      ).toMatchObject({ title: 'test' });
+      ).toBe(false)
     });
   });
 


### PR DESCRIPTION
**What**:
When row is not collapsed do not pass value down so other props will not be effected by this object. This helps to prevent accidental `title` on first cell.