### PR TITLE
fix(Table): Update table styles based on new styling from pf-next v 175

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/BodyWrapper.js
+++ b/packages/patternfly-4/react-table/src/components/Table/BodyWrapper.js
@@ -1,10 +1,22 @@
-import React, { Component } from 'react';
+import React, { Component, Children, Fragment } from 'react';
 import styles from '@patternfly/patternfly/components/Table/table.css';
 import { css } from '@patternfly/react-styles';
+import { mapOpenedRows } from './utils/headerUtils';
 
-const BodyWrapper = (rows) => {
+const BodyWrapper = (rows, onCollapse) => {
   class TableBody extends Component {
     render() {
+      if (onCollapse) {
+        return (
+          <Fragment>
+            {mapOpenedRows(rows, Children.toArray(this.props.children)).map((oneRow, key) => (
+                <tbody {...this.props} className={css(oneRow.isOpen && styles.modifiers.expanded)} key={`tbody-${key}`}>
+                {oneRow.rows}
+              </tbody>
+            ))}
+          </Fragment>
+        )
+      }
       return (
         <tbody {...this.props} className={css(
           rows.some(row => row.isOpen && !row.hasOwnProperty('parent')) && styles.modifiers.expanded

--- a/packages/patternfly-4/react-table/src/components/Table/CollapseColumn.js
+++ b/packages/patternfly-4/react-table/src/components/Table/CollapseColumn.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { AngleDownIcon } from '@patternfly/react-icons';
+import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { Button } from '@patternfly/react-core';
 import styles from '@patternfly/patternfly/components/Table/table.css';
@@ -19,7 +19,15 @@ const defaultProps = {
 const CollapseColumn = ({ children, onToggle, isOpen, className, ...props }) => (
   <React.Fragment>
     {isOpen !== undefined &&
-      <Button className={css(className, isOpen && styles.modifiers.expanded)} {...props} variant="plain" aria-label="Details" onClick={onToggle} aria-expanded={isOpen}><AngleDownIcon /></Button>
+      <Button className={css(className, isOpen && styles.modifiers.expanded)}
+        {...props}
+        variant="plain"
+        aria-label="Details"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+      >
+       { isOpen ? <AngleDownIcon /> : <AngleRightIcon /> }
+      </Button>
     }
     {children}
   </React.Fragment>

--- a/packages/patternfly-4/react-table/src/components/Table/SortColumn.js
+++ b/packages/patternfly-4/react-table/src/components/Table/SortColumn.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { AngleUpIcon, AngleDownIcon, SortIcon } from '@patternfly/react-icons';
+import { LongArrowAltUpIcon, LongArrowAltDownIcon, ArrowsAltVIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/patternfly/components/Table/table.css';
 
@@ -25,7 +25,7 @@ export const SortByDirection = {
 };
 
 const SortColumn = ({ isSortedBy, children, className, onSort, sortDirection, ...props }) => {
-  const SortedByIcon = isSortedBy ? (sortDirection === 'asc' ? AngleUpIcon : AngleDownIcon) : SortIcon;
+  const SortedByIcon = isSortedBy ? (sortDirection === 'asc' ? LongArrowAltUpIcon : LongArrowAltDownIcon) : ArrowsAltVIcon;
   return (
     <button {...props} className={css(className)} onClick={event => onSort && onSort(event)}>
       {children}

--- a/packages/patternfly-4/react-table/src/components/Table/Table.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.js
@@ -183,7 +183,7 @@ class Table extends React.Component {
           {...props}
           renderers={{
             body: {
-              wrapper: BodyWrapper(rows),
+              wrapper: BodyWrapper(rows, onCollapse),
               row: RowWrapper,
               cell: BodyCell
             },

--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
@@ -1194,7 +1194,7 @@ exports[`Actions table 1`] = `
                           <span
                             className="pf-c-table__sort-indicator"
                           >
-                            <SortIcon
+                            <ArrowsAltVIcon
                               color="currentColor"
                               size="sm"
                               title={null}
@@ -1210,15 +1210,15 @@ exports[`Actions table 1`] = `
                                     "verticalAlign": "-0.125em",
                                   }
                                 }
-                                viewBox="0 0 320 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                   transform=""
                                 />
                               </svg>
-                            </SortIcon>
+                            </ArrowsAltVIcon>
                           </span>
                         </button>
                       </SortColumn>
@@ -8300,7 +8300,7 @@ exports[`Cell header table 1`] = `
                           <span
                             className="pf-c-table__sort-indicator"
                           >
-                            <SortIcon
+                            <ArrowsAltVIcon
                               color="currentColor"
                               size="sm"
                               title={null}
@@ -8316,15 +8316,15 @@ exports[`Cell header table 1`] = `
                                     "verticalAlign": "-0.125em",
                                   }
                                 }
-                                viewBox="0 0 320 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                   transform=""
                                 />
                               </svg>
-                            </SortIcon>
+                            </ArrowsAltVIcon>
                           </span>
                         </button>
                       </SortColumn>
@@ -12555,7 +12555,7 @@ exports[`Collapsible nested table 1`] = `
                           <span
                             className="pf-c-table__sort-indicator"
                           >
-                            <SortIcon
+                            <ArrowsAltVIcon
                               color="currentColor"
                               size="sm"
                               title={null}
@@ -12571,15 +12571,15 @@ exports[`Collapsible nested table 1`] = `
                                     "verticalAlign": "-0.125em",
                                   }
                                 }
-                                viewBox="0 0 320 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                   transform=""
                                 />
                               </svg>
-                            </SortIcon>
+                            </ArrowsAltVIcon>
                           </span>
                         </button>
                       </SortColumn>
@@ -13265,6 +13265,7 @@ exports[`Collapsible nested table 1`] = `
             >
               <tbody
                 className=""
+                key="tbody-0"
               >
                 <BodyRow
                   columns={
@@ -13491,7 +13492,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key="0-row"
+                  key=".$0-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -13590,7 +13591,7 @@ exports[`Collapsible nested table 1`] = `
                                 tabIndex={null}
                                 type="button"
                               >
-                                <AngleDownIcon
+                                <AngleRightIcon
                                   color="currentColor"
                                   size="sm"
                                   title={null}
@@ -13606,15 +13607,15 @@ exports[`Collapsible nested table 1`] = `
                                         "verticalAlign": "-0.125em",
                                       }
                                     }
-                                    viewBox="0 0 320 512"
+                                    viewBox="0 0 256 512"
                                     width="1em"
                                   >
                                     <path
-                                      d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
                                       transform=""
                                     />
                                   </svg>
-                                </AngleDownIcon>
+                                </AngleRightIcon>
                               </button>
                             </Button>
                           </CollapseColumn>
@@ -13913,7 +13914,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key="1-row"
+                  key=".$1-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -14326,7 +14327,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key="2-row"
+                  key=".$2-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -14455,6 +14456,11 @@ exports[`Collapsible nested table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-1"
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -14680,7 +14686,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key="3-row"
+                  key=".$3-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -14779,7 +14785,7 @@ exports[`Collapsible nested table 1`] = `
                                 tabIndex={null}
                                 type="button"
                               >
-                                <AngleDownIcon
+                                <AngleRightIcon
                                   color="currentColor"
                                   size="sm"
                                   title={null}
@@ -14795,15 +14801,15 @@ exports[`Collapsible nested table 1`] = `
                                         "verticalAlign": "-0.125em",
                                       }
                                     }
-                                    viewBox="0 0 320 512"
+                                    viewBox="0 0 256 512"
                                     width="1em"
                                   >
                                     <path
-                                      d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
                                       transform=""
                                     />
                                   </svg>
-                                </AngleDownIcon>
+                                </AngleRightIcon>
                               </button>
                             </Button>
                           </CollapseColumn>
@@ -15102,7 +15108,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key="4-row"
+                  key=".$4-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -15231,6 +15237,11 @@ exports[`Collapsible nested table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-2"
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -15456,7 +15467,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key="5-row"
+                  key=".$5-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -15594,6 +15605,11 @@ exports[`Collapsible nested table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-3"
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -15819,7 +15835,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key="6-row"
+                  key=".$6-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -15957,6 +15973,11 @@ exports[`Collapsible nested table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-4"
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -16182,7 +16203,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key="7-row"
+                  key=".$7-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -16320,6 +16341,11 @@ exports[`Collapsible nested table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-5"
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -16545,7 +16571,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key="8-row"
+                  key=".$8-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -16785,6 +16811,9 @@ exports[`Collapsible table 1`] = `
   border-bottom-color: #ededed;
   border-bottom-width: 1px;
 }
+.pf-m-expanded {
+  display: block;
+}
 .pf-c-table__toggle {
   display: block;
   vertical-align: top;
@@ -16869,9 +16898,6 @@ exports[`Collapsible table 1`] = `
 .pf-c-table__toggle {
   display: block;
   vertical-align: top;
-}
-.pf-m-expanded {
-  display: block;
 }
 .pf-c-table {
   display: block;
@@ -17541,7 +17567,7 @@ exports[`Collapsible table 1`] = `
                           <span
                             className="pf-c-table__sort-indicator"
                           >
-                            <SortIcon
+                            <ArrowsAltVIcon
                               color="currentColor"
                               size="sm"
                               title={null}
@@ -17557,15 +17583,15 @@ exports[`Collapsible table 1`] = `
                                     "verticalAlign": "-0.125em",
                                   }
                                 }
-                                viewBox="0 0 320 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                   transform=""
                                 />
                               </svg>
-                            </SortIcon>
+                            </ArrowsAltVIcon>
                           </span>
                         </button>
                       </SortColumn>
@@ -18246,6 +18272,7 @@ exports[`Collapsible table 1`] = `
             >
               <tbody
                 className="pf-m-expanded"
+                key="tbody-0"
               >
                 <BodyRow
                   columns={
@@ -18472,7 +18499,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key="0-row"
+                  key=".$0-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -18894,7 +18921,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key="1-row"
+                  key=".$1-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -19023,6 +19050,11 @@ exports[`Collapsible table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-1"
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -19248,7 +19280,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key="2-row"
+                  key=".$2-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -19386,6 +19418,11 @@ exports[`Collapsible table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-2"
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -19611,7 +19648,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key="3-row"
+                  key=".$3-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -19710,7 +19747,7 @@ exports[`Collapsible table 1`] = `
                                 tabIndex={null}
                                 type="button"
                               >
-                                <AngleDownIcon
+                                <AngleRightIcon
                                   color="currentColor"
                                   size="sm"
                                   title={null}
@@ -19726,15 +19763,15 @@ exports[`Collapsible table 1`] = `
                                         "verticalAlign": "-0.125em",
                                       }
                                     }
-                                    viewBox="0 0 320 512"
+                                    viewBox="0 0 256 512"
                                     width="1em"
                                   >
                                     <path
-                                      d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
                                       transform=""
                                     />
                                   </svg>
-                                </AngleDownIcon>
+                                </AngleRightIcon>
                               </button>
                             </Button>
                           </CollapseColumn>
@@ -20033,7 +20070,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key="4-row"
+                  key=".$4-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -20162,6 +20199,11 @@ exports[`Collapsible table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-3"
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -20387,7 +20429,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key="5-row"
+                  key=".$5-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -20525,6 +20567,11 @@ exports[`Collapsible table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-4"
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -20750,7 +20797,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key="6-row"
+                  key=".$6-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -20888,6 +20935,11 @@ exports[`Collapsible table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-5"
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -21113,7 +21165,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key="7-row"
+                  key=".$7-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -21251,6 +21303,11 @@ exports[`Collapsible table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-6"
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -21476,7 +21533,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key="8-row"
+                  key=".$8-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -26463,7 +26520,7 @@ exports[`Selectable table 1`] = `
                           <span
                             className="pf-c-table__sort-indicator"
                           >
-                            <SortIcon
+                            <ArrowsAltVIcon
                               color="currentColor"
                               size="sm"
                               title={null}
@@ -26479,15 +26536,15 @@ exports[`Selectable table 1`] = `
                                     "verticalAlign": "-0.125em",
                                   }
                                 }
-                                viewBox="0 0 320 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                   transform=""
                                 />
                               </svg>
-                            </SortIcon>
+                            </ArrowsAltVIcon>
                           </span>
                         </button>
                       </SortColumn>
@@ -42700,7 +42757,7 @@ exports[`Sortable table 1`] = `
                           <span
                             className="pf-c-table__sort-indicator"
                           >
-                            <SortIcon
+                            <ArrowsAltVIcon
                               color="currentColor"
                               size="sm"
                               title={null}
@@ -42716,15 +42773,15 @@ exports[`Sortable table 1`] = `
                                     "verticalAlign": "-0.125em",
                                   }
                                 }
-                                viewBox="0 0 320 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                   transform=""
                                 />
                               </svg>
-                            </SortIcon>
+                            </ArrowsAltVIcon>
                           </span>
                         </button>
                       </SortColumn>
@@ -46675,7 +46732,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                           <span
                             className="pf-c-table__sort-indicator"
                           >
-                            <SortIcon
+                            <ArrowsAltVIcon
                               color="currentColor"
                               size="sm"
                               title={null}
@@ -46691,15 +46748,15 @@ exports[`Table variants Breakpoint - grid 1`] = `
                                     "verticalAlign": "-0.125em",
                                   }
                                 }
-                                viewBox="0 0 320 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                   transform=""
                                 />
                               </svg>
-                            </SortIcon>
+                            </ArrowsAltVIcon>
                           </span>
                         </button>
                       </SortColumn>
@@ -50650,7 +50707,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                           <span
                             className="pf-c-table__sort-indicator"
                           >
-                            <SortIcon
+                            <ArrowsAltVIcon
                               color="currentColor"
                               size="sm"
                               title={null}
@@ -50666,15 +50723,15 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                                     "verticalAlign": "-0.125em",
                                   }
                                 }
-                                viewBox="0 0 320 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                   transform=""
                                 />
                               </svg>
-                            </SortIcon>
+                            </ArrowsAltVIcon>
                           </span>
                         </button>
                       </SortColumn>
@@ -54625,7 +54682,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                           <span
                             className="pf-c-table__sort-indicator"
                           >
-                            <SortIcon
+                            <ArrowsAltVIcon
                               color="currentColor"
                               size="sm"
                               title={null}
@@ -54641,15 +54698,15 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                                     "verticalAlign": "-0.125em",
                                   }
                                 }
-                                viewBox="0 0 320 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                   transform=""
                                 />
                               </svg>
-                            </SortIcon>
+                            </ArrowsAltVIcon>
                           </span>
                         </button>
                       </SortColumn>
@@ -58600,7 +58657,7 @@ exports[`Table variants Size - compact 1`] = `
                           <span
                             className="pf-c-table__sort-indicator"
                           >
-                            <SortIcon
+                            <ArrowsAltVIcon
                               color="currentColor"
                               size="sm"
                               title={null}
@@ -58616,15 +58673,15 @@ exports[`Table variants Size - compact 1`] = `
                                     "verticalAlign": "-0.125em",
                                   }
                                 }
-                                viewBox="0 0 320 512"
+                                viewBox="0 0 256 512"
                                 width="1em"
                               >
                                 <path
-                                  d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"
+                                  d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
                                   transform=""
                                 />
                               </svg>
-                            </SortIcon>
+                            </ArrowsAltVIcon>
                           </span>
                         </button>
                       </SortColumn>

--- a/packages/patternfly-4/react-table/src/components/Table/examples/CollapsibleTable.js
+++ b/packages/patternfly-4/react-table/src/components/Table/examples/CollapsibleTable.js
@@ -25,21 +25,14 @@ class CollapsibleTable extends React.Component {
         isOpen: false,
         cells: ['parent - 2', 'two', 'three', 'four', 'five'],
       }, {
-        isOpen: false,
         parent: 3,
-        cells: ['child and parent'],
-      }, {
-        parent: 4,
         cells: ['child - 2'],
       }, {
         isOpen: false,
         cells: ['parent - 3', 'two', 'three', 'four', 'five'],
       }, {
-        parent: 6,
+        parent: 5,
         cells: ['child - 3'],
-      }, {
-        parent: 6,
-        cells: ['child - 4'],
       }]
     };
     this.onCollapse = this.onCollapse.bind(this);

