### PR TITLE
build(docbuild): increase gatsby build memory

### DIFF
--- a/packages/patternfly-4/react-docs/package.json
+++ b/packages/patternfly-4/react-docs/package.json
@@ -37,8 +37,8 @@
     "gatsby"
   ],
   "scripts": {
-    "docbuild": "node build/copyDocs.js && gatsby build",
-    "pr-build": "node build/copyDocs.js && gatsby build --prefix-paths",
+    "docbuild": "node build/copyDocs.js && node --max_old_space_size=4096 ./node_modules/.bin/gatsby build",
+    "pr-build": "node build/copyDocs.js && node --max_old_space_size=4096 ./node_modules/.bin/gatsby build --prefix-paths",
     "develop": "gatsby develop"
   },
   "browserslist": [


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Adds the suggested fix [here](https://github.com/gatsbyjs/gatsby/issues/2796#issuecomment-342017625) to increase Gatsby's memory while compiling static assets.

Bumping from [1.5ish gbs](https://github.com/nodejs/help/issues/1377#issuecomment-403801254) to 4gb. I think we can technically increase to 7.5 gb from the [Ubuntu Travis image docs](https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system), but this should be enough for now...

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
