### PR TITLE
PF4 Table:  'Select All' checkbox updates

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.js
@@ -141,7 +141,18 @@ class Table extends React.Component {
     this.state = {
       headerData: []
     };
+    this.isSelected = this.isSelected.bind(this);
+    this.areAllRowsSelected = this.areAllRowsSelected.bind(this);
   }
+
+  isSelected(row) {
+    return row.selected === true;
+  }
+
+  areAllRowsSelected(rows) {
+    return rows.every(this.isSelected);
+  }
+
   render() {
     const {
       caption,
@@ -169,6 +180,7 @@ class Table extends React.Component {
       sortBy,
       onSort,
       onSelect,
+      allRowsSelected: onSelect ? this.areAllRowsSelected(rows) : false,
       actions,
       onCollapse,
       rowLabeledBy,

--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
@@ -502,6 +502,7 @@ exports[`Actions table 1`] = `
                 "title": "Third action",
               },
             ],
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -556,6 +557,7 @@ exports[`Actions table 1`] = `
                 "title": "Third action",
               },
             ],
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -609,6 +611,7 @@ exports[`Actions table 1`] = `
                 "title": "Third action",
               },
             ],
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -662,6 +665,7 @@ exports[`Actions table 1`] = `
                 "title": "Third action",
               },
             ],
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -715,6 +719,7 @@ exports[`Actions table 1`] = `
                 "title": "Third action",
               },
             ],
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -769,6 +774,7 @@ exports[`Actions table 1`] = `
                 "title": "Third action",
               },
             ],
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -868,6 +874,7 @@ exports[`Actions table 1`] = `
                             "title": "Third action",
                           },
                         ],
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -922,6 +929,7 @@ exports[`Actions table 1`] = `
                             "title": "Third action",
                           },
                         ],
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -975,6 +983,7 @@ exports[`Actions table 1`] = `
                             "title": "Third action",
                           },
                         ],
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -1028,6 +1037,7 @@ exports[`Actions table 1`] = `
                             "title": "Third action",
                           },
                         ],
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -1081,6 +1091,7 @@ exports[`Actions table 1`] = `
                             "title": "Third action",
                           },
                         ],
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -1135,6 +1146,7 @@ exports[`Actions table 1`] = `
                             "title": "Third action",
                           },
                         ],
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -1335,6 +1347,7 @@ exports[`Actions table 1`] = `
                       "title": "Third action",
                     },
                   ],
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -1389,6 +1402,7 @@ exports[`Actions table 1`] = `
                       "title": "Third action",
                     },
                   ],
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -1442,6 +1456,7 @@ exports[`Actions table 1`] = `
                       "title": "Third action",
                     },
                   ],
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -1495,6 +1510,7 @@ exports[`Actions table 1`] = `
                       "title": "Third action",
                     },
                   ],
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -1548,6 +1564,7 @@ exports[`Actions table 1`] = `
                       "title": "Third action",
                     },
                   ],
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -1602,6 +1619,7 @@ exports[`Actions table 1`] = `
                       "title": "Third action",
                     },
                   ],
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -2124,6 +2142,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -2178,6 +2197,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -2231,6 +2251,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -2284,6 +2305,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -2337,6 +2359,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -2391,6 +2414,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -2771,6 +2795,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -2825,6 +2850,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -2878,6 +2904,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -2931,6 +2958,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -2984,6 +3012,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -3038,6 +3067,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -3418,6 +3448,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -3472,6 +3503,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -3525,6 +3557,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -3578,6 +3611,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -3631,6 +3665,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -3685,6 +3720,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -4065,6 +4101,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -4119,6 +4156,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -4172,6 +4210,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -4225,6 +4264,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -4278,6 +4318,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -4332,6 +4373,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -4712,6 +4754,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -4766,6 +4809,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -4819,6 +4863,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -4872,6 +4917,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -4925,6 +4971,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -4979,6 +5026,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -5359,6 +5407,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -5413,6 +5462,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -5466,6 +5516,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -5519,6 +5570,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -5572,6 +5624,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -5626,6 +5679,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -6006,6 +6060,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -6060,6 +6115,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -6113,6 +6169,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -6166,6 +6223,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -6219,6 +6277,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -6273,6 +6332,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -6653,6 +6713,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -6707,6 +6768,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -6760,6 +6822,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -6813,6 +6876,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -6866,6 +6930,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -6920,6 +6985,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -7300,6 +7366,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -7354,6 +7421,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -7407,6 +7475,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -7460,6 +7529,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -7513,6 +7583,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -7567,6 +7638,7 @@ exports[`Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -8113,6 +8185,7 @@ exports[`Cell header table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -8149,6 +8222,7 @@ exports[`Cell header table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -8184,6 +8258,7 @@ exports[`Cell header table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -8219,6 +8294,7 @@ exports[`Cell header table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -8254,6 +8330,7 @@ exports[`Cell header table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -8335,6 +8412,7 @@ exports[`Cell header table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -8371,6 +8449,7 @@ exports[`Cell header table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -8406,6 +8485,7 @@ exports[`Cell header table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -8441,6 +8521,7 @@ exports[`Cell header table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -8476,6 +8557,7 @@ exports[`Cell header table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -8647,6 +8729,7 @@ exports[`Cell header table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -8683,6 +8766,7 @@ exports[`Cell header table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -8718,6 +8802,7 @@ exports[`Cell header table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -8753,6 +8838,7 @@ exports[`Cell header table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -8788,6 +8874,7 @@ exports[`Cell header table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -9292,6 +9379,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -9328,6 +9416,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -9363,6 +9452,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -9398,6 +9488,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -9433,6 +9524,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -9609,6 +9701,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -9645,6 +9738,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -9680,6 +9774,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -9715,6 +9810,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -9750,6 +9846,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -9926,6 +10023,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -9962,6 +10060,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -9997,6 +10096,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10032,6 +10132,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10067,6 +10168,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10243,6 +10345,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10279,6 +10382,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10314,6 +10418,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10349,6 +10454,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10384,6 +10490,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10560,6 +10667,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10596,6 +10704,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10631,6 +10740,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10666,6 +10776,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10701,6 +10812,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10877,6 +10989,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10913,6 +11026,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10948,6 +11062,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -10983,6 +11098,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11018,6 +11134,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11194,6 +11311,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11230,6 +11348,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11265,6 +11384,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11300,6 +11420,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11335,6 +11456,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11511,6 +11633,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11547,6 +11670,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11582,6 +11706,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11617,6 +11742,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11652,6 +11778,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11828,6 +11955,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11864,6 +11992,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11899,6 +12028,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11934,6 +12064,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -11969,6 +12100,7 @@ exports[`Cell header table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -12496,6 +12628,7 @@ exports[`Collapsible nested table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -12535,6 +12668,7 @@ exports[`Collapsible nested table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -12572,6 +12706,7 @@ exports[`Collapsible nested table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -12608,6 +12743,7 @@ exports[`Collapsible nested table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -12644,6 +12780,7 @@ exports[`Collapsible nested table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -12680,6 +12817,7 @@ exports[`Collapsible nested table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -12761,6 +12899,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -12800,6 +12939,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -12837,6 +12977,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -12873,6 +13014,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -12909,6 +13051,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -12945,6 +13088,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -13127,6 +13271,7 @@ exports[`Collapsible nested table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -13166,6 +13311,7 @@ exports[`Collapsible nested table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -13203,6 +13349,7 @@ exports[`Collapsible nested table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -13239,6 +13386,7 @@ exports[`Collapsible nested table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -13275,6 +13423,7 @@ exports[`Collapsible nested table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -13311,6 +13460,7 @@ exports[`Collapsible nested table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -13831,6 +13981,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -13870,6 +14021,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -13907,6 +14059,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -13943,6 +14096,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -13979,6 +14133,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14015,6 +14170,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14269,6 +14425,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14308,6 +14465,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14345,6 +14503,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14381,6 +14540,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14417,6 +14577,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14453,6 +14614,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14698,6 +14860,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14737,6 +14900,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14774,6 +14938,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14810,6 +14975,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14846,6 +15012,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -14882,6 +15049,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15073,6 +15241,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15112,6 +15281,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15149,6 +15319,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15185,6 +15356,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15221,6 +15393,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15257,6 +15430,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15511,6 +15685,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15550,6 +15725,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15587,6 +15763,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15623,6 +15800,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15659,6 +15837,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15695,6 +15874,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15886,6 +16066,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15925,6 +16106,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15962,6 +16144,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -15998,6 +16181,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16034,6 +16218,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16070,6 +16255,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16270,6 +16456,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16309,6 +16496,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16346,6 +16534,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16382,6 +16571,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16418,6 +16608,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16454,6 +16645,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16654,6 +16846,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16693,6 +16886,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16730,6 +16924,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16766,6 +16961,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16802,6 +16998,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -16838,6 +17035,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -17038,6 +17236,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -17077,6 +17276,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -17114,6 +17314,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -17150,6 +17351,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -17186,6 +17388,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -17222,6 +17425,7 @@ exports[`Collapsible nested table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -17742,6 +17946,7 @@ exports[`Collapsible table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -17781,6 +17986,7 @@ exports[`Collapsible table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -17818,6 +18024,7 @@ exports[`Collapsible table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -17854,6 +18061,7 @@ exports[`Collapsible table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -17890,6 +18098,7 @@ exports[`Collapsible table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -17926,6 +18135,7 @@ exports[`Collapsible table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -18007,6 +18217,7 @@ exports[`Collapsible table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -18046,6 +18257,7 @@ exports[`Collapsible table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -18083,6 +18295,7 @@ exports[`Collapsible table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -18119,6 +18332,7 @@ exports[`Collapsible table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -18155,6 +18369,7 @@ exports[`Collapsible table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -18191,6 +18406,7 @@ exports[`Collapsible table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -18373,6 +18589,7 @@ exports[`Collapsible table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -18412,6 +18629,7 @@ exports[`Collapsible table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -18449,6 +18667,7 @@ exports[`Collapsible table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -18485,6 +18704,7 @@ exports[`Collapsible table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -18521,6 +18741,7 @@ exports[`Collapsible table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -18557,6 +18778,7 @@ exports[`Collapsible table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -19072,6 +19294,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19111,6 +19334,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19148,6 +19372,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19184,6 +19409,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19220,6 +19446,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19256,6 +19483,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19510,6 +19738,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19549,6 +19778,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19586,6 +19816,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19622,6 +19853,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19658,6 +19890,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19694,6 +19927,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19885,6 +20119,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19924,6 +20159,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19961,6 +20197,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -19997,6 +20234,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20033,6 +20271,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20069,6 +20308,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20269,6 +20509,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20308,6 +20549,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20345,6 +20587,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20381,6 +20624,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20417,6 +20661,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20453,6 +20698,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20707,6 +20953,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20746,6 +20993,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20783,6 +21031,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20819,6 +21068,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20855,6 +21105,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -20891,6 +21142,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21082,6 +21334,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21121,6 +21374,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21158,6 +21412,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21194,6 +21449,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21230,6 +21486,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21266,6 +21523,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21466,6 +21724,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21505,6 +21764,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21542,6 +21802,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21578,6 +21839,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21614,6 +21876,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21650,6 +21913,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21850,6 +22114,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21889,6 +22154,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21926,6 +22192,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21962,6 +22229,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -21998,6 +22266,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -22034,6 +22303,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -22234,6 +22504,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -22273,6 +22544,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -22310,6 +22582,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -22346,6 +22619,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -22382,6 +22656,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -22418,6 +22693,7 @@ exports[`Collapsible table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -22803,6 +23079,7 @@ exports[`Header width table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -22839,6 +23116,7 @@ exports[`Header width table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -22874,6 +23152,7 @@ exports[`Header width table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -22910,6 +23189,7 @@ exports[`Header width table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -22945,6 +23225,7 @@ exports[`Header width table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -23027,6 +23308,7 @@ exports[`Header width table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -23063,6 +23345,7 @@ exports[`Header width table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -23098,6 +23381,7 @@ exports[`Header width table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -23134,6 +23418,7 @@ exports[`Header width table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -23169,6 +23454,7 @@ exports[`Header width table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -23302,6 +23588,7 @@ exports[`Header width table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -23338,6 +23625,7 @@ exports[`Header width table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -23373,6 +23661,7 @@ exports[`Header width table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -23409,6 +23698,7 @@ exports[`Header width table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -23444,6 +23734,7 @@ exports[`Header width table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -23964,6 +24255,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24000,6 +24292,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24035,6 +24328,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24071,6 +24365,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24106,6 +24401,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24285,6 +24581,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24321,6 +24618,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24356,6 +24654,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24392,6 +24691,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24427,6 +24727,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24609,6 +24910,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24645,6 +24947,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24680,6 +24983,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24716,6 +25020,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24751,6 +25056,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24931,6 +25237,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -24967,6 +25274,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25002,6 +25310,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25038,6 +25347,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25073,6 +25383,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25252,6 +25563,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25288,6 +25600,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25323,6 +25636,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25359,6 +25673,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25394,6 +25709,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25574,6 +25890,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25610,6 +25927,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25645,6 +25963,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25681,6 +26000,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25716,6 +26036,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25893,6 +26214,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25929,6 +26251,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -25964,6 +26287,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -26000,6 +26324,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -26035,6 +26360,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -26212,6 +26538,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -26248,6 +26575,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -26283,6 +26611,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -26319,6 +26648,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -26354,6 +26684,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -26531,6 +26862,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -26567,6 +26899,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -26602,6 +26935,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -26638,6 +26972,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -26673,6 +27008,7 @@ exports[`Header width table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -27149,6 +27485,7 @@ exports[`Selectable table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -27186,6 +27523,7 @@ exports[`Selectable table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -27222,6 +27560,7 @@ exports[`Selectable table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -27257,6 +27596,7 @@ exports[`Selectable table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -27292,6 +27632,7 @@ exports[`Selectable table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -27327,6 +27668,7 @@ exports[`Selectable table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -27408,6 +27750,7 @@ exports[`Selectable table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -27445,6 +27788,7 @@ exports[`Selectable table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -27481,6 +27825,7 @@ exports[`Selectable table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -27516,6 +27861,7 @@ exports[`Selectable table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -27551,6 +27897,7 @@ exports[`Selectable table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -27586,6 +27933,7 @@ exports[`Selectable table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -27630,12 +27978,14 @@ exports[`Selectable table 1`] = `
                     >
                       <SelectColumn
                         aria-label="Select all rows"
+                        checked={false}
                         className=""
                         name="check-all"
                         onSelect={[Function]}
                       >
                         <input
                           aria-label="Select all rows"
+                          checked={false}
                           className="pf-c-check__input"
                           name="check-all"
                           onChange={[Function]}
@@ -27786,6 +28136,7 @@ exports[`Selectable table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -27823,6 +28174,7 @@ exports[`Selectable table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -27859,6 +28211,7 @@ exports[`Selectable table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -27894,6 +28247,7 @@ exports[`Selectable table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -27929,6 +28283,7 @@ exports[`Selectable table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -27964,6 +28319,7 @@ exports[`Selectable table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -28483,6 +28839,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -28520,6 +28877,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -28556,6 +28914,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -28591,6 +28950,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -28626,6 +28986,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -28661,6 +29022,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -28871,6 +29233,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -28908,6 +29271,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -28944,6 +29308,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -28979,6 +29344,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29014,6 +29380,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29049,6 +29416,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29243,6 +29611,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29280,6 +29649,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29316,6 +29686,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29351,6 +29722,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29386,6 +29758,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29421,6 +29794,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29613,6 +29987,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29650,6 +30025,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29686,6 +30062,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29721,6 +30098,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29756,6 +30134,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -29791,6 +30170,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30001,6 +30381,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30038,6 +30419,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30074,6 +30456,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30109,6 +30492,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30144,6 +30528,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30179,6 +30564,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30371,6 +30757,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30408,6 +30795,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30444,6 +30832,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30479,6 +30868,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30514,6 +30904,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30549,6 +30940,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30757,6 +31149,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30794,6 +31187,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30830,6 +31224,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30865,6 +31260,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30900,6 +31296,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -30935,6 +31332,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -31143,6 +31541,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -31180,6 +31579,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -31216,6 +31616,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -31251,6 +31652,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -31286,6 +31688,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -31321,6 +31724,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -31529,6 +31933,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -31566,6 +31971,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -31602,6 +32008,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -31637,6 +32044,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -31672,6 +32080,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -31707,6 +32116,7 @@ exports[`Selectable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -32050,6 +32460,7 @@ exports[`Simple table aria-label 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -32085,6 +32496,7 @@ exports[`Simple table aria-label 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -32120,6 +32532,7 @@ exports[`Simple table aria-label 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -32155,6 +32568,7 @@ exports[`Simple table aria-label 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -32190,6 +32604,7 @@ exports[`Simple table aria-label 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -32270,6 +32685,7 @@ exports[`Simple table aria-label 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -32305,6 +32721,7 @@ exports[`Simple table aria-label 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -32340,6 +32757,7 @@ exports[`Simple table aria-label 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -32375,6 +32793,7 @@ exports[`Simple table aria-label 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -32410,6 +32829,7 @@ exports[`Simple table aria-label 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -32535,6 +32955,7 @@ exports[`Simple table aria-label 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -32570,6 +32991,7 @@ exports[`Simple table aria-label 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -32605,6 +33027,7 @@ exports[`Simple table aria-label 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -32640,6 +33063,7 @@ exports[`Simple table aria-label 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -32675,6 +33099,7 @@ exports[`Simple table aria-label 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -33178,6 +33603,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33213,6 +33639,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33248,6 +33675,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33283,6 +33711,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33318,6 +33747,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33493,6 +33923,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33528,6 +33959,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33563,6 +33995,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33598,6 +34031,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33633,6 +34067,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33808,6 +34243,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33843,6 +34279,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33878,6 +34315,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33913,6 +34351,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -33948,6 +34387,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34123,6 +34563,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34158,6 +34599,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34193,6 +34635,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34228,6 +34671,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34263,6 +34707,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34438,6 +34883,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34473,6 +34919,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34508,6 +34955,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34543,6 +34991,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34578,6 +35027,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34753,6 +35203,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34788,6 +35239,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34823,6 +35275,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34858,6 +35311,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -34893,6 +35347,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35068,6 +35523,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35103,6 +35559,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35138,6 +35595,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35173,6 +35631,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35208,6 +35667,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35383,6 +35843,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35418,6 +35879,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35453,6 +35915,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35488,6 +35951,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35523,6 +35987,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35698,6 +36163,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35733,6 +36199,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35768,6 +36235,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35803,6 +36271,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -35838,6 +36307,7 @@ exports[`Simple table aria-label 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -36148,6 +36618,7 @@ exports[`Simple table caption 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -36183,6 +36654,7 @@ exports[`Simple table caption 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -36218,6 +36690,7 @@ exports[`Simple table caption 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -36253,6 +36726,7 @@ exports[`Simple table caption 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -36288,6 +36762,7 @@ exports[`Simple table caption 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -36370,6 +36845,7 @@ exports[`Simple table caption 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -36405,6 +36881,7 @@ exports[`Simple table caption 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -36440,6 +36917,7 @@ exports[`Simple table caption 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -36475,6 +36953,7 @@ exports[`Simple table caption 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -36510,6 +36989,7 @@ exports[`Simple table caption 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -36635,6 +37115,7 @@ exports[`Simple table caption 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -36670,6 +37151,7 @@ exports[`Simple table caption 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -36705,6 +37187,7 @@ exports[`Simple table caption 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -36740,6 +37223,7 @@ exports[`Simple table caption 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -36775,6 +37259,7 @@ exports[`Simple table caption 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -37278,6 +37763,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -37313,6 +37799,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -37348,6 +37835,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -37383,6 +37871,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -37418,6 +37907,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -37593,6 +38083,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -37628,6 +38119,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -37663,6 +38155,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -37698,6 +38191,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -37733,6 +38227,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -37908,6 +38403,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -37943,6 +38439,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -37978,6 +38475,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38013,6 +38511,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38048,6 +38547,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38223,6 +38723,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38258,6 +38759,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38293,6 +38795,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38328,6 +38831,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38363,6 +38867,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38538,6 +39043,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38573,6 +39079,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38608,6 +39115,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38643,6 +39151,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38678,6 +39187,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38853,6 +39363,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38888,6 +39399,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38923,6 +39435,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38958,6 +39471,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -38993,6 +39507,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39168,6 +39683,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39203,6 +39719,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39238,6 +39755,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39273,6 +39791,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39308,6 +39827,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39483,6 +40003,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39518,6 +40039,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39553,6 +40075,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39588,6 +40111,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39623,6 +40147,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39798,6 +40323,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39833,6 +40359,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39868,6 +40395,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39903,6 +40431,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -39938,6 +40467,7 @@ exports[`Simple table caption 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -40255,6 +40785,7 @@ exports[`Simple table header 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -40290,6 +40821,7 @@ exports[`Simple table header 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -40325,6 +40857,7 @@ exports[`Simple table header 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -40360,6 +40893,7 @@ exports[`Simple table header 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -40395,6 +40929,7 @@ exports[`Simple table header 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -40474,6 +41009,7 @@ exports[`Simple table header 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -40509,6 +41045,7 @@ exports[`Simple table header 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -40544,6 +41081,7 @@ exports[`Simple table header 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -40579,6 +41117,7 @@ exports[`Simple table header 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -40614,6 +41153,7 @@ exports[`Simple table header 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -40739,6 +41279,7 @@ exports[`Simple table header 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -40774,6 +41315,7 @@ exports[`Simple table header 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -40809,6 +41351,7 @@ exports[`Simple table header 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -40844,6 +41387,7 @@ exports[`Simple table header 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -40879,6 +41423,7 @@ exports[`Simple table header 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -41382,6 +41927,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -41417,6 +41963,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -41452,6 +41999,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -41487,6 +42035,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -41522,6 +42071,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -41697,6 +42247,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -41732,6 +42283,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -41767,6 +42319,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -41802,6 +42355,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -41837,6 +42391,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42012,6 +42567,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42047,6 +42603,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42082,6 +42639,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42117,6 +42675,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42152,6 +42711,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42327,6 +42887,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42362,6 +42923,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42397,6 +42959,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42432,6 +42995,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42467,6 +43031,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42642,6 +43207,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42677,6 +43243,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42712,6 +43279,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42747,6 +43315,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42782,6 +43351,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42957,6 +43527,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -42992,6 +43563,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43027,6 +43599,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43062,6 +43635,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43097,6 +43671,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43272,6 +43847,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43307,6 +43883,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43342,6 +43919,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43377,6 +43955,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43412,6 +43991,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43587,6 +44167,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43622,6 +44203,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43657,6 +44239,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43692,6 +44275,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43727,6 +44311,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43902,6 +44487,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43937,6 +44523,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -43972,6 +44559,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -44007,6 +44595,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -44042,6 +44631,7 @@ exports[`Simple table header 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -44399,6 +44989,7 @@ exports[`Sortable table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -44435,6 +45026,7 @@ exports[`Sortable table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -44470,6 +45062,7 @@ exports[`Sortable table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -44505,6 +45098,7 @@ exports[`Sortable table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -44540,6 +45134,7 @@ exports[`Sortable table 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -44620,6 +45215,7 @@ exports[`Sortable table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -44656,6 +45252,7 @@ exports[`Sortable table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -44691,6 +45288,7 @@ exports[`Sortable table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -44726,6 +45324,7 @@ exports[`Sortable table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -44761,6 +45360,7 @@ exports[`Sortable table 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -44931,6 +45531,7 @@ exports[`Sortable table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -44967,6 +45568,7 @@ exports[`Sortable table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -45002,6 +45604,7 @@ exports[`Sortable table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -45037,6 +45640,7 @@ exports[`Sortable table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -45072,6 +45676,7 @@ exports[`Sortable table 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -45575,6 +46180,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -45611,6 +46217,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -45646,6 +46253,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -45681,6 +46289,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -45716,6 +46325,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -45891,6 +46501,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -45927,6 +46538,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -45962,6 +46574,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -45997,6 +46610,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46032,6 +46646,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46207,6 +46822,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46243,6 +46859,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46278,6 +46895,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46313,6 +46931,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46348,6 +46967,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46523,6 +47143,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46559,6 +47180,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46594,6 +47216,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46629,6 +47252,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46664,6 +47288,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46839,6 +47464,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46875,6 +47501,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46910,6 +47537,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46945,6 +47573,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -46980,6 +47609,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47155,6 +47785,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47191,6 +47822,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47226,6 +47858,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47261,6 +47894,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47296,6 +47930,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47471,6 +48106,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47507,6 +48143,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47542,6 +48179,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47577,6 +48215,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47612,6 +48251,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47787,6 +48427,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47823,6 +48464,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47858,6 +48500,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47893,6 +48536,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -47928,6 +48572,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -48103,6 +48748,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -48139,6 +48785,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -48174,6 +48821,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -48209,6 +48857,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -48244,6 +48893,7 @@ exports[`Sortable table 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -48599,6 +49249,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -48635,6 +49286,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -48670,6 +49322,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -48705,6 +49358,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -48740,6 +49394,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -48820,6 +49475,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -48856,6 +49512,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -48891,6 +49548,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -48926,6 +49584,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -48961,6 +49620,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -49131,6 +49791,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -49167,6 +49828,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -49202,6 +49864,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -49237,6 +49900,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -49272,6 +49936,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -49775,6 +50440,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -49811,6 +50477,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -49846,6 +50513,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -49881,6 +50549,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -49916,6 +50585,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50091,6 +50761,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50127,6 +50798,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50162,6 +50834,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50197,6 +50870,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50232,6 +50906,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50407,6 +51082,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50443,6 +51119,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50478,6 +51155,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50513,6 +51191,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50548,6 +51227,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50723,6 +51403,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50759,6 +51440,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50794,6 +51476,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50829,6 +51512,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -50864,6 +51548,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51039,6 +51724,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51075,6 +51761,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51110,6 +51797,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51145,6 +51833,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51180,6 +51869,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51355,6 +52045,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51391,6 +52082,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51426,6 +52118,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51461,6 +52154,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51496,6 +52190,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51671,6 +52366,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51707,6 +52403,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51742,6 +52439,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51777,6 +52475,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51812,6 +52511,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -51987,6 +52687,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -52023,6 +52724,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -52058,6 +52760,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -52093,6 +52796,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -52128,6 +52832,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -52303,6 +53008,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -52339,6 +53045,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -52374,6 +53081,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -52409,6 +53117,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -52444,6 +53153,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -52799,6 +53509,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -52835,6 +53546,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -52870,6 +53582,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -52905,6 +53618,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -52940,6 +53654,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -53020,6 +53735,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -53056,6 +53772,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -53091,6 +53808,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -53126,6 +53844,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -53161,6 +53880,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -53331,6 +54051,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -53367,6 +54088,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -53402,6 +54124,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -53437,6 +54160,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -53472,6 +54196,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -53975,6 +54700,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54011,6 +54737,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54046,6 +54773,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54081,6 +54809,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54116,6 +54845,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54291,6 +55021,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54327,6 +55058,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54362,6 +55094,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54397,6 +55130,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54432,6 +55166,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54607,6 +55342,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54643,6 +55379,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54678,6 +55415,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54713,6 +55451,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54748,6 +55487,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54923,6 +55663,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54959,6 +55700,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -54994,6 +55736,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55029,6 +55772,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55064,6 +55808,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55239,6 +55984,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55275,6 +56021,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55310,6 +56057,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55345,6 +56093,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55380,6 +56129,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55555,6 +56305,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55591,6 +56342,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55626,6 +56378,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55661,6 +56414,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55696,6 +56450,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55871,6 +56626,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55907,6 +56663,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55942,6 +56699,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -55977,6 +56735,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -56012,6 +56771,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -56187,6 +56947,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -56223,6 +56984,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -56258,6 +57020,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -56293,6 +57056,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -56328,6 +57092,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -56503,6 +57268,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -56539,6 +57305,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -56574,6 +57341,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -56609,6 +57377,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -56644,6 +57413,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -56999,6 +57769,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -57035,6 +57806,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -57070,6 +57842,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -57105,6 +57878,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -57140,6 +57914,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -57220,6 +57995,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -57256,6 +58032,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -57291,6 +58068,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -57326,6 +58104,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -57361,6 +58140,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -57531,6 +58311,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -57567,6 +58348,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -57602,6 +58384,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -57637,6 +58420,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -57672,6 +58456,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -58175,6 +58960,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58211,6 +58997,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58246,6 +59033,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58281,6 +59069,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58316,6 +59105,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58491,6 +59281,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58527,6 +59318,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58562,6 +59354,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58597,6 +59390,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58632,6 +59426,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58807,6 +59602,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58843,6 +59639,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58878,6 +59675,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58913,6 +59711,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -58948,6 +59747,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59123,6 +59923,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59159,6 +59960,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59194,6 +59996,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59229,6 +60032,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59264,6 +60068,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59439,6 +60244,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59475,6 +60281,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59510,6 +60317,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59545,6 +60353,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59580,6 +60389,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59755,6 +60565,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59791,6 +60602,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59826,6 +60638,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59861,6 +60674,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -59896,6 +60710,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60071,6 +60886,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60107,6 +60923,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60142,6 +60959,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60177,6 +60995,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60212,6 +61031,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60387,6 +61207,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60423,6 +61244,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60458,6 +61280,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60493,6 +61316,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60528,6 +61352,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60703,6 +61528,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60739,6 +61565,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60774,6 +61601,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60809,6 +61637,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -60844,6 +61673,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -61199,6 +62029,7 @@ exports[`Table variants Size - compact 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -61235,6 +62066,7 @@ exports[`Table variants Size - compact 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -61270,6 +62102,7 @@ exports[`Table variants Size - compact 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -61305,6 +62138,7 @@ exports[`Table variants Size - compact 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -61340,6 +62174,7 @@ exports[`Table variants Size - compact 1`] = `
           },
           "extraParams": Object {
             "actions": undefined,
+            "allRowsSelected": false,
             "contentId": "expanded-content",
             "dropdownDirection": "down",
             "dropdownPosition": "right",
@@ -61420,6 +62255,7 @@ exports[`Table variants Size - compact 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -61456,6 +62292,7 @@ exports[`Table variants Size - compact 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -61491,6 +62328,7 @@ exports[`Table variants Size - compact 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -61526,6 +62364,7 @@ exports[`Table variants Size - compact 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -61561,6 +62400,7 @@ exports[`Table variants Size - compact 1`] = `
                       },
                       "extraParams": Object {
                         "actions": undefined,
+                        "allRowsSelected": false,
                         "contentId": "expanded-content",
                         "dropdownDirection": "down",
                         "dropdownPosition": "right",
@@ -61731,6 +62571,7 @@ exports[`Table variants Size - compact 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -61767,6 +62608,7 @@ exports[`Table variants Size - compact 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -61802,6 +62644,7 @@ exports[`Table variants Size - compact 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -61837,6 +62680,7 @@ exports[`Table variants Size - compact 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -61872,6 +62716,7 @@ exports[`Table variants Size - compact 1`] = `
                 },
                 "extraParams": Object {
                   "actions": undefined,
+                  "allRowsSelected": false,
                   "contentId": "expanded-content",
                   "dropdownDirection": "down",
                   "dropdownPosition": "right",
@@ -62375,6 +63220,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -62411,6 +63257,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -62446,6 +63293,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -62481,6 +63329,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -62516,6 +63365,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -62691,6 +63541,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -62727,6 +63578,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -62762,6 +63614,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -62797,6 +63650,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -62832,6 +63686,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63007,6 +63862,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63043,6 +63899,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63078,6 +63935,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63113,6 +63971,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63148,6 +64007,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63323,6 +64183,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63359,6 +64220,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63394,6 +64256,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63429,6 +64292,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63464,6 +64328,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63639,6 +64504,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63675,6 +64541,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63710,6 +64577,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63745,6 +64613,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63780,6 +64649,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63955,6 +64825,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -63991,6 +64862,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64026,6 +64898,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64061,6 +64934,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64096,6 +64970,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64271,6 +65146,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64307,6 +65183,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64342,6 +65219,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64377,6 +65255,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64412,6 +65291,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64587,6 +65467,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64623,6 +65504,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64658,6 +65540,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64693,6 +65576,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64728,6 +65612,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64903,6 +65788,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64939,6 +65825,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -64974,6 +65861,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -65009,6 +65897,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",
@@ -65044,6 +65933,7 @@ exports[`Table variants Size - compact 1`] = `
                         },
                         "extraParams": Object {
                           "actions": undefined,
+                          "allRowsSelected": false,
                           "contentId": "expanded-content",
                           "dropdownDirection": "down",
                           "dropdownPosition": "right",

--- a/packages/patternfly-4/react-table/src/components/Table/examples/SelectableTable.js
+++ b/packages/patternfly-4/react-table/src/components/Table/examples/SelectableTable.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Table, TableHeader, TableBody, headerCol } from '@patternfly/react-table';
+import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 
 class SelectableTable extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
       columns: [
-        { title: 'Repositories', cellTransforms: [headerCol()] },
+        { title: 'Repositories' },
         'Branches',
         { title: 'Pull requests' },
         'Workspaces',

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/selectable.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/selectable.js
@@ -7,7 +7,7 @@ export default (
   label,
   {
     column: {
-      extraParams: { onSelect, rowLabeledBy = 'simple-node' }
+      extraParams: { onSelect, allRowsSelected, rowLabeledBy = 'simple-node' }
     },
     rowIndex,
     rowData
@@ -21,9 +21,10 @@ export default (
     };
   }
   const rowId = rowIndex !== undefined ? rowIndex : -1;
+
   function selectClick(event) {
     const selected = rowIndex === undefined ? event.target.checked : rowData && !rowData.selected;
-    onSelect && onSelect(selected, selected, rowId);
+    onSelect && onSelect(event, selected, rowId);
   }
   const customProps = {
     ...(rowId !== -1
@@ -32,6 +33,7 @@ export default (
           'aria-labelledby': rowLabeledBy + rowIndex
         }
       : {
+          checked: allRowsSelected,
           'aria-label': 'Select all rows'
         })
   };


### PR DESCRIPTION
When all rows of the table are selected, the select-all checkbox is now selected automatically. Likewise, when the select-all checkbox is selected, and I deselect one or more rows, the select-all check box is deselected automatically.

Fixes #1352

![pf4-table](https://user-images.githubusercontent.com/12733153/52590730-12b95100-2e10-11e9-8f81-c82bd06ec92a.gif)

