### PR TITLE
refactor(Switch): Aria label reflects the message when on

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Switch/Switch.js
+++ b/packages/patternfly-4/react-core/src/components/Switch/Switch.js
@@ -18,7 +18,7 @@ const propTypes = {
   isDisabled: PropTypes.bool,
   /** A callback for when the Switch selection changes. (isChecked, event) => {} */
   onChange: PropTypes.func,
-  /** Adds accessible text to the Switch. */
+  /** Adds accessible text to the Switch, and should describe the isChecked="true" state. When label is defined, aria-label should be set to the text string that is visible when isChecked is true. */
   'aria-label': props => {
     if (!props.id && !props['aria-label']) {
       return new Error('Switch requires either an id or aria-label to be specified');

--- a/packages/patternfly-4/react-core/src/components/Switch/examples/DisabledSwitch.js
+++ b/packages/patternfly-4/react-core/src/components/Switch/examples/DisabledSwitch.js
@@ -5,11 +5,11 @@ class DisabledSwitch extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Switch id="disabled-switch-on" aria-label="disabled checked switch example" label="Message when on" isChecked isDisabled />
+        <Switch id="disabled-switch-on" aria-label="Message when on" label="Message when on" isChecked isDisabled />
         <br />
         <Switch
           id="disabled-switch-off"
-          aria-label="disabled switch example"
+          aria-label="Message when on"
           label="Message when off"
           isChecked={false}
           isDisabled
@@ -17,14 +17,14 @@ class DisabledSwitch extends React.Component {
         <br />
         <Switch
           id="disabled-no-label-switch-on"
-          aria-label="disabled no label checked switch example"
+          aria-label="Message when on"
           isChecked
           isDisabled
         />
         <br />
         <Switch
           id="disabled-no-label-switch-off"
-          aria-label="disabled no label switch example"
+          aria-label="Message when on"
           isChecked={false}
           isDisabled
         />

--- a/packages/patternfly-4/react-core/src/components/Switch/examples/NoLabelSwitch.js
+++ b/packages/patternfly-4/react-core/src/components/Switch/examples/NoLabelSwitch.js
@@ -15,7 +15,7 @@ class NoLabelSwitch extends React.Component {
     return (
       <Switch
         id="no-label-switch-on"
-        aria-label="no label checked switch example"
+        aria-label="Message when on"
         isChecked={isChecked}
         onChange={this.handleChange}
       />

--- a/packages/patternfly-4/react-core/src/components/Switch/examples/SimpleSwitch.js
+++ b/packages/patternfly-4/react-core/src/components/Switch/examples/SimpleSwitch.js
@@ -18,7 +18,7 @@ class SimpleSwitch extends React.Component {
         label={isChecked ? 'Message when on' : 'Message when off'}
         isChecked={isChecked}
         onChange={this.handleChange}
-        aria-label="simple Switch example"
+        aria-label="Message when on"
       />
     );
   }

--- a/packages/patternfly-4/react-core/src/components/Switch/examples/UncontrolledSwitch.js
+++ b/packages/patternfly-4/react-core/src/components/Switch/examples/UncontrolledSwitch.js
@@ -5,19 +5,19 @@ class UncontrolledSwitch extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Switch id="uncontrolled-switch-on" aria-label="uncontrolled checked switch example" label="Message when on" isChecked />
+        <Switch id="uncontrolled-switch-on" aria-label="Message when on" label="Message when on" isChecked />
         <br />
-        <Switch id="uncontrolled-switch-off" aria-label="uncontrolled switch example" label="Message when off" isChecked={false} />
+        <Switch id="uncontrolled-switch-off" aria-label="Message when on" label="Message when off" isChecked={false} />
         <br />
         <Switch
           id="uncontrolled-no-label-switch-on"
-          aria-label="uncontrolled no label checked switch example"
+          aria-label="Message when on"
           isChecked
         />
         <br />
         <Switch
           id="uncontrolled-no-label-switch-off"
-          aria-label="uncontrolled no label switch example"
+          aria-label="Message when on"
           isChecked={false}
         />
       </React.Fragment>


### PR DESCRIPTION
I updated the examples so the aria-label is the "on" message and changed the aria-label documentation per @jgiardino's notes in #1602.

Fixes #1602.