### PR TITLE
fix(Alert): Make Alert consistent with core

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Alert/Alert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/Alert.js
@@ -43,7 +43,7 @@ const defaultProps = {
   variantLabel: null
 };
 
-const getDefaultAriaLabel = variant => `${capitalize(AlertVariant[variant])} Notification`;
+const getDefaultAriaLabel = variant => `${capitalize(AlertVariant[variant])} Alert`;
 
 const Alert = ({
   variant,
@@ -58,7 +58,7 @@ const Alert = ({
   variantLabel = variantLabel || capitalize(AlertVariant[variant]);
   const readerTitle = (
     <React.Fragment>
-      <span className={css(accessibleStyles.screenReader)}>{variantLabel}: </span>
+      <span className={css(accessibleStyles.screenReader)}>{variantLabel + " alert:"}</span>
       {title}
     </React.Fragment>
   );
@@ -74,7 +74,8 @@ const Alert = ({
           <p>{children}</p>
         </div>
       )}
-      {action && <div className={css(styles.alertAction, className)}>{action}</div>}
+      {action && <div className={css(styles.alertAction, className)}>{React.cloneElement(action,
+           {title, variantLabel})}</div>}
     </div>
   );
 };

--- a/packages/patternfly-4/react-core/src/components/Alert/AlertActionCloseButton.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/AlertActionCloseButton.js
@@ -15,12 +15,13 @@ const propTypes = {
 };
 
 const defaultProps = {
+  'aria-label': '',
   className: '',
   onClose: () => undefined,
 };
 
 const AlertActionCloseButton = ({ className, onClose, 'aria-label': ariaLabel, title, variantLabel, ...props }) => (
-  <Button variant={ButtonVariant.plain} onClick={onClose} aria-label={ariaLabel ? ariaLabel : `Close ${variantLabel} alert: ${title}`} {...props}>
+  <Button variant={ButtonVariant.plain} onClick={onClose} aria-label={ariaLabel === '' ? `Close ${variantLabel} alert: ${title}` : ariaLabel} {...props}>
     <TimesIcon />
   </Button>
 );

--- a/packages/patternfly-4/react-core/src/components/Alert/AlertActionCloseButton.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/AlertActionCloseButton.js
@@ -17,11 +17,10 @@ const propTypes = {
 const defaultProps = {
   className: '',
   onClose: () => undefined,
-  'aria-label': 'Close'
 };
 
-const AlertActionCloseButton = ({ className, onClose, 'aria-label': ariaLabel, ...props }) => (
-  <Button variant={ButtonVariant.plain} onClick={onClose} aria-label={ariaLabel} {...props}>
+const AlertActionCloseButton = ({ className, onClose, 'aria-label': ariaLabel, title, variantLabel, ...props }) => (
+  <Button variant={ButtonVariant.plain} onClick={onClose} aria-label={ariaLabel ? ariaLabel : `Close ${variantLabel} alert: ${title}`} {...props}>
     <TimesIcon />
   </Button>
 );

--- a/packages/patternfly-4/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Alert/__snapshots__/Alert.test.js.snap
@@ -60,7 +60,7 @@ exports[`Alert - danger Action Close Button 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Danger Notification"
+    aria-label="Danger Alert"
     className="pf-c-alert pf-m-danger"
   >
     <AlertIcon
@@ -111,6 +111,8 @@ exports[`Alert - danger Action Close Button 1`] = `
         aria-label="Close"
         className=""
         onClose={[MockFunction]}
+        title=""
+        variantLabel="Danger"
       >
         <Button
           aria-label="Close"
@@ -227,7 +229,7 @@ exports[`Alert - danger Action Link 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Danger Notification"
+    aria-label="Danger Alert"
     className="pf-c-alert pf-m-danger"
   >
     <AlertIcon
@@ -276,6 +278,8 @@ exports[`Alert - danger Action Link 1`] = `
     >
       <AlertActionLink
         className=""
+        title=""
+        variantLabel="Danger"
       >
         <Button
           aria-label={null}
@@ -286,8 +290,10 @@ exports[`Alert - danger Action Link 1`] = `
           isDisabled={false}
           isFocus={false}
           isHover={false}
+          title=""
           type="button"
           variant="link"
+          variantLabel="Danger"
         >
           <button
             aria-disabled={null}
@@ -295,7 +301,9 @@ exports[`Alert - danger Action Link 1`] = `
             className="pf-c-button pf-m-link"
             disabled={false}
             tabIndex={null}
+            title=""
             type="button"
+            variantLabel="Danger"
           >
             test
           </button>
@@ -381,7 +389,7 @@ exports[`Alert - danger Action and Title 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Danger Notification"
+    aria-label="Danger Alert"
     className="pf-c-alert pf-m-danger"
   >
     <AlertIcon
@@ -424,8 +432,7 @@ exports[`Alert - danger Action and Title 1`] = `
       <span
         className="pf-u-screen-reader"
       >
-        Danger
-        : 
+        Danger alert:
       </span>
       Some title
     </h4>
@@ -441,6 +448,8 @@ exports[`Alert - danger Action and Title 1`] = `
     >
       <AlertActionLink
         className=""
+        title="Some title"
+        variantLabel="Danger"
       >
         <Button
           aria-label={null}
@@ -451,8 +460,10 @@ exports[`Alert - danger Action and Title 1`] = `
           isDisabled={false}
           isFocus={false}
           isHover={false}
+          title="Some title"
           type="button"
           variant="link"
+          variantLabel="Danger"
         >
           <button
             aria-disabled={null}
@@ -460,7 +471,9 @@ exports[`Alert - danger Action and Title 1`] = `
             className="pf-c-button pf-m-link"
             disabled={false}
             tabIndex={null}
+            title="Some title"
             type="button"
+            variantLabel="Danger"
           >
             test
           </button>
@@ -590,8 +603,7 @@ exports[`Alert - danger Custom aria label 1`] = `
       <span
         className="pf-u-screen-reader"
       >
-        Danger
-        : 
+        Danger alert:
       </span>
       Some title
     </h4>
@@ -607,6 +619,8 @@ exports[`Alert - danger Custom aria label 1`] = `
     >
       <AlertActionLink
         className=""
+        title="Some title"
+        variantLabel="Danger"
       >
         <Button
           aria-label={null}
@@ -617,8 +631,10 @@ exports[`Alert - danger Custom aria label 1`] = `
           isDisabled={false}
           isFocus={false}
           isHover={false}
+          title="Some title"
           type="button"
           variant="link"
+          variantLabel="Danger"
         >
           <button
             aria-disabled={null}
@@ -626,7 +642,9 @@ exports[`Alert - danger Custom aria label 1`] = `
             className="pf-c-button pf-m-link"
             disabled={false}
             tabIndex={null}
+            title="Some title"
             type="button"
+            variantLabel="Danger"
           >
             test
           </button>
@@ -671,7 +689,7 @@ exports[`Alert - danger Description 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Danger Notification"
+    aria-label="Danger Alert"
     className="pf-c-alert pf-m-danger"
   >
     <AlertIcon
@@ -768,7 +786,7 @@ exports[`Alert - danger Title 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Danger Notification"
+    aria-label="Danger Alert"
     className="pf-c-alert pf-m-danger"
   >
     <AlertIcon
@@ -811,8 +829,7 @@ exports[`Alert - danger Title 1`] = `
       <span
         className="pf-u-screen-reader"
       >
-        Danger
-        : 
+        Danger alert:
       </span>
       Some title
     </h4>
@@ -887,7 +904,7 @@ exports[`Alert - info Action Close Button 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Info Notification"
+    aria-label="Info Alert"
     className="pf-c-alert pf-m-info"
   >
     <AlertIcon
@@ -938,6 +955,8 @@ exports[`Alert - info Action Close Button 1`] = `
         aria-label="Close"
         className=""
         onClose={[MockFunction]}
+        title=""
+        variantLabel="Info"
       >
         <Button
           aria-label="Close"
@@ -1054,7 +1073,7 @@ exports[`Alert - info Action Link 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Info Notification"
+    aria-label="Info Alert"
     className="pf-c-alert pf-m-info"
   >
     <AlertIcon
@@ -1103,6 +1122,8 @@ exports[`Alert - info Action Link 1`] = `
     >
       <AlertActionLink
         className=""
+        title=""
+        variantLabel="Info"
       >
         <Button
           aria-label={null}
@@ -1113,8 +1134,10 @@ exports[`Alert - info Action Link 1`] = `
           isDisabled={false}
           isFocus={false}
           isHover={false}
+          title=""
           type="button"
           variant="link"
+          variantLabel="Info"
         >
           <button
             aria-disabled={null}
@@ -1122,7 +1145,9 @@ exports[`Alert - info Action Link 1`] = `
             className="pf-c-button pf-m-link"
             disabled={false}
             tabIndex={null}
+            title=""
             type="button"
+            variantLabel="Info"
           >
             test
           </button>
@@ -1208,7 +1233,7 @@ exports[`Alert - info Action and Title 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Info Notification"
+    aria-label="Info Alert"
     className="pf-c-alert pf-m-info"
   >
     <AlertIcon
@@ -1251,8 +1276,7 @@ exports[`Alert - info Action and Title 1`] = `
       <span
         className="pf-u-screen-reader"
       >
-        Info
-        : 
+        Info alert:
       </span>
       Some title
     </h4>
@@ -1268,6 +1292,8 @@ exports[`Alert - info Action and Title 1`] = `
     >
       <AlertActionLink
         className=""
+        title="Some title"
+        variantLabel="Info"
       >
         <Button
           aria-label={null}
@@ -1278,8 +1304,10 @@ exports[`Alert - info Action and Title 1`] = `
           isDisabled={false}
           isFocus={false}
           isHover={false}
+          title="Some title"
           type="button"
           variant="link"
+          variantLabel="Info"
         >
           <button
             aria-disabled={null}
@@ -1287,7 +1315,9 @@ exports[`Alert - info Action and Title 1`] = `
             className="pf-c-button pf-m-link"
             disabled={false}
             tabIndex={null}
+            title="Some title"
             type="button"
+            variantLabel="Info"
           >
             test
           </button>
@@ -1417,8 +1447,7 @@ exports[`Alert - info Custom aria label 1`] = `
       <span
         className="pf-u-screen-reader"
       >
-        Info
-        : 
+        Info alert:
       </span>
       Some title
     </h4>
@@ -1434,6 +1463,8 @@ exports[`Alert - info Custom aria label 1`] = `
     >
       <AlertActionLink
         className=""
+        title="Some title"
+        variantLabel="Info"
       >
         <Button
           aria-label={null}
@@ -1444,8 +1475,10 @@ exports[`Alert - info Custom aria label 1`] = `
           isDisabled={false}
           isFocus={false}
           isHover={false}
+          title="Some title"
           type="button"
           variant="link"
+          variantLabel="Info"
         >
           <button
             aria-disabled={null}
@@ -1453,7 +1486,9 @@ exports[`Alert - info Custom aria label 1`] = `
             className="pf-c-button pf-m-link"
             disabled={false}
             tabIndex={null}
+            title="Some title"
             type="button"
+            variantLabel="Info"
           >
             test
           </button>
@@ -1498,7 +1533,7 @@ exports[`Alert - info Description 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Info Notification"
+    aria-label="Info Alert"
     className="pf-c-alert pf-m-info"
   >
     <AlertIcon
@@ -1595,7 +1630,7 @@ exports[`Alert - info Title 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Info Notification"
+    aria-label="Info Alert"
     className="pf-c-alert pf-m-info"
   >
     <AlertIcon
@@ -1638,8 +1673,7 @@ exports[`Alert - info Title 1`] = `
       <span
         className="pf-u-screen-reader"
       >
-        Info
-        : 
+        Info alert:
       </span>
       Some title
     </h4>
@@ -1714,7 +1748,7 @@ exports[`Alert - success Action Close Button 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Success Notification"
+    aria-label="Success Alert"
     className="pf-c-alert pf-m-success"
   >
     <AlertIcon
@@ -1765,6 +1799,8 @@ exports[`Alert - success Action Close Button 1`] = `
         aria-label="Close"
         className=""
         onClose={[MockFunction]}
+        title=""
+        variantLabel="Success"
       >
         <Button
           aria-label="Close"
@@ -1881,7 +1917,7 @@ exports[`Alert - success Action Link 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Success Notification"
+    aria-label="Success Alert"
     className="pf-c-alert pf-m-success"
   >
     <AlertIcon
@@ -1930,6 +1966,8 @@ exports[`Alert - success Action Link 1`] = `
     >
       <AlertActionLink
         className=""
+        title=""
+        variantLabel="Success"
       >
         <Button
           aria-label={null}
@@ -1940,8 +1978,10 @@ exports[`Alert - success Action Link 1`] = `
           isDisabled={false}
           isFocus={false}
           isHover={false}
+          title=""
           type="button"
           variant="link"
+          variantLabel="Success"
         >
           <button
             aria-disabled={null}
@@ -1949,7 +1989,9 @@ exports[`Alert - success Action Link 1`] = `
             className="pf-c-button pf-m-link"
             disabled={false}
             tabIndex={null}
+            title=""
             type="button"
+            variantLabel="Success"
           >
             test
           </button>
@@ -2035,7 +2077,7 @@ exports[`Alert - success Action and Title 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Success Notification"
+    aria-label="Success Alert"
     className="pf-c-alert pf-m-success"
   >
     <AlertIcon
@@ -2078,8 +2120,7 @@ exports[`Alert - success Action and Title 1`] = `
       <span
         className="pf-u-screen-reader"
       >
-        Success
-        : 
+        Success alert:
       </span>
       Some title
     </h4>
@@ -2095,6 +2136,8 @@ exports[`Alert - success Action and Title 1`] = `
     >
       <AlertActionLink
         className=""
+        title="Some title"
+        variantLabel="Success"
       >
         <Button
           aria-label={null}
@@ -2105,8 +2148,10 @@ exports[`Alert - success Action and Title 1`] = `
           isDisabled={false}
           isFocus={false}
           isHover={false}
+          title="Some title"
           type="button"
           variant="link"
+          variantLabel="Success"
         >
           <button
             aria-disabled={null}
@@ -2114,7 +2159,9 @@ exports[`Alert - success Action and Title 1`] = `
             className="pf-c-button pf-m-link"
             disabled={false}
             tabIndex={null}
+            title="Some title"
             type="button"
+            variantLabel="Success"
           >
             test
           </button>
@@ -2244,8 +2291,7 @@ exports[`Alert - success Custom aria label 1`] = `
       <span
         className="pf-u-screen-reader"
       >
-        Success
-        : 
+        Success alert:
       </span>
       Some title
     </h4>
@@ -2261,6 +2307,8 @@ exports[`Alert - success Custom aria label 1`] = `
     >
       <AlertActionLink
         className=""
+        title="Some title"
+        variantLabel="Success"
       >
         <Button
           aria-label={null}
@@ -2271,8 +2319,10 @@ exports[`Alert - success Custom aria label 1`] = `
           isDisabled={false}
           isFocus={false}
           isHover={false}
+          title="Some title"
           type="button"
           variant="link"
+          variantLabel="Success"
         >
           <button
             aria-disabled={null}
@@ -2280,7 +2330,9 @@ exports[`Alert - success Custom aria label 1`] = `
             className="pf-c-button pf-m-link"
             disabled={false}
             tabIndex={null}
+            title="Some title"
             type="button"
+            variantLabel="Success"
           >
             test
           </button>
@@ -2325,7 +2377,7 @@ exports[`Alert - success Description 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Success Notification"
+    aria-label="Success Alert"
     className="pf-c-alert pf-m-success"
   >
     <AlertIcon
@@ -2422,7 +2474,7 @@ exports[`Alert - success Title 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Success Notification"
+    aria-label="Success Alert"
     className="pf-c-alert pf-m-success"
   >
     <AlertIcon
@@ -2465,8 +2517,7 @@ exports[`Alert - success Title 1`] = `
       <span
         className="pf-u-screen-reader"
       >
-        Success
-        : 
+        Success alert:
       </span>
       Some title
     </h4>
@@ -2541,7 +2592,7 @@ exports[`Alert - warning Action Close Button 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Warning Notification"
+    aria-label="Warning Alert"
     className="pf-c-alert pf-m-warning"
   >
     <AlertIcon
@@ -2592,6 +2643,8 @@ exports[`Alert - warning Action Close Button 1`] = `
         aria-label="Close"
         className=""
         onClose={[MockFunction]}
+        title=""
+        variantLabel="Warning"
       >
         <Button
           aria-label="Close"
@@ -2708,7 +2761,7 @@ exports[`Alert - warning Action Link 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Warning Notification"
+    aria-label="Warning Alert"
     className="pf-c-alert pf-m-warning"
   >
     <AlertIcon
@@ -2757,6 +2810,8 @@ exports[`Alert - warning Action Link 1`] = `
     >
       <AlertActionLink
         className=""
+        title=""
+        variantLabel="Warning"
       >
         <Button
           aria-label={null}
@@ -2767,8 +2822,10 @@ exports[`Alert - warning Action Link 1`] = `
           isDisabled={false}
           isFocus={false}
           isHover={false}
+          title=""
           type="button"
           variant="link"
+          variantLabel="Warning"
         >
           <button
             aria-disabled={null}
@@ -2776,7 +2833,9 @@ exports[`Alert - warning Action Link 1`] = `
             className="pf-c-button pf-m-link"
             disabled={false}
             tabIndex={null}
+            title=""
             type="button"
+            variantLabel="Warning"
           >
             test
           </button>
@@ -2862,7 +2921,7 @@ exports[`Alert - warning Action and Title 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Warning Notification"
+    aria-label="Warning Alert"
     className="pf-c-alert pf-m-warning"
   >
     <AlertIcon
@@ -2905,8 +2964,7 @@ exports[`Alert - warning Action and Title 1`] = `
       <span
         className="pf-u-screen-reader"
       >
-        Warning
-        : 
+        Warning alert:
       </span>
       Some title
     </h4>
@@ -2922,6 +2980,8 @@ exports[`Alert - warning Action and Title 1`] = `
     >
       <AlertActionLink
         className=""
+        title="Some title"
+        variantLabel="Warning"
       >
         <Button
           aria-label={null}
@@ -2932,8 +2992,10 @@ exports[`Alert - warning Action and Title 1`] = `
           isDisabled={false}
           isFocus={false}
           isHover={false}
+          title="Some title"
           type="button"
           variant="link"
+          variantLabel="Warning"
         >
           <button
             aria-disabled={null}
@@ -2941,7 +3003,9 @@ exports[`Alert - warning Action and Title 1`] = `
             className="pf-c-button pf-m-link"
             disabled={false}
             tabIndex={null}
+            title="Some title"
             type="button"
+            variantLabel="Warning"
           >
             test
           </button>
@@ -3071,8 +3135,7 @@ exports[`Alert - warning Custom aria label 1`] = `
       <span
         className="pf-u-screen-reader"
       >
-        Warning
-        : 
+        Warning alert:
       </span>
       Some title
     </h4>
@@ -3088,6 +3151,8 @@ exports[`Alert - warning Custom aria label 1`] = `
     >
       <AlertActionLink
         className=""
+        title="Some title"
+        variantLabel="Warning"
       >
         <Button
           aria-label={null}
@@ -3098,8 +3163,10 @@ exports[`Alert - warning Custom aria label 1`] = `
           isDisabled={false}
           isFocus={false}
           isHover={false}
+          title="Some title"
           type="button"
           variant="link"
+          variantLabel="Warning"
         >
           <button
             aria-disabled={null}
@@ -3107,7 +3174,9 @@ exports[`Alert - warning Custom aria label 1`] = `
             className="pf-c-button pf-m-link"
             disabled={false}
             tabIndex={null}
+            title="Some title"
             type="button"
+            variantLabel="Warning"
           >
             test
           </button>
@@ -3152,7 +3221,7 @@ exports[`Alert - warning Description 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Warning Notification"
+    aria-label="Warning Alert"
     className="pf-c-alert pf-m-warning"
   >
     <AlertIcon
@@ -3249,7 +3318,7 @@ exports[`Alert - warning Title 1`] = `
   variantLabel={null}
 >
   <div
-    aria-label="Warning Notification"
+    aria-label="Warning Alert"
     className="pf-c-alert pf-m-warning"
   >
     <AlertIcon
@@ -3292,8 +3361,7 @@ exports[`Alert - warning Title 1`] = `
       <span
         className="pf-u-screen-reader"
       >
-        Warning
-        : 
+        Warning alert:
       </span>
       Some title
     </h4>

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/DangerAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/DangerAlert.js
@@ -13,25 +13,25 @@ class DangerAlert extends React.Component {
         {alertOneVisible && (
           <Alert
             variant="danger"
-            title="Danger notification title"
+            title="Danger alert title"
             action={<AlertActionCloseButton action={<AlertActionCloseButton onClose={this.hideAlertOne} />} />}
           >
-            Danger notification description. <a href="#">This is a link.</a>
+            Danger alert description. <a href="#">This is a link.</a>
           </Alert>
         )}
         {alertTwoVisible && (
           <Alert
             variant="danger"
-            title="Danger notification title"
+            title="Danger alert title"
             action={<AlertActionCloseButton onClose={this.hideAlertTwo} />}
           />
         )}
         <Alert
           variant="danger"
-          title="Danger notification title"
+          title="Danger alert title"
           action={<AlertActionLink>Action Button</AlertActionLink>}
         />
-        ><Alert variant="danger" title="Danger notification title" />
+        <Alert variant="danger" title="Danger alert title" />
       </React.Fragment>
     );
   }

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/InfoAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/InfoAlert.js
@@ -13,25 +13,25 @@ class InfoAlert extends React.Component {
         {alertOneVisible && (
           <Alert
             variant="info"
-            title="Info notification title"
+            title="Info alert title"
             action={<AlertActionCloseButton onClose={this.hideAlertOne} />}
           >
-            Info notification description. <a href="#">This is a link.</a>
+            Info alert description. <a href="#">This is a link.</a>
           </Alert>
         )}
         {alertTwoVisible && (
           <Alert
             variant="info"
-            title="Info notification title"
+            title="Info alert title"
             action={<AlertActionCloseButton onClose={this.hideAlertTwo} />}
           />
         )}
         <Alert
           variant="info"
-          title="Info notification title"
+          title="Info alert title"
           action={<AlertActionLink>Action Button</AlertActionLink>}
         />
-        <Alert variant="info" title="Info notification title" />
+        <Alert variant="info" title="Info alert title" />
       </React.Fragment>
     );
   }

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/SuccessAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/SuccessAlert.js
@@ -13,25 +13,25 @@ class SuccessAlert extends React.Component {
         {alertOneVisible && (
           <Alert
             variant="success"
-            title="Success notification title"
+            title="Success alert title"
             action={<AlertActionCloseButton onClose={this.hideAlertOne} />}
           >
-            Success notification description. <a href="#">This is a link.</a>
+            Success alert description. <a href="#">This is a link.</a>
           </Alert>
         )}
         {alertTwoVisible && (
           <Alert
             variant="success"
-            title="Success notification title"
+            title="Success alert title"
             action={<AlertActionCloseButton onClose={this.hideAlertTwo} />}
           />
         )}
         <Alert
           variant="success"
-          title="Success notification title"
+          title="Success alert title"
           action={<AlertActionLink>Action Button</AlertActionLink>}
         />
-        <Alert variant="success" title="Success notification title" />
+        <Alert variant="success" title="Success alert title" />
       </React.Fragment>
     );
   }

--- a/packages/patternfly-4/react-core/src/components/Alert/examples/WarningAlert.js
+++ b/packages/patternfly-4/react-core/src/components/Alert/examples/WarningAlert.js
@@ -13,25 +13,25 @@ class WarningAlert extends React.Component {
         {alertOneVisible && (
           <Alert
             variant="warning"
-            title="Warning notification title"
+            title="Warning alert title"
             action={<AlertActionCloseButton onClose={this.hideAlertOne} />}
           >
-            Warning notification description. <a href="#">This is a link.</a>
+            Warning alert description. <a href="#">This is a link.</a>
           </Alert>
         )}
         {alertTwoVisible && (
           <Alert
             variant="warning"
-            title="Warning notification title"
+            title="Warning alert title"
             action={<AlertActionCloseButton onClose={this.hideAlertTwo} />}
           />
         )}
         <Alert
           variant="warning"
-          title="Warning notification title"
+          title="Warning alert title"
           action={<AlertActionLink>Action Button</AlertActionLink>}
         />
-        <Alert variant="warning" title="Warning notification title" />
+        <Alert variant="warning" title="Warning alert title" />
       </React.Fragment>
     );
   }


### PR DESCRIPTION
I updated the aria-label for the close button and the screen reader text to be more descriptive and removed the caret in the Danger Alert example. I also replaced all instances of "notification" with "alert" and updated the Alert snapshots.

Fixes #1286.