### PR TITLE
docs(siteConstants.js): PF3: Link to react-bootstrap legacy docs instead of new (incompatible) docs

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Tabs/Tabs.stories.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Tabs/Tabs.stories.js
@@ -13,8 +13,8 @@ const stories = storiesOf(`${storybookPackageName(name)}/${STORYBOOK_CATEGORY.WI
 const description = (
   <p>
     This component is based on React Bootstrap Tabs component. See{' '}
-    <a href="https://react-bootstrap.github.io/components.html#tabs">React Bootstrap Docs</a> for complete Tabs
-    component documentation.
+    <a href={`${DOCUMENTATION_URL.REACT_BOOTSTRAP_COMPONENT}tabs/`}>React Bootstrap Docs</a> for complete Tabs component
+    documentation.
   </p>
 );
 stories.addDecorator(withKnobs);

--- a/storybook/constants/siteConstants.js
+++ b/storybook/constants/siteConstants.js
@@ -3,7 +3,7 @@ const PATTERNFLY_ORG = 'http://www.patternfly.org/';
 export const BASE_URL = {
   PATTERNFLY_ORG,
   PATTERNFLY_LIBRARY: `${PATTERNFLY_ORG}pattern-library/`,
-  REACT_BOOTSTRAP: 'https://react-bootstrap.github.io/'
+  REACT_BOOTSTRAP: 'https://5c507d49471426000887a6a7--react-bootstrap.netlify.com/'
 };
 
 export const DOCUMENTATION_URL = {


### PR DESCRIPTION
**What**:

react-bootstrap's v1 release targets bootstrap v4, which is incompatible with patternfly.
The new documentation they released breaks all of our deep links into the old docs from Storybook.

This legacy URL comes from the "To find the documentation for the latest Bootstrap 3 compatible
release, go here" link at https://github.com/react-bootstrap/react-bootstrap.