### PR TITLE
fix(codemod): fix tests failing due to prettier

### DIFF
--- a/packages/react-codemods/transforms/pf3-pf4.button.test.js
+++ b/packages/react-codemods/transforms/pf3-pf4.button.test.js
@@ -3,25 +3,9 @@ import prettier from 'prettier';
 import { defineInlineTest } from 'jscodeshift/dist/testUtils';
 import transform from './pf3-pf4';
 
-/**
- * Codemod outputs should follow the EOL pattern of the target codebase, not
- * Patternfly's. Patternfly currently enforces LF as line ending, independent of
- * the OS building the codebase.
- *
- * JSCodeShift produces OS-dependent line endings however, LF for Unix based
- * systems, and CRLF for Windows based ones. This is also likely what most
- * projects would like to see the codemod prduce.
- *
- * To make sure we both adhere to Patternfly's conventions, and compare the
- * correct OS-specific line endings during the test cases' assertions, we store
- * expected values with LF line endings, and convert them into the OS-specific
- * ones at runtime using prettier.
- */
-const PRETTIER_EOL = SYSTEM_EOL === '\r\n' ? 'crlf' : 'cr';
 const prettierConfig = {
   ...prettier.resolveConfig.sync(process.cwd()),
-  parser: 'babel',
-  endOfLine: PRETTIER_EOL
+  parser: 'babel'
 };
 const pretty = src => prettier.format(src, prettierConfig);
 

--- a/packages/react-codemods/transforms/pf3-pf4.test.js
+++ b/packages/react-codemods/transforms/pf3-pf4.test.js
@@ -3,25 +3,9 @@ import prettier from 'prettier';
 import { defineInlineTest, runInlineTest } from 'jscodeshift/dist/testUtils';
 import transform from './pf3-pf4';
 
-/**
- * Codemod outputs should follow the EOL pattern of the target codebase, not
- * Patternfly's. Patternfly currently enforces LF as line ending, independent of
- * the OS building the codebase.
- *
- * JSCodeShift produces OS-dependent line endings however, LF for Unix based
- * systems, and CRLF for Windows based ones. This is also likely what most
- * projects would like to see the codemod prduce.
- *
- * To make sure we both adhere to Patternfly's conventions, and compare the
- * correct OS-specific line endings during the test cases' assertions, we store
- * expected values with LF line endings, and convert them into the OS-specific
- * ones at runtime using prettier.
- */
-const PRETTIER_EOL = SYSTEM_EOL === '\r\n' ? 'crlf' : 'cr';
 const prettierConfig = {
   ...prettier.resolveConfig.sync(process.cwd()),
-  parser: 'babel',
-  endOfLine: PRETTIER_EOL
+  parser: 'babel'
 };
 const pretty = src => prettier.format(src, prettierConfig);
 


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Remove prettier EOL config option during tests. Tests fail whenever it is specified on *nix-based systems after #1255

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
