### PR TITLE
fix(TypeAheadSelect): Fix input height overflow issue without breaking IE11 compatibility

### DIFF
--- a/packages/patternfly-3/patternfly-react/less/type-ahead-select.less
+++ b/packages/patternfly-3/patternfly-react/less/type-ahead-select.less
@@ -4,8 +4,8 @@
   padding: 2px 6px;
 }
 
-.rbt-input-multi {
-  height: fit-content;
+.form-control.rbt-input-multi {
+  height: auto;
 }
 
 .rbt-menu.dropdown-menu {

--- a/packages/patternfly-3/patternfly-react/sass/patternfly-react/_type-ahead-select.scss
+++ b/packages/patternfly-3/patternfly-react/sass/patternfly-react/_type-ahead-select.scss
@@ -4,8 +4,8 @@
   padding: 2px 6px;
 }
 
-.rbt-input-multi {
-  height: fit-content;
+.form-control.rbt-input-multi {
+  height: auto;
 }
 
 .rbt-menu.dropdown-menu {


### PR DESCRIPTION
Fixes #1362 (replaces original fix for #413)

This TypeAheadSelect input should allow its height to expand to fit the contents, which is accomplished in the dependency's CSS by a simple `height: auto`. However, the original issue #413 was caused by our patternfly CSS overriding that height with a rule for `.form-control`.

The original fix in PR #409 used `height: fit-content`, but this value is only supported by Chrome, according to https://developer.mozilla.org/en-US/docs/Web/CSS/height.

This replacement fix uses both classes (`.form-control.rbt-input-multi`) to ensure a higher specificity and resets the height back to `auto` for this kind of input.