### PR TITLE
feat(VerticalNav): add id, data-id to secondary items

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/VerticalNav/VerticalNav.js
+++ b/packages/patternfly-3/patternfly-react/src/components/VerticalNav/VerticalNav.js
@@ -268,6 +268,8 @@ class BaseVerticalNav extends React.Component {
           {primaryItem.subItems &&
             primaryItem.subItems.map(secondaryItem => (
               <VerticalNavSecondaryItem
+                id={secondaryItem.id}
+                dataID={secondaryItem.dataID}
                 isDivider={secondaryItem.isDivider}
                 preventHref={secondaryItem.preventHref}
                 item={secondaryItem}

--- a/packages/patternfly-3/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
+++ b/packages/patternfly-3/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
@@ -194,7 +194,9 @@ class BaseVerticalNavItemHelper extends React.Component {
       showBadges,
       children,
       isMobile,
-      pinnedPath
+      pinnedPath,
+      id,
+      dataID
     } = this.props;
 
     // The nav item can either be passed directly as one item object prop, or as individual props.
@@ -267,7 +269,7 @@ class BaseVerticalNavItemHelper extends React.Component {
         // NOTE onItemBlur takes a boolean, we want to prevent it being passed a truthy event.
         onMouseLeave={e => this.onItemBlur(false)}
       >
-        <a href={href || '#'} onClick={this.onItemClick}>
+        <a id={id} data-id={dataID} href={href || '#'} onClick={this.onItemClick}>
           {depth === 'primary' &&
             icon &&
             (!isMobile && navCollapsed ? (
@@ -326,7 +328,11 @@ BaseVerticalNavItemHelper.propTypes = {
   /** Divider bool */
   isDivider: PropTypes.bool,
   /** should Prevent Href */
-  preventHref: PropTypes.bool
+  preventHref: PropTypes.bool,
+  /** anchor id */
+  id: PropTypes.string,
+  /** anchor data-id */
+  dataID: PropTypes.string
 };
 
 BaseVerticalNavItemHelper.defaultProps = {
@@ -334,7 +340,9 @@ BaseVerticalNavItemHelper.defaultProps = {
   children: null,
   title: '',
   isDivider: false,
-  preventHref: true
+  preventHref: true,
+  id: '',
+  dataID: ''
 };
 
 const VerticalNavItemHelper = getContext(navContextTypes)(BaseVerticalNavItemHelper);


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
add id, data-id to secondary items

Not sure if i'm missing something but I don't see an option to pass these props.
Required for QE testing
<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
