### PR TITLE
fix(ts-fixes): ts definition changes

### DIFF
--- a/packages/patternfly-4/react-core/src/components/ContextSelector/ContextSelector.d.ts
+++ b/packages/patternfly-4/react-core/src/components/ContextSelector/ContextSelector.d.ts
@@ -1,7 +1,7 @@
-import { FunctionComponent, HTMLProps, ReactNode } from 'react';
-import { OneOf } from '../../typeUtils';
+import { FunctionComponent, ReactNode } from 'react';
+import { OneOf } from '../../helpers/typeUtils';
 
-export interface ContextSelectorProps extends HTMLProps<HTMLDivElement> {
+export interface ContextSelectorProps {
   children?: ReactNode;
   isOpen?: boolean;
   onToggle?(value: boolean): void;

--- a/packages/patternfly-4/react-core/src/components/ContextSelector/ContextSelectorItem.d.ts
+++ b/packages/patternfly-4/react-core/src/components/ContextSelector/ContextSelectorItem.d.ts
@@ -1,6 +1,6 @@
 import { FunctionComponent, HTMLProps, ReactType } from 'react';
 
-export interface ContextSelectorItemProps extends HTMLProps<HTMLButtonElement> {
+export interface ContextSelectorItemProps {
   isDisabled?: boolean;
   isSelected?: boolean;
   isHovered?: boolean;

--- a/packages/patternfly-4/react-table/src/components/Table/index.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/index.d.ts
@@ -9,11 +9,13 @@ export {
   ICell,
   IRow,
   IRowData,
+  IColumn,
+  IExtra,
   IExtraData,
   IExtraColumnData
 } from './Table';
 export { default as TableHeader, HeaderProps } from './Header';
 export { default as TableBody, TableBodyProps } from './Body';
 export { default as ExpandableRowContent } from './ExpandableRowContent';
-export { sortable, headerCol, cellWidth, ISortable, IExtra, expandable, isRowExpanded } from './utils';
-export { SortByDirection } from './SortColumn'; 
+export { sortable, headerCol, cellWidth, ISortable, expandable, isRowExpanded } from './utils';
+export { SortByDirection } from './SortColumn';

--- a/packages/patternfly-4/react-table/src/components/Table/utils/index.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/index.d.ts
@@ -11,4 +11,3 @@ export const headerCol: () => { component: string };
 export const cellWidth: (width: string) => () => { className: string };
 export const expandable: (value: ReactNode, extra: IExtra) => ReactNode;
 export const isRowExpanded: (row: IRow, rows: Array<IRow>) => boolean | undefined;
-export { IExtra };

--- a/packages/patternfly-4/react-table/src/components/Table/utils/index.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/index.d.ts
@@ -3,7 +3,7 @@ import { IRow, IExtra } from '../Table';
 
 export interface ISortable {
   className: string;
-  children: ReactNode
+  children: ReactNode;
 }
 
 export const sortable: (label: string, extra: IExtra) => ISortable;
@@ -11,3 +11,4 @@ export const headerCol: () => { component: string };
 export const cellWidth: (width: string) => () => { className: string };
 export const expandable: (value: ReactNode, extra: IExtra) => ReactNode;
 export const isRowExpanded: (row: IRow, rows: Array<IRow>) => boolean | undefined;
+export { IExtra };


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
A few ts definitions out of sync today... probably easiest to remove the `extends HTMLProps<HTMLDivElement>` piece for now. There is nested element types returned so not really necessary on these.

```
ERROR in /Users/priley/GitHub/web-ui/frontend/node_modules/@patternfly/react-core/dist/js/components/ContextSelector/ContextSelector.d.ts(4,18):
TS2430: Interface 'ContextSelectorProps' incorrectly extends interface 'HTMLProps<HTMLDivElement>'.
  Types of property 'onSelect' are incompatible.
    Type '(event: SyntheticEvent<Element>, value: ReactNode) => void' is not assignable to type '(event: SyntheticEvent<HTMLDivElement>) => void'.
ERROR in /Users/priley/GitHub/web-ui/frontend/node_modules/@patternfly/react-core/dist/js/components/ContextSelector/ContextSelectorItem.d.ts(3,18):
TS2430: Interface 'ContextSelectorItemProps' incorrectly extends interface 'HTMLProps<HTMLButtonElement>'.
  Types of property 'onClick' are incompatible.
    Type 'Function' is not assignable to type '(event: MouseEvent<HTMLButtonElement>) => void'.
      Type 'Function' provides no match for the signature '(event: MouseEvent<HTMLButtonElement>): void'.
ERROR in /Users/priley/GitHub/web-ui/frontend/node_modules/@patternfly/react-table/dist/js/components/Table/index.d.ts(18,53):
TS2305: Module '"/Users/priley/GitHub/web-ui/frontend/node_modules/@patternfly/react-table/dist/js/components/Table/utils/index"' has no exported member 'IExtra'.
```

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
