### PR TITLE
feat(Dropdown): add support for disabled dropdown menus

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.docs.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.docs.js
@@ -1,6 +1,7 @@
 import { Dropdown, KebabToggle, DropdownItem, DropdownSeparator, DropdownToggle } from '@patternfly/react-core';
 import Panel from './examples/DropdownPanel';
 import Simple from './examples/SimpleDropdown';
+import Disabled from './examples/DisabledDropdown';
 import Kebab from './examples/KebabDropdown';
 import IconDropdown from './examples/IconDropdown';
 import PositionRight from './examples/PositionRightDropdown';
@@ -19,6 +20,7 @@ export default {
   variablesRoot: 'pf-c-dropdown',
   examples: [
     { component: Simple, title: 'Dropdown' },
+    { component: Disabled, title: 'Dropdown - disabled' },
     { component: PositionRight, title: 'Dropdown - position right' },
     { component: DirectionUp, title: 'Dropdown - direction up' },
     { component: Kebab, title: 'Kebab' },

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Toggle.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Toggle.js
@@ -120,6 +120,7 @@ class DropdownToggle extends Component {
           isHovered && styles.modifiers.hover,
           isActive && styles.modifiers.active,
           isPlain && styles.modifiers.plain,
+          isDisabled && styles.modifiers.disabled,
           className
         )}
         type={type || 'button'}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/examples/DisabledDropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/examples/DisabledDropdown.js
@@ -1,0 +1,52 @@
+import React, { Component } from 'react';
+import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator } from '@patternfly/react-core';
+
+export default class DisabledDropdown extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false
+    };
+  }
+
+  onToggle = isOpen => {
+    this.setState({
+      isOpen
+    });
+  };
+
+  onSelect = event => {
+    this.setState({
+      isOpen: !this.state.isOpen
+    });
+  };
+
+  render() {
+    const { isOpen } = this.state;
+    const dropdownItems = [
+      <DropdownItem key="link">Link</DropdownItem>,
+      <DropdownItem key="action" component="button">
+        Action
+      </DropdownItem>,
+      <DropdownItem key="disabled link" isDisabled>
+        Disabled Link
+      </DropdownItem>,
+      <DropdownItem key="disabled action" isDisabled component="button">
+        Disabled Action
+      </DropdownItem>,
+      <DropdownSeparator key="separator" />,
+      <DropdownItem key="separated link">Separated Link</DropdownItem>,
+      <DropdownItem key="separated action" component="button">
+        Separated Action
+      </DropdownItem>
+    ];
+    return (
+      <Dropdown
+        onSelect={this.onSelect}
+        toggle={<DropdownToggle isDisabled onToggle={this.onToggle}>Dropdown</DropdownToggle>}
+        isOpen={isOpen}
+        dropdownItems={dropdownItems}
+      />
+    );
+  }
+}

--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
@@ -37417,7 +37417,7 @@ exports[`Simple Actions table 1`] = `
   padding-bottom: 0px;
   vertical-align: middle;
 }
-.pf-c-dropdown__toggle.pf-m-plain {
+.pf-c-dropdown__toggle.pf-m-plain.pf-m-disabled {
   display: flex;
   position: relative;
   align-items: center;
@@ -37430,6 +37430,7 @@ exports[`Simple Actions table 1`] = `
   line-height: 1.5;
   color: #72767b;
   background-color: transparent;
+  pointer-events: none;
 }
 .pf-c-dropdown {
   display: inline-block;
@@ -47855,7 +47856,7 @@ exports[`Simple Actions table 1`] = `
                                       aria-expanded={false}
                                       aria-haspopup={true}
                                       aria-label="Actions"
-                                      className="pf-c-dropdown__toggle pf-m-plain"
+                                      className="pf-c-dropdown__toggle pf-m-plain pf-m-disabled"
                                       disabled={true}
                                       id="pf-toggle-id-9"
                                       onClick={[Function]}


### PR DESCRIPTION
**What**:

closes #1501 

- [x] add the `isDisabled` prop
- [x] add an example of disabled dropdown
- [x] update `@patternfly/patternfly` to 1.0.219

//cc @mcoker 