### PR TITLE
fix(tsconfig): avatar tsx change

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Avatar/Avatar.tsx
+++ b/packages/patternfly-4/react-core/src/components/Avatar/Avatar.tsx
@@ -1,8 +1,6 @@
-
 import styles from '@patternfly/patternfly/components/Avatar/avatar.css';
 import { css } from '@patternfly/react-styles';
-import React, { DetailedHTMLProps, ImgHTMLAttributes } from 'react';
-
+import * as React from 'react';
 
 const defaultProps = {
   className: '',
@@ -12,7 +10,8 @@ const defaultProps = {
 /**
  * Column properties.
  */
-export interface AvatarProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>{
+export interface AvatarProps
+  extends React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement> {
   /** Additional classes added to the Avatar. */
   className?: string;
   /** Attribute that specifies the URL of the image for the Avatar. */
@@ -21,7 +20,7 @@ export interface AvatarProps extends DetailedHTMLProps<ImgHTMLAttributes<HTMLIma
   alt: string;
 }
 
-const Avatar:React.FunctionComponent<AvatarProps> = (props) => (
+const Avatar: React.FunctionComponent<AvatarProps> = props => (
   <img {...props} className={css(styles.avatar, props.className)} />
 );
 

--- a/packages/patternfly-4/react-core/src/tsconfig.dts.json
+++ b/packages/patternfly-4/react-core/src/tsconfig.dts.json
@@ -1,35 +1,23 @@
 {
   "compilerOptions": {
     "outDir": "../dist/js",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": false,
+    "esModuleInterop": false,
     "baseUrl": ".",
     "moduleResolution": "node",
     "declaration": true,
     "emitDeclarationOnly": true,
     "skipLibCheck": true,
     "sourceMap": false,
-    "lib": [
-      "es2017",
-      "dom"
-    ],
+    "lib": ["es2017", "dom"],
     "noEmit": false,
     "module": "commonjs",
     "jsx": "react",
     "target": "es5",
     "paths": {
-      "*": [
-        "../dist/esm/*"
-      ]
+      "*": ["../dist/esm/*"]
     }
   },
-  "include": [
-    "./**/*"
-  ],
-  "exclude": [
-    "./**/*.d.ts",
-    "./**/**.test.tsx",
-    "./**/**.test.ts",
-    "./**/examples/**"
-  ]
+  "include": ["./**/*"],
+  "exclude": ["./**/*.d.ts", "./**/**.test.tsx", "./**/**.test.ts", "./**/examples/**"]
 }


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
This change disables `allowSyntheticDefaultImports` and `esModuleInterop`. From a library perspective, I believe we will need to ensure that we can support Typescript consumers who have this option disabled OR enabled. This was discovered today while testing OpenShift tests downstream. 

It is generally considered good practice now to enable these flags (and from a Node JS/Common JS perspective) this is the typical path, however some consumers may not elect to enable them.

This should resolve the current issue and help us strategize for future TSX conversion.

cc: @dgutride @rhamilto @spadgett @tlabaj 

For additional detail, with this flags disabled downstream, but enabled upstream, we'll run into these:
```
ERROR in /Users/priley/GitHub/web-ui/frontend/node_modules/@patternfly/react-core/dist/js/components/Avatar/Avatar.d.ts
(1,8): Module '"/Users/priley/GitHub/web-ui/frontend/node_modules/@types/react/index"' has no default export.
```
<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
