### PR TITLE
feat(Switch): Add icon and fix labels

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Switch/Switch.js
+++ b/packages/patternfly-4/react-core/src/components/Switch/Switch.js
@@ -3,6 +3,7 @@ import styles from '@patternfly/patternfly/components/Switch/switch.css';
 import { css } from '@patternfly/react-styles';
 import PropTypes from 'prop-types';
 import { getUniqueId } from '../../helpers/util';
+import { CheckIcon } from '@patternfly/react-icons';
 
 const propTypes = {
   /** id for the label. */
@@ -53,12 +54,21 @@ class Switch extends React.Component {
           checked={isChecked}
           disabled={isDisabled}
         />
-        <span className={css(styles.switchToggle)} />
-        {label && (
-          <span className={css(styles.switchLabel)} aria-hidden="true">
-            {label}
-          </span>
-        )}
+        {label !== ''
+          ? <React.Fragment>
+              <span className={css(styles.switchToggle)} />
+              <span className={css(styles.switchLabel, styles.modifiers.on)} aria-hidden="true">
+                {label}
+              </span>
+              <span className={css(styles.switchLabel, styles.modifiers.off)} aria-hidden="true">
+                {label}
+              </span>
+            </React.Fragment>
+          : <span className={css(styles.switchToggle)}>
+              <div className={css(styles.switchToggleIcon)} aria-hidden="true">
+                <CheckIcon noVerticalAlign />
+              </div>
+            </span>}
       </label>
     );
   }

--- a/packages/patternfly-4/react-core/src/components/Switch/__snapshots__/Switch.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Switch/__snapshots__/Switch.test.js.snap
@@ -4,6 +4,9 @@ exports[`no label switch is checked 1`] = `
 .pf-c-switch__input {
   display: block;
 }
+.pf-c-switch__toggle-icon {
+  display: block;
+}
 .pf-c-switch__toggle {
   display: block;
 }
@@ -30,12 +33,27 @@ exports[`no label switch is checked 1`] = `
   />
   <span
     className="pf-c-switch__toggle"
