### PR TITLE
fix(nav): fix React warning with onExpand prop

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Nav/NavExpandable.js
+++ b/packages/patternfly-4/react-core/src/components/Nav/NavExpandable.js
@@ -67,7 +67,7 @@ class NavExpandable extends React.Component {
   };
 
   render() {
-    const { id, title, srText, isExpanded, children, className, groupId, isActive, ...props } = this.props;
+    const { id, title, srText, isExpanded, children, className, groupId, isActive, onExpand, ...props } = this.props;
     const { expandedState } = this.state;
 
     return (


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
fix React warning introduced in #1490 

```
Warning: Unknown event handler property `onExpand`. It will be ignored.
    in li (created by NavToggle)
    in NavToggle
    in NavExpandable (created by NavSection)
    in NavSection (created by Connect(NavSection))
    in Connect(NavSection) (created by Navigation)
    in ul (created by NavList)
    in NavList (created by Navigation)
    in nav (created by Nav)
    in Nav (created by Navigation)
    in div (created by PageSidebar)
    in PageSidebar (created by Navigation)
    in Navigation (created by App)
    in div (created by Page)
    in Page (created by App)
    in App (created by Route)
    in Route
    in Router
    in Provider
```

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
