### PR TITLE
feat(Icons): Add fa regular icons and update solid icons

### DIFF
--- a/packages/react-icons/build/generateIcons.js
+++ b/packages/react-icons/build/generateIcons.js
@@ -7,7 +7,8 @@ const pascalCase = plop.getHelper('pascalCase');
 const kebabCase = plop.getHelper('kebabCase');
 
 const allIcons = [
-  ...icons.fontAwesome.solid.map(getFontAwesomeIcon),
+  ...icons.fontAwesome.solid.map((icon) => getFontAwesomeIcon(icon, 'solid')),
+  ...icons.fontAwesome.regular.map((icon) => getFontAwesomeIcon(icon, 'regular', 'outlined')),
   ...Object.keys(icons.pfIcons).map(getPfIcon)
 ];
 
@@ -23,9 +24,9 @@ function getPfIcon(iconName) {
   return generateIcon(currentIcon, `${iconName}`)
 }
 
-function getFontAwesomeIcon(name) {
-  const faIconDef = require(`@fortawesome/free-solid-svg-icons/${name}`); // eslint-disable-line
-  const iconName = kebabCase(name.substr(2)); // remove fa and make name kebab cased
+function getFontAwesomeIcon(name, packageType, prefix = '') {
+  const faIconDef = require(`@fortawesome/free-${packageType}-svg-icons/${name}`); // eslint-disable-line
+  const iconName = kebabCase(`${prefix}${name.substr(2)}`); // remove fa and make name kebab cased
 
   return generateIcon(faIconDef, iconName);
 }

--- a/packages/react-icons/build/icons.js
+++ b/packages/react-icons/build/icons.js
@@ -1,8 +1,10 @@
 const { fas } = require('@fortawesome/free-solid-svg-icons');
+const { far } = require('@fortawesome/free-regular-svg-icons');
 const { pfIcons } = require('./pfIcons');
 module.exports = {
   fontAwesome: {
-    solid: Object.keys(fas)
+    solid: Object.keys(fas),
+    regular: Object.keys(far)
   },
 
   pfIcons

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -31,7 +31,8 @@
     "build:ts": "node ./scripts/copyTS.js"
   },
   "devDependencies": {
-    "@fortawesome/free-solid-svg-icons": "^5.3.1",
+    "@fortawesome/free-solid-svg-icons": "^5.7.2",
+    "@fortawesome/free-regular-svg-icons": "^5.7.2",
     "@patternfly/patternfly": "1.0.184",
     "fs-extra": "^6.0.1",
     "glob": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1032,15 +1032,21 @@
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
 
-"@fortawesome/fontawesome-common-types@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.4.tgz#7c560ff732c6c7c7c179ae25227ce5449e6f6d65"
+"@fortawesome/fontawesome-common-types@^0.2.15":
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.15.tgz#16af950653083d1e3064061de9f8e5e3b579f688"
 
-"@fortawesome/free-solid-svg-icons@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.3.1.tgz#9660bece3c4850d58f1653e26c1693487ff74b08"
+"@fortawesome/free-regular-svg-icons@^5.7.2":
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.7.2.tgz#7113bf9df5a970918b8cac8eb45e5ad120818741"
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.4"
+    "@fortawesome/fontawesome-common-types" "^0.2.15"
+
+"@fortawesome/free-solid-svg-icons@^5.7.2":
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.7.2.tgz#9ec2ed353d630092a8e19cc8aae2f716572963e5"
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.15"
 
 "@koa/cors@^2.2.1":
   version "2.2.3"


### PR DESCRIPTION
**What**:
Because new icons were added to solid icons we should pull them and expose them for others as well.

Also add new package with regular icons (outlined solid) with prefix `outlined${IconName}` so we don't have any name clashes.

Overall adds 277 of new icons!
