### PR TITLE
fix(Table): Allow mixins of object, strings and numbers as row cell

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
@@ -2,10 +2,6 @@ import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf, Omit } from '../../../../react-core/src/typeUtils';
 import { SortByDirection } from './SortColumn';
 import { DropdownPosition, DropdownDirection } from '@patternfly/react-core';
-export interface ISortBy {
-  index?: Number;
-  direction?: OneOf<typeof SortByDirection, keyof typeof SortByDirection>;
-}
 
 export const TableGridBreakpoint: {
   grid: 'grid',
@@ -15,6 +11,11 @@ export const TableGridBreakpoint: {
 
 export const TableVariant: {
   'compact': 'compact'
+}
+
+export interface ISortBy {
+  index?: Number;
+  direction?: OneOf<typeof SortByDirection, keyof typeof SortByDirection>;
 }
 
 export interface IAction {
@@ -32,19 +33,19 @@ export interface ICell {
   cellTransforms: Array<Function>;
   formatters: Array<Function>;
   cellFormatters: Array<Function>;
-  props: Object;
+  props: unknown;
 }
 
 export interface IRowCell {
   title: ReactNode;
-  props: Object;
+  props: unknown;
 }
 
 export interface IRow {
   cells: Array<ReactNode | IRowCell>;
   isOpen: Boolean;
   parent: Number;
-  props: Object;
+  props: unknown;
 }
 
 export interface TableProps extends Omit<Omit<HTMLProps<HTMLTableElement>, 'onSelect'>, 'rows'> {

--- a/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
@@ -35,10 +35,16 @@ export interface ICell {
   props: Object;
 }
 
+export interface IRowCell {
+  title: ReactNode;
+  props: Object;
+}
+
 export interface IRow {
-  cells: Array<String>;
+  cells: Array<ReactNode | IRowCell>;
   isOpen: Boolean;
   parent: Number;
+  props: Object;
 }
 
 export interface TableProps extends Omit<Omit<HTMLProps<HTMLTableElement>, 'onSelect'>, 'rows'> {

--- a/packages/patternfly-4/react-table/src/components/Table/Table.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.js
@@ -52,7 +52,14 @@ const propTypes = {
   rows: PropTypes.arrayOf(
     PropTypes.oneOfType([
       PropTypes.shape({
-        cells: PropTypes.arrayOf(PropTypes.node),
+        cells: ropTypes.arrayOf(
+          PropTypes.oneOfType([
+            PropTypes.node,
+            PropTypes.shape({
+              title: PropTypes.node
+            })
+          ])
+        ),
         isOpen: PropTypes.bool,
         parent: PropTypes.number,
         props: PropTypes.any

--- a/packages/patternfly-4/react-table/src/components/Table/Table.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.js
@@ -52,7 +52,7 @@ const propTypes = {
   rows: PropTypes.arrayOf(
     PropTypes.oneOfType([
       PropTypes.shape({
-        cells: ropTypes.arrayOf(
+        cells: PropTypes.arrayOf(
           PropTypes.oneOfType([
             PropTypes.node,
             PropTypes.shape({


### PR DESCRIPTION
**What**:
Allow different data types for row cells.
cells: [`String | Number | HTML | { title: String | Number | HTML }`]
