### PR TITLE
fix(Table): allow colspan to be set in props for each cell

### DIFF
--- a/packages/patternfly-4/react-table/README.md
+++ b/packages/patternfly-4/react-table/README.md
@@ -69,6 +69,23 @@ export default SimpleTable;
 
 This library makes use of the babel plugin from [@patternfly/react-styles](../react-styles/README.md) to enable providing the CSS alongside the components. This removes the need for consumers to use (style|css|sass)-loaders. For an example of using CSS from core you can reference [Button.js](./src/components/Button/Button.js). For any CSS not provided by core please use the `StyleSheet.create` utility from [@patternfly/react-styles](../react-styles/README.md). This will prevent collisions with any consumers, and allow the CSS to be bundled with the component.
 
+### Custom transformators
+If you want to add custom transformators to show some special column (collapsible, checkbox) you have to include `isVisible` there as well so cellRenderer knows which cells to render (main purpose is for colSpan).
+
+Example of such transformator can be:
+```JSX
+function someTransform(value) {
+  return {
+    isVisible: true,
+    children: <div>cell</div>
+  }
+}
+```
+
+If you want to add this transformer as default cell (first, last, any,...) for each row you also want to change function `calculateColumns`in [HeaderUtils.js](src/components/Table/utils/HeaderUtils.js).
+
+Notice: Any data provided as cell will be visible by default, no need to add `isVisible` if you want to change how data are displayed.
+
 ### Documentation
 
 This project uses Gatsby. For an overview of the project structure please refer to the [Gatsby documentation - Building with Components](https://www.gatsbyjs.org/docs/building-with-components/).

--- a/packages/patternfly-4/react-table/src/components/Table/BodyCell.js
+++ b/packages/patternfly-4/react-table/src/components/Table/BodyCell.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropsType from 'prop-types';
 
-const BodyCell = ({ ['data-label']: dataLabel, parentId, component: Component, colSpan, ...props }) => {
+const BodyCell = ({ ['data-label']: dataLabel, parentId, isVisible, component: Component, colSpan, ...props }) => {
   const mappedProps = {
     ...dataLabel ? { 'data-label': dataLabel } : {},
     ...props
   }
-  return (parentId !== undefined && colSpan === undefined) ?
+  return (parentId !== undefined && colSpan === undefined) || !isVisible ?
     null :
     <Component {...mappedProps} colSpan={colSpan} />;
 };

--- a/packages/patternfly-4/react-table/src/components/Table/HeaderCell.js
+++ b/packages/patternfly-4/react-table/src/components/Table/HeaderCell.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropsType from 'prop-types';
 
-const HeaderCell = ({ ['data-label']: dataLabel, scope, component: Component, ...props }) => {
+const HeaderCell = ({ ['data-label']: dataLabel, isVisible, scope, component: Component, ...props }) => {
   const mappedProps = {
     ...scope ? { scope } : {},
     ...props

--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
@@ -1725,7 +1725,9 @@ exports[`Actions table 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -1736,26 +1738,36 @@ exports[`Actions table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -1766,26 +1778,36 @@ exports[`Actions table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -1796,26 +1818,36 @@ exports[`Actions table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -1826,26 +1858,36 @@ exports[`Actions table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -1856,26 +1898,36 @@ exports[`Actions table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -1886,26 +1938,36 @@ exports[`Actions table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -1916,26 +1978,36 @@ exports[`Actions table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -1946,26 +2018,36 @@ exports[`Actions table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -1976,20 +2058,28 @@ exports[`Actions table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -2340,7 +2430,9 @@ exports[`Actions table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -2351,20 +2443,28 @@ exports[`Actions table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -2384,6 +2484,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -2397,6 +2498,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -2410,6 +2512,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -2423,6 +2526,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -2436,6 +2540,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -2450,6 +2555,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={5}
                         data-label=""
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -2971,7 +3077,9 @@ exports[`Actions table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -2982,20 +3090,28 @@ exports[`Actions table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -3015,6 +3131,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -3028,6 +3145,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -3041,6 +3159,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -3054,6 +3173,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -3067,6 +3187,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -3081,6 +3202,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={5}
                         data-label=""
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -3602,7 +3724,9 @@ exports[`Actions table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -3613,20 +3737,28 @@ exports[`Actions table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -3646,6 +3778,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -3659,6 +3792,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -3672,6 +3806,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -3685,6 +3820,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -3698,6 +3834,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -3712,6 +3849,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={5}
                         data-label=""
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -4233,7 +4371,9 @@ exports[`Actions table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -4244,20 +4384,28 @@ exports[`Actions table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -4277,6 +4425,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -4290,6 +4439,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -4303,6 +4453,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -4316,6 +4467,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -4329,6 +4481,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -4343,6 +4496,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={5}
                         data-label=""
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -4864,7 +5018,9 @@ exports[`Actions table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -4875,20 +5031,28 @@ exports[`Actions table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -4908,6 +5072,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -4921,6 +5086,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -4934,6 +5100,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -4947,6 +5114,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -4960,6 +5128,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -4974,6 +5143,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={5}
                         data-label=""
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -5495,7 +5665,9 @@ exports[`Actions table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -5506,20 +5678,28 @@ exports[`Actions table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -5539,6 +5719,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -5552,6 +5733,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -5565,6 +5747,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -5578,6 +5761,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -5591,6 +5775,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -5605,6 +5790,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={5}
                         data-label=""
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -6126,7 +6312,9 @@ exports[`Actions table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -6137,20 +6325,28 @@ exports[`Actions table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -6170,6 +6366,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -6183,6 +6380,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -6196,6 +6394,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -6209,6 +6408,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -6222,6 +6422,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -6236,6 +6437,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={5}
                         data-label=""
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -6757,7 +6959,9 @@ exports[`Actions table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -6768,20 +6972,28 @@ exports[`Actions table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -6801,6 +7013,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -6814,6 +7027,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -6827,6 +7041,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -6840,6 +7055,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -6853,6 +7069,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -6867,6 +7084,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={5}
                         data-label=""
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -7388,7 +7606,9 @@ exports[`Actions table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -7399,20 +7619,28 @@ exports[`Actions table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -7432,6 +7660,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -7445,6 +7674,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -7458,6 +7688,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -7471,6 +7702,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -7484,6 +7716,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -7498,6 +7731,7 @@ exports[`Actions table 1`] = `
                         component="td"
                         data-key={5}
                         data-label=""
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -8676,7 +8910,9 @@ exports[`Cell header table 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -8687,26 +8923,36 @@ exports[`Cell header table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -8717,26 +8963,36 @@ exports[`Cell header table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -8747,26 +9003,36 @@ exports[`Cell header table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -8777,26 +9043,36 @@ exports[`Cell header table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -8807,26 +9083,36 @@ exports[`Cell header table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -8837,26 +9123,36 @@ exports[`Cell header table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -8867,26 +9163,36 @@ exports[`Cell header table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -8897,26 +9203,36 @@ exports[`Cell header table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -8927,20 +9243,28 @@ exports[`Cell header table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -9147,7 +9471,9 @@ exports[`Cell header table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -9158,20 +9484,28 @@ exports[`Cell header table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -9191,6 +9525,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -9204,6 +9539,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -9217,6 +9553,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -9230,6 +9567,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -9243,6 +9581,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -9449,7 +9788,9 @@ exports[`Cell header table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -9460,20 +9801,28 @@ exports[`Cell header table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -9493,6 +9842,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -9506,6 +9856,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -9519,6 +9870,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -9532,6 +9884,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -9545,6 +9898,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -9751,7 +10105,9 @@ exports[`Cell header table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -9762,20 +10118,28 @@ exports[`Cell header table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -9795,6 +10159,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -9808,6 +10173,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -9821,6 +10187,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -9834,6 +10201,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -9847,6 +10215,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -10053,7 +10422,9 @@ exports[`Cell header table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -10064,20 +10435,28 @@ exports[`Cell header table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -10097,6 +10476,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -10110,6 +10490,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -10123,6 +10504,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -10136,6 +10518,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -10149,6 +10532,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -10355,7 +10739,9 @@ exports[`Cell header table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -10366,20 +10752,28 @@ exports[`Cell header table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -10399,6 +10793,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -10412,6 +10807,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -10425,6 +10821,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -10438,6 +10835,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -10451,6 +10849,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -10657,7 +11056,9 @@ exports[`Cell header table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -10668,20 +11069,28 @@ exports[`Cell header table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -10701,6 +11110,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -10714,6 +11124,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -10727,6 +11138,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -10740,6 +11152,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -10753,6 +11166,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -10959,7 +11373,9 @@ exports[`Cell header table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -10970,20 +11386,28 @@ exports[`Cell header table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -11003,6 +11427,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -11016,6 +11441,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -11029,6 +11455,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -11042,6 +11469,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -11055,6 +11483,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -11261,7 +11690,9 @@ exports[`Cell header table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -11272,20 +11703,28 @@ exports[`Cell header table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -11305,6 +11744,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -11318,6 +11758,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -11331,6 +11772,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -11344,6 +11786,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -11357,6 +11800,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -11563,7 +12007,9 @@ exports[`Cell header table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -11574,20 +12020,28 @@ exports[`Cell header table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -11607,6 +12061,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -11620,6 +12075,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -11633,6 +12089,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -11646,6 +12103,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -11659,6 +12117,7 @@ exports[`Cell header table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -12980,7 +13439,9 @@ exports[`Collapsible nested table 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -12991,27 +13452,37 @@ exports[`Collapsible nested table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "isOpen": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -13022,29 +13493,39 @@ exports[`Collapsible nested table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "isExpanded": false,
                   "isOpen": true,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "parent": 0,
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -13055,28 +13536,38 @@ exports[`Collapsible nested table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "isExpanded": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "parent": 1,
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -13087,27 +13578,37 @@ exports[`Collapsible nested table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "isOpen": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -13118,28 +13619,38 @@ exports[`Collapsible nested table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "isExpanded": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "parent": 3,
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -13150,26 +13661,36 @@ exports[`Collapsible nested table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -13180,26 +13701,36 @@ exports[`Collapsible nested table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -13210,26 +13741,36 @@ exports[`Collapsible nested table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -13240,20 +13781,28 @@ exports[`Collapsible nested table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -13503,7 +14052,9 @@ exports[`Collapsible nested table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -13514,21 +14065,29 @@ exports[`Collapsible nested table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "isOpen": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -13550,6 +14109,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -13624,6 +14184,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -13637,6 +14198,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -13650,6 +14212,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -13663,6 +14226,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -13676,6 +14240,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -13925,7 +14490,9 @@ exports[`Collapsible nested table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -13936,23 +14503,31 @@ exports[`Collapsible nested table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "isExpanded": false,
                       "isOpen": true,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "parent": 0,
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -13975,6 +14550,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -14050,6 +14626,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                         parentId={0}
                       >
@@ -14074,6 +14651,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                         parentId={0}
                       />
@@ -14081,6 +14659,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                         parentId={0}
                       />
@@ -14088,6 +14667,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                         parentId={0}
                       />
@@ -14095,6 +14675,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                         parentId={0}
                       />
@@ -14338,7 +14919,9 @@ exports[`Collapsible nested table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -14349,22 +14932,30 @@ exports[`Collapsible nested table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "isExpanded": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "parent": 1,
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -14386,6 +14977,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -14404,6 +14996,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                         parentId={1}
                       >
@@ -14428,6 +15021,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                         parentId={1}
                       />
@@ -14435,6 +15029,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                         parentId={1}
                       />
@@ -14442,6 +15037,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                         parentId={1}
                       />
@@ -14449,6 +15045,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                         parentId={1}
                       />
@@ -14692,7 +15289,9 @@ exports[`Collapsible nested table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -14703,21 +15302,29 @@ exports[`Collapsible nested table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "isOpen": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -14739,6 +15346,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -14813,6 +15421,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -14826,6 +15435,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -14839,6 +15449,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -14852,6 +15463,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -14865,6 +15477,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -15114,7 +15727,9 @@ exports[`Collapsible nested table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -15125,22 +15740,30 @@ exports[`Collapsible nested table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "isExpanded": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "parent": 3,
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -15162,6 +15785,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -15180,6 +15804,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                         parentId={3}
                       >
@@ -15204,6 +15829,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                         parentId={3}
                       />
@@ -15211,6 +15837,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                         parentId={3}
                       />
@@ -15218,6 +15845,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                         parentId={3}
                       />
@@ -15225,6 +15853,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                         parentId={3}
                       />
@@ -15468,7 +16097,9 @@ exports[`Collapsible nested table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -15479,20 +16110,28 @@ exports[`Collapsible nested table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -15513,6 +16152,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -15530,6 +16170,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -15543,6 +16184,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -15556,6 +16198,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -15569,6 +16212,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -15582,6 +16226,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -15831,7 +16476,9 @@ exports[`Collapsible nested table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -15842,20 +16489,28 @@ exports[`Collapsible nested table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -15876,6 +16531,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -15893,6 +16549,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -15906,6 +16563,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -15919,6 +16577,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -15932,6 +16591,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -15945,6 +16605,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -16194,7 +16855,9 @@ exports[`Collapsible nested table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -16205,20 +16868,28 @@ exports[`Collapsible nested table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -16239,6 +16910,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -16256,6 +16928,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -16269,6 +16942,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -16282,6 +16956,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -16295,6 +16970,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -16308,6 +16984,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -16557,7 +17234,9 @@ exports[`Collapsible nested table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -16568,20 +17247,28 @@ exports[`Collapsible nested table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -16602,6 +17289,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -16619,6 +17307,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -16632,6 +17321,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -16645,6 +17335,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -16658,6 +17349,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -16671,6 +17363,7 @@ exports[`Collapsible nested table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -17964,7 +18657,9 @@ exports[`Collapsible table 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -17975,27 +18670,37 @@ exports[`Collapsible table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "isOpen": true,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -18006,28 +18711,38 @@ exports[`Collapsible table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "isExpanded": true,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "parent": 0,
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -18038,26 +18753,36 @@ exports[`Collapsible table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -18068,27 +18793,37 @@ exports[`Collapsible table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "isOpen": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -18099,28 +18834,38 @@ exports[`Collapsible table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "isExpanded": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "parent": 3,
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -18131,26 +18876,36 @@ exports[`Collapsible table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -18161,26 +18916,36 @@ exports[`Collapsible table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -18191,26 +18956,36 @@ exports[`Collapsible table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -18221,20 +18996,28 @@ exports[`Collapsible table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -18484,7 +19267,9 @@ exports[`Collapsible table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -18495,21 +19280,29 @@ exports[`Collapsible table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "isOpen": true,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -18531,6 +19324,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -18605,6 +19399,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -18618,6 +19413,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -18631,6 +19427,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -18644,6 +19441,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -18657,6 +19455,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -18906,7 +19705,9 @@ exports[`Collapsible table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -18917,22 +19718,30 @@ exports[`Collapsible table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "isExpanded": true,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "parent": 0,
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -18954,6 +19763,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -18972,6 +19782,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                         parentId={0}
                       >
@@ -18996,6 +19807,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                         parentId={0}
                       />
@@ -19003,6 +19815,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                         parentId={0}
                       />
@@ -19010,6 +19823,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                         parentId={0}
                       />
@@ -19017,6 +19831,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                         parentId={0}
                       />
@@ -19260,7 +20075,9 @@ exports[`Collapsible table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -19271,20 +20088,28 @@ exports[`Collapsible table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -19305,6 +20130,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -19322,6 +20148,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -19335,6 +20162,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -19348,6 +20176,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -19361,6 +20190,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -19374,6 +20204,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -19623,7 +20454,9 @@ exports[`Collapsible table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -19634,21 +20467,29 @@ exports[`Collapsible table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "isOpen": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -19670,6 +20511,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -19744,6 +20586,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -19757,6 +20600,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -19770,6 +20614,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -19783,6 +20628,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -19796,6 +20642,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -20045,7 +20892,9 @@ exports[`Collapsible table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -20056,22 +20905,30 @@ exports[`Collapsible table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "isExpanded": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "parent": 3,
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -20093,6 +20950,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -20111,6 +20969,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                         parentId={3}
                       >
@@ -20135,6 +20994,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                         parentId={3}
                       />
@@ -20142,6 +21002,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                         parentId={3}
                       />
@@ -20149,6 +21010,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                         parentId={3}
                       />
@@ -20156,6 +21018,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                         parentId={3}
                       />
@@ -20399,7 +21262,9 @@ exports[`Collapsible table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -20410,20 +21275,28 @@ exports[`Collapsible table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -20444,6 +21317,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -20461,6 +21335,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -20474,6 +21349,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -20487,6 +21363,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -20500,6 +21377,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -20513,6 +21391,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -20762,7 +21641,9 @@ exports[`Collapsible table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -20773,20 +21654,28 @@ exports[`Collapsible table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -20807,6 +21696,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -20824,6 +21714,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -20837,6 +21728,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -20850,6 +21742,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -20863,6 +21756,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -20876,6 +21770,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -21125,7 +22020,9 @@ exports[`Collapsible table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -21136,20 +22033,28 @@ exports[`Collapsible table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -21170,6 +22075,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -21187,6 +22093,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -21200,6 +22107,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -21213,6 +22121,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -21226,6 +22135,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -21239,6 +22149,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -21488,7 +22399,9 @@ exports[`Collapsible table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -21499,20 +22412,28 @@ exports[`Collapsible table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -21533,6 +22454,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -21550,6 +22472,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -21563,6 +22486,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -21576,6 +22500,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -21589,6 +22514,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -21602,6 +22528,7 @@ exports[`Collapsible table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -22589,7 +23516,9 @@ exports[`Header width table 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -22600,27 +23529,37 @@ exports[`Header width table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "isOpen": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -22631,29 +23570,39 @@ exports[`Header width table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "isExpanded": false,
                   "isOpen": true,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "parent": 0,
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -22664,28 +23613,38 @@ exports[`Header width table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "isExpanded": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "parent": 1,
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -22696,27 +23655,37 @@ exports[`Header width table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "isOpen": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -22727,28 +23696,38 @@ exports[`Header width table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "isExpanded": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "parent": 3,
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -22759,26 +23738,36 @@ exports[`Header width table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -22789,26 +23778,36 @@ exports[`Header width table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -22819,26 +23818,36 @@ exports[`Header width table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -22849,20 +23858,28 @@ exports[`Header width table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -23071,7 +24088,9 @@ exports[`Header width table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -23082,21 +24101,29 @@ exports[`Header width table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "isOpen": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -23117,6 +24144,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -23130,6 +24158,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -23143,6 +24172,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -23156,6 +24186,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -23169,6 +24200,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -23377,7 +24409,9 @@ exports[`Header width table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -23388,23 +24422,31 @@ exports[`Header width table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "isExpanded": false,
                       "isOpen": true,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "parent": 0,
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -23426,6 +24468,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -23439,6 +24482,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -23452,6 +24496,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -23465,6 +24510,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -23478,6 +24524,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -23686,7 +24733,9 @@ exports[`Header width table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -23697,22 +24746,30 @@ exports[`Header width table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "isExpanded": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "parent": 1,
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -23733,6 +24790,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -23746,6 +24804,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -23759,6 +24818,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -23772,6 +24832,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -23785,6 +24846,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -23993,7 +25055,9 @@ exports[`Header width table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -24004,21 +25068,29 @@ exports[`Header width table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "isOpen": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -24039,6 +25111,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -24052,6 +25125,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -24065,6 +25139,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -24078,6 +25153,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -24091,6 +25167,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -24299,7 +25376,9 @@ exports[`Header width table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -24310,22 +25389,30 @@ exports[`Header width table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "isExpanded": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "parent": 3,
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -24346,6 +25433,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -24359,6 +25447,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -24372,6 +25461,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -24385,6 +25475,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -24398,6 +25489,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -24606,7 +25698,9 @@ exports[`Header width table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -24617,20 +25711,28 @@ exports[`Header width table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -24650,6 +25752,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -24663,6 +25766,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -24676,6 +25780,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -24689,6 +25794,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -24702,6 +25808,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -24910,7 +26017,9 @@ exports[`Header width table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -24921,20 +26030,28 @@ exports[`Header width table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -24954,6 +26071,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -24967,6 +26085,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -24980,6 +26099,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -24993,6 +26113,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -25006,6 +26127,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -25214,7 +26336,9 @@ exports[`Header width table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -25225,20 +26349,28 @@ exports[`Header width table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -25258,6 +26390,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -25271,6 +26404,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -25284,6 +26418,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -25297,6 +26432,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -25310,6 +26446,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -25518,7 +26655,9 @@ exports[`Header width table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -25529,20 +26668,28 @@ exports[`Header width table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -25562,6 +26709,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -25575,6 +26723,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -25588,6 +26737,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -25601,6 +26751,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -25614,6 +26765,7 @@ exports[`Header width table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -26411,6 +27563,7 @@ exports[`Selectable table 1`] = `
                     component="td"
                     data-key={0}
                     data-label=""
+                    isVisible={true}
                     key="0-header"
                     scope=""
                   >
@@ -26882,7 +28035,9 @@ exports[`Selectable table 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -26893,27 +28048,37 @@ exports[`Selectable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "isOpen": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -26924,29 +28089,39 @@ exports[`Selectable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "isExpanded": false,
                   "isOpen": true,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "parent": 0,
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -26957,28 +28132,38 @@ exports[`Selectable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "isExpanded": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "parent": 1,
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -26989,27 +28174,37 @@ exports[`Selectable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "isOpen": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -27020,28 +28215,38 @@ exports[`Selectable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "isExpanded": false,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "parent": 3,
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -27052,26 +28257,36 @@ exports[`Selectable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -27082,26 +28297,36 @@ exports[`Selectable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -27112,26 +28337,36 @@ exports[`Selectable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -27142,20 +28377,28 @@ exports[`Selectable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -27399,7 +28642,9 @@ exports[`Selectable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -27410,21 +28655,29 @@ exports[`Selectable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "isOpen": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -27446,6 +28699,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                         scope=""
                       >
@@ -27476,6 +28730,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -27489,6 +28744,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -27502,6 +28758,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -27515,6 +28772,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -27528,6 +28786,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -27771,7 +29030,9 @@ exports[`Selectable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -27782,23 +29043,31 @@ exports[`Selectable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "isExpanded": false,
                       "isOpen": true,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "parent": 0,
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -27820,6 +29089,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                         scope=""
                       >
@@ -27832,6 +29102,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -27845,6 +29116,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -27858,6 +29130,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -27871,6 +29144,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -27884,6 +29158,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -28127,7 +29402,9 @@ exports[`Selectable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -28138,22 +29415,30 @@ exports[`Selectable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "isExpanded": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "parent": 1,
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -28174,6 +29459,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                         scope=""
                       >
@@ -28186,6 +29472,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -28199,6 +29486,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -28212,6 +29500,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -28225,6 +29514,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -28238,6 +29528,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -28481,7 +29772,9 @@ exports[`Selectable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -28492,21 +29785,29 @@ exports[`Selectable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "isOpen": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -28528,6 +29829,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                         scope=""
                       >
@@ -28558,6 +29860,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -28571,6 +29874,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -28584,6 +29888,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -28597,6 +29902,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -28610,6 +29916,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -28853,7 +30160,9 @@ exports[`Selectable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -28864,22 +30173,30 @@ exports[`Selectable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "isExpanded": false,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "parent": 3,
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -28900,6 +30217,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                         scope=""
                       >
@@ -28912,6 +30230,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -28925,6 +30244,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -28938,6 +30258,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -28951,6 +30272,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -28964,6 +30286,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -29207,7 +30530,9 @@ exports[`Selectable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -29218,20 +30543,28 @@ exports[`Selectable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -29252,6 +30585,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                         scope=""
                       >
@@ -29282,6 +30616,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -29295,6 +30630,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -29308,6 +30644,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -29321,6 +30658,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -29334,6 +30672,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -29577,7 +30916,9 @@ exports[`Selectable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -29588,20 +30929,28 @@ exports[`Selectable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -29622,6 +30971,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                         scope=""
                       >
@@ -29652,6 +31002,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -29665,6 +31016,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -29678,6 +31030,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -29691,6 +31044,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -29704,6 +31058,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -29947,7 +31302,9 @@ exports[`Selectable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -29958,20 +31315,28 @@ exports[`Selectable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -29992,6 +31357,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                         scope=""
                       >
@@ -30022,6 +31388,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -30035,6 +31402,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -30048,6 +31416,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -30061,6 +31430,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -30074,6 +31444,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -30317,7 +31688,9 @@ exports[`Selectable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -30328,20 +31701,28 @@ exports[`Selectable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -30362,6 +31743,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label=""
+                        isVisible={true}
                         key="0-cell"
                         scope=""
                       >
@@ -30392,6 +31774,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Header cell"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -30405,6 +31788,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Branches"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -30418,6 +31802,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -30431,6 +31816,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -30444,6 +31830,7 @@ exports[`Selectable table 1`] = `
                         component="td"
                         data-key={5}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="5-cell"
                       >
                         <td
@@ -31353,7 +32740,9 @@ exports[`Simple table aria-label 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -31364,26 +32753,36 @@ exports[`Simple table aria-label 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -31394,26 +32793,36 @@ exports[`Simple table aria-label 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -31424,26 +32833,36 @@ exports[`Simple table aria-label 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -31454,26 +32873,36 @@ exports[`Simple table aria-label 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -31484,26 +32913,36 @@ exports[`Simple table aria-label 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -31514,26 +32953,36 @@ exports[`Simple table aria-label 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -31544,26 +32993,36 @@ exports[`Simple table aria-label 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -31574,26 +33033,36 @@ exports[`Simple table aria-label 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -31604,20 +33073,28 @@ exports[`Simple table aria-label 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -31822,7 +33299,9 @@ exports[`Simple table aria-label 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -31833,20 +33312,28 @@ exports[`Simple table aria-label 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -31866,6 +33353,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -31879,6 +33367,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -31892,6 +33381,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -31905,6 +33395,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -31918,6 +33409,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -32122,7 +33614,9 @@ exports[`Simple table aria-label 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -32133,20 +33627,28 @@ exports[`Simple table aria-label 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -32166,6 +33668,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -32179,6 +33682,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -32192,6 +33696,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -32205,6 +33710,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -32218,6 +33724,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -32422,7 +33929,9 @@ exports[`Simple table aria-label 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -32433,20 +33942,28 @@ exports[`Simple table aria-label 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -32466,6 +33983,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -32479,6 +33997,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -32492,6 +34011,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -32505,6 +34025,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -32518,6 +34039,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -32722,7 +34244,9 @@ exports[`Simple table aria-label 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -32733,20 +34257,28 @@ exports[`Simple table aria-label 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -32766,6 +34298,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -32779,6 +34312,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -32792,6 +34326,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -32805,6 +34340,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -32818,6 +34354,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -33022,7 +34559,9 @@ exports[`Simple table aria-label 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -33033,20 +34572,28 @@ exports[`Simple table aria-label 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -33066,6 +34613,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -33079,6 +34627,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -33092,6 +34641,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -33105,6 +34655,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -33118,6 +34669,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -33322,7 +34874,9 @@ exports[`Simple table aria-label 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -33333,20 +34887,28 @@ exports[`Simple table aria-label 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -33366,6 +34928,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -33379,6 +34942,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -33392,6 +34956,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -33405,6 +34970,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -33418,6 +34984,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -33622,7 +35189,9 @@ exports[`Simple table aria-label 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -33633,20 +35202,28 @@ exports[`Simple table aria-label 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -33666,6 +35243,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -33679,6 +35257,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -33692,6 +35271,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -33705,6 +35285,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -33718,6 +35299,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -33922,7 +35504,9 @@ exports[`Simple table aria-label 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -33933,20 +35517,28 @@ exports[`Simple table aria-label 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -33966,6 +35558,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -33979,6 +35572,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -33992,6 +35586,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -34005,6 +35600,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -34018,6 +35614,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -34222,7 +35819,9 @@ exports[`Simple table aria-label 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -34233,20 +35832,28 @@ exports[`Simple table aria-label 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -34266,6 +35873,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -34279,6 +35887,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -34292,6 +35901,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -34305,6 +35915,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -34318,6 +35929,7 @@ exports[`Simple table aria-label 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -35228,7 +36840,9 @@ exports[`Simple table caption 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -35239,26 +36853,36 @@ exports[`Simple table caption 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -35269,26 +36893,36 @@ exports[`Simple table caption 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -35299,26 +36933,36 @@ exports[`Simple table caption 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -35329,26 +36973,36 @@ exports[`Simple table caption 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -35359,26 +37013,36 @@ exports[`Simple table caption 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -35389,26 +37053,36 @@ exports[`Simple table caption 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -35419,26 +37093,36 @@ exports[`Simple table caption 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -35449,26 +37133,36 @@ exports[`Simple table caption 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -35479,20 +37173,28 @@ exports[`Simple table caption 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -35697,7 +37399,9 @@ exports[`Simple table caption 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -35708,20 +37412,28 @@ exports[`Simple table caption 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -35741,6 +37453,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -35754,6 +37467,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -35767,6 +37481,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -35780,6 +37495,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -35793,6 +37509,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -35997,7 +37714,9 @@ exports[`Simple table caption 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -36008,20 +37727,28 @@ exports[`Simple table caption 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -36041,6 +37768,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -36054,6 +37782,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -36067,6 +37796,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -36080,6 +37810,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -36093,6 +37824,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -36297,7 +38029,9 @@ exports[`Simple table caption 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -36308,20 +38042,28 @@ exports[`Simple table caption 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -36341,6 +38083,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -36354,6 +38097,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -36367,6 +38111,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -36380,6 +38125,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -36393,6 +38139,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -36597,7 +38344,9 @@ exports[`Simple table caption 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -36608,20 +38357,28 @@ exports[`Simple table caption 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -36641,6 +38398,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -36654,6 +38412,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -36667,6 +38426,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -36680,6 +38440,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -36693,6 +38454,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -36897,7 +38659,9 @@ exports[`Simple table caption 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -36908,20 +38672,28 @@ exports[`Simple table caption 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -36941,6 +38713,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -36954,6 +38727,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -36967,6 +38741,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -36980,6 +38755,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -36993,6 +38769,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -37197,7 +38974,9 @@ exports[`Simple table caption 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -37208,20 +38987,28 @@ exports[`Simple table caption 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -37241,6 +39028,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -37254,6 +39042,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -37267,6 +39056,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -37280,6 +39070,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -37293,6 +39084,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -37497,7 +39289,9 @@ exports[`Simple table caption 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -37508,20 +39302,28 @@ exports[`Simple table caption 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -37541,6 +39343,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -37554,6 +39357,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -37567,6 +39371,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -37580,6 +39385,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -37593,6 +39399,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -37797,7 +39604,9 @@ exports[`Simple table caption 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -37808,20 +39617,28 @@ exports[`Simple table caption 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -37841,6 +39658,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -37854,6 +39672,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -37867,6 +39686,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -37880,6 +39700,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -37893,6 +39714,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -38097,7 +39919,9 @@ exports[`Simple table caption 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -38108,20 +39932,28 @@ exports[`Simple table caption 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -38141,6 +39973,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -38154,6 +39987,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -38167,6 +40001,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -38180,6 +40015,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -38193,6 +40029,7 @@ exports[`Simple table caption 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -39107,7 +40944,9 @@ exports[`Simple table header 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -39118,26 +40957,36 @@ exports[`Simple table header 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -39148,26 +40997,36 @@ exports[`Simple table header 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -39178,26 +41037,36 @@ exports[`Simple table header 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -39208,26 +41077,36 @@ exports[`Simple table header 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -39238,26 +41117,36 @@ exports[`Simple table header 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -39268,26 +41157,36 @@ exports[`Simple table header 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -39298,26 +41197,36 @@ exports[`Simple table header 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -39328,26 +41237,36 @@ exports[`Simple table header 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -39358,20 +41277,28 @@ exports[`Simple table header 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -39576,7 +41503,9 @@ exports[`Simple table header 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -39587,20 +41516,28 @@ exports[`Simple table header 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -39620,6 +41557,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -39633,6 +41571,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -39646,6 +41585,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -39659,6 +41599,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -39672,6 +41613,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -39876,7 +41818,9 @@ exports[`Simple table header 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -39887,20 +41831,28 @@ exports[`Simple table header 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -39920,6 +41872,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -39933,6 +41886,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -39946,6 +41900,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -39959,6 +41914,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -39972,6 +41928,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -40176,7 +42133,9 @@ exports[`Simple table header 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -40187,20 +42146,28 @@ exports[`Simple table header 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -40220,6 +42187,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -40233,6 +42201,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -40246,6 +42215,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -40259,6 +42229,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -40272,6 +42243,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -40476,7 +42448,9 @@ exports[`Simple table header 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -40487,20 +42461,28 @@ exports[`Simple table header 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -40520,6 +42502,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -40533,6 +42516,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -40546,6 +42530,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -40559,6 +42544,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -40572,6 +42558,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -40776,7 +42763,9 @@ exports[`Simple table header 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -40787,20 +42776,28 @@ exports[`Simple table header 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -40820,6 +42817,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -40833,6 +42831,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -40846,6 +42845,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -40859,6 +42859,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -40872,6 +42873,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -41076,7 +43078,9 @@ exports[`Simple table header 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -41087,20 +43091,28 @@ exports[`Simple table header 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -41120,6 +43132,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -41133,6 +43146,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -41146,6 +43160,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -41159,6 +43174,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -41172,6 +43188,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -41376,7 +43393,9 @@ exports[`Simple table header 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -41387,20 +43406,28 @@ exports[`Simple table header 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -41420,6 +43447,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -41433,6 +43461,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -41446,6 +43475,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -41459,6 +43489,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -41472,6 +43503,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -41676,7 +43708,9 @@ exports[`Simple table header 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -41687,20 +43721,28 @@ exports[`Simple table header 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -41720,6 +43762,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -41733,6 +43776,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -41746,6 +43790,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -41759,6 +43804,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -41772,6 +43818,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -41976,7 +44023,9 @@ exports[`Simple table header 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -41987,20 +44036,28 @@ exports[`Simple table header 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -42020,6 +44077,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -42033,6 +44091,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -42046,6 +44105,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -42059,6 +44119,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -42072,6 +44133,7 @@ exports[`Simple table header 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -43075,7 +45137,9 @@ exports[`Sortable table 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -43086,26 +45150,36 @@ exports[`Sortable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -43116,26 +45190,36 @@ exports[`Sortable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -43146,26 +45230,36 @@ exports[`Sortable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -43176,26 +45270,36 @@ exports[`Sortable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -43206,26 +45310,36 @@ exports[`Sortable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -43236,26 +45350,36 @@ exports[`Sortable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -43266,26 +45390,36 @@ exports[`Sortable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -43296,26 +45430,36 @@ exports[`Sortable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -43326,20 +45470,28 @@ exports[`Sortable table 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -43545,7 +45697,9 @@ exports[`Sortable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -43556,20 +45710,28 @@ exports[`Sortable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -43589,6 +45751,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -43602,6 +45765,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -43615,6 +45779,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -43628,6 +45793,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -43641,6 +45807,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -43846,7 +46013,9 @@ exports[`Sortable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -43857,20 +46026,28 @@ exports[`Sortable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -43890,6 +46067,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -43903,6 +46081,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -43916,6 +46095,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -43929,6 +46109,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -43942,6 +46123,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -44147,7 +46329,9 @@ exports[`Sortable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -44158,20 +46342,28 @@ exports[`Sortable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -44191,6 +46383,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -44204,6 +46397,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -44217,6 +46411,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -44230,6 +46425,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -44243,6 +46439,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -44448,7 +46645,9 @@ exports[`Sortable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -44459,20 +46658,28 @@ exports[`Sortable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -44492,6 +46699,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -44505,6 +46713,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -44518,6 +46727,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -44531,6 +46741,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -44544,6 +46755,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -44749,7 +46961,9 @@ exports[`Sortable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -44760,20 +46974,28 @@ exports[`Sortable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -44793,6 +47015,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -44806,6 +47029,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -44819,6 +47043,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -44832,6 +47057,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -44845,6 +47071,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -45050,7 +47277,9 @@ exports[`Sortable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -45061,20 +47290,28 @@ exports[`Sortable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -45094,6 +47331,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -45107,6 +47345,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -45120,6 +47359,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -45133,6 +47373,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -45146,6 +47387,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -45351,7 +47593,9 @@ exports[`Sortable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -45362,20 +47606,28 @@ exports[`Sortable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -45395,6 +47647,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -45408,6 +47661,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -45421,6 +47675,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -45434,6 +47689,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -45447,6 +47703,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -45652,7 +47909,9 @@ exports[`Sortable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -45663,20 +47922,28 @@ exports[`Sortable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -45696,6 +47963,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -45709,6 +47977,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -45722,6 +47991,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -45735,6 +48005,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -45748,6 +48019,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -45953,7 +48225,9 @@ exports[`Sortable table 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -45964,20 +48238,28 @@ exports[`Sortable table 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -45997,6 +48279,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -46010,6 +48293,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -46023,6 +48307,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -46036,6 +48321,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -46049,6 +48335,7 @@ exports[`Sortable table 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -47050,7 +49337,9 @@ exports[`Table variants Breakpoint - grid 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -47061,26 +49350,36 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -47091,26 +49390,36 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -47121,26 +49430,36 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -47151,26 +49470,36 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -47181,26 +49510,36 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -47211,26 +49550,36 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -47241,26 +49590,36 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -47271,26 +49630,36 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -47301,20 +49670,28 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -47520,7 +49897,9 @@ exports[`Table variants Breakpoint - grid 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -47531,20 +49910,28 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -47564,6 +49951,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -47577,6 +49965,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -47590,6 +49979,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -47603,6 +49993,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -47616,6 +50007,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -47821,7 +50213,9 @@ exports[`Table variants Breakpoint - grid 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -47832,20 +50226,28 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -47865,6 +50267,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -47878,6 +50281,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -47891,6 +50295,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -47904,6 +50309,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -47917,6 +50323,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -48122,7 +50529,9 @@ exports[`Table variants Breakpoint - grid 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -48133,20 +50542,28 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -48166,6 +50583,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -48179,6 +50597,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -48192,6 +50611,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -48205,6 +50625,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -48218,6 +50639,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -48423,7 +50845,9 @@ exports[`Table variants Breakpoint - grid 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -48434,20 +50858,28 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -48467,6 +50899,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -48480,6 +50913,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -48493,6 +50927,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -48506,6 +50941,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -48519,6 +50955,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -48724,7 +51161,9 @@ exports[`Table variants Breakpoint - grid 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -48735,20 +51174,28 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -48768,6 +51215,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -48781,6 +51229,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -48794,6 +51243,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -48807,6 +51257,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -48820,6 +51271,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -49025,7 +51477,9 @@ exports[`Table variants Breakpoint - grid 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -49036,20 +51490,28 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -49069,6 +51531,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -49082,6 +51545,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -49095,6 +51559,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -49108,6 +51573,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -49121,6 +51587,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -49326,7 +51793,9 @@ exports[`Table variants Breakpoint - grid 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -49337,20 +51806,28 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -49370,6 +51847,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -49383,6 +51861,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -49396,6 +51875,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -49409,6 +51889,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -49422,6 +51903,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -49627,7 +52109,9 @@ exports[`Table variants Breakpoint - grid 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -49638,20 +52122,28 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -49671,6 +52163,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -49684,6 +52177,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -49697,6 +52191,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -49710,6 +52205,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -49723,6 +52219,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -49928,7 +52425,9 @@ exports[`Table variants Breakpoint - grid 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -49939,20 +52438,28 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -49972,6 +52479,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -49985,6 +52493,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -49998,6 +52507,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -50011,6 +52521,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -50024,6 +52535,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -51025,7 +53537,9 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -51036,26 +53550,36 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -51066,26 +53590,36 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -51096,26 +53630,36 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -51126,26 +53670,36 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -51156,26 +53710,36 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -51186,26 +53750,36 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -51216,26 +53790,36 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -51246,26 +53830,36 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -51276,20 +53870,28 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -51495,7 +54097,9 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -51506,20 +54110,28 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -51539,6 +54151,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -51552,6 +54165,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -51565,6 +54179,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -51578,6 +54193,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -51591,6 +54207,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -51796,7 +54413,9 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -51807,20 +54426,28 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -51840,6 +54467,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -51853,6 +54481,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -51866,6 +54495,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -51879,6 +54509,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -51892,6 +54523,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -52097,7 +54729,9 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -52108,20 +54742,28 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -52141,6 +54783,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -52154,6 +54797,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -52167,6 +54811,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -52180,6 +54825,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -52193,6 +54839,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -52398,7 +55045,9 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -52409,20 +55058,28 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -52442,6 +55099,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -52455,6 +55113,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -52468,6 +55127,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -52481,6 +55141,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -52494,6 +55155,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -52699,7 +55361,9 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -52710,20 +55374,28 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -52743,6 +55415,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -52756,6 +55429,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -52769,6 +55443,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -52782,6 +55457,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -52795,6 +55471,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -53000,7 +55677,9 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -53011,20 +55690,28 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -53044,6 +55731,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -53057,6 +55745,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -53070,6 +55759,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -53083,6 +55773,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -53096,6 +55787,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -53301,7 +55993,9 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -53312,20 +56006,28 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -53345,6 +56047,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -53358,6 +56061,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -53371,6 +56075,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -53384,6 +56089,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -53397,6 +56103,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -53602,7 +56309,9 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -53613,20 +56322,28 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -53646,6 +56363,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -53659,6 +56377,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -53672,6 +56391,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -53685,6 +56405,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -53698,6 +56419,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -53903,7 +56625,9 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -53914,20 +56638,28 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -53947,6 +56679,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -53960,6 +56693,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -53973,6 +56707,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -53986,6 +56721,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -53999,6 +56735,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -55000,7 +57737,9 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -55011,26 +57750,36 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -55041,26 +57790,36 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -55071,26 +57830,36 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -55101,26 +57870,36 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -55131,26 +57910,36 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -55161,26 +57950,36 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -55191,26 +57990,36 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -55221,26 +58030,36 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -55251,20 +58070,28 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -55470,7 +58297,9 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -55481,20 +58310,28 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -55514,6 +58351,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -55527,6 +58365,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -55540,6 +58379,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -55553,6 +58393,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -55566,6 +58407,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -55771,7 +58613,9 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -55782,20 +58626,28 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -55815,6 +58667,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -55828,6 +58681,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -55841,6 +58695,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -55854,6 +58709,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -55867,6 +58723,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -56072,7 +58929,9 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -56083,20 +58942,28 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -56116,6 +58983,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -56129,6 +58997,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -56142,6 +59011,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -56155,6 +59025,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -56168,6 +59039,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -56373,7 +59245,9 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -56384,20 +59258,28 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -56417,6 +59299,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -56430,6 +59313,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -56443,6 +59327,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -56456,6 +59341,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -56469,6 +59355,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -56674,7 +59561,9 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -56685,20 +59574,28 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -56718,6 +59615,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -56731,6 +59629,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -56744,6 +59643,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -56757,6 +59657,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -56770,6 +59671,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -56975,7 +59877,9 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -56986,20 +59890,28 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -57019,6 +59931,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -57032,6 +59945,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -57045,6 +59959,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -57058,6 +59973,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -57071,6 +59987,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -57276,7 +60193,9 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -57287,20 +60206,28 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -57320,6 +60247,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -57333,6 +60261,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -57346,6 +60275,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -57359,6 +60289,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -57372,6 +60303,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -57577,7 +60509,9 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -57588,20 +60522,28 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -57621,6 +60563,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -57634,6 +60577,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -57647,6 +60591,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -57660,6 +60605,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -57673,6 +60619,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -57878,7 +60825,9 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -57889,20 +60838,28 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -57922,6 +60879,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -57935,6 +60893,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -57948,6 +60907,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -57961,6 +60921,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -57974,6 +60935,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -58975,7 +61937,9 @@ exports[`Table variants Size - compact 1`] = `
               Array [
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -58986,26 +61950,36 @@ exports[`Table variants Size - compact 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 0,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -59016,26 +61990,36 @@ exports[`Table variants Size - compact 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 1,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -59046,26 +62030,36 @@ exports[`Table variants Size - compact 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 2,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -59076,26 +62070,36 @@ exports[`Table variants Size - compact 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 3,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -59106,26 +62110,36 @@ exports[`Table variants Size - compact 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 4,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -59136,26 +62150,36 @@ exports[`Table variants Size - compact 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 5,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -59166,26 +62190,36 @@ exports[`Table variants Size - compact 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 6,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -59196,26 +62230,36 @@ exports[`Table variants Size - compact 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 7,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
                 Object {
                   "branches": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "two",
                   },
                   "cells": Array [
@@ -59226,20 +62270,28 @@ exports[`Table variants Size - compact 1`] = `
                     "five",
                   ],
                   "header-cell": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "one",
                   },
                   "id": 8,
                   "last-commit": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "five",
                   },
                   "pull-requests": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "three",
                   },
                   "workspaces": Object {
-                    "props": undefined,
+                    "props": Object {
+                      "isVisible": true,
+                    },
                     "title": "four",
                   },
                 },
@@ -59445,7 +62497,9 @@ exports[`Table variants Size - compact 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -59456,20 +62510,28 @@ exports[`Table variants Size - compact 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 0,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -59489,6 +62551,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -59502,6 +62565,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -59515,6 +62579,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -59528,6 +62593,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -59541,6 +62607,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -59746,7 +62813,9 @@ exports[`Table variants Size - compact 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -59757,20 +62826,28 @@ exports[`Table variants Size - compact 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 1,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -59790,6 +62867,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -59803,6 +62881,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -59816,6 +62895,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -59829,6 +62909,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -59842,6 +62923,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -60047,7 +63129,9 @@ exports[`Table variants Size - compact 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -60058,20 +63142,28 @@ exports[`Table variants Size - compact 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 2,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -60091,6 +63183,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -60104,6 +63197,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -60117,6 +63211,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -60130,6 +63225,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -60143,6 +63239,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -60348,7 +63445,9 @@ exports[`Table variants Size - compact 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -60359,20 +63458,28 @@ exports[`Table variants Size - compact 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 3,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -60392,6 +63499,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -60405,6 +63513,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -60418,6 +63527,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -60431,6 +63541,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -60444,6 +63555,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -60649,7 +63761,9 @@ exports[`Table variants Size - compact 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -60660,20 +63774,28 @@ exports[`Table variants Size - compact 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 4,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -60693,6 +63815,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -60706,6 +63829,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -60719,6 +63843,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -60732,6 +63857,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -60745,6 +63871,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -60950,7 +64077,9 @@ exports[`Table variants Size - compact 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -60961,20 +64090,28 @@ exports[`Table variants Size - compact 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 5,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -60994,6 +64131,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -61007,6 +64145,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -61020,6 +64159,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -61033,6 +64173,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -61046,6 +64187,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -61251,7 +64393,9 @@ exports[`Table variants Size - compact 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -61262,20 +64406,28 @@ exports[`Table variants Size - compact 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 6,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -61295,6 +64447,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -61308,6 +64461,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -61321,6 +64475,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -61334,6 +64489,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -61347,6 +64503,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -61552,7 +64709,9 @@ exports[`Table variants Size - compact 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -61563,20 +64722,28 @@ exports[`Table variants Size - compact 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 7,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -61596,6 +64763,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -61609,6 +64777,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -61622,6 +64791,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -61635,6 +64805,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -61648,6 +64819,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td
@@ -61853,7 +65025,9 @@ exports[`Table variants Size - compact 1`] = `
                   rowData={
                     Object {
                       "branches": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "two",
                       },
                       "cells": Array [
@@ -61864,20 +65038,28 @@ exports[`Table variants Size - compact 1`] = `
                         "five",
                       ],
                       "header-cell": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "one",
                       },
                       "id": 8,
                       "last-commit": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "five",
                       },
                       "pull-requests": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "three",
                       },
                       "workspaces": Object {
-                        "props": undefined,
+                        "props": Object {
+                          "isVisible": true,
+                        },
                         "title": "four",
                       },
                     }
@@ -61897,6 +65079,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={0}
                         data-label="Header cell"
+                        isVisible={true}
                         key="0-cell"
                       >
                         <td
@@ -61910,6 +65093,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={1}
                         data-label="Branches"
+                        isVisible={true}
                         key="1-cell"
                       >
                         <td
@@ -61923,6 +65107,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={2}
                         data-label="Pull requests"
+                        isVisible={true}
                         key="2-cell"
                       >
                         <td
@@ -61936,6 +65121,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={3}
                         data-label="Workspaces"
+                        isVisible={true}
                         key="3-cell"
                       >
                         <td
@@ -61949,6 +65135,7 @@ exports[`Table variants Size - compact 1`] = `
                         component="td"
                         data-key={4}
                         data-label="Last Commit"
+                        isVisible={true}
                         key="4-cell"
                       >
                         <td

--- a/packages/patternfly-4/react-table/src/components/Table/examples/SimpleTable.js
+++ b/packages/patternfly-4/react-table/src/components/Table/examples/SimpleTable.js
@@ -18,10 +18,8 @@ class SimpleTable extends React.Component {
         [
           {
             title: <div>one - 2</div>,
-            props: { title: 'hover title' }
+            props: { title: 'hover title', colSpan: 3 }
           },
-          'two - 2',
-          'three - 2',
           'four - 2',
           'five - 2'
         ]

--- a/packages/patternfly-4/react-table/src/components/Table/utils/__snapshots__/transformers.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/__snapshots__/transformers.test.js.snap
@@ -13,6 +13,7 @@ Object {
   </SelectColumn>,
   "className": "pf-c-table__check",
   "component": "td",
+  "isVisible": true,
   "scope": "",
 }
 `;

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/cellActions.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/cellActions.js
@@ -13,6 +13,7 @@ export default actions => (
   }
 ) => ({
   className: css(styles.tableAction),
+  isVisible: true,
   children: (
     <ActionsColumn
       items={actions}

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/collapsible.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/collapsible.js
@@ -19,6 +19,7 @@ export const collapsible = (
   }
   return {
     className: css(styles.tableToggle),
+    isVisible: true,
     children: (
       <CollapseColumn
         aria-labelledby={`${rowLabeledBy}${rowIndex} ${expandId}${rowIndex}`}

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/selectable.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/selectable.js
@@ -13,9 +13,10 @@ export default (
     rowData
   }
 ) => {
-  if (rowData && rowData.hasOwnProperty('parent') && !rowData.showSelect) {
+  if ((rowData && rowData.hasOwnProperty('parent')) && !rowData.showSelect) {
     return {
       component: 'td',
+      isVisible: true,
       scope: ''
     };
   }
@@ -39,6 +40,7 @@ export default (
     className: css(styles.tableCheck),
     component: 'td',
     scope: '',
+    isVisible: true,
     children: (
       <SelectColumn {...customProps} onSelect={selectClick} name={rowId !== -1 ? `checkrow${rowIndex}` : 'check-all'}>
         {label}


### PR DESCRIPTION
**What**:
Colspan is not fully supported in reactabular implementation and they ignore it. However with this implementation we will set for each cell provided as data and for custom calculated cells (select, expand, collapsed, actions) special property called `isVisible` this will eventually allow consumers to hide some columns if they want to as well.
