### PR TITLE
PF4 Charts: Added ChartPoint for custom dash legend symbol

### DIFF
--- a/packages/patternfly-4/react-charts/package.json
+++ b/packages/patternfly-4/react-charts/package.json
@@ -42,7 +42,8 @@
   "optionalDependencies": {
     "@types/victory": "^0.9.19",
     "hoist-non-react-statics": "^3.1.0",
-    "victory": "^30.1.0"
+    "victory": "^30.1.0",
+    "victory-core": "^31.1.0"
   },
   "devDependencies": {
     "@patternfly/patternfly": "1.0.184",

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.js
@@ -4,6 +4,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import { VictoryLegend } from 'victory';
 import { default as ChartTheme } from '../ChartTheme/ChartTheme';
 import ChartContainer from '../ChartContainer/ChartContainer';
+import ChartPoint from '../ChartPoint/ChartPoint';
 
 export const propTypes = {
   /**

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.test.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import ChartLegend from '../ChartDonut/ChartDonut';
+import ChartLegend from './ChartLegend';
 
 Object.values([true, false]).forEach(isRead => {
   test(`Chart`, () => {

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.d.ts
@@ -1,0 +1,10 @@
+import * as victory from 'victory';
+// import { OneOf } from '../../typeUtils';
+
+export interface ChartPointProps extends victory.VictoryLegendProps {
+  symbol: string;
+}
+
+declare const Chartpoint: React.ComponentClass<ChartPointProps>;
+
+export default Chartpoint;

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import hoistNonReactStatics from 'hoist-non-react-statics';
+import { Point } from 'victory';
+import { Helpers } from 'victory-core';
+import pathHelpers from './path-helpers';
+
+export const propTypes = {
+  ...Point.propTypes,
+  symbol: PropTypes.oneOfType([
+    PropTypes.oneOf([
+      'circle',
+      'diamond',
+      'plus',
+      'minus',
+      'square',
+      'star',
+      'triangleDown',
+      'triangleUp',
+      'dash',
+    ]),
+    PropTypes.func
+  ])
+};
+
+// Todo: Submit dash symbol to victory-core, providing PF4 doesn't need a smaller lineHeight for dash and minus?
+class VictoryPoint extends Point {
+  getPath(props) {
+    const { datum, active, x, y } = props;
+    const size = Helpers.evaluateProp(props.size, datum, active);
+    if (props.getPath) {
+      return props.getPath(x, y, size);
+    }
+    const pathFunctions = {
+      circle: pathHelpers.circle,
+      square: pathHelpers.square,
+      diamond: pathHelpers.diamond,
+      triangleDown: pathHelpers.triangleDown,
+      triangleUp: pathHelpers.triangleUp,
+      plus: pathHelpers.plus,
+      minus: pathHelpers.minus,
+      star: pathHelpers.star,
+      dash: pathHelpers.dash
+    };
+    const symbol = Helpers.evaluateProp(props.symbol, datum, active);
+    const symbolFunction = typeof pathFunctions[symbol] === 'function' ? pathFunctions[symbol] : pathFunctions.circle;
+    return symbolFunction(x, y, size);
+  }
+}
+
+const ChartPoint = (props) => (
+  <VictoryPoint {...props}/>
+);
+
+hoistNonReactStatics(ChartPoint, Point);
+ChartPoint.propTypes = propTypes;
+
+export default ChartPoint;

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.test.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ChartLegend from '../ChartLegend/ChartLegend';
+import ChartPoint from './ChartPoint';
+
+Object.values([true, false]).forEach(isRead => {
+  test(`Chart`, () => {
+    const view = shallow(<ChartLegend dataComponent={<ChartPoint />}/>);
+    expect(view).toMatchSnapshot();
+  });
+});
+
+test('renders component data', () => {
+  const view = shallow(
+    <ChartLegend
+      data={[
+        { name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash'} }
+      ]}
+      title="Average number of pets"
+      height={50}
+      width={200}
+    />
+  );
+  expect(view).toMatchSnapshot();
+});

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.js.snap
@@ -22,11 +22,7 @@ exports[`Chart 1`] = `
       },
     ]
   }
-  dataComponent={
-    <Point
-      pathComponent={<Path />}
-    />
-  }
+  dataComponent={<ChartPoint />}
   groupComponent={<g />}
   labelComponent={
     <VictoryLabel
@@ -519,11 +515,7 @@ exports[`Chart 2`] = `
       },
     ]
   }
-  dataComponent={
-    <Point
-      pathComponent={<Path />}
-    />
-  }
+  dataComponent={<ChartPoint />}
   groupComponent={<g />}
   labelComponent={
     <VictoryLabel
@@ -1013,6 +1005,9 @@ exports[`renders component data 1`] = `
       },
       Object {
         "name": "Dogs",
+        "symbol": Object {
+          "type": "dash",
+        },
       },
     ]
   }

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/index.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/index.d.ts
@@ -1,0 +1,1 @@
+export { default as ChartPoint, ChartPointProps } from './ChartPoint';

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/index.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/index.js
@@ -1,0 +1,1 @@
+export { default as ChartPoint } from './ChartPoint';

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/path-helpers.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/path-helpers.js
@@ -1,0 +1,124 @@
+export default {
+  circle(x, y, size) {
+    return `M ${x}, ${y}
+      m ${-size}, 0
+      a ${size}, ${size} 0 1,0 ${size * 2},0
+      a ${size}, ${size} 0 1,0 ${-size * 2},0`;
+  },
+
+  square(x, y, size) {
+    const baseSize = 0.87 * size;
+    const x0 = x - baseSize;
+    const y1 = y + baseSize;
+    const distance = x + baseSize - x0;
+    return `M ${x0}, ${y1}
+      h${distance}
+      v-${distance}
+      h-${distance}
+      z`;
+  },
+
+  diamond(x, y, size) {
+    const baseSize = 0.87 * size;
+    const length = Math.sqrt(2 * (baseSize * baseSize));
+    return `M ${x}, ${y + length}
+      l ${length}, -${length}
+      l -${length}, -${length}
+      l -${length}, ${length}
+      l ${length}, ${length}
+      z`;
+  },
+
+  triangleDown(x, y, size) {
+    const height = (size / 2) * Math.sqrt(3);
+    const x0 = x - size;
+    const x1 = x + size;
+    const y0 = y - size;
+    const y1 = y + height;
+    return `M ${x0}, ${y0}
+      L ${x1}, ${y0}
+      L ${x}, ${y1}
+      z`;
+  },
+
+  triangleUp(x, y, size) {
+    const height = (size / 2) * Math.sqrt(3);
+    const x0 = x - size;
+    const x1 = x + size;
+    const y0 = y - height;
+    const y1 = y + size;
+    return `M ${x0}, ${y1}
+      L ${x1}, ${y1}
+      L ${x}, ${y0}
+      z`;
+  },
+
+  plus(x, y, size) {
+    const baseSize = 1.1 * size;
+    const distance = baseSize / 1.5;
+    return `
+      M ${x - distance / 2}, ${y + baseSize}
+      v-${distance}
+      h-${distance}
+      v-${distance}
+      h${distance}
+      v-${distance}
+      h${distance}
+      v${distance}
+      h${distance}
+      v${distance}
+      h-${distance}
+      v${distance}
+      z`;
+  },
+
+  minus(x, y, size) {
+    const baseSize = 1.1 * size;
+    const lineHeight = baseSize - baseSize * 0.3;
+    const x0 = x - baseSize;
+    const y1 = y + lineHeight / 2;
+    const distance = x + baseSize - x0;
+    return `M ${x0}, ${y1}
+      h${distance}
+      v-${lineHeight}
+      h-${distance}
+      z`;
+  },
+
+  star(x, y, size) {
+    const baseSize = 1.35 * size;
+    const angle = Math.PI / 5;
+    const range = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const starCoords = range.map(index => {
+      const length = index % 2 === 0 ? baseSize : baseSize / 2;
+      return `${length * Math.sin(angle * (index + 1)) + x},
+        ${length * Math.cos(angle * (index + 1)) + y}`;
+    });
+    return `M ${starCoords.join('L')} z`;
+  },
+
+  // Todo: Submit dash symbol to victory-core, providing PF4 doesn't need a smaller lineHeight for dash and minus?
+  dash(x, y, size) {
+    const baseSize = 1.1 * size;
+    const lineHeight = baseSize - baseSize * 0.3;
+    const x0 = x - baseSize;
+    const y1 = y + lineHeight / 2;
+    const distance = (x + baseSize - x0) * 0.3;
+    const padding = distance / 3;
+    return `M ${x0}, ${y1}
+      h${distance}
+      v-${lineHeight}
+      h-${distance}
+      z
+      M ${x0 + distance + padding}, ${y1}
+      h${distance}
+      v-${lineHeight}
+      h-${distance}
+      z
+      M ${x0 + distance * 2 + padding * 2}, ${y1}
+      h${distance}
+      v-${lineHeight}
+      h-${distance}
+      z`;
+  }
+};

--- a/packages/patternfly-4/react-charts/src/components/LineChart/examples/SimpleChart.js
+++ b/packages/patternfly-4/react-charts/src/components/LineChart/examples/SimpleChart.js
@@ -1,21 +1,61 @@
 import React from 'react';
-import { Chart, ChartGroup, ChartLine, ChartTheme } from '@patternfly/react-charts';
+import { Chart, ChartGroup, ChartLegend, ChartLine, ChartTheme } from '@patternfly/react-charts';
 import { Grid, GridItem, Text, TextVariants } from '@patternfly/react-core';
 
 class SimpleChart extends React.Component {
-  // interpolation="natural"
-
   getChart = theme => (
     <Chart minDomain={{ y: 0 }} theme={theme} height={200} width={300}>
       <ChartGroup>
-        <ChartLine data={[{ x: 1, y: 1 }, { x: 2, y: 2 }, { x: 3, y: 5 }, { x: 4, y: 3 }]} />
-        <ChartLine data={[{ x: 1, y: 2 }, { x: 2, y: 1 }, { x: 3, y: 7 }, { x: 4, y: 4 }]} />
-        <ChartLine data={[{ x: 1, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 9 }, { x: 4, y: 5 }]} />
-        <ChartLine data={[{ x: 1, y: 3 }, { x: 2, y: 3 }, { x: 3, y: 8 }, { x: 4, y: 7 }]} />
+        <ChartLine
+          data={[
+            { name: 'Cats', x: 1, y: 1 },
+            { name: 'Cats', x: 2, y: 2 },
+            { name: 'Cats', x: 3, y: 5 },
+            { name: 'Cats', x: 4, y: 3 }
+          ]}
+        />
+        <ChartLine
+          data={[
+            { name: 'Dogs', x: 1, y: 2 },
+            { name: 'Dogs', x: 2, y: 1 },
+            { name: 'Dogs', x: 3, y: 7 },
+            { name: 'Dogs', x: 4, y: 4 }
+          ]}
+          style={{
+            data: {
+              strokeDasharray: '3,3'
+            }
+          }}
+        />
+        <ChartLine
+          data={[
+            { name: 'Birds', x: 1, y: 3 },
+            { name: 'Birds', x: 2, y: 4 },
+            { name: 'Birds', x: 3, y: 9 },
+            { name: 'Birds', x: 4, y: 5 }
+          ]}
+        />
+        <ChartLine
+          data={[
+            { name: 'Mice', x: 1, y: 3 },
+            { name: 'Mice', x: 2, y: 3 },
+            { name: 'Mice', x: 3, y: 8 },
+            { name: 'Mice', x: 4, y: 7 }
+          ]}
+        />
       </ChartGroup>
       <ChartAxis tickValues={[2, 3, 4]} />
       <ChartAxis dependentAxis tickValues={[2, 5, 8]} />
     </Chart>
+  );
+
+  getlegend = theme => (
+    <ChartLegend
+      data={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash'} }, { name: 'Birds' }, { name: 'Mice' }]}
+      title="Average number of pets"
+      height={50}
+      theme={theme}
+    />
   );
 
   render() {
@@ -26,14 +66,28 @@ class SimpleChart extends React.Component {
             Green Theme
           </Text>
           <div className="chart-inline">
-            <div className="chart-container chart-margin chart-overflow">{this.getChart(ChartTheme.light.green)}</div>
+            <div className="chart-container chart-margin chart-overflow">
+              <div>
+                {this.getChart(ChartTheme.light.green)}
+              </div>
+              <div className="chart-legend">
+                {this.getlegend(ChartTheme.light.green)}
+              </div>
+            </div>
           </div>
         </GridItem>
         <GridItem lg={3}>
           <Text className="chart-title" component={TextVariants.h2}>
             Multi Color Theme
           </Text>
-          <div className="chart-container chart-margin chart-overflow">{this.getChart(ChartTheme.light.multi)}</div>
+          <div className="chart-container chart-margin chart-overflow">
+            <div>
+              {this.getChart(ChartTheme.light.multi)}
+            </div>
+            <div className="chart-legend">
+              {this.getlegend(ChartTheme.light.multi)}
+            </div>
+          </div>
         </GridItem>
       </Grid>
     );

--- a/packages/patternfly-4/react-charts/src/components/LineChart/examples/common/getContainerProps.js
+++ b/packages/patternfly-4/react-charts/src/components/LineChart/examples/common/getContainerProps.js
@@ -4,7 +4,7 @@ const styles = StyleSheet.create({
   demoLayout: {
     '& > *': {
       '.chart-container': {
-        height: '200px',
+        height: '250px',
         width: '300px'
       },
       '.chart-margin': {
@@ -13,6 +13,9 @@ const styles = StyleSheet.create({
       },
       '.chart-inline': {
         display: 'inline-flex'
+      },
+      '.chart-legend': {
+        marginTop: '30px'
       },
       '.chart-overflow': {
         '& svg': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20592,6 +20592,19 @@ victory-core@^30.3.1:
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
 
+victory-core@^31.1.0:
+  version "31.2.0"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-31.2.0.tgz#c526abbeb8003460ac157419c13f9c1935a980f1"
+  dependencies:
+    d3-ease "^1.0.0"
+    d3-interpolate "^1.1.1"
+    d3-scale "^1.0.0"
+    d3-shape "^1.2.0"
+    d3-timer "^1.0.0"
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+
 victory-create-container@^30.5.1:
   version "30.5.1"
   resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-30.5.1.tgz#516c34333945874b489b00c50b0fe11f1f75edfc"


### PR DESCRIPTION
The Cost Management project needs to show charts with dotted lines. However, Victory does not support a dash symbol in the legend -- only symbols like plus, minus, star, etc.

Ultimately, my plan is to submit the new symbol upstream to Victory. However, I believe it needs to bake here for a bit. It's possible PF4 may still adjust the line heights for these symbols?

Per Kyle's high fidelity mocks:
https://redhat.invisionapp.com/share/ENPJQTBXTAC#/screens/336412758

Cost Management Charts:
<img width="1390" alt="screen shot 2019-01-30 at 3 33 18 pm" src="https://user-images.githubusercontent.com/17481322/52061707-f0385580-253c-11e9-9aba-d7cc1c015b99.png">

PatternFly React Example:
<img width="910" alt="screen shot 2019-02-01 at 10 08 29 pm" src="https://user-images.githubusercontent.com/17481322/52159140-13165700-266e-11e9-981d-51cdc78c9196.png">