### PR TITLE
fix(types): popover, tooltip, and helper types fixes

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.d.ts
@@ -1,4 +1,4 @@
-import { FunctionComponent, Element, ReactElement } from 'react';
+import { FunctionComponent, HTMLProps, ReactElement } from 'react';
 import { Omit } from '../../typeUtils';
 import { Instance, BasicPlacement, Props } from 'tippy.js';
 
@@ -9,7 +9,7 @@ export const PopoverPosition: {
   right: 'right';
 };
 
-export interface PopoverProps extends Omit<Props, 'children'> {
+export interface PopoverProps extends HTMLProps<HTMLDivElement> {
   /** Popover position */
   position?: BasicPlacement;
   /** If true, tries to keep the popover in view by flipping it if necessary */
@@ -21,10 +21,10 @@ export interface PopoverProps extends Omit<Props, 'children'> {
   /** Accessible label, required when header is not present */
   'aria-label'?: string;
   /** Header content, leave empty for no header */
-  headerContent?: Element;
+  headerContent?: ReactElement<any>;
   /** Body content */
-  bodyContent: Element;
-  /** 
+  bodyContent: ReactElement<any>;
+  /**
    * True to show the popover programmatically. Used in conjunction with the shouldClose prop.
    * By default, the popover child element handles click events automatically. If you want to control this programmatically,
    * the popover will not auto-close if the Close button is clicked, ESC key is used, or if a click occurs outside the popover.
@@ -37,7 +37,7 @@ export interface PopoverProps extends Omit<Props, 'children'> {
    */
   shouldClose?(instance: Instance): void;
   /** The element to append the popover to, defaults to body */
-  appendTo?: Element | ((ref: Element) => Element);
+  appendTo?: ReactElement<any> | ((ref: ReactElement<any>) => ReactElement<any>);
   /** Hides the popover when a click occurs outside */
   hideOnOutsideClick?: boolean;
   /** Lifecycle function invoked when the popover begins to transition out. */

--- a/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.d.ts
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactElement } from 'react';
+import { FunctionComponent, HTMLProps, ReactElement } from 'react';
 import { Omit } from '../../typeUtils';
 import { BasicPlacement, Props } from 'tippy.js';
 
@@ -9,7 +9,7 @@ export const TooltipPosition: {
   right: 'right';
 };
 
-export interface TooltipProps extends Omit<Props, 'content' | 'children'> {
+export interface TooltipProps extends Omit<HTMLProps<HTMLDivElement>, 'content' | 'children'> {
   /** Tooltip position */
   position?: BasicPlacement;
   /** If true, tries to keep the tooltip in view by flipping it if necessary */
@@ -25,7 +25,7 @@ export interface TooltipProps extends Omit<Props, 'content' | 'children'> {
   /** Delay in ms before a tooltip disappears */
   exitDelay?: number;
   /** The element to append the tooltip to, defaults to body */
-  appendTo?: Element | ((ref: Element) => Element);
+  appendTo?: ReactElement<any> | ((ref: ReactElement<any>) => ReactElement<any>);
   /** z-index of the tooltip */
   zIndex?: number;
   /** Size of the tooltip */

--- a/packages/patternfly-4/react-core/src/helpers/GenerateId/GenerateId.d.ts
+++ b/packages/patternfly-4/react-core/src/helpers/GenerateId/GenerateId.d.ts
@@ -5,6 +5,6 @@ export interface GenerateIdProps {
   children(id: string): ReactNode;
 }
 
-declare const GenerateId: ComponentClass<GenerateId>;
+declare const GenerateId: ComponentClass<GenerateIdProps>;
 
 export default GenerateId;


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
fixes #1340 

`Element` is not currently exported in the version of `@types/react` used here, so updating with `ReactElement`. Also, `Omit<Props>` is incorrectly extending the interface for these components (which internally render div's). Updating to `HTMLProps<HTMLDivElement>` respectively.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
