### PR TITLE
fix(Table): Pass calculated rows to body wrapper to eliminate re-renders

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Body.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Body.js
@@ -70,7 +70,7 @@ class ContextBody extends React.Component {
     }));
     return (
       <React.Fragment>
-        {mappedRows && <Body {...props} rows={mappedRows} onRow={this.onRow} rowKey={rowKey} className={className} />}
+        {mappedRows && <Body {...props} mappedRows={mappedRows} rows={mappedRows} onRow={this.onRow} rowKey={rowKey} className={className} />}
       </React.Fragment>
     )
   }

--- a/packages/patternfly-4/react-table/src/components/Table/BodyWrapper.js
+++ b/packages/patternfly-4/react-table/src/components/Table/BodyWrapper.js
@@ -2,30 +2,35 @@ import React, { Component, Children, Fragment } from 'react';
 import styles from '@patternfly/patternfly/components/Table/table.css';
 import { css } from '@patternfly/react-styles';
 import { mapOpenedRows } from './utils/headerUtils';
+import PropTypes from 'prop-types';
 
-const BodyWrapper = (rows, onCollapse) => {
-  class TableBody extends Component {
-    render() {
-      if (onCollapse) {
-        return (
-          <Fragment>
-            {mapOpenedRows(rows, Children.toArray(this.props.children)).map((oneRow, key) => (
-                <tbody {...this.props} className={css(oneRow.isOpen && styles.modifiers.expanded)} key={`tbody-${key}`}>
-                {oneRow.rows}
-              </tbody>
-            ))}
-          </Fragment>
-        )
-      }
+class BodyWrapper extends Component {
+  render() {
+    const { mappedRows, ...props } = this.props;
+    if (mappedRows.some(row => row.hasOwnProperty('isOpen'))) {
       return (
-        <tbody {...this.props} className={css(
-          rows.some(row => row.isOpen && !row.hasOwnProperty('parent')) && styles.modifiers.expanded
-        )} />
+        <Fragment>
+          {mapOpenedRows(mappedRows, this.props.children).map((oneRow, key) => (
+            <tbody {...props} className={css(oneRow.isOpen && styles.modifiers.expanded)} key={`tbody-${key}`}>
+              {oneRow.rows}
+            </tbody>
+          ))}
+        </Fragment>
       )
     }
-  };
+    return (
+      <tbody {...props} />
+    )
+  }
+}
 
-  return TableBody;
+BodyWrapper.propTypes = {
+  rows: PropTypes.array,
+  onCollapse: PropTypes.func
+}
+
+BodyWrapper.defaultProps = {
+  rows: []
 }
 
 export default BodyWrapper;

--- a/packages/patternfly-4/react-table/src/components/Table/Table.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.js
@@ -202,7 +202,7 @@ class Table extends React.Component {
           {...props}
           renderers={{
             body: {
-              wrapper: BodyWrapper(rows, onCollapse),
+              wrapper: BodyWrapper,
               row: RowWrapper,
               cell: BodyCell
             },

--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
@@ -1737,6 +1737,370 @@ exports[`Actions table 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -2104,11 +2468,377 @@ exports[`Actions table 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -7988,7 +8718,7 @@ exports[`Actions table 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -8991,6 +9721,370 @@ exports[`Cell header table 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -9358,11 +10452,377 @@ exports[`Cell header table 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -12263,7 +13723,7 @@ exports[`Cell header table 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -13583,6 +15043,379 @@ exports[`Collapsible nested table 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "isOpen": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "isExpanded": false,
+                  "isOpen": true,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "parent": 0,
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "isExpanded": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "parent": 1,
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "isOpen": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "isExpanded": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "parent": 3,
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -13959,12 +15792,387 @@ exports[`Collapsible nested table 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "isOpen": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "isExpanded": false,
+                    "isOpen": true,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "parent": 0,
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "isExpanded": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "parent": 1,
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "isOpen": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "isExpanded": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "parent": 3,
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
                 key="tbody-0"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -14197,7 +16405,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key=".$0-row"
+                  key="0-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -14641,7 +16849,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key=".$1-row"
+                  key="1-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -15076,7 +17284,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key=".$2-row"
+                  key="2-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -15225,6 +17433,7 @@ exports[`Collapsible nested table 1`] = `
               <tbody
                 className=""
                 key="tbody-1"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -15457,7 +17666,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key=".$3-row"
+                  key="3-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -15901,7 +18110,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key=".$4-row"
+                  key="4-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -16050,6 +18259,7 @@ exports[`Collapsible nested table 1`] = `
               <tbody
                 className=""
                 key="tbody-2"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -16282,7 +18492,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key=".$5-row"
+                  key="5-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -16440,6 +18650,7 @@ exports[`Collapsible nested table 1`] = `
               <tbody
                 className=""
                 key="tbody-3"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -16672,7 +18883,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key=".$6-row"
+                  key="6-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -16830,6 +19041,7 @@ exports[`Collapsible nested table 1`] = `
               <tbody
                 className=""
                 key="tbody-4"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -17062,7 +19274,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key=".$7-row"
+                  key="7-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -17220,6 +19432,7 @@ exports[`Collapsible nested table 1`] = `
               <tbody
                 className=""
                 key="tbody-5"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -17452,7 +19665,7 @@ exports[`Collapsible nested table 1`] = `
                       },
                     ]
                   }
-                  key=".$8-row"
+                  key="8-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -17607,7 +19820,7 @@ exports[`Collapsible nested table 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -18899,6 +21112,376 @@ exports[`Collapsible table 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "isOpen": true,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "isExpanded": true,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "parent": 0,
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "isOpen": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "isExpanded": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "parent": 3,
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -19272,12 +21855,384 @@ exports[`Collapsible table 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "isOpen": true,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "isExpanded": true,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "parent": 0,
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "isOpen": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "isExpanded": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "parent": 3,
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className="pf-m-expanded"
                 key="tbody-0"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -19510,7 +22465,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key=".$0-row"
+                  key="0-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -19954,7 +22909,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key=".$1-row"
+                  key="1-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -20103,6 +23058,7 @@ exports[`Collapsible table 1`] = `
               <tbody
                 className=""
                 key="tbody-1"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -20335,7 +23291,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key=".$2-row"
+                  key="2-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -20493,6 +23449,7 @@ exports[`Collapsible table 1`] = `
               <tbody
                 className=""
                 key="tbody-2"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -20725,7 +23682,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key=".$3-row"
+                  key="3-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -21169,7 +24126,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key=".$4-row"
+                  key="4-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -21318,6 +24275,7 @@ exports[`Collapsible table 1`] = `
               <tbody
                 className=""
                 key="tbody-3"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -21550,7 +24508,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key=".$5-row"
+                  key="5-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -21708,6 +24666,7 @@ exports[`Collapsible table 1`] = `
               <tbody
                 className=""
                 key="tbody-4"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -21940,7 +24899,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key=".$6-row"
+                  key="6-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -22098,6 +25057,7 @@ exports[`Collapsible table 1`] = `
               <tbody
                 className=""
                 key="tbody-5"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -22330,7 +25290,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key=".$7-row"
+                  key="7-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -22488,6 +25448,7 @@ exports[`Collapsible table 1`] = `
               <tbody
                 className=""
                 key="tbody-6"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -22720,7 +25681,7 @@ exports[`Collapsible table 1`] = `
                       },
                     ]
                   }
-                  key=".$8-row"
+                  key="8-row"
                   onRow={[Function]}
                   renderers={
                     Object {
@@ -22875,7 +25836,7 @@ exports[`Collapsible table 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -23858,6 +26819,379 @@ exports[`Header width table 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "isOpen": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "isExpanded": false,
+                  "isOpen": true,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "parent": 0,
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "isExpanded": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "parent": 1,
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "isOpen": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "isExpanded": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "parent": 3,
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -24234,11 +27568,387 @@ exports[`Header width table 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "isOpen": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "isExpanded": false,
+                    "isOpen": true,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "parent": 0,
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "isExpanded": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "parent": 1,
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "isOpen": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "isExpanded": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "parent": 3,
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
+                key="tbody-0"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -25222,6 +28932,12 @@ exports[`Header width table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-1"
+                rows={Array []}
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -25875,6 +29591,12 @@ exports[`Header width table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-2"
+                rows={Array []}
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -26199,6 +29921,12 @@ exports[`Header width table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-3"
+                rows={Array []}
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -26523,6 +30251,12 @@ exports[`Header width table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-4"
+                rows={Array []}
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -26847,6 +30581,12 @@ exports[`Header width table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-5"
+                rows={Array []}
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -27172,7 +30912,7 @@ exports[`Header width table 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -28442,6 +32182,379 @@ exports[`Selectable table 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "isOpen": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "isExpanded": false,
+                  "isOpen": true,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "parent": 0,
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "isExpanded": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "parent": 1,
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "isOpen": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "isExpanded": false,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "parent": 3,
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -28818,11 +32931,387 @@ exports[`Selectable table 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "isOpen": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "isExpanded": false,
+                    "isOpen": true,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "parent": 0,
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "isExpanded": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "parent": 1,
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "isOpen": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "isExpanded": false,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "parent": 3,
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
+                key="tbody-0"
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -29972,6 +34461,12 @@ exports[`Selectable table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-1"
+                rows={Array []}
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -30742,6 +35237,12 @@ exports[`Selectable table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-2"
+                rows={Array []}
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -31134,6 +35635,12 @@ exports[`Selectable table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-3"
+                rows={Array []}
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -31526,6 +36033,12 @@ exports[`Selectable table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-4"
+                rows={Array []}
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -31918,6 +36431,12 @@ exports[`Selectable table 1`] = `
                     </tr>
                   </RowWrapper>
                 </BodyRow>
+              </tbody>
+              <tbody
+                className=""
+                key="tbody-5"
+                rows={Array []}
+              >
                 <BodyRow
                   columns={
                     Array [
@@ -32311,7 +36830,7 @@ exports[`Selectable table 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -33216,6 +37735,370 @@ exports[`Simple table aria-label 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -33583,11 +38466,377 @@ exports[`Simple table aria-label 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -36470,7 +41719,7 @@ exports[`Simple table aria-label 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -37376,6 +42625,370 @@ exports[`Simple table caption 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -37743,11 +43356,377 @@ exports[`Simple table caption 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -40630,7 +46609,7 @@ exports[`Simple table caption 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -41540,6 +47519,370 @@ exports[`Simple table header 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -41907,11 +48250,377 @@ exports[`Simple table header 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -44794,7 +51503,7 @@ exports[`Simple table header 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -45793,6 +52502,370 @@ exports[`Sortable table 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -46160,11 +53233,377 @@ exports[`Sortable table 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -49056,7 +56495,7 @@ exports[`Sortable table 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -50053,6 +57492,370 @@ exports[`Table variants Breakpoint - grid 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -50420,11 +58223,377 @@ exports[`Table variants Breakpoint - grid 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -53316,7 +61485,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -54313,6 +62482,370 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -54680,11 +63213,377 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -57576,7 +66475,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -58573,6 +67472,370 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -58940,11 +68203,377 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -61836,7 +71465,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>
@@ -62833,6 +72462,370 @@ exports[`Table variants Size - compact 1`] = `
         >
           <Body
             className=""
+            mappedRows={
+              Array [
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 0,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 1,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 2,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 3,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 4,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 5,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 6,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 7,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+                Object {
+                  "branches": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "two",
+                  },
+                  "cells": Array [
+                    "one",
+                    "two",
+                    "three",
+                    "four",
+                    "five",
+                  ],
+                  "header-cell": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "one",
+                  },
+                  "id": 8,
+                  "last-commit": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "five",
+                  },
+                  "pull-requests": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "three",
+                  },
+                  "workspaces": Object {
+                    "props": Object {
+                      "isVisible": true,
+                    },
+                    "title": "four",
+                  },
+                },
+              ]
+            }
             onRow={[Function]}
             rowKey="id"
             rows={
@@ -63200,11 +73193,377 @@ exports[`Table variants Size - compact 1`] = `
               ]
             }
           >
-            <TableBody
+            <BodyWrapper
               className=""
+              mappedRows={
+                Array [
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 0,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 1,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 2,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 3,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 4,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 5,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 6,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 7,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                  Object {
+                    "branches": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "two",
+                    },
+                    "cells": Array [
+                      "one",
+                      "two",
+                      "three",
+                      "four",
+                      "five",
+                    ],
+                    "header-cell": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "one",
+                    },
+                    "id": 8,
+                    "last-commit": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "five",
+                    },
+                    "pull-requests": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "three",
+                    },
+                    "workspaces": Object {
+                      "props": Object {
+                        "isVisible": true,
+                      },
+                      "title": "four",
+                    },
+                  },
+                ]
+              }
+              rows={Array []}
             >
               <tbody
                 className=""
+                rows={Array []}
               >
                 <BodyRow
                   columns={
@@ -66096,7 +76455,7 @@ exports[`Table variants Size - compact 1`] = `
                   </RowWrapper>
                 </BodyRow>
               </tbody>
-            </TableBody>
+            </BodyWrapper>
           </Body>
         </ContextBody>
       </TableBody>


### PR DESCRIPTION
**What**:
React automatically checks if there were some changes in rows, help him with this by providing component instead of function to row wrapper. This will eliminate most of the re-renders if shallow data remain the same.

**Additional issues**:
Parially resolves: https://github.com/patternfly/patternfly-react/issues/1399
<!-- feel free to add additional comments -->
