### PR TITLE
fix(tokens): Use only light theme variables

### DIFF
--- a/packages/patternfly-4/react-tokens/build/generateTokens.js
+++ b/packages/patternfly-4/react-tokens/build/generateTokens.js
@@ -21,9 +21,10 @@ cssFiles.forEach(filePath => {
   const absFilePath = resolve(pfStylesDir, filePath);
   const cssAst = parse(readFileSync(absFilePath, 'utf8'));
   cssAst.stylesheet.rules.forEach(node => {
-    if (node.type !== 'rule') {
+    if (node.type !== 'rule' || node.selectors.indexOf('.pf-t-dark') !== -1) {
       return;
     }
+
     node.declarations.forEach(decl => {
       if (decl.type !== 'declaration') {
         return;


### PR DESCRIPTION
**What**:
This fixes bug that shows incorrect values for light theme on tokens page. Issue https://github.com/patternfly/patternfly-react/issues/1329 to allow importing dark theme values as well. Before this PR we didn't really knew which value was used and vars were not matching actual value.

### Before 
![screenshot from 2019-02-06 09-27-51](https://user-images.githubusercontent.com/3439771/52328920-92e74d00-29f1-11e9-8928-d3205220087c.png)

### After
![screenshot from 2019-02-06 12-25-52](https://user-images.githubusercontent.com/3439771/52338327-6429a080-2a0a-11e9-89ee-4009f23abe94.png)
