### PR TITLE
build(sass): Inline the CSS of imported files in patternfly-react.scss

### DIFF
--- a/packages/patternfly-3/patternfly-react/build/node-sass-tilde-importer.js
+++ b/packages/patternfly-3/patternfly-react/build/node-sass-tilde-importer.js
@@ -1,0 +1,8 @@
+function importer(url) {
+  if (url[0] === '~') {
+    return { file: `../../../../../node_modules/${url.substr(1)}` };
+  }
+  return { file: url };
+}
+
+module.exports = importer;

--- a/packages/patternfly-3/patternfly-react/package.json
+++ b/packages/patternfly-3/patternfly-react/package.json
@@ -62,10 +62,11 @@
     "build:babel:cjs": "cross-env BABEL_ENV=production:cjs babel src --out-dir dist/js",
     "build:babel:esm": "cross-env BABEL_ENV=production:esm babel src --out-dir dist/esm",
     "build:less": "shx mkdir -p dist/less && shx cp -r less/* dist/less",
-    "build:sass": "shx mkdir -p dist/sass && shx cp -r sass/patternfly-react/* dist/sass && cross-env node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o dist/css sass/patternfly-react.scss",
+    "build:sass": "shx mkdir -p dist/sass && shx cp -r sass/patternfly-react/* dist/sass && cross-env node-sass --output-style compressed --include-path sass --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome --importer=build/node-sass-tilde-importer.js -o dist/css sass/patternfly-react.scss && cleancss -o dist/css/patternfly-react.css dist/css/patternfly-react.css",
     "clean": "rimraf dist"
   },
   "devDependencies": {
+    "clean-css-cli": "^4.2.1",
     "react-axe": "^3.0.2",
     "rimraf": "^2.6.2",
     "shx": "^0.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5916,11 +5916,27 @@ classnames@^2.2.3, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
 
+clean-css-cli@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/clean-css-cli/-/clean-css-cli-4.2.1.tgz#0a367077ad85cb4451148ac1f2edb4eb1992b4ed"
+  integrity sha512-ST2yi9F2kAmLRs9phSpGRUm44SbRy29QGm1OuAKfTU0KCLilFMTcz+/Fxhbdi5GrsjIMhTBdFUQhc55CjM3Isw==
+  dependencies:
+    clean-css "^4.2.1"
+    commander "2.x"
+    glob "7.x"
+
 clean-css@4.1.x:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"
   dependencies:
     source-map "0.5.x"
+
+clean-css@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17"
+  integrity sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==
+  dependencies:
+    source-map "~0.6.0"
 
 cli-boxes@^1.0.0:
   version "1.0.0"
@@ -6255,7 +6271,7 @@ commander@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.6.0.tgz#9df7e52fb2a0cb0fb89058ee80c3104225f37e1d"
 
-commander@^2.12.1, commander@^2.8.1:
+commander@2.x, commander@^2.12.1, commander@^2.8.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
 
@@ -10338,7 +10354,7 @@ glob@7.1.2, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glo
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.3, glob@^7.1.3:
+glob@7.1.3, glob@7.x, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
@@ -19129,7 +19145,7 @@ source-map@^0.4.2, source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 


### PR DESCRIPTION
Fixes #673.

This PR adds a step to the `build:sass` script in `packages/patternfly-3/patternfly-react` which uses a custom node-sass importer to change the tilde-based path `~react-bootstrap-typeahead/css/Typeahead.css` to a true relative path, and then calls `cleancss` to convert that local import into inlined CSS.

Details on the `--importer` option I'm passing to `node-sass`: https://github.com/sass/node-sass#importer--v200---experimental

Before writing the custom `build/node-sass-tilde-importer.js` file, I tried using https://www.npmjs.com/package/node-sass-tilde-importer, but that converts the import to an absolute path, which cleancss was refusing to resolve. Maybe a different CSS processor could handle that.

I have a feeling there is a better way, but this works. It seems something like this is now necessary because of an upstream change in node-sass: https://github.com/sass/node-sass/issues/2362

@seanforyou23 I'm curious about your thoughts on this solution.