### PR TITLE
build(package.json): Upgrade react-bootstrap-typeahead to 3.4.1

### DIFF
--- a/packages/patternfly-3/patternfly-react/package.json
+++ b/packages/patternfly-3/patternfly-react/package.json
@@ -32,7 +32,7 @@
     "patternfly": "^3.58.0",
     "react-bootstrap": "^0.32.1",
     "react-bootstrap-switch": "^15.5.3",
-    "react-bootstrap-typeahead": "^3.1.3",
+    "react-bootstrap-typeahead": "^3.4.1",
     "react-c3js": "^0.1.20",
     "react-click-outside": "^3.0.1",
     "react-collapse": "^4.0.3",

--- a/packages/patternfly-3/patternfly-react/src/components/TypeAheadSelect/__snapshots__/AsyncTypeAheadSelect.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/TypeAheadSelect/__snapshots__/AsyncTypeAheadSelect.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AsyncTypeAheadSelect is working !! 1`] = `
-<AsyncContainer(OnClickOutside(TypeaheadContainer(WrappedTypeahead)))
+<AsyncContainer(TypeaheadContainer(WrappedTypeahead))
   delay={200}
   isLoading={false}
   labelKey="login"

--- a/packages/patternfly-3/patternfly-react/src/components/TypeAheadSelect/__snapshots__/TypeAheadSelect.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/TypeAheadSelect/__snapshots__/TypeAheadSelect.test.js.snap
@@ -2,17 +2,37 @@
 
 exports[`TypeAheadSelect is working !! 1`] = `
 <p>
-  <OnClickOutside(TypeaheadContainer(WrappedTypeahead))
+  <TypeaheadContainer(WrappedTypeahead)
+    a11yNumResults={[Function]}
+    a11yNumSelected={[Function]}
+    align="justify"
     allowNew={true}
+    autoFocus={false}
+    caseSensitive={false}
     clearButton={true}
-    eventTypes={
-      Array [
-        "mousedown",
-        "touchstart",
-      ]
-    }
-    excludeScrollbar={false}
+    defaultInputValue=""
+    defaultOpen={false}
+    defaultSelected={Array []}
+    disabled={false}
+    dropup={false}
+    emptyLabel="No matches found."
+    filterBy={Array []}
+    flip={false}
+    highlightOnlyResult={false}
+    ignoreDiacritics={true}
+    inputProps={Object {}}
+    isInvalid={false}
+    isLoading={false}
+    isValid={false}
+    labelKey="label"
+    maxResults={100}
+    minLength={0}
     multiple={true}
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onInputChange={[Function]}
+    onKeyDown={[Function]}
+    onPaginate={[Function]}
     options={
       Array [
         "One",
@@ -20,9 +40,10 @@ exports[`TypeAheadSelect is working !! 1`] = `
         "Three",
       ]
     }
-    outsideClickIgnoreClass="ignore-react-onclickoutside"
-    preventDefault={false}
-    stopPropagation={false}
+    paginate={true}
+    paginationText="Display additional results..."
+    placeholder=""
+    selectHintOnEnter={false}
   />
 </p>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6688,6 +6688,14 @@ create-react-class@^15.5.2, create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@<=0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
+  integrity sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 create-react-context@^0.2.1, create-react-context@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
@@ -8375,25 +8383,6 @@ eslint-plugin-node@^6.0.1:
     minimatch "^3.0.4"
     resolve "^1.3.3"
     semver "^5.4.1"
-
-"eslint-plugin-patternfly-react@file:packages/eslint-plugin-patternfly-react":
-  version "0.2.1"
-  dependencies:
-    babel-eslint "^9.0.0"
-    eslint-config-airbnb "^16.1.0"
-    eslint-config-prettier "^2.9.0"
-    eslint-config-standard "^11.0.0"
-    eslint-config-standard-jsx "^5.0.0"
-    eslint-config-standard-react "^6.0.0"
-    eslint-plugin-import "^2.13.0"
-    eslint-plugin-jest "^21.15.0"
-    eslint-plugin-jsx-a11y "^6.0.3"
-    eslint-plugin-node "^6.0.1"
-    eslint-plugin-prettier "^2.6.0"
-    eslint-plugin-promise "^3.7.0"
-    eslint-plugin-react "^7.7.0"
-    eslint-plugin-rulesdir "^0.1.0"
-    eslint-plugin-standard "^3.0.1"
 
 eslint-plugin-prettier@^2.6.0:
   version "2.6.0"
