### PR TITLE
fix(Modal): remove backdropOpen class from body when Modal is removed

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Modal/Modal.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/Modal.js
@@ -92,6 +92,7 @@ class Modal extends React.Component {
   componentWillUnmount() {
     document.body.removeChild(this.container);
     document.removeEventListener('keydown', this.handleEscKeyClick, false);
+    document.body.classList.remove(css(styles.backdropOpen));
   }
 
   render() {

--- a/packages/patternfly-4/react-core/src/components/Modal/Modal.test.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/Modal.test.js
@@ -1,8 +1,10 @@
 import Modal from './Modal';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { KEY_CODES } from '../../helpers/constants';
+import { css } from '../../../../react-styles/dist/js';
+import styles from '@patternfly/patternfly/components/Backdrop/backdrop.css';
 
 jest.spyOn(ReactDOM, 'createPortal');
 jest.spyOn(document, 'createElement');
@@ -44,4 +46,14 @@ test('Each modal is given a new id', () => {
   const first = shallow(<Modal {...props} />);
   const second = shallow(<Modal {...props} />);
   expect(first.props().id).not.toBe(second.props().id);
+});
+
+test('modal removes body backdropOpen class when removed', () => {
+  const TestRemoval = testProps => (testProps.display ? <Modal {...props} isOpen /> : <p>Not displayed</p>);
+  const view = mount(<TestRemoval display />);
+  view.update();
+  expect(document.body.className).toContain(css(styles.backdropOpen));
+  view.setProps({ display: false });
+  view.update();
+  expect(document.body.className).not.toContain(css(styles.backdropOpen));
 });


### PR DESCRIPTION
1. Add a test that fails because the class is not removed
2. Added the fix (remove the backdropOpen class from the body in `componentWillUnmount`)
3. Test is passing

This is not related to this fix, but having multiple modals in one screen may not be a good idea...

Closes #1531

