### PR TITLE
build(cross-var): use cross-env instead of cross-var to fix OSX 10.13.6 error

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/package.json
+++ b/packages/patternfly-3/patternfly-react-extensions/package.json
@@ -35,7 +35,7 @@
     "build:babel:cjs": "cross-env BABEL_ENV=production:cjs babel src --out-dir dist/js",
     "build:babel:esm": "cross-env BABEL_ENV=production:esm babel src --out-dir dist/esm",
     "build:less": "shx mkdir -p dist/less && shx cp -r less/* dist/less",
-    "build:sass": "shx mkdir -p dist/sass && shx cp -r sass/patternfly-react-extensions/* dist/sass && cross-var node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react-extensions.scss"
+    "build:sass": "shx mkdir -p dist/sass && shx cp -r sass/patternfly-react-extensions/* dist/sass && cross-env node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react-extensions.scss"
   },
   "dependencies": {
     "breakjs": "^1.0.0",
@@ -52,8 +52,5 @@
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2"
-  },
-  "devDependencies": {
-    "cross-var": "^1.1.0"
   }
 }

--- a/packages/patternfly-3/patternfly-react/package.json
+++ b/packages/patternfly-3/patternfly-react/package.json
@@ -63,10 +63,9 @@
     "build:babel:cjs": "cross-env BABEL_ENV=production:cjs babel src --out-dir dist/js",
     "build:babel:esm": "cross-env BABEL_ENV=production:esm babel src --out-dir dist/esm",
     "build:less": "shx mkdir -p dist/less && shx cp -r less/* dist/less",
-    "build:sass": "shx mkdir -p dist/sass && shx cp -r sass/patternfly-react/* dist/sass && cross-var node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react.scss"
+    "build:sass": "shx mkdir -p dist/sass && shx cp -r sass/patternfly-react/* dist/sass && cross-env node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react.scss"
   },
   "devDependencies": {
-    "cross-var": "^1.1.0",
     "react-axe": "^3.0.2",
     "shx": "^0.3.2"
   }

--- a/packages/patternfly-3/react-console/package.json
+++ b/packages/patternfly-3/react-console/package.json
@@ -35,7 +35,7 @@
     "build:babel:cjs": "cross-env BABEL_ENV=production:cjs babel src --out-dir dist/js",
     "build:babel:esm": "cross-env BABEL_ENV=production:esm babel src --out-dir dist/esm",
     "build:less": "shx mkdir -p dist/less && shx cp -r less/* dist/less",
-    "build:sass": "shx mkdir -p dist/sass && shx cp -r sass/* dist/sass && cross-var node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/console.scss"
+    "build:sass": "shx mkdir -p dist/sass && shx cp -r sass/* dist/sass && cross-env node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/console.scss"
   },
   "dependencies": {
     "@novnc/novnc": "^1.0.0",
@@ -45,7 +45,6 @@
     "xterm": "^3.3.0"
   },
   "devDependencies": {
-    "cross-var": "^1.1.0",
     "patternfly": "^3.58.0",
     "patternfly-react": "^2.29.9"
   },


### PR DESCRIPTION
**What**: Fix cross-var causing babel-loader error on OSX 10.13.6:

```
$ yarn build:sass && yarn build:less
$ shx mkdir -p dist/sass && shx cp -r sass/patternfly-react-extensions/* dist/sass && cross-var node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react-extensions.scss
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

lerna ERR! yarn run prebuild stderr:
/Users/zallen/src/patternfly-react/node_modules/babel-core/lib/transformation/file/options/option-manager.js:328
        throw e;
        ^

Error: Options {"loose":true} passed to /Users/zallen/src/patternfly-react/node_modules/babel-preset-env/lib/index.js which does not accept options. (While processing preset: "/Users/zallen/src/patternfly-react/node_modules/babel-preset-env/lib/index.js") (While processing preset: "/Users/zallen/src/patternfly-react/node_modules/babel-preset-env/lib/index.js") (While processing preset: "/Users/zallen/src/patternfly-react/packages/patternfly-3/.babelrc.js") (While processing preset: "/Users/zallen/src/patternfly-react/packages/patternfly-3/.babelrc.js") (While processing preset: "/Users/zallen/src/patternfly-react/packages/patternfly-3/.babelrc.js") (While processing preset: "/Users/zallen/src/patternfly-react/packages/patternfly-3/.babelrc.js") (While processing preset: "/Users/zallen/src/patternfly-react/packages/patternfly-3/.babelrc.js") (While processing preset: "/Users/zallen/src/patternfly-react/node_modules/babel-preset-es2015/lib/index.js")
    at /Users/zallen/src/patternfly-react/node_modules/babel-core/lib/transformation/file/options/option-manager.js:314:17
    at Array.map (<anonymous>)
    at OptionManager.resolvePresets (/Users/zallen/src/patternfly-react/node_modules/babel-core/lib/transformation/file/options/option-manager.js:275:20)
    at OptionManager.mergePresets (/Users/zallen/src/patternfly-react/node_modules/babel-core/lib/transformation/file/options/option-manager.js:264:10)
    at OptionManager.mergeOptions (/Users/zallen/src/patternfly-react/node_modules/babel-core/lib/transformation/file/options/option-manager.js:249:14)
    at OptionManager.init (/Users/zallen/src/patternfly-react/node_modules/babel-core/lib/transformation/file/options/option-manager.js:368:12)
    at compile (/Users/zallen/src/patternfly-react/node_modules/babel-register/lib/node.js:103:45)
    at loader (/Users/zallen/src/patternfly-react/node_modules/babel-register/lib/node.js:144:14)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/zallen/src/patternfly-react/node_modules/babel-register/lib/node.js:154:7)
    at Module.load (module.js:566:32)
error Command failed with exit code 1.
error Command failed with exit code 1.

lerna ERR! yarn run prebuild exited 1 in 'patternfly-react-extensions'
lerna WARN complete Waiting for 4 child processes to exit. CTRL-C to exit immediately.
error Command failed with exit code 1.
```