### PR TITLE
chore(TableDoc): Update Documentation for for using 'title' prop in table cells.

### DIFF
--- a/packages/patternfly-4/react-docs/src/components/propsTable/propsTable.js
+++ b/packages/patternfly-4/react-docs/src/components/propsTable/propsTable.js
@@ -54,7 +54,7 @@ export const PropsTable = ({ name, description: preface, props, enumValues }) =>
             </TD>
             <TD align="center">{prop.required && <ExclamationCircleIcon />}</TD>
             <TD>{Boolean(prop.defaultValue) && prop.defaultValue.value}</TD>
-            <TD>{prop.description && prop.description.text}</TD>
+            <TD>{prop.description && <span dangerouslySetInnerHTML={{__html: prop.description.text}}/>}</TD>
           </Row>
         ))}
       </Body>

--- a/packages/patternfly-4/react-table/src/components/Table/Table.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.js
@@ -53,7 +53,15 @@ const propTypes = {
   actionResolver: PropTypes.func,
   /** Function should resolve if action is disabled for each row */
   areActionsDisabled: PropTypes.func,
-  /** Actual rows to display in table. Either array of strings or row ojects. */
+  /** Actual rows to display in table. Either array of strings or row objects. <br/>
+   * If you want to use components in row cells you can pass them as title prop in cells definition. <br/>
+   * <pre>Ex: rows:[
+   *   {cells:[
+   *     {title: &lt;div>Some component&lt;/div>}
+   *     ...
+   *   ]}
+   * ]
+   * </pre>*/
   rows: PropTypes.arrayOf(
     PropTypes.oneOfType([
       PropTypes.shape({


### PR DESCRIPTION
Fixes #1473 - a P1 issue, which is why I chose it, but it's a simple doc change.

Updated table doc to:

![image](https://user-images.githubusercontent.com/12733153/54131681-365cc080-43e9-11e9-8b2f-19a2a54317b2.png)

**Note:** The ability to now use HTML in the Description column.   This is accomplished via:
`<span dangerouslySetInnerHTML={{__html: prop.description.text}}/>`  -wondering if there is any downside/risk in using this method?