### PR TITLE
fix (Wizard): remove console.log from save

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/patternfly-4/react-core/src/components/Wizard/Wizard.tsx
@@ -157,7 +157,6 @@ class Wizard extends React.Component<WizardProps> {
     if (currentStep >= maxSteps) {
       // Hit the save button at the end of the wizard
       if (onSave) {
-        console.log('save');
         return onSave();
       }
       return onClose!();


### PR DESCRIPTION
**What**: Noticed this `console.log` in the Wizard component while trying it out in `2.8.2`.

I didn't find any issues related to this that I could link.

**Additional issues**: None

I know this is still in `prerelease` so feel free to close this if removing the `console.log` is premature.