@@ -15454,9 +15443,10 @@ pnp-webpack-plugin@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.1.0.tgz#947a96d1db94bb5a1fc014d83b581e428699ac8c"
 
-popper.js@^1.14.1:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.3.tgz#1438f98d046acf7b4d78cd502bf418ac64d4f095"
+popper.js@^1.14.4:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.7.tgz#e31ec06cfac6a97a53280c3e55e4e0c860e7738e"
+  integrity sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ==
 
 popper.js@^1.14.6:
   version "1.14.6"
@@ -16819,20 +16809,21 @@ react-bootstrap-switch@^15.5.3:
   version "15.5.3"
   resolved "https://registry.yarnpkg.com/react-bootstrap-switch/-/react-bootstrap-switch-15.5.3.tgz#97287791d4ec0d1892d142542e7e5248002b1251"
 
-react-bootstrap-typeahead@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/react-bootstrap-typeahead/-/react-bootstrap-typeahead-3.1.3.tgz#4841ad672cba2e5efa4242bb08054e0714c902b1"
+react-bootstrap-typeahead@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/react-bootstrap-typeahead/-/react-bootstrap-typeahead-3.4.1.tgz#484c3c1be635c49898ca8dce59a6c71f2fce5888"
+  integrity sha512-Isutst1PaIO+GSlyDfoAskCdvp5biyUIL/VdDjfSYFaFmZ89W8pSCJ6rALowkvTlCVxoRHJMrmhxb/5KOTAPzQ==
   dependencies:
     classnames "^2.2.0"
+    create-react-context "^0.2.3"
     escape-string-regexp "^1.0.5"
     invariant "^2.2.1"
     lodash "^4.17.2"
     prop-types "^15.5.8"
     prop-types-extra "^1.0.1"
-    react-onclickoutside "^6.1.1"
     react-overlays "^0.8.1"
-    react-popper "^0.9.0"
-    warning "^3.0.0"
+    react-popper "^1.0.0"
+    warning "^4.0.1"
 
 react-bootstrap@^0.32.1:
   version "0.32.1"
@@ -17153,7 +17144,7 @@ react-motion@^0.5.2:
     prop-types "^15.5.8"
     raf "^3.1.0"
 
-react-onclickoutside@^6.1.1, react-onclickoutside@^6.5.0:
+react-onclickoutside@^6.5.0:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
 
@@ -17168,12 +17159,17 @@ react-overlays@^0.8.0, react-overlays@^0.8.1:
     react-transition-group "^2.2.0"
     warning "^3.0.0"
 
-react-popper@^0.9.0:
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.9.5.tgz#02a24ef3eec33af9e54e8358ab70eb0e331edd05"
+react-popper@^1.0.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.3.tgz#2c6cef7515a991256b4f0536cd4bdcb58a7b6af6"
+  integrity sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==
   dependencies:
-    popper.js "^1.14.1"
+    "@babel/runtime" "^7.1.2"
+    create-react-context "<=0.2.2"
+    popper.js "^1.14.4"
     prop-types "^15.6.1"
+    typed-styles "^0.0.7"
+    warning "^4.0.2"
 
 react-prop-types@^0.4.0:
   version "0.4.0"
@@ -20062,6 +20058,11 @@ type-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/type-of/-/type-of-2.0.1.tgz#e72a1741896568e9f628378d816d6912f7f23972"
 
+typed-styles@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
+  integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
+
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -20934,6 +20935,13 @@ warning@^3.0.0:
 warning@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
Closes #1366.
Closes #1491.