### PR TITLE
fix: PF4 Fix HelperText definition in LoginForm

### DIFF
--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginForm.d.ts
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginForm.d.ts
@@ -3,7 +3,7 @@ import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 export interface LoginFormProps extends HTMLProps<HTMLFormElement> {
   children?: ReactNode;
   showHelperText?: boolean;
-  helperText?: string;
+  helperText?: ReactNode;
   usernameLabel?: string;
   usernameValue?: string;
   onChangeUsername?: Function;


### PR DESCRIPTION
HelperText need to be ReactNode

Fix #1550