--- a/packages/patternfly-4/react-table/src/components/Table/utils/headerUtils.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/headerUtils.js
@@ -148,6 +148,25 @@ const expandContent = (header, { onCollapse }) => {
 }
 
 /**
+ * Function to join parent and their children so they can be rendered in tbody.
+ * @param {*} rows raw data to find out if it's child or parent.
+ * @param {*} children data to render (array of react children).
+ */
+export const mapOpenedRows = (rows, children) => {
+  return rows.reduce((acc, curr, key) => {
+    if (curr.hasOwnProperty('parent')) {
+      const parent = acc.length > 0 && acc[acc.length - 1];
+      if (parent) {
+        acc[acc.length - 1].rows = [...acc[acc.length - 1].rows, children[key]];
+      }
+    } else {
+      acc = [...acc, { ...curr, rows: [children[key]] }];
+    }
+    return acc;
+  }, []);
+}
+
+/**
  * Function to calculate columns based on custom config.
  * It adds some custom cells for collapse, select, if expanded row and actions.
  * @param {*} headerRows custom object with described table header cells.

--- a/packages/patternfly-4/react-table/src/components/Table/utils/headerUtils.test.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/headerUtils.test.js
@@ -1,4 +1,4 @@
-import { calculateColumns } from './headerUtils';
+import { calculateColumns, mapOpenedRows } from './headerUtils';
 
 describe('headerUtils', () => {
   describe('calculateColumns', () => {
@@ -140,6 +140,44 @@ describe('headerUtils', () => {
         expect(result[0].cell.formatters.find(formatter => formatter.name === 'testFunc')).toBeDefined();
         expect(result[0].cell.transforms.find(transform => transform.name === 'testFunc')).toBeDefined();
       });
+    });
+  });
+
+  describe('mapOpenedRows', () => {
+    test('flat structure', () => {
+      const rows = [{}, { parent: 0 }, {}, { parent: 2 }];
+      const children = ['one', 'two', 'three', 'four'];
+      const mappedRows = mapOpenedRows(rows, children);
+      expect(mappedRows.length).toBe(2);
+      expect(mappedRows[0].rows.length).toBe(2);
+      expect(mappedRows[0]).toMatchObject({rows: ['one', 'two']});
+    });
+
+    test('nested children', () => {
+      const rows = [{}, { parent: 0 }, { parent: 1 }, { parent: 2 }];
+      const children = ['one', 'two', 'three', 'four'];
+      const mappedRows = mapOpenedRows(rows, children);
+      expect(mappedRows.length).toBe(1);
+      expect(mappedRows[0].rows.length).toBe(4);
+      expect(mappedRows[0]).toMatchObject({ rows: children });
+    });
+
+    test('no parent', () => {
+      const rows = [{ parent: 'something' }, { parent: 0 }, { }, { parent: 2 }];
+      const children = ['one', 'two', 'three', 'four'];
+      const mappedRows = mapOpenedRows(rows, children);
+      expect(mappedRows.length).toBe(1);
+      expect(mappedRows[0].rows.length).toBe(2);
+      expect(mappedRows[0]).toMatchObject({ rows: ['three', 'four'] });
+    });
+
+    test('should add rest props', () => {
+      const rows = [{ isOpen: true, somethig: 'other' }, { parent: 0 }, { isOpen: false }, { parent: 2 }];
+      const children = ['one', 'two', 'three', 'four'];
+      const mappedRows = mapOpenedRows(rows, children);
+      expect(mappedRows.length).toBe(2);
+      expect(mappedRows[0].rows.length).toBe(2);
+      expect(mappedRows[0]).toMatchObject({ ...rows[0], rows: ['one', 'two'] });
     });
   });
 });


### PR DESCRIPTION
**What**:
Because we updated to newer version of PF-next we have to update collapsible and sort implementation.

#### Before collapsible
![screenshot from 2019-02-04 12-20-10](https://user-images.githubusercontent.com/3439771/52205412-437d1180-2877-11e9-99e4-299c1f1b2355.png)
#### After collapsible
![screenshot from 2019-02-04 12-19-55](https://user-images.githubusercontent.com/3439771/52205410-437d1180-2877-11e9-9b26-c0f90e5e7db2.png)

#### Before sortable
![screenshot from 2019-02-04 12-22-18](https://user-images.githubusercontent.com/3439771/52205502-8e972480-2877-11e9-8aee-4d1448f00482.png)
#### After sortable
![screenshot from 2019-02-04 12-22-26](https://user-images.githubusercontent.com/3439771/52205503-8e972480-2877-11e9-9879-08d62cf1309a.png)