-  />
+  >
+    <div
+      aria-hidden="true"
+      className="pf-c-switch__toggle-icon"
+    >
+      <CheckIcon
+        color="currentColor"
+        noVerticalAlign={true}
+        size="sm"
+        title={null}
+      />
+    </div>
+  </span>
 </label>
 `;
 
 exports[`no label switch is not checked 1`] = `
 .pf-c-switch__input {
+  display: block;
+}
+.pf-c-switch__toggle-icon {
   display: block;
 }
 .pf-c-switch__toggle {
@@ -64,7 +82,19 @@ exports[`no label switch is not checked 1`] = `
   />
   <span
     className="pf-c-switch__toggle"
-  />
+  >
+    <div
+      aria-hidden="true"
+      className="pf-c-switch__toggle-icon"
+    >
+      <CheckIcon
+        color="currentColor"
+        noVerticalAlign={true}
+        size="sm"
+        title={null}
+      />
+    </div>
+  </span>
 </label>
 `;
 
@@ -75,7 +105,10 @@ exports[`switch is checked 1`] = `
 .pf-c-switch__toggle {
   display: block;
 }
-.pf-c-switch__label {
+.pf-c-switch__label.pf-m-on {
+  display: block;
+}
+.pf-c-switch__label.pf-m-off {
   display: block;
 }
 .pf-c-switch {
@@ -104,7 +137,13 @@ exports[`switch is checked 1`] = `
   />
   <span
     aria-hidden="true"
-    className="pf-c-switch__label"
+    className="pf-c-switch__label pf-m-on"
+  >
+    On
+  </span>
+  <span
+    aria-hidden="true"
+    className="pf-c-switch__label pf-m-off"
   >
     On
   </span>
@@ -113,6 +152,9 @@ exports[`switch is checked 1`] = `
 
 exports[`switch is checked and disabled 1`] = `
 .pf-c-switch__input {
+  display: block;
+}
+.pf-c-switch__toggle-icon {
   display: block;
 }
 .pf-c-switch__toggle {
@@ -141,7 +183,19 @@ exports[`switch is checked and disabled 1`] = `
   />
   <span
     className="pf-c-switch__toggle"
-  />
+  >
+    <div
+      aria-hidden="true"
+      className="pf-c-switch__toggle-icon"
+    >
+      <CheckIcon
+        color="currentColor"
+        noVerticalAlign={true}
+        size="sm"
+        title={null}
+      />
+    </div>
+  </span>
 </label>
 `;
 
@@ -152,7 +206,10 @@ exports[`switch is not checked 1`] = `
 .pf-c-switch__toggle {
   display: block;
 }
-.pf-c-switch__label {
+.pf-c-switch__label.pf-m-on {
+  display: block;
+}
+.pf-c-switch__label.pf-m-off {
   display: block;
 }
 .pf-c-switch {
@@ -181,7 +238,13 @@ exports[`switch is not checked 1`] = `
   />
   <span
     aria-hidden="true"
-    className="pf-c-switch__label"
+    className="pf-c-switch__label pf-m-on"
+  >
+    Off
+  </span>
+  <span
+    aria-hidden="true"
+    className="pf-c-switch__label pf-m-off"
   >
     Off
   </span>
@@ -190,6 +253,9 @@ exports[`switch is not checked 1`] = `
 
 exports[`switch is not checked and disabled 1`] = `
 .pf-c-switch__input {
+  display: block;
+}
+.pf-c-switch__toggle-icon {
   display: block;
 }
 .pf-c-switch__toggle {
@@ -218,6 +284,18 @@ exports[`switch is not checked and disabled 1`] = `
   />
   <span
     className="pf-c-switch__toggle"
-  />
+  >
+    <div
+      aria-hidden="true"
+      className="pf-c-switch__toggle-icon"
+    >
+      <CheckIcon
+        color="currentColor"
+        noVerticalAlign={true}
+        size="sm"
+        title={null}
+      />
+    </div>
+  </span>
 </label>
 `;

--- a/packages/patternfly-4/react-core/src/components/Switch/examples/DisabledSwitch.js
+++ b/packages/patternfly-4/react-core/src/components/Switch/examples/DisabledSwitch.js
@@ -5,12 +5,12 @@ class DisabledSwitch extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Switch id="disabled-switch-on" aria-label="disabled checked switch example" label="On" isChecked isDisabled />
+        <Switch id="disabled-switch-on" aria-label="disabled checked switch example" label="Message when on" isChecked isDisabled />
         <br />
         <Switch
           id="disabled-switch-off"
           aria-label="disabled switch example"
-          label="Off"
+          label="Message when off"
           isChecked={false}
           isDisabled
         />

--- a/packages/patternfly-4/react-core/src/components/Switch/examples/SimpleSwitch.js
+++ b/packages/patternfly-4/react-core/src/components/Switch/examples/SimpleSwitch.js
@@ -15,7 +15,7 @@ class SimpleSwitch extends React.Component {
     return (
       <Switch
         id="simple-switch"
-        label={isChecked ? 'On' : 'Off'}
+        label={isChecked ? 'Message when on' : 'Message when off'}
         isChecked={isChecked}
         onChange={this.handleChange}
         aria-label="simple Switch example"

--- a/packages/patternfly-4/react-core/src/components/Switch/examples/UncontrolledSwitch.js
+++ b/packages/patternfly-4/react-core/src/components/Switch/examples/UncontrolledSwitch.js
@@ -5,9 +5,9 @@ class UncontrolledSwitch extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Switch id="uncontrolled-switch-on" aria-label="uncontrolled checked switch example" label="On" isChecked />
+        <Switch id="uncontrolled-switch-on" aria-label="uncontrolled checked switch example" label="Message when on" isChecked />
         <br />
-        <Switch id="uncontrolled-switch-off" aria-label="uncontrolled switch example" label="Off" isChecked={false} />
+        <Switch id="uncontrolled-switch-off" aria-label="uncontrolled switch example" label="Message when off" isChecked={false} />
         <br />
         <Switch
           id="uncontrolled-no-label-switch-on"

--- a/packages/react-icons/src/createIcon.js
+++ b/packages/react-icons/src/createIcon.js
@@ -14,15 +14,16 @@ const createIcon = iconDefinition => {
     id = `icon-title-${currentId++}`;
 
     render() {
-      const { size, color, title, ...props } = this.props;
+      const { size, color, title, noStyle, noVerticalAlign, ...props } = this.props;
 
       const hasTitle = Boolean(title);
       const heightWidth = getSize(size);
       const baseAlign = -.125 * Number.parseFloat(heightWidth);
+      const style = noVerticalAlign ? null : { verticalAlign: `${baseAlign}em` };
 
       return (
         <svg
-          style={{ verticalAlign: `${baseAlign}em` }}
+          style={style}
           fill={color}
           height={heightWidth}
           width={heightWidth}


### PR DESCRIPTION
I added the icon to unlabeled switches, updated HTML and CSS classes to match core/avoid CSS labels, and updated the example labels to match core.

Fixes #1296 and #1546.