### PR TITLE
fix(Table): Expandable row should not prevent select all checkbox fro…

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.js
@@ -151,7 +151,7 @@ class Table extends React.Component {
   }
 
   areAllRowsSelected(rows) {
-    return rows.every(this.isSelected);
+    return rows.every(row => this.isSelected(row) || (row.hasOwnProperty('parent') && !row.showSelect));
   }
 
   render() {

--- a/packages/patternfly-4/react-table/src/components/Table/Table.test.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.test.js
@@ -170,3 +170,29 @@ test('Header width table', () => {
   );
   expect(view).toMatchSnapshot();
 });
+
+test('Selectable table with selected expandable row', () => {
+  const data = {
+    cells: ['column'],
+    rows: [
+      {
+        cells: ['one'],
+        selected: true
+      },
+      {
+        cells: ['one'],
+        parent: 0
+      }
+    ],
+    onSelect: f => f
+  };
+
+  const view = mount(
+    <Table aria-label="Aria labeled" {...data}>
+      <TableHeader />
+      <TableBody />
+    </Table>
+  );
+
+  expect(view.find('input[name="check-all"]').prop('checked')).toEqual(true);
+});


### PR DESCRIPTION
…m being checked

**What**:

If the table combines expandable and selectable rows then select-all checkbox never renders checked.
This happens because areAllRowsSelected() considers all rows even those that do not have checkboxes.
This change modifies areAllRowsSelected() to only consider rows with checkboxes.

**Additional issues**:

