### PR TITLE
fix(AboutModal): Use paragraph in heading

### DIFF
--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxHeader.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxHeader.js
@@ -25,7 +25,7 @@ const defaultProps = {
 const AboutModalBoxHeader = ({ className, productName, trademark, id, ...props }) => (
   <div {...props} className={css(styles.aboutModalBoxHeader, className)}>
     <div className={css(styles.aboutModalBoxHeaderStrapline)}>
-      <h2 className={css(titleStyles.title)}>{trademark}</h2>
+      <p className={css(titleStyles.title)}>{trademark}</p>
     </div>
     <Title size="4xl" id={id}>
       {productName}

--- a/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalBoxHeader.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalBoxHeader.test.js.snap
@@ -24,11 +24,11 @@ exports[`AboutModalBoxHeader Test 1`] = `
   <div
     className="pf-c-about-modal-box__header-strapline"
   >
-    <h2
+    <p
       className="pf-c-title"
     >
       trademark
-    </h2>
+    </p>
   </div>
   <Title
     className=""


### PR DESCRIPTION
In PF core heading types of AboutModal were updated. This PR updates PF react with those changes.

closes #1265 