### PR TITLE
docs(EmptyState): add example to set icon size

### DIFF
--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.docs.js
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.docs.js
@@ -1,5 +1,6 @@
 import { EmptyState, EmptyStateBody, EmptyStateSecondaryActions } from '@patternfly/react-core';
 import Simple from './examples/SimpleEmptyState';
+import IconSize from './examples/IconSize';
 
 export default {
   title: 'EmptyState',
@@ -8,6 +9,10 @@ export default {
     {
       component: Simple,
       title: 'Simple'
+    },
+    {
+      component: IconSize,
+      title: 'Icon size'
     }
   ]
 };

--- a/packages/patternfly-4/react-core/src/components/EmptyState/examples/IconSize.js
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/examples/IconSize.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import {
+  Title,
+  Button,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateSecondaryActions
+} from '@patternfly/react-core';
+import { CommentDollarIcon } from '@patternfly/react-icons';
+
+class IconSize extends React.Component {
+  render() {
+    return (
+      <EmptyState>
+        <EmptyStateIcon icon={CommentDollarIcon} size="xl" />
+        <Title size="xl">Title</Title>
+        <EmptyStateBody>This represents an empty state pattern in Patternfly 4.</EmptyStateBody>
+        <Button variant="primary">Primary Action</Button>
+        <EmptyStateSecondaryActions>
+          <Button variant="link">Secondary Action</Button>
+        </EmptyStateSecondaryActions>
+      </EmptyState>
+    );
+  }
+}
+
+export default IconSize;


### PR DESCRIPTION
**What**:

closes #1434

Added an example of how to set the icon size through `EmptyStateIcon`.

In general, `EmptyStateIcon` also has `color` and `title` props that set the icon color and title.