### PR TITLE
fix(TypeAheadSelect): Remove `height: fit-content` rule not supported by IE11

### DIFF
--- a/packages/patternfly-3/patternfly-react/less/type-ahead-select.less
+++ b/packages/patternfly-3/patternfly-react/less/type-ahead-select.less
@@ -4,10 +4,6 @@
   padding: 2px 6px;
 }
 
-.rbt-input-multi {
-  height: fit-content;
-}
-
 .rbt-menu.dropdown-menu {
   &.show {
     margin: 0;

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_type-ahead-select.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_type-ahead-select.scss
@@ -4,10 +4,6 @@
   padding: 2px 6px;
 }
 
-.rbt-input-multi {
-  height: fit-content;
-}
-
 .rbt-menu.dropdown-menu {
   &.show {
     margin: 0;


### PR DESCRIPTION
Related to issue #1362. It's possible we don't need this rule. PR is just to create a preview link for
testing.