### PR TITLE
Fixed ChartPoint errors

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.js
@@ -15,7 +15,13 @@ export const propTypes = {
 
 // Note: VictoryLegend.role must be hoisted
 const container = <ChartContainer responsive={false} />;
-const ChartLegend = props => <VictoryLegend containerComponent={container} theme={ChartTheme.default} {...props} />;
+const ChartLegend = props => (
+  <VictoryLegend
+    containerComponent={container}
+    dataComponent={<ChartPoint />}
+    theme={ChartTheme.default} {...props}
+  />
+);
 hoistNonReactStatics(ChartLegend, VictoryLegend);
 ChartLegend.propTypes = propTypes;
 

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.js.snap
@@ -22,11 +22,7 @@ exports[`Chart 1`] = `
       },
     ]
   }
-  dataComponent={
-    <Point
-      pathComponent={<Path />}
-    />
-  }
+  dataComponent={<ChartPoint />}
   groupComponent={<g />}
   labelComponent={
     <VictoryLabel
@@ -519,11 +515,7 @@ exports[`Chart 2`] = `
       },
     ]
   }
-  dataComponent={
-    <Point
-      pathComponent={<Path />}
-    />
-  }
+  dataComponent={<ChartPoint />}
   groupComponent={<g />}
   labelComponent={
     <VictoryLabel
@@ -1016,11 +1008,7 @@ exports[`renders component data 1`] = `
       },
     ]
   }
-  dataComponent={
-    <Point
-      pathComponent={<Path />}
-    />
-  }
+  dataComponent={<ChartPoint />}
   groupComponent={<g />}
   height={50}
   labelComponent={

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.d.ts
@@ -1,10 +1,3 @@
-import * as victory from 'victory';
-// import { OneOf } from '../../typeUtils';
-
-export interface ChartPointProps extends victory.VictoryLegendProps {
-  symbol: string;
-}
-
-declare const Chartpoint: React.ComponentClass<ChartPointProps>;
+declare const Chartpoint: React.ComponentClass;
 
 export default Chartpoint;

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.js
@@ -5,26 +5,26 @@ import { Point } from 'victory';
 import { Helpers } from 'victory-core';
 import pathHelpers from './path-helpers';
 
-export const propTypes = {
-  ...Point.propTypes,
-  symbol: PropTypes.oneOfType([
-    PropTypes.oneOf([
-      'circle',
-      'diamond',
-      'plus',
-      'minus',
-      'square',
-      'star',
-      'triangleDown',
-      'triangleUp',
-      'dash',
-    ]),
-    PropTypes.func
-  ])
-};
-
 // Todo: Submit dash symbol to victory-core, providing PF4 doesn't need a smaller lineHeight for dash and minus?
 class VictoryPoint extends Point {
+  static propTypes = {
+    ...Point.propTypes,
+    symbol: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        'circle',
+        'diamond',
+        'plus',
+        'minus',
+        'square',
+        'star',
+        'triangleDown',
+        'triangleUp',
+        'dash',
+      ]),
+      PropTypes.func
+    ])
+  };
+
   getPath(props) {
     const { datum, active, x, y } = props;
     const size = Helpers.evaluateProp(props.size, datum, active);
@@ -53,6 +53,5 @@ const ChartPoint = (props) => (
 );
 
 hoistNonReactStatics(ChartPoint, Point);
-ChartPoint.propTypes = propTypes;
 
 export default ChartPoint;

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.js.snap
@@ -1011,11 +1011,7 @@ exports[`renders component data 1`] = `
       },
     ]
   }
-  dataComponent={
-    <Point
-      pathComponent={<Path />}
-    />
-  }
+  dataComponent={<ChartPoint />}
   groupComponent={<g />}
   height={50}
   labelComponent={

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/index.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/index.d.ts
@@ -1,1 +1,1 @@
-export { default as ChartPoint, ChartPointProps } from './ChartPoint';
+export { default as ChartPoint } from './ChartPoint';


### PR DESCRIPTION
Fixed a couple errors after testing ChartPoint with the Cost Management UI.

- ChartLegend must make use of new ChartPoint to support the 'dash' symbol
- Fixed TypeScript error encountered while building Cost Management
- Fixed invalid prop symbol warning seen with ChartLine example

TypeScript build error:
<img width="1092" alt="screen shot 2019-02-25 at 9 19 57 pm" src="https://user-images.githubusercontent.com/17481322/53382727-32d62d80-3943-11e9-8fc1-ec9a31f66753.png">

Browser invalid prop symbol warning:
<img width="439" alt="screen shot 2019-02-25 at 8 42 59 pm" src="https://user-images.githubusercontent.com/17481322/53381478-da049600-393e-11e9-972b-3b1562b9f91f.png">