### PR TITLE
fix(DataList): Add aria-label and aria-labelledby improvements

### DIFF
--- a/packages/patternfly-4/react-core/src/components/DataList/DataList.test.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataList.test.js
@@ -65,13 +65,13 @@ describe('DataList', () => {
     });
   });
 
-  test('Toggle default', () => {
+  test('Toggle default with aria label', () => {
     const view = shallow(
       <DataListToggle aria-label="Toggle details for" aria-labelledby="ex-toggle2 ex-item2" id="ex-toggle2" />
     );
 
     expect(view.find(Button).props()['aria-label']).toBe('Toggle details for');
-    expect(view.find(Button).props()['aria-labelledby']).toBe('ex-toggle2 ex-item2');
+    expect(view.find(Button).props()['aria-labelledby']).toBe(null);
     expect(view.find(Button).props()['aria-expanded']).toBe(false);
     expect(view.find(Button).props().id).toBe('ex-toggle2');
     expect(view.find(Button).props().id).toBe('ex-toggle2');
@@ -81,7 +81,6 @@ describe('DataList', () => {
     const view = shallow(
       <DataListToggle
         aria-label="Toggle details for"
-        aria-labelledby="ex-toggle2 ex-item2"
         id="ex-toggle2"
         isExpanded
       />

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListAction.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListAction.js
@@ -3,13 +3,13 @@ import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
 import styles from '@patternfly/patternfly/components/DataList/data-list.css';
 import { EllipsisVIcon } from '@patternfly/react-icons';
-import { Button } from '../Button';
+import { Button, ButtonVariant } from '../Button';
 
 class DataListAction extends React.Component {
   render() {
     const {className, id, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, rowid, ...rest} = this.props;
     return <div className={css(styles.dataListAction, className)} {...rest}>
-      <Button variant="plain" id={id} aria-labelledby={ariaLabelledBy} aria-label={ariaLabel}>
+      <Button variant={ButtonVariant.plain} id={id} aria-labelledby={ariaLabelledBy} aria-label={ariaLabel}>
         <EllipsisVIcon />
       </Button>
     </div>;

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListAction.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListAction.js
@@ -5,16 +5,13 @@ import styles from '@patternfly/patternfly/components/DataList/data-list.css';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import { Button, ButtonVariant } from '../Button';
 
-class DataListAction extends React.Component {
-  render() {
-    const {className, id, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, rowid, ...rest} = this.props;
-    return <div className={css(styles.dataListAction, className)} {...rest}>
-      <Button variant={ButtonVariant.plain} id={id} aria-labelledby={ariaLabelledBy} aria-label={ariaLabel}>
-        <EllipsisVIcon />
-      </Button>
-    </div>;
-  }
-}
+const DataListAction = ({ className, id, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, rowid, ...props }) => (
+  <div className={css(styles.dataListAction, className)} {...props}>
+    <Button variant={ButtonVariant.plain} id={id} aria-labelledby={ariaLabelledBy} aria-label={ariaLabel}>
+      <EllipsisVIcon />
+    </Button>
+  </div>
+);
 
 DataListAction.propTypes = {
   /** Content rendered inside the DataList list */

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListAction.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListAction.js
@@ -5,13 +5,16 @@ import styles from '@patternfly/patternfly/components/DataList/data-list.css';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import { Button } from '../Button';
 
-const DataListAction = ({ className, id, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, ...props }) => (
-  <div className={css(styles.dataListAction, className)} {...props}>
-    <Button variant="plain" id={id} aria-labelledby={ariaLabelledBy} aria-label={ariaLabel}>
-      <EllipsisVIcon />
-    </Button>
-  </div>
-);
+class DataListAction extends React.Component {
+  render() {
+    const {className, id, 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledBy, rowid, ...rest} = this.props;
+    return <div className={css(styles.dataListAction, className)} {...rest}>
+      <Button variant="plain" id={id} aria-labelledby={ariaLabelledBy} aria-label={ariaLabel}>
+        <EllipsisVIcon />
+      </Button>
+    </div>;
+  }
+}
 
 DataListAction.propTypes = {
   /** Content rendered inside the DataList list */

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListCell.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListCell.js
@@ -3,17 +3,14 @@ import { css, getModifier } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
 import styles from '@patternfly/patternfly/components/DataList/data-list.css';
 
-class DataListCell extends React.Component {
-  render() {
-    const {rowid, width, className, children, ...rest} = this.props;
-    return <div
-      className={css(styles.dataListCell, width > 1 && getModifier(styles, `flex_${width}`, ''), className)}
-      {...rest}
-    >
-      {children}
-    </div>;
-  }
-}
+const DataListCell = ({ children, className, width, rowid, ...props }) => (
+  <div
+    className={css(styles.dataListCell, width > 1 && getModifier(styles, `flex_${width}`, ''), className)}
+    {...props}
+  >
+    {children}
+  </div>
+);
 
 DataListCell.propTypes = {
   /** Content rendered inside the DataList cell */

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListCell.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListCell.js
@@ -3,14 +3,17 @@ import { css, getModifier } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
 import styles from '@patternfly/patternfly/components/DataList/data-list.css';
 
-const DataListCell = ({ children, className, width, ...props }) => (
-  <div
-    className={css(styles.dataListCell, width > 1 && getModifier(styles, `flex_${width}`, ''), className)}
-    {...props}
-  >
-    {children}
-  </div>
-);
+class DataListCell extends React.Component {
+  render() {
+    const {rowid, width, className, children, ...rest} = this.props;
+    return <div
+      className={css(styles.dataListCell, width > 1 && getModifier(styles, `flex_${width}`, ''), className)}
+      {...rest}
+    >
+      {children}
+    </div>;
+  }
+}
 
 DataListCell.propTypes = {
   /** Content rendered inside the DataList cell */

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListContent.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListContent.js
@@ -3,22 +3,28 @@ import PropTypes from 'prop-types';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/patternfly/components/DataList/data-list.css';
 
-const DataListContent = ({ className, children, isHidden, 'aria-label': ariaLabel, ...props }) => (
-  <section
-    className={css(styles.dataListExpandableContent, className)}
-    hidden={isHidden}
-    aria-label={ariaLabel}
-    {...props}
-  >
-    {children}
-  </section>
-);
+class DataListContent extends React.Component {
+  render() {
+    const {className, children, id, isHidden, 'aria-label': ariaLabel, rowid, ...rest} = this.props;
+    return <section
+      id={id}
+      className={css(styles.dataListExpandableContent, className)}
+      hidden={isHidden}
+      aria-label={ariaLabel}
+      {...rest}
+    >
+      {children}
+    </section>;
+  }
+}
 
 DataListContent.propTypes = {
   /** Content rendered inside the DataList item */
   children: PropTypes.node,
   /** Additional classes added to the DataList cell */
   className: PropTypes.string,
+  /** Identify the DataListContent item */
+  id: PropTypes.string,
   /** Flag to show if the expanded content of the DataList item is visible */
   isHidden: PropTypes.bool,
   /** Adds accessible text to the DataList toggle */
@@ -29,6 +35,7 @@ DataListContent.propTypes = {
 
 DataListContent.defaultProps = {
   className: '',
+  id: '',
   isHidden: false
 };
 

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListContent.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListContent.js
@@ -3,20 +3,17 @@ import PropTypes from 'prop-types';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/patternfly/components/DataList/data-list.css';
 
-class DataListContent extends React.Component {
-  render() {
-    const {className, children, id, isHidden, 'aria-label': ariaLabel, rowid, ...rest} = this.props;
-    return <section
-      id={id}
-      className={css(styles.dataListExpandableContent, className)}
-      hidden={isHidden}
-      aria-label={ariaLabel}
-      {...rest}
-    >
-      {children}
-    </section>;
-  }
-}
+const DataListContent = ({ className, children, id, isHidden, 'aria-label': ariaLabel, rowid, ...props }) => (
+  <section
+    id={id}
+    className={css(styles.dataListExpandableContent, className)}
+    hidden={isHidden}
+    aria-label={ariaLabel}
+    {...props}
+  >
+    {children}
+  </section>
+);
 
 DataListContent.propTypes = {
   /** Content rendered inside the DataList item */

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListItem.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListItem.js
@@ -9,7 +9,11 @@ const DataListItem = ({ children, className, isExpanded, 'aria-labelledby': aria
     aria-labelledby={ariaLabelledBy}
     {...props}
   >
-    {children}
+    {React.Children.map(children, child =>
+      React.cloneElement(child, {
+        rowid: ariaLabelledBy
+      })
+    )}
   </li>
 );
 

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListToggle.d.ts
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListToggle.d.ts
@@ -3,8 +3,9 @@ import { Omit } from '../../typeUtils';
 
 export interface DataListToggleProps extends Omit<HTMLProps<HTMLDivElement>, 'aria-labelledby' | 'aria-label' | 'id'> {
   isExpanded: boolean;
-  'aria-labelledby': string;
-  'aria-label': string;
+  'aria-controls'?: string;
+  'aria-labelledby'?: string;
+  'aria-label'?: string;
   id: string;
 }
 

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListToggle.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListToggle.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { css } from '@patternfly/react-styles';
 import { AngleRightIcon } from '@patternfly/react-icons';
 import styles from '@patternfly/patternfly/components/DataList/data-list.css';
-import { Button } from '../Button';
+import { Button, ButtonVariant } from '../Button';
 
 const DataListToggle = ({
   className,
@@ -16,7 +16,7 @@ const DataListToggle = ({
   ...props
 }) => (
   <div className={css(styles.dataListToggle, className)} {...props}>
-    <Button id={id} variant="plain" aria-controls={ariaControls !== '' && ariaControls} aria-label={ariaLabel} aria-labelledby={ariaLabel !== "Details" ? null : `${rowid} ${id}`} aria-expanded={isExpanded}>
+    <Button id={id} variant={ButtonVariant.plain} aria-controls={ariaControls !== '' && ariaControls} aria-label={ariaLabel} aria-labelledby={ariaLabel !== "Details" ? null : `${rowid} ${id}`} aria-expanded={isExpanded}>
       <AngleRightIcon />
     </Button>
   </div>

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListToggle.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListToggle.js
@@ -8,13 +8,15 @@ import { Button } from '../Button';
 const DataListToggle = ({
   className,
   isExpanded,
+  'aria-controls': ariaControls,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
+  rowid,
   id,
   ...props
 }) => (
   <div className={css(styles.dataListToggle, className)} {...props}>
-    <Button id={id} variant="plain" aria-label={ariaLabel} aria-labelledby={ariaLabelledBy} aria-expanded={isExpanded}>
+    <Button id={id} variant="plain" aria-controls={ariaControls !== '' && ariaControls} aria-label={ariaLabel} aria-labelledby={ariaLabel !== "Details" ? null : `${rowid} ${id}`} aria-expanded={isExpanded}>
       <AngleRightIcon />
     </Button>
   </div>
@@ -28,14 +30,19 @@ DataListToggle.propTypes = {
   /** Identify the DataList toggle number */
   id: PropTypes.string.isRequired,
   /** Adds accessible text to the DataList toggle */
-  'aria-labelledby': PropTypes.string.isRequired,
+  'aria-labelledby': PropTypes.string,
   /** Adds accessible text to the DataList toggle */
-  'aria-label': PropTypes.string.isRequired,
+  'aria-label': PropTypes.string,
+  /** Allows users of some screen readers to shift focus to the controlled element. Should be used when the controlled contents are not adjacent to the toggle that controls them. */
+  'aria-controls': PropTypes.string,
   /** Additional props are spread to the container <div> */
   '': PropTypes.any
 };
 
 DataListToggle.defaultProps = {
+  'aria-controls': '',
+  'aria-label': 'Details',
+  'aria-labelledby': '',
   className: '',
   isExpanded: false
 };

--- a/packages/patternfly-4/react-core/src/components/DataList/examples/ExpandableDataList.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/examples/ExpandableDataList.js
@@ -29,8 +29,7 @@ class ExpandableDataList extends React.Component {
             onClick={() => toggle('ex-toggle1')}
             isExpanded={this.state.expanded.includes('ex-toggle1')}
             id="ex-toggle1"
-            aria-labelledby="ex-toggle1 ex-item1"
-            aria-label="Toggle details for"
+            aria-controls="ex-expand1"
           />
           <DataListCheck aria-labelledby="ex-item1" name="ex-check1" />
           <DataListCell>
@@ -41,7 +40,7 @@ class ExpandableDataList extends React.Component {
             <span>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
           </DataListCell>
           <DataListAction aria-labelledby="ex-item1 ex-action1" id="ex-action1" aria-label="Actions" />
-          <DataListContent aria-label="Primary Content Details" isHidden={!this.state.expanded.includes('ex-toggle1')}>
+          <DataListContent aria-label="Primary Content Details" id="ex-expand1" isHidden={!this.state.expanded.includes('ex-toggle1')}>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua.
@@ -53,8 +52,7 @@ class ExpandableDataList extends React.Component {
             onClick={() => toggle('ex-toggle2')}
             isExpanded={this.state.expanded.includes('ex-toggle2')}
             id="ex-toggle2"
-            aria-labelledby="ex-toggle2 ex-item2"
-            aria-label="Toggle details for"
+            aria-controls="ex-expand2"
           />
           <DataListCheck aria-labelledby="ex-item2" name="ex-check2" />
           <DataListCell>
@@ -64,7 +62,7 @@ class ExpandableDataList extends React.Component {
             <span>Lorem ipsum dolor sit amet.</span>
           </DataListCell>
           <DataListAction aria-labelledby="ex-item2 ex-action2" id="ex-action2" aria-label="Actions" />
-          <DataListContent aria-label="Primary Content Details" isHidden={!this.state.expanded.includes('ex-toggle2')}>
+          <DataListContent aria-label="Primary Content Details" id="ex-expand2" isHidden={!this.state.expanded.includes('ex-toggle2')}>
             <p>
               Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
               dolore magna aliqua.

--- a/packages/patternfly-4/react-core/src/components/DataList/examples/ModifiersDataList.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/examples/ModifiersDataList.js
@@ -78,8 +78,7 @@ class ModifiersDataList extends React.Component {
             <DataListToggle
               isExpanded={this.state.show}
               id="width-ex3-toggle1"
-              aria-labelledby="width-ex3-toggle1 width-ex3-item1"
-              aria-label="Toggle details for"
+              aria-controls="width-ex3-expand1"
               onClick={() => this.setState({ show: !this.state.show })}
             />
             <DataListCheck aria-labelledby="width-ex3-check1" name="width-ex3-check1" />
@@ -103,7 +102,7 @@ class ModifiersDataList extends React.Component {
               id="width-ex3-action1"
               aria-label="Actions"
             />
-            <DataListContent aria-label="Primary Content Details" isHidden={!this.state.show}>
+            <DataListContent aria-label="Primary Content Details" id="width-ex3-expand1" isHidden={!this.state.show}>
               <p>
                 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et
                 dolore magna aliqua.


### PR DESCRIPTION
The DataListToggle aria label now defaults to "Details." If the consumer provides an aria label, there is no aria-labelledby. If the consumer uses the default aria label, aria-labelledby will be in the
following format: aria-labelledby=`${aria-labelledby of DataListItem} ${id}`. Users can also add an id prop to DataListContent and a corresponding aria-controls prop to DataListToggle.

Affects #1163.