### PR TITLE
fix(ListViewItem) - initExpanded being passed to children

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/ListView/ListViewItem.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ListView/ListViewItem.js
@@ -42,6 +42,7 @@ class ListViewItem extends React.Component {
       compoundExpand,
       compoundExpanded,
       onCloseCompoundExpand,
+      initExpanded,
       ...other
     } = this.props;
     const { expanded } = this.state;


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Fix initExpanded being passed to children
<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
