### PR TITLE
fix(Nav): do not render the examples page

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavDefaultList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavDefaultList.js
@@ -17,16 +17,16 @@ class NavDefaultList extends React.Component {
     return (
       <Nav onSelect={this.onSelect} aria-label="Primary Nav Default Example">
         <NavList>
-          <NavItem to="#default-link1" itemId={0} isActive={activeItem === 0}>
+          <NavItem id="default-link1" to="#default-link1" itemId={0} isActive={activeItem === 0}>
             Link 1
           </NavItem>
-          <NavItem to="#default-link2" itemId={1} isActive={activeItem === 1}>
+          <NavItem id="default-link2" to="#default-link2" itemId={1} isActive={activeItem === 1}>
             Link 2
           </NavItem>
-          <NavItem to="#default-link3" itemId={2} isActive={activeItem === 2}>
+          <NavItem id="default-link3" to="#default-link3" itemId={2} isActive={activeItem === 2}>
             Link 3
           </NavItem>
-          <NavItem to="#default-link4" itemId={3} isActive={activeItem === 3}>
+          <NavItem id="default-link4" to="#default-link4" itemId={3} isActive={activeItem === 3}>
             Link 4
           </NavItem>
         </NavList>

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavExpandableList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavExpandableList.js
@@ -30,11 +30,11 @@ class NavExpandableList extends React.Component {
       <Nav onSelect={this.onSelect} onToggle={this.onToggle} aria-label="Primary Nav Expandable Example">
         <NavList>
           <NavExpandable title="Link 1" groupId="grp-1" isActive={activeGroup === 'grp-1'} isExpanded>
-            <NavItem to="#expandable-1" groupId="grp-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
+            <NavItem preventDefault to="#expandable-1" groupId="grp-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
               Subnav Link 1
             </NavItem>
             <NavItem
-              to="#expandable-2"
+              preventDefault
               groupId="grp-1"
               itemId="grp-1_itm-2"
               isActive={activeItem === 'grp-1_itm-2'}
@@ -56,13 +56,13 @@ class NavExpandableList extends React.Component {
             >
               Custom onClick
             </NavItem>
-            <NavItem to="#expandable-4" groupId="grp-2" itemId="grp-2_itm-1" isActive={activeItem === 'grp-2_itm-1'}>
+            <NavItem preventDefault to="#expandable-4" groupId="grp-2" itemId="grp-2_itm-1" isActive={activeItem === 'grp-2_itm-1'}>
               Subnav Link 1
             </NavItem>
-            <NavItem to="#expandable-5" groupId="grp-2" itemId="grp-2_itm-2" isActive={activeItem === 'grp-2_itm-2'}>
+            <NavItem preventDefault to="#expandable-5" groupId="grp-2" itemId="grp-2_itm-2" isActive={activeItem === 'grp-2_itm-2'}>
               Subnav Link 2
             </NavItem>
-            <NavItem to="#expandable-6" groupId="grp-2" itemId="grp-2_itm-3" isActive={activeItem === 'grp-2_itm-3'}>
+            <NavItem preventDefault to="#expandable-6" groupId="grp-2" itemId="grp-2_itm-3" isActive={activeItem === 'grp-2_itm-3'}>
               Subnav Link 3
             </NavItem>
           </NavExpandable>

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavExpandableTitlesList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavExpandableTitlesList.js
@@ -20,24 +20,24 @@ class NavExpandableTitlesList extends React.Component {
       <Nav onSelect={this.onSelect} onToggle={this.onToggle} aria-label="Nav Expandable with screen reader headings">
         <NavList>
           <NavExpandable title="Link 1" srText="SR Link" groupId="grp-1" isActive={activeGroup === 'grp-1'} isExpanded>
-            <NavItem to="#sr-expandable-1" groupId="grp-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
+            <NavItem preventDefault to="#sr-expandable-1" groupId="grp-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
               Subnav Link 1
             </NavItem>
-            <NavItem to="#sr-expandable-2" groupId="grp-1" itemId="grp-1_itm-2" isActive={activeItem === 'grp-1_itm-2'}>
+            <NavItem preventDefault to="#sr-expandable-2" groupId="grp-1" itemId="grp-1_itm-2" isActive={activeItem === 'grp-1_itm-2'}>
               Subnav Link 2
             </NavItem>
-            <NavItem to="#sr-expandable-3" groupId="grp-1" itemId="grp-1_itm-3" isActive={activeItem === 'grp-1_itm-3'}>
+            <NavItem preventDefault to="#sr-expandable-3" groupId="grp-1" itemId="grp-1_itm-3" isActive={activeItem === 'grp-1_itm-3'}>
               Subnav Link 3
             </NavItem>
           </NavExpandable>
           <NavExpandable title="Link 2" srText="SR Link 2" groupId="grp-2" isActive={activeGroup === 'grp-2'}>
-            <NavItem to="#sr-expandable-4" groupId="grp-2" itemId="grp-2_itm-1" isActive={activeItem === 'grp-2_itm-1'}>
+            <NavItem preventDefault to="#sr-expandable-4" groupId="grp-2" itemId="grp-2_itm-1" isActive={activeItem === 'grp-2_itm-1'}>
               Subnav Link 1
             </NavItem>
-            <NavItem to="#sr-expandable-5" groupId="grp-2" itemId="grp-2_itm-2" isActive={activeItem === 'grp-2_itm-2'}>
+            <NavItem preventDefault to="#sr-expandable-5" groupId="grp-2" itemId="grp-2_itm-2" isActive={activeItem === 'grp-2_itm-2'}>
               Subnav Link 2
             </NavItem>
-            <NavItem to="#sr-expandable-6" groupId="grp-2" itemId="grp-2_itm-3" isActive={activeItem === 'grp-2_itm-3'}>
+            <NavItem preventDefault to="#sr-expandable-6" groupId="grp-2" itemId="grp-2_itm-3" isActive={activeItem === 'grp-2_itm-3'}>
               Subnav Link 3
             </NavItem>
           </NavExpandable>

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavGroupedList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavGroupedList.js
@@ -17,24 +17,24 @@ class NavGroupedList extends React.Component {
     return (
       <Nav onSelect={this.onSelect} aria-label="Primary Nav Grouped Example">
         <NavGroup title="Section title 1">
-          <NavItem to="#grouped-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
+          <NavItem preventDefault to="#grouped-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
             Link 1
           </NavItem>
-          <NavItem to="#grouped-2" itemId="grp-1_itm-2" isActive={activeItem === 'grp-1_itm-2'}>
+          <NavItem preventDefault to="#grouped-2" itemId="grp-1_itm-2" isActive={activeItem === 'grp-1_itm-2'}>
             Link 2
           </NavItem>
-          <NavItem to="#grouped-3" itemId="grp-1_itm-3" isActive={activeItem === 'grp-1_itm-3'}>
+          <NavItem preventDefault to="#grouped-3" itemId="grp-1_itm-3" isActive={activeItem === 'grp-1_itm-3'}>
             Link 3
           </NavItem>
         </NavGroup>
         <NavGroup title="Section title 2">
-          <NavItem to="#grouped-4" itemId="grp-2_itm-1" isActive={activeItem === 'grp-2_itm-1'}>
+          <NavItem preventDefault to="#grouped-4" itemId="grp-2_itm-1" isActive={activeItem === 'grp-2_itm-1'}>
             Link 1
           </NavItem>
-          <NavItem to="#grouped-5" itemId="grp-2_itm-2" isActive={activeItem === 'grp-2_itm-2'}>
+          <NavItem preventDefault to="#grouped-5" itemId="grp-2_itm-2" isActive={activeItem === 'grp-2_itm-2'}>
             Link 2
           </NavItem>
-          <NavItem to="#grouped-6" itemId="grp-2_itm-3" isActive={activeItem === 'grp-2_itm-3'}>
+          <NavItem preventDefault to="#grouped-6" itemId="grp-2_itm-3" isActive={activeItem === 'grp-2_itm-3'}>
             Link 3
           </NavItem>
         </NavGroup>

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavHorizontalList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavHorizontalList.js
@@ -18,13 +18,13 @@ class NavHorizontalList extends React.Component {
       <div style={{ backgroundColor: '#292e34', padding: '1rem' }}>
         <Nav onSelect={this.onSelect} aria-label="Primary Nav Horizontal Example">
           <NavList variant={NavVariants.horizontal}>
-            <NavItem to="#horizontal-link1" itemId={0} isActive={activeItem === 0}>
+            <NavItem preventDefault to="#horizontal-link1" itemId={0} isActive={activeItem === 0}>
               Item 1
             </NavItem>
-            <NavItem to="#horizontal-link2" itemId={1} isActive={activeItem === 1}>
+            <NavItem preventDefault to="#horizontal-link2" itemId={1} isActive={activeItem === 1}>
               Item 2
             </NavItem>
-            <NavItem to="#horizontal-link3" itemId={2} isActive={activeItem === 2}>
+            <NavItem preventDefault to="#horizontal-link3" itemId={2} isActive={activeItem === 2}>
               Item 3
             </NavItem>
           </NavList>

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavMixedList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavMixedList.js
@@ -19,28 +19,28 @@ class NavMixedList extends React.Component {
     return (
       <Nav onSelect={this.onSelect} aria-label="Primary Nav Mixed Example">
         <NavList>
-          <NavItem to="#mixed-1" itemId="itm-1" isActive={activeItem === 'itm-1'}>
+          <NavItem preventDefault to="#mixed-1" itemId="itm-1" isActive={activeItem === 'itm-1'}>
             Link 1 (not expandable)
           </NavItem>
           <NavExpandable title="Link 2 - expandable" groupId="grp-1" isActive={activeGroup === 'grp-1'}>
-            <NavItem to="#mixed-2" groupId="grp-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
+            <NavItem preventDefault to="#mixed-2" groupId="grp-1" itemId="grp-1_itm-1" isActive={activeItem === 'grp-1_itm-1'}>
               Link 1
             </NavItem>
-            <NavItem to="#mixed-3" groupId="grp-1" itemId="grp-1_itm-2" isActive={activeItem === 'grp-1_itm-2'}>
+            <NavItem preventDefault to="#mixed-3" groupId="grp-1" itemId="grp-1_itm-2" isActive={activeItem === 'grp-1_itm-2'}>
               Link 2
             </NavItem>
-            <NavItem to="#mixed-4" groupId="grp-1" itemId="grp-1_itm-3" isActive={activeItem === 'grp-1_itm-3'}>
+            <NavItem preventDefault to="#mixed-4" groupId="grp-1" itemId="grp-1_itm-3" isActive={activeItem === 'grp-1_itm-3'}>
               Link 3
             </NavItem>
           </NavExpandable>
           <NavExpandable title="Link 3 - expandable" groupId="grp-2" isActive={activeGroup === 'grp-2'}>
-            <NavItem to="#mixed-5" groupId="grp-2" itemId="grp-2_itm-1" isActive={activeItem === 'grp-2_itm-1'}>
+            <NavItem preventDefault to="#mixed-5" groupId="grp-2" itemId="grp-2_itm-1" isActive={activeItem === 'grp-2_itm-1'}>
               Link 1
             </NavItem>
-            <NavItem to="#mixed-6" groupId="grp-2" itemId="grp-2_itm-2" isActive={activeItem === 'grp-2_itm-2'}>
+            <NavItem preventDefault to="#mixed-6" groupId="grp-2" itemId="grp-2_itm-2" isActive={activeItem === 'grp-2_itm-2'}>
               Link 2
             </NavItem>
-            <NavItem to="#mixed-7" groupId="grp-2" itemId="grp-2_itm-3" isActive={activeItem === 'grp-2_itm-3'}>
+            <NavItem preventDefault to="#mixed-7" groupId="grp-2" itemId="grp-2_itm-3" isActive={activeItem === 'grp-2_itm-3'}>
               Link 3
             </NavItem>
           </NavExpandable>

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavSimpleList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavSimpleList.js
@@ -17,16 +17,16 @@ class NavSimpleList extends React.Component {
     return (
       <Nav onSelect={this.onSelect} id="nav-primary-simple" aria-label="Primary Nav, Simple List Example">
         <NavList variant={NavVariants.simple}>
-          <NavItem to="#simple-link1" itemId={0} isActive={activeItem === 0}>
+          <NavItem preventDefault to="#simple-link1" itemId={0} isActive={activeItem === 0}>
             Link 1
           </NavItem>
-          <NavItem to="#simple-link2" itemId={1} isActive={activeItem === 1}>
+          <NavItem preventDefault to="#simple-link2" itemId={1} isActive={activeItem === 1}>
             Link 2
           </NavItem>
-          <NavItem to="#simple-link3" itemId={2} isActive={activeItem === 2} isSeparated={true}>
+          <NavItem preventDefault to="#simple-link3" itemId={2} isActive={activeItem === 2} isSeparated={true}>
             Link 3 with separator
           </NavItem>
-          <NavItem to="#simple-link4" itemId={3} isActive={activeItem === 3}>
+          <NavItem preventDefault to="#simple-link4" itemId={3} isActive={activeItem === 3}>
             Link 4
           </NavItem>
         </NavList>

--- a/packages/patternfly-4/react-core/src/components/Nav/examples/NavTertiaryList.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/examples/NavTertiaryList.js
@@ -17,16 +17,16 @@ class NavTertiaryList extends React.Component {
     return (
       <Nav onSelect={this.onSelect} aria-label="Tertiary Example">
         <NavList variant={NavVariants.tertiary}>
-          <NavItem to="#tertiary-link1" itemId={0} isActive={activeItem === 0}>
+          <NavItem preventDefault to="#tertiary-link1" itemId={0} isActive={activeItem === 0}>
             Link 1
           </NavItem>
-          <NavItem to="#tertiary-link2" itemId={1} isActive={activeItem === 1}>
+          <NavItem preventDefault to="#tertiary-link2" itemId={1} isActive={activeItem === 1}>
             Link 2
           </NavItem>
-          <NavItem to="#tertiary-link3" itemId={2} isActive={activeItem === 2}>
+          <NavItem preventDefault to="#tertiary-link3" itemId={2} isActive={activeItem === 2}>
             Link 3
           </NavItem>
-          <NavItem to="#tertiary-link4" itemId={3} isActive={activeItem === 3}>
+          <NavItem preventDefault to="#tertiary-link4" itemId={3} isActive={activeItem === 3}>
             Link 4
           </NavItem>
         </NavList>


### PR DESCRIPTION
**What**:

Clicking on the links in the Nav examples refresh the page itself and causing the state to be reset.
Adding `preventDefault` will prevent from refreshing the page and fix this problem.

fixes #1263 

//cc @ibolton336 