### PR TITLE
fix(table): remove Typescript 3+ "unknown" type

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
@@ -45,19 +45,19 @@ export interface ICell {
   cellTransforms: Array<Function>;
   formatters: Array<Function>;
   cellFormatters: Array<Function>;
-  props: unknown;
+  props: any;
 }
 
 export interface IRowCell {
   title: ReactNode;
-  props: unknown;
+  props: any;
 }
 
 export interface IRow {
   cells: Array<ReactNode | IRowCell>;
   isOpen: Boolean;
   parent: Number;
-  props: unknown;
+  props: any;
 }
 
 export interface TableProps extends Omit<Omit<HTMLProps<HTMLTableElement>, 'onSelect'>, 'rows'> {
@@ -66,11 +66,11 @@ export interface TableProps extends Omit<Omit<HTMLProps<HTMLTableElement>, 'onSe
   variant?: OneOf<typeof TableVariant, keyof typeof TableVariant>;
   gridBreakPoint?: OneOf<typeof TableGridBreakpoint, keyof typeof TableGridBreakpoint>;
   sortBy?: ISortBy;
-  onCollapse?: (event: MouseEvent, rowIndex: number,isOpen: boolean, rowData: IRowData, extraData: IExtraData) => void;
+  onCollapse?: (event: MouseEvent, rowIndex: number, isOpen: boolean, rowData: IRowData, extraData: IExtraData) => void;
   onSelect?: (event: MouseEvent, isSelected: boolean, rowIndex: number, rowData: IRowData, extraData: IExtraData) => void;
   onSort?: (event: MouseEvent, columnIndex: number, extraData: IExtraColumnData) => void;
   actions?: Array<IAction | ISeparator>;
-  actionResolver?: (rowData: IRowData,  extraData: IExtraData) => Array<IAction | ISeparator>;
+  actionResolver?: (rowData: IRowData, extraData: IExtraData) => Array<IAction | ISeparator>;
   areActionsDisabled?: (rowData: IRowData, extraData: IExtraData) => boolean;
   header?: ReactNode;
   caption?: ReactNode;


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: OpenShift uses Typescript 2, so let them still get typechecking goodness by removing the new TS3 "unknown" type.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: Closes #1606

<!-- feel free to add additional comments -->
