### PR TITLE
refactor(ApplicationLauncher): Refactor so it no longer uses Dropdown

### DIFF
--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/ApplicationLauncher.d.ts
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/ApplicationLauncher.d.ts
@@ -1,14 +1,14 @@
 import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf } from '../../typeUtils';
-import { DropdownPosition, DropdownDirection } from '../Dropdown/dropdownConstants';
+import { ApplicationLauncherDirection, ApplicationLauncherPosition } from './applicationLauncherConstants';
 
 export interface ApplicationLauncherProps extends HTMLProps<HTMLDivElement> {
-  direction?: OneOf<typeof DropdownDirection, keyof typeof DropdownDirection>;
+  direction?: OneOf<typeof ApplicationLauncherDirection, keyof typeof ApplicationLauncherDirection>;
   dropdownItems: ReactNode[];
   isOpen?: boolean;
   onSelect(event: React.SyntheticEvent<HTMLDivElement>): void;
   onToggle?(event: React.SyntheticEvent<HTMLDivElement>): void;
-  position?: OneOf<typeof DropdownPosition, keyof typeof DropdownPosition>;
+  position?: OneOf<typeof ApplicationLauncherPosition, keyof typeof ApplicationLauncherPosition>;
 }
 
 declare const ApplicationLauncher: FunctionComponent<ApplicationLauncherProps>;

--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/ApplicationLauncher.js
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/ApplicationLauncher.js
@@ -7,6 +7,7 @@ import Toggle from './Toggle';
 import { ThIcon } from '@patternfly/react-icons';
 import { ApplicationLauncherDirection, ApplicationLauncherPosition } from './applicationLauncherConstants';
 import { DropdownContext } from '../Dropdown/dropdownConstants';
+import GenerateId from '../../helpers/GenerateId/GenerateId';
 
 export const propTypes = {
   /** Additional element css classes */
@@ -26,9 +27,6 @@ export const propTypes = {
   /** Adds accessible text to the button. Required for plain buttons */
   'aria-label': PropTypes.string
 };
-
-// seed for the aria-labelledby ID
-let currentId = 0;
 
 export const defaultProps = {
   className: '',
@@ -51,40 +49,41 @@ class ApplicationLauncher extends React.Component {
   }
 
   render() {
-    const {'aria-label': ariaLabel, children, dropdownItems, className, isOpen, onSelect, onToggle, toggleID, ...props} = this.props;
-    const id = `pf-toggle-id-${currentId++}`;
-    const toggle = <Toggle id={id} aria-label={ariaLabel} onToggle={onToggle}><ThIcon /></Toggle>;
-    return <div
-                className={css(
-                  styles.appLauncher,
-                  isOpen && styles.modifiers.expanded,
-                  className
-                )}
-                ref={ref => {
-                    this.parentRef = ref;}}>
-      {Children.map(toggle, oneToggle =>
-        cloneElement(oneToggle, {
-          parentRef: this.parentRef,
-          isOpen,
-          id,
-          isPlain: true,
-          ariaHasPopup: true,
-          onEnter: this.onEnter
-        })
-      )}
-      {isOpen && (
-          <DropdownContext.Provider value={event => onSelect && onSelect(event)}>
-      <ApplicationLauncherMenu
-        isOpen={isOpen}
-        position="left"
-        aria-labelledby={ariaLabel}
-        openedOnEnter={this.openedOnEnter}
-      >
-        {dropdownItems}
-      </ApplicationLauncherMenu>
-      </DropdownContext.Provider>
+    const {'aria-label': ariaLabel, children, dropdownItems, className, isOpen, onSelect, onToggle, ...props} = this.props;
+    return <GenerateId>{randomId => (
+      <div
+        className={css(
+          styles.appLauncher,
+          isOpen && styles.modifiers.expanded,
+          className
         )}
-    </div>;
+        ref={ref => {
+            this.parentRef = ref;}}>
+        {Children.map(
+          <Toggle id={`pf-toggle-id-${randomId}`} aria-label={ariaLabel} onToggle={onToggle}><ThIcon /></Toggle>, oneToggle =>
+            cloneElement(oneToggle, {
+              parentRef: this.parentRef,
+              id: randomId,
+              isOpen,
+              isPlain: true,
+              ariaHasPopup: true,
+              onEnter: this.onEnter
+          })
+        )}
+        {isOpen && (
+            <DropdownContext.Provider value={event => onSelect && onSelect(event)}>
+        <ApplicationLauncherMenu
+          isOpen={isOpen}
+          position="left"
+          aria-labelledby={ariaLabel}
+          openedOnEnter={this.openedOnEnter}
+        >
+          {dropdownItems}
+        </ApplicationLauncherMenu>
+        </DropdownContext.Provider>
+          )}
+      </div>
+    )}</GenerateId>;
   }
 }
 

--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/ApplicationLauncher.js
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/ApplicationLauncher.js
@@ -1,15 +1,18 @@
-import React from 'react';
+import React, { Children, cloneElement } from 'react';
+import styles from '@patternfly/patternfly/components/AppLauncher/app-launcher.css';
+import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
-import { Dropdown, DropdownDirection, DropdownToggle, DropdownPosition } from '../Dropdown';
+import ApplicationLauncherMenu from './ApplicationLauncherMenu';
+import Toggle from './Toggle';
 import { ThIcon } from '@patternfly/react-icons';
-
-const defaultAriaLabel = 'Application Launcher';
+import { ApplicationLauncherDirection, ApplicationLauncherPosition } from './applicationLauncherConstants';
+import { DropdownContext } from '../Dropdown/dropdownConstants';
 
 export const propTypes = {
   /** Additional element css classes */
   className: PropTypes.string,
   /** Display menu above or below dropdown toggle */
-  direction: PropTypes.oneOf(Object.values(DropdownDirection)),
+  direction: PropTypes.oneOf(Object.values(ApplicationLauncherDirection)),
   /** Array of DropdownItem nodes that will be rendered in the dropdown Menu list */
   dropdownItems: PropTypes.array,
   /** open bool */
@@ -19,33 +22,71 @@ export const propTypes = {
   /** Callback called when application launcher toggle is clicked */
   onToggle: PropTypes.func,
   /** Indicates where menu will be alligned horizontally */
-  position: PropTypes.oneOf(Object.values(DropdownPosition)),
+  position: PropTypes.oneOf(Object.values(ApplicationLauncherPosition)),
   /** Adds accessible text to the button. Required for plain buttons */
   'aria-label': PropTypes.string
 };
 
+// seed for the aria-labelledby ID
+let currentId = 0;
+
 export const defaultProps = {
   className: '',
-  direction: DropdownDirection.down,
+  direction: ApplicationLauncherDirection.down,
   dropdownItems: [],
   isOpen: false,
   onSelect: Function.prototype,
   onToggle: Function.prototype,
-  position: DropdownPosition.left,
-  'aria-label': defaultAriaLabel
+  position: ApplicationLauncherPosition.left,
+  'aria-label': 'Actions'
 };
 
-const ApplicationLauncher = ({ 'aria-label': ariaLabel, onToggle, ...props }) => (
-  <Dropdown
-    {...props}
-    toggle={
-      <DropdownToggle aria-label={ariaLabel} iconComponent={null} onToggle={onToggle}>
-        <ThIcon />
-      </DropdownToggle>
-    }
-    isPlain
-  />
-);
+class ApplicationLauncher extends React.Component {
+  onEnter = () => {
+    this.openedOnEnter = true;
+  };
+
+  componentDidUpdate() {
+    if (!this.props.isOpen) this.openedOnEnter = false;
+  }
+
+  render() {
+    const {'aria-label': ariaLabel, children, dropdownItems, className, isOpen, onSelect, onToggle, toggleID, ...props} = this.props;
+    const id = `pf-toggle-id-${currentId++}`;
+    const toggle = <Toggle id={id} aria-label={ariaLabel} onToggle={onToggle}><ThIcon /></Toggle>;
+    return <div
+                className={css(
+                  styles.appLauncher,
+                  isOpen && styles.modifiers.expanded,
+                  className
+                )}
+                ref={ref => {
+                    this.parentRef = ref;}}>
+      {Children.map(toggle, oneToggle =>
+        cloneElement(oneToggle, {
+          parentRef: this.parentRef,
+          isOpen,
+          id,
+          isPlain: true,
+          ariaHasPopup: true,
+          onEnter: this.onEnter
+        })
+      )}
+      {isOpen && (
+          <DropdownContext.Provider value={event => onSelect && onSelect(event)}>
+      <ApplicationLauncherMenu
+        isOpen={isOpen}
+        position="left"
+        aria-labelledby={ariaLabel}
+        openedOnEnter={this.openedOnEnter}
+      >
+        {dropdownItems}
+      </ApplicationLauncherMenu>
+      </DropdownContext.Provider>
+        )}
+    </div>;
+  }
+}
 
 ApplicationLauncher.propTypes = propTypes;
 ApplicationLauncher.defaultProps = defaultProps;

--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/ApplicationLauncherMenu.js
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/ApplicationLauncherMenu.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import styles from '@patternfly/patternfly/components/AppLauncher/app-launcher.css';
+import { css } from '@patternfly/react-styles';
+import PropTypes from 'prop-types';
+import { ApplicationLauncherPosition } from './applicationLauncherConstants';
+import { DropdownContext, DropdownArrowContext } from '../Dropdown/dropdownConstants';
+import ReactDOM from 'react-dom';
+
+const propTypes = {
+  /** Anything which can be rendered as dropdown items */
+  children: PropTypes.node,
+  /** Classess applied to root element of dropdown menu */
+  className: PropTypes.string,
+  /** Flag to indicate if menu is opened */
+  isOpen: PropTypes.bool,
+  /** Indicates where menu will be alligned horizontally */
+  position: PropTypes.oneOf(Object.values(ApplicationLauncherPosition)),
+  /** Additional props are spread to the container component */
+  '': PropTypes.any
+};
+
+const defaultProps = {
+  children: null,
+  className: '',
+  isOpen: true,
+  position: ApplicationLauncherPosition.left,
+};
+
+class ApplicationLauncherMenu extends React.Component {
+  refsCollection = {};
+
+  keyHandler = (index, position, custom = false) => {
+    const kids = this.props.children;
+    if (!Array.isArray(kids)) return;
+    let nextIndex;
+    if (position === 'up') {
+      if (index === 0) {
+        // loop back to end
+        nextIndex = kids.length - 1;
+      } else {
+        nextIndex = index - 1;
+      }
+    } else if (index === kids.length - 1) {
+      // loop back to beginning
+      nextIndex = 0;
+    } else {
+      nextIndex = index + 1;
+    }
+    if (this.refsCollection[`item-${nextIndex}`] === null) {
+      this.keyHandler(nextIndex, position, custom);
+    } else {
+      custom
+        ? (this.refsCollection[`item-${nextIndex}`].current.focus &&
+            this.refsCollection[`item-${nextIndex}`].current.focus()) ||
+          ReactDOM.findDOMNode(this.refsCollection[`item-${nextIndex}`].current).focus()
+        : this.refsCollection[`item-${nextIndex}`].focus();
+    }
+  };
+
+  onKeyDown = event => {
+    // Detected key press on this item, notify the menu parent so that the appropriate
+    // item can be focused
+    if (event.key === 'Tab') return;
+    event.preventDefault();
+    if (event.key === 'ArrowUp') {
+      this.keyHandler(this.props.index, 'up');
+    } else if (event.key === 'ArrowDown') {
+      this.keyHandler(this.props.index, 'down');
+    } else if (event.key === 'Enter') {
+      if (!this.ref.current.getAttribute) ReactDOM.findDOMNode(this.ref.current).click();
+      else {
+        this.ref.current.click && this.ref.current.click();
+      }
+    }
+  };
+
+  componentDidMount() {
+    if (this.props.openedOnEnter) {
+      this.refsCollection['item-0'].focus();
+    }
+  }
+
+  sendRef = (index, node, isDisabled) => {
+    if (!node.getAttribute) {
+      this.refsCollection[`item-${index}`] = ReactDOM.findDOMNode(node);
+    } else if (isDisabled || node.getAttribute('role') === 'separator') {
+      this.refsCollection[`item-${index}`] = null;
+    } else {
+      this.refsCollection[`item-${index}`] = node;
+    }
+  };
+
+  extendChildren() {
+    return React.Children.map(this.props.children, (child, index) =>
+      React.cloneElement(child, {
+        index, isAppLauncher: true
+      })
+    );
+  }
+
+  render() {
+    const { className, isOpen, position, children, component: Component, openedOnEnter, ...props } = this.props;
+
+    return (
+      <DropdownArrowContext.Provider
+        value={{
+          keyHandler: this.keyHandler,
+          sendRef: this.sendRef
+        }}
+      >
+        <ul
+          {...props}
+          className={css(
+            styles.appLauncherMenu,
+            className
+          )}
+          hidden={!isOpen}
+          role="menu"
+        >
+          {this.extendChildren()}
+        </ul>
+      </DropdownArrowContext.Provider>
+    );
+  }
+}
+
+ApplicationLauncherMenu.propTypes = propTypes;
+ApplicationLauncherMenu.defaultProps = defaultProps;
+
+export default ApplicationLauncherMenu;

--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/Toggle.js
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/Toggle.js
@@ -1,0 +1,129 @@
+import React, { Component } from 'react';
+import styles from '@patternfly/patternfly/components/Button/button.css';
+import { css } from '@patternfly/react-styles';
+import PropTypes from 'prop-types';
+import { KEY_CODES } from '../../internal/constants';
+
+const propTypes = {
+  /** HTML ID of toggle */
+  id: PropTypes.string.isRequired,
+  /** Anything which can be rendered as toggle */
+  children: PropTypes.node,
+  /** Classes applied to root element of toggle */
+  className: PropTypes.string,
+  /** Flag to indicate if menu is opened */
+  isOpen: PropTypes.bool,
+  /** Callback called when toggle is clicked */
+  onToggle: PropTypes.func,
+  /** Element which wraps toggle */
+  parentRef: PropTypes.any,
+  /** Forces focus state */
+  isFocused: PropTypes.bool,
+  /** Forces hover state */
+  isHovered: PropTypes.bool,
+  /** Forces active state */
+  isActive: PropTypes.bool,
+  /** Display the toggle with no border or background */
+  isPlain: PropTypes.bool,
+  /** Additional props are spread to the container <button> */
+  '': PropTypes.any
+};
+
+const defaultProps = {
+  children: null,
+  className: '',
+  isOpen: false,
+  parentRef: null,
+  isFocused: false,
+  isHovered: false,
+  isActive: false,
+  isPlain: false,
+  onToggle: Function.prototype
+};
+
+class ApplicationLauncherToggle extends Component {
+  componentDidMount = () => {
+    document.addEventListener('mousedown', this.onDocClick);
+    document.addEventListener('touchstart', this.onDocClick);
+    document.addEventListener('keydown', this.onEscPress);
+  };
+
+  componentWillUnmount = () => {
+    document.removeEventListener('mousedown', this.onDocClick);
+    document.removeEventListener('touchstart', this.onDocClick);
+    document.removeEventListener('keydown', this.onEscPress);
+  };
+
+  onDocClick = event => {
+    if (this.props.isOpen && this.props.parentRef && !this.props.parentRef.contains(event.target)) {
+      this.props.onToggle && this.props.onToggle(false);
+      this.toggle.focus();
+    }
+  };
+
+  onEscPress = event => {
+    const { parentRef } = this.props;
+    const keyCode = event.keyCode || event.which;
+    if (this.props.isOpen && (keyCode === KEY_CODES.ESCAPE_KEY || event.key === 'Tab') && parentRef && parentRef.contains(event.target)) {
+      this.props.onToggle && this.props.onToggle(false);
+      this.toggle.focus();
+    }
+  };
+
+  onKeyDown = event => {
+    if (event.key === 'Tab' && !this.props.isOpen) return;
+    event.preventDefault();
+    if ((event.key === 'Tab' || event.key === 'Enter' || event.key === ' ') && this.props.isOpen) {
+      this.props.onToggle(!this.props.isOpen);
+    } else if ((event.key === 'Enter' || event.key === ' ') && !this.props.isOpen) {
+      this.props.onToggle(!this.props.isOpen);
+      this.props.onEnter();
+    }
+  };
+
+  render() {
+    const {
+      className,
+      children,
+      isOpen,
+      isFocused,
+      isActive,
+      isHovered,
+      isPlain,
+      onToggle,
+      onEnter,
+      parentRef,
+      id,
+      type,
+      ...props
+    } = this.props;
+    return (
+      <button
+        {...props}
+        id={id}
+        ref={toggle => {
+          this.toggle = toggle;
+        }}
+        className={css(
+          styles.button,
+          isFocused && styles.modifiers.focus,
+          isHovered && styles.modifiers.hover,
+          isActive && styles.modifiers.active,
+          isPlain && styles.modifiers.plain,
+          className
+        )}
+        type={type || 'button'}
+        onClick={_event => onToggle && onToggle(!isOpen)}
+        aria-expanded={isOpen}
+        onKeyDown={this.onKeyDown}
+      >
+        {children}
+      </button>
+    );
+  }
+}
+
+ApplicationLauncherToggle.propTypes = propTypes;
+ApplicationLauncherToggle.defaultProps = defaultProps;
+
+export default ApplicationLauncherToggle;

--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/Toggle.js
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/Toggle.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import styles from '@patternfly/patternfly/components/Button/button.css';
 import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
-import { KEY_CODES } from '../../internal/constants';
+import { KEY_CODES } from '../../helpers/constants';
 
 const propTypes = {
   /** HTML ID of toggle */

--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/__snapshots__/ApplicationLauncher.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/__snapshots__/ApplicationLauncher.test.js.snap
@@ -1,301 +1,113 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApplicationLauncher dropup + right aligned 1`] = `
-<Dropdown
-  className=""
-  direction="up"
-  dropdownItems={
-    Array [
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Link
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Action
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={true}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Disabled Link
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={true}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Disabled Action
-      </DropdownItem>,
-      <Separator
-        className=""
-        component="a"
-        href="#"
-        isDisabled={false}
-        isHovered={false}
-      />,
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Separated Link
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Separated Action
-      </DropdownItem>,
-    ]
-  }
-  isOpen={false}
-  isPlain={true}
-  onSelect={[Function]}
-  position="right"
-  toggle={
-    <DropdownToggle
-      aria-label="Application Launcher"
-      className=""
-      iconComponent={null}
-      id=""
-      isActive={false}
-      isFocused={false}
-      isHovered={false}
-      isOpen={false}
-      isPlain={false}
-      onToggle={[Function]}
-      parentRef={null}
-    >
-      <ThIcon
-        color="currentColor"
-        size="sm"
-        title={null}
-      />
-    </DropdownToggle>
-  }
-/>
+.pf-c-app-launcher {
+  display: inline-block;
+  position: relative;
+  max-width: 100%;
+}
+
+<div
+  className="pf-c-app-launcher"
+>
+  <ApplicationLauncherToggle
+    aria-label="Actions"
+    ariaHasPopup={true}
+    className=""
+    id="pf-toggle-id-3"
+    isActive={false}
+    isFocused={false}
+    isHovered={false}
+    isOpen={false}
+    isPlain={true}
+    key=".0"
+    onEnter={[Function]}
+    onToggle={[Function]}
+    parentRef={null}
+  >
+    <ThIcon
+      color="currentColor"
+      size="sm"
+      title={null}
+    />
+  </ApplicationLauncherToggle>
+</div>
 `;
 
 exports[`ApplicationLauncher dropup 1`] = `
-<Dropdown
-  className=""
-  direction="up"
-  dropdownItems={
-    Array [
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Link
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Action
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={true}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Disabled Link
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={true}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Disabled Action
-      </DropdownItem>,
-      <Separator
-        className=""
-        component="a"
-        href="#"
-        isDisabled={false}
-        isHovered={false}
-      />,
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Separated Link
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Separated Action
-      </DropdownItem>,
-    ]
-  }
-  isOpen={false}
-  isPlain={true}
-  onSelect={[Function]}
-  position="left"
-  toggle={
-    <DropdownToggle
-      aria-label="Application Launcher"
-      className=""
-      iconComponent={null}
-      id=""
-      isActive={false}
-      isFocused={false}
-      isHovered={false}
-      isOpen={false}
-      isPlain={false}
-      onToggle={[Function]}
-      parentRef={null}
-    >
-      <ThIcon
-        color="currentColor"
-        size="sm"
-        title={null}
-      />
-    </DropdownToggle>
-  }
-/>
+.pf-c-app-launcher {
+  display: inline-block;
+  position: relative;
+  max-width: 100%;
+}
+
+<div
+  className="pf-c-app-launcher"
+>
+  <ApplicationLauncherToggle
+    aria-label="Actions"
+    ariaHasPopup={true}
+    className=""
+    id="pf-toggle-id-2"
+    isActive={false}
+    isFocused={false}
+    isHovered={false}
+    isOpen={false}
+    isPlain={true}
+    key=".0"
+    onEnter={[Function]}
+    onToggle={[Function]}
+    parentRef={null}
+  >
+    <ThIcon
+      color="currentColor"
+      size="sm"
+      title={null}
+    />
+  </ApplicationLauncherToggle>
+</div>
 `;
 
 exports[`ApplicationLauncher expanded 1`] = `
-<Dropdown
-  className=""
-  direction="down"
-  dropdownItems={
-    Array [
+.pf-c-app-launcher.pf-m-expanded {
+  display: inline-block;
+  position: relative;
+  max-width: 100%;
+}
+
+<div
+  className="pf-c-app-launcher pf-m-expanded"
+>
+  <ApplicationLauncherToggle
+    aria-label="Actions"
+    ariaHasPopup={true}
+    className=""
+    id="pf-toggle-id-4"
+    isActive={false}
+    isFocused={false}
+    isHovered={false}
+    isOpen={true}
+    isPlain={true}
+    key=".0"
+    onEnter={[Function]}
+    onToggle={[Function]}
+    parentRef={null}
+  >
+    <ThIcon
+      color="currentColor"
+      size="sm"
+      title={null}
+    />
+  </ApplicationLauncherToggle>
+  <[object Object]
+    value={[Function]}
+  >
+    <ApplicationLauncherMenu
+      aria-labelledby="Actions"
+      className=""
+      isOpen={true}
+      position="left"
+    >
       <DropdownItem
         className=""
         component="a"
@@ -309,10 +121,11 @@ exports[`ApplicationLauncher expanded 1`] = `
         index={-1}
         isDisabled={false}
         isHovered={false}
+        key="link"
         onClick={[Function]}
       >
         Link
-      </DropdownItem>,
+      </DropdownItem>
       <DropdownItem
         className=""
         component="button"
@@ -326,10 +139,11 @@ exports[`ApplicationLauncher expanded 1`] = `
         index={-1}
         isDisabled={false}
         isHovered={false}
+        key="action"
         onClick={[Function]}
       >
         Action
-      </DropdownItem>,
+      </DropdownItem>
       <DropdownItem
         className=""
         component="a"
@@ -343,10 +157,11 @@ exports[`ApplicationLauncher expanded 1`] = `
         index={-1}
         isDisabled={true}
         isHovered={false}
+        key="disabled link"
         onClick={[Function]}
       >
         Disabled Link
-      </DropdownItem>,
+      </DropdownItem>
       <DropdownItem
         className=""
         component="button"
@@ -360,17 +175,19 @@ exports[`ApplicationLauncher expanded 1`] = `
         index={-1}
         isDisabled={true}
         isHovered={false}
+        key="disabled action"
         onClick={[Function]}
       >
         Disabled Action
-      </DropdownItem>,
+      </DropdownItem>
       <Separator
         className=""
         component="a"
         href="#"
         isDisabled={false}
         isHovered={false}
-      />,
+        key="separator"
+      />
       <DropdownItem
         className=""
         component="a"
@@ -384,10 +201,11 @@ exports[`ApplicationLauncher expanded 1`] = `
         index={-1}
         isDisabled={false}
         isHovered={false}
+        key="separated link"
         onClick={[Function]}
       >
         Separated Link
-      </DropdownItem>,
+      </DropdownItem>
       <DropdownItem
         className=""
         component="button"
@@ -401,326 +219,80 @@ exports[`ApplicationLauncher expanded 1`] = `
         index={-1}
         isDisabled={false}
         isHovered={false}
+        key="separated action"
         onClick={[Function]}
       >
         Separated Action
-      </DropdownItem>,
-    ]
-  }
-  isOpen={true}
-  isPlain={true}
-  onSelect={[Function]}
-  position="left"
-  toggle={
-    <DropdownToggle
-      aria-label="Application Launcher"
-      className=""
-      iconComponent={null}
-      id=""
-      isActive={false}
-      isFocused={false}
-      isHovered={false}
-      isOpen={false}
-      isPlain={false}
-      onToggle={[Function]}
-      parentRef={null}
-    >
-      <ThIcon
-        color="currentColor"
-        size="sm"
-        title={null}
-      />
-    </DropdownToggle>
-  }
-/>
+      </DropdownItem>
+    </ApplicationLauncherMenu>
+  </[object Object]>
+</div>
 `;
 
 exports[`ApplicationLauncher regular 1`] = `
-<Dropdown
-  className=""
-  direction="down"
-  dropdownItems={
-    Array [
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Link
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Action
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={true}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Disabled Link
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={true}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Disabled Action
-      </DropdownItem>,
-      <Separator
-        className=""
-        component="a"
-        href="#"
-        isDisabled={false}
-        isHovered={false}
-      />,
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Separated Link
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Separated Action
-      </DropdownItem>,
-    ]
-  }
-  isOpen={false}
-  isPlain={true}
-  onSelect={[Function]}
-  position="left"
-  toggle={
-    <DropdownToggle
-      aria-label="Application Launcher"
-      className=""
-      iconComponent={null}
-      id=""
-      isActive={false}
-      isFocused={false}
-      isHovered={false}
-      isOpen={false}
-      isPlain={false}
-      onToggle={[Function]}
-      parentRef={null}
-    >
-      <ThIcon
-        color="currentColor"
-        size="sm"
-        title={null}
-      />
-    </DropdownToggle>
-  }
-/>
+.pf-c-app-launcher {
+  display: inline-block;
+  position: relative;
+  max-width: 100%;
+}
+
+<div
+  className="pf-c-app-launcher"
+>
+  <ApplicationLauncherToggle
+    aria-label="Actions"
+    ariaHasPopup={true}
+    className=""
+    id="pf-toggle-id-0"
+    isActive={false}
+    isFocused={false}
+    isHovered={false}
+    isOpen={false}
+    isPlain={true}
+    key=".0"
+    onEnter={[Function]}
+    onToggle={[Function]}
+    parentRef={null}
+  >
+    <ThIcon
+      color="currentColor"
+      size="sm"
+      title={null}
+    />
+  </ApplicationLauncherToggle>
+</div>
 `;
 
 exports[`ApplicationLauncher right aligned 1`] = `
-<Dropdown
-  className=""
-  direction="down"
-  dropdownItems={
-    Array [
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Link
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Action
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={true}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Disabled Link
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={true}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Disabled Action
-      </DropdownItem>,
-      <Separator
-        className=""
-        component="a"
-        href="#"
-        isDisabled={false}
-        isHovered={false}
-      />,
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Separated Link
-      </DropdownItem>,
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        onClick={[Function]}
-      >
-        Separated Action
-      </DropdownItem>,
-    ]
-  }
-  isOpen={false}
-  isPlain={true}
-  onSelect={[Function]}
-  position="right"
-  toggle={
-    <DropdownToggle
-      aria-label="Application Launcher"
-      className=""
-      iconComponent={null}
-      id=""
-      isActive={false}
-      isFocused={false}
-      isHovered={false}
-      isOpen={false}
-      isPlain={false}
-      onToggle={[Function]}
-      parentRef={null}
-    >
-      <ThIcon
-        color="currentColor"
-        size="sm"
-        title={null}
-      />
-    </DropdownToggle>
-  }
-/>
+.pf-c-app-launcher {
+  display: inline-block;
+  position: relative;
+  max-width: 100%;
+}
+
+<div
+  className="pf-c-app-launcher"
+>
+  <ApplicationLauncherToggle
+    aria-label="Actions"
+    ariaHasPopup={true}
+    className=""
+    id="pf-toggle-id-1"
+    isActive={false}
+    isFocused={false}
+    isHovered={false}
+    isOpen={false}
+    isPlain={true}
+    key=".0"
+    onEnter={[Function]}
+    onToggle={[Function]}
+    parentRef={null}
+  >
+    <ThIcon
+      color="currentColor"
+      size="sm"
+      title={null}
+    />
+  </ApplicationLauncherToggle>
+</div>
 `;

--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/__snapshots__/ApplicationLauncher.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/__snapshots__/ApplicationLauncher.test.js.snap
@@ -1,298 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApplicationLauncher dropup + right aligned 1`] = `
-.pf-c-app-launcher {
-  display: inline-block;
-  position: relative;
-  max-width: 100%;
-}
-
-<div
-  className="pf-c-app-launcher"
->
-  <ApplicationLauncherToggle
-    aria-label="Actions"
-    ariaHasPopup={true}
-    className=""
-    id="pf-toggle-id-3"
-    isActive={false}
-    isFocused={false}
-    isHovered={false}
-    isOpen={false}
-    isPlain={true}
-    key=".0"
-    onEnter={[Function]}
-    onToggle={[Function]}
-    parentRef={null}
-  >
-    <ThIcon
-      color="currentColor"
-      size="sm"
-      title={null}
-    />
-  </ApplicationLauncherToggle>
-</div>
+<GenerateId
+  prefix="pf-random-id-"
+/>
 `;
 
 exports[`ApplicationLauncher dropup 1`] = `
-.pf-c-app-launcher {
-  display: inline-block;
-  position: relative;
-  max-width: 100%;
-}
-
-<div
-  className="pf-c-app-launcher"
->
-  <ApplicationLauncherToggle
-    aria-label="Actions"
-    ariaHasPopup={true}
-    className=""
-    id="pf-toggle-id-2"
-    isActive={false}
-    isFocused={false}
-    isHovered={false}
-    isOpen={false}
-    isPlain={true}
-    key=".0"
-    onEnter={[Function]}
-    onToggle={[Function]}
-    parentRef={null}
-  >
-    <ThIcon
-      color="currentColor"
-      size="sm"
-      title={null}
-    />
-  </ApplicationLauncherToggle>
-</div>
+<GenerateId
+  prefix="pf-random-id-"
+/>
 `;
 
 exports[`ApplicationLauncher expanded 1`] = `
-.pf-c-app-launcher.pf-m-expanded {
-  display: inline-block;
-  position: relative;
-  max-width: 100%;
-}
-
-<div
-  className="pf-c-app-launcher pf-m-expanded"
->
-  <ApplicationLauncherToggle
-    aria-label="Actions"
-    ariaHasPopup={true}
-    className=""
-    id="pf-toggle-id-4"
-    isActive={false}
-    isFocused={false}
-    isHovered={false}
-    isOpen={true}
-    isPlain={true}
-    key=".0"
-    onEnter={[Function]}
-    onToggle={[Function]}
-    parentRef={null}
-  >
-    <ThIcon
-      color="currentColor"
-      size="sm"
-      title={null}
-    />
-  </ApplicationLauncherToggle>
-  <[object Object]
-    value={[Function]}
-  >
-    <ApplicationLauncherMenu
-      aria-labelledby="Actions"
-      className=""
-      isOpen={true}
-      position="left"
-    >
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        key="link"
-        onClick={[Function]}
-      >
-        Link
-      </DropdownItem>
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        key="action"
-        onClick={[Function]}
-      >
-        Action
-      </DropdownItem>
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={true}
-        isHovered={false}
-        key="disabled link"
-        onClick={[Function]}
-      >
-        Disabled Link
-      </DropdownItem>
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={true}
-        isHovered={false}
-        key="disabled action"
-        onClick={[Function]}
-      >
-        Disabled Action
-      </DropdownItem>
-      <Separator
-        className=""
-        component="a"
-        href="#"
-        isDisabled={false}
-        isHovered={false}
-        key="separator"
-      />
-      <DropdownItem
-        className=""
-        component="a"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        key="separated link"
-        onClick={[Function]}
-      >
-        Separated Link
-      </DropdownItem>
-      <DropdownItem
-        className=""
-        component="button"
-        context={
-          Object {
-            "keyHandler": [Function],
-            "sendRef": [Function],
-          }
-        }
-        href="#"
-        index={-1}
-        isDisabled={false}
-        isHovered={false}
-        key="separated action"
-        onClick={[Function]}
-      >
-        Separated Action
-      </DropdownItem>
-    </ApplicationLauncherMenu>
-  </[object Object]>
-</div>
+<GenerateId
+  prefix="pf-random-id-"
+/>
 `;
 
 exports[`ApplicationLauncher regular 1`] = `
-.pf-c-app-launcher {
-  display: inline-block;
-  position: relative;
-  max-width: 100%;
-}
-
-<div
-  className="pf-c-app-launcher"
->
-  <ApplicationLauncherToggle
-    aria-label="Actions"
-    ariaHasPopup={true}
-    className=""
-    id="pf-toggle-id-0"
-    isActive={false}
-    isFocused={false}
-    isHovered={false}
-    isOpen={false}
-    isPlain={true}
-    key=".0"
-    onEnter={[Function]}
-    onToggle={[Function]}
-    parentRef={null}
-  >
-    <ThIcon
-      color="currentColor"
-      size="sm"
-      title={null}
-    />
-  </ApplicationLauncherToggle>
-</div>
+<GenerateId
+  prefix="pf-random-id-"
+/>
 `;
 
 exports[`ApplicationLauncher right aligned 1`] = `
-.pf-c-app-launcher {
-  display: inline-block;
-  position: relative;
-  max-width: 100%;
-}
-
-<div
-  className="pf-c-app-launcher"
->
-  <ApplicationLauncherToggle
-    aria-label="Actions"
-    ariaHasPopup={true}
-    className=""
-    id="pf-toggle-id-1"
-    isActive={false}
-    isFocused={false}
-    isHovered={false}
-    isOpen={false}
-    isPlain={true}
-    key=".0"
-    onEnter={[Function]}
-    onToggle={[Function]}
-    parentRef={null}
-  >
-    <ThIcon
-      color="currentColor"
-      size="sm"
-      title={null}
-    />
-  </ApplicationLauncherToggle>
-</div>
+<GenerateId
+  prefix="pf-random-id-"
+/>
 `;

--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/applicationLauncherConstants.d.ts
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/applicationLauncherConstants.d.ts
@@ -1,0 +1,9 @@
+export const ApplicationLauncherPosition: {
+  right: 'right';
+  left: 'left';
+};
+
+export const ApplicationLauncherDirection: {
+  up: 'up';
+  down: 'down';
+};

--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/applicationLauncherConstants.js
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/applicationLauncherConstants.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export const ApplicationLauncherPosition = {
+  right: 'right',
+  left: 'left'
+};
+
+export const ApplicationLauncherDirection = {
+  up: 'up',
+  down: 'down'
+};

--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/examples/SimpleApplicationLauncher.js
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/examples/SimpleApplicationLauncher.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { ApplicationLauncher, DropdownItem, DropdownSeparator } from '@patternfly/react-core';
+import { ApplicationLauncher, DropdownItem } from '@patternfly/react-core';
 
 export default class SimpleApplicationLauncher extends Component {
   state = {
@@ -21,22 +21,21 @@ export default class SimpleApplicationLauncher extends Component {
   render() {
     const { isOpen } = this.state;
     const dropdownItems = [
-      <DropdownItem key="application_1" component="button">
+      <DropdownItem key="application_1" component="a">
         Application 1
       </DropdownItem>,
-      <DropdownItem key="application_2" component="button">
+      <DropdownItem key="application_2" component="a">
         Application 2
       </DropdownItem>,
-      <DropdownItem key="application_3" component="button">
+      <DropdownItem key="application_3" component="a">
         Application 3
       </DropdownItem>,
-      <DropdownItem key="disabled_application_4" isDisabled component="button">
+      <DropdownItem key="disabled_application_4" isDisabled component="a">
         Unavailable Application
       </DropdownItem>
     ];
     return (
       <ApplicationLauncher
-        aria-label="My Application Launcher"
         onSelect={this.onSelect}
         onToggle={this.onToggle}
         isOpen={isOpen}

--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/examples/TooltipApplicationLauncher.js
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/examples/TooltipApplicationLauncher.js
@@ -21,16 +21,16 @@ export default class TooltipApplicationLauncher extends Component {
   render() {
     const { isOpen } = this.state;
     const dropdownItems = [
-      <DropdownItem key="application_1" component="button">
+      <DropdownItem key="application_1" component="a">
         Application 1
       </DropdownItem>,
-      <DropdownItem key="application_2" component="button">
+      <DropdownItem key="application_2" component="a">
         Application 2
       </DropdownItem>,
-      <DropdownItem key="application_3" component="button">
+      <DropdownItem key="application_3" component="a">
         Application 3
       </DropdownItem>,
-      <DropdownItem key="disabled_application_4" isDisabled component="button">
+      <DropdownItem key="disabled_application_4" isDisabled component="a">
         Unavailable Application
       </DropdownItem>
     ];
@@ -43,7 +43,6 @@ export default class TooltipApplicationLauncher extends Component {
         }
       >
         <ApplicationLauncher
-          aria-label="Tool Tip Application Launcher"
           onSelect={this.onSelect}
           onToggle={this.onToggle}
           isOpen={isOpen}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import styles from '@patternfly/patternfly/components/Dropdown/dropdown.css';
+import dropdownStyles from '@patternfly/patternfly/components/Dropdown/dropdown.css';
+import appLauncherStyles from '@patternfly/patternfly/components/AppLauncher/app-launcher.css';
 import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
 import { componentShape } from '../../helpers/componentShape';
@@ -77,17 +78,25 @@ class DropdownItem extends React.Component {
       context,
       onClick,
       component: Component,
+      isAppLauncher,
       isDisabled,
       index,
       ...props
     } = this.props;
     const additionalProps = props;
+    let classes;
     if (Component === 'a') {
       additionalProps['aria-disabled'] = isDisabled;
       additionalProps.tabIndex = isDisabled ? -1 : additionalProps.tabIndex;
     } else if (Component === 'button') {
       additionalProps.disabled = isDisabled;
       additionalProps.type = additionalProps.type || 'button';
+    }
+
+    if (isAppLauncher) {
+      classes = css(appLauncherStyles.appLauncherMenuItem, isDisabled && appLauncherStyles.modifiers.disabled, isHovered && appLauncherStyles.modifiers.hover, className);
+    } else {
+      this.props.role === "separator" ?  classes = className : classes = css(dropdownStyles.dropdownMenuItem, isDisabled && dropdownStyles.modifiers.disabled, isHovered && dropdownStyles.modifiers.hover, className);
     }
     return (
       <DropdownContext.Consumer>
@@ -97,8 +106,8 @@ class DropdownItem extends React.Component {
               React.Children.map(children, child =>
                 React.cloneElement(child, {
                   className: `${css(
-                    isDisabled && styles.modifiers.disabled,
-                    isHovered && styles.modifiers.hover,
+                    isDisabled && dropdownStyles.modifiers.disabled,
+                    isHovered && dropdownStyles.modifiers.hover,
                     className
                   )} ${child.props.className}`,
                   ref: this.ref,
@@ -108,13 +117,13 @@ class DropdownItem extends React.Component {
                       onClick && onClick(event);
                       onSelect && onSelect(event);
                     }
-                  }
+                  },
                 })
               )
             ) : (
               <Component
                 {...additionalProps}
-                className={css(isDisabled && styles.modifiers.disabled, isHovered && styles.modifiers.hover, className)}
+                className={classes}
                 ref={this.ref}
                 onKeyDown={this.onKeyDown}
                 onClick={event => {

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Item.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Item.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import DropdownItem from './DropdownItem';
-import styles from '@patternfly/patternfly/components/Dropdown/dropdown.css';
 import { css } from '@patternfly/react-styles';
 import { componentShape } from '../../helpers/componentShape';
 import { DropdownArrowContext } from './dropdownConstants';
@@ -14,7 +13,6 @@ const Item = ({ className, ...props }) => (
         context={context}
         role="menuitem"
         tabIndex={-1}
-        className={css(styles.dropdownMenuItem, className)}
       />
     )}
   </DropdownArrowContext.Consumer>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -640,11 +640,59 @@ exports[`KebabToggle expanded 1`] = `
   line-height: 1.5;
   background-color: transparent;
 }
-.pf-m-disabled {
+.pf-c-dropdown__menu-item {
   display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #282d33;
+  text-align: left;
+  white-space: nowrap;
+  background-color: transparent;
+  text-decoration: none;
 }
-.pf-m-disabled {
+.pf-c-dropdown__menu-item {
   display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #282d33;
+  text-align: left;
+  white-space: nowrap;
+  background-color: transparent;
+  text-decoration: none;
+}
+.pf-c-dropdown__menu-item.pf-m-disabled {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #282d33;
+  text-align: left;
+  white-space: nowrap;
+  background-color: transparent;
+  text-decoration: none;
+  pointer-events: none;
+}
+.pf-c-dropdown__menu-item.pf-m-disabled {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #282d33;
+  text-align: left;
+  white-space: nowrap;
+  background-color: transparent;
+  text-decoration: none;
+  pointer-events: none;
 }
 .pf-c-dropdown__separator {
   display: block;
@@ -659,6 +707,32 @@ exports[`KebabToggle expanded 1`] = `
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
   background-color: #ededed;
+}
+.pf-c-dropdown__menu-item {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #282d33;
+  text-align: left;
+  white-space: nowrap;
+  background-color: transparent;
+  text-decoration: none;
+}
+.pf-c-dropdown__menu-item {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #282d33;
+  text-align: left;
+  white-space: nowrap;
+  background-color: transparent;
+  text-decoration: none;
 }
 .pf-c-dropdown__menu {
   display: block;
@@ -917,7 +991,7 @@ exports[`KebabToggle expanded 1`] = `
           >
             <a
               aria-disabled={false}
-              className=""
+              className="pf-c-dropdown__menu-item"
               href="#"
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -946,7 +1020,7 @@ exports[`KebabToggle expanded 1`] = `
             role="none"
           >
             <button
-              className=""
+              className="pf-c-dropdown__menu-item"
               disabled={false}
               href="#"
               onClick={[Function]}
@@ -978,7 +1052,7 @@ exports[`KebabToggle expanded 1`] = `
           >
             <a
               aria-disabled={true}
-              className="pf-m-disabled"
+              className="pf-c-dropdown__menu-item pf-m-disabled"
               href="#"
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -1008,7 +1082,7 @@ exports[`KebabToggle expanded 1`] = `
             role="none"
           >
             <button
-              className="pf-m-disabled"
+              className="pf-c-dropdown__menu-item pf-m-disabled"
               disabled={true}
               href="#"
               onClick={[Function]}
@@ -1078,7 +1152,7 @@ exports[`KebabToggle expanded 1`] = `
           >
             <a
               aria-disabled={false}
-              className=""
+              className="pf-c-dropdown__menu-item"
               href="#"
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -1107,7 +1181,7 @@ exports[`KebabToggle expanded 1`] = `
             role="none"
           >
             <button
-              className=""
+              className="pf-c-dropdown__menu-item"
               disabled={false}
               href="#"
               onClick={[Function]}
@@ -2509,11 +2583,59 @@ exports[`dropdown expanded 1`] = `
   line-height: 1.5;
   background-color: transparent;
 }
-.pf-m-disabled {
+.pf-c-dropdown__menu-item {
   display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #282d33;
+  text-align: left;
+  white-space: nowrap;
+  background-color: transparent;
+  text-decoration: none;
 }
-.pf-m-disabled {
+.pf-c-dropdown__menu-item {
   display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #282d33;
+  text-align: left;
+  white-space: nowrap;
+  background-color: transparent;
+  text-decoration: none;
+}
+.pf-c-dropdown__menu-item.pf-m-disabled {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #282d33;
+  text-align: left;
+  white-space: nowrap;
+  background-color: transparent;
+  text-decoration: none;
+  pointer-events: none;
+}
+.pf-c-dropdown__menu-item.pf-m-disabled {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #282d33;
+  text-align: left;
+  white-space: nowrap;
+  background-color: transparent;
+  text-decoration: none;
+  pointer-events: none;
 }
 .pf-c-dropdown__separator {
   display: block;
@@ -2528,6 +2650,32 @@ exports[`dropdown expanded 1`] = `
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
   background-color: #ededed;
+}
+.pf-c-dropdown__menu-item {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #282d33;
+  text-align: left;
+  white-space: nowrap;
+  background-color: transparent;
+  text-decoration: none;
+}
+.pf-c-dropdown__menu-item {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 1rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #282d33;
+  text-align: left;
+  white-space: nowrap;
+  background-color: transparent;
+  text-decoration: none;
 }
 .pf-c-dropdown__menu {
   display: block;
@@ -2793,7 +2941,7 @@ exports[`dropdown expanded 1`] = `
           >
             <a
               aria-disabled={false}
-              className=""
+              className="pf-c-dropdown__menu-item"
               href="#"
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -2822,7 +2970,7 @@ exports[`dropdown expanded 1`] = `
             role="none"
           >
             <button
-              className=""
+              className="pf-c-dropdown__menu-item"
               disabled={false}
               href="#"
               onClick={[Function]}
@@ -2854,7 +3002,7 @@ exports[`dropdown expanded 1`] = `
           >
             <a
               aria-disabled={true}
-              className="pf-m-disabled"
+              className="pf-c-dropdown__menu-item pf-m-disabled"
               href="#"
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -2884,7 +3032,7 @@ exports[`dropdown expanded 1`] = `
             role="none"
           >
             <button
-              className="pf-m-disabled"
+              className="pf-c-dropdown__menu-item pf-m-disabled"
               disabled={true}
               href="#"
               onClick={[Function]}
@@ -2954,7 +3102,7 @@ exports[`dropdown expanded 1`] = `
           >
             <a
               aria-disabled={false}
-              className=""
+              className="pf-c-dropdown__menu-item"
               href="#"
               onClick={[Function]}
               onKeyDown={[Function]}
@@ -2983,7 +3131,7 @@ exports[`dropdown expanded 1`] = `
             role="none"
           >
             <button
-              className=""
+              className="pf-c-dropdown__menu-item"
               disabled={false}
               href="#"
               onClick={[Function]}


### PR DESCRIPTION
Refactored ApplicationLauncher into its own component. It still uses DropdownItem and dropdown contexts so as not to break client code.

Fixes #1241.