### PR TITLE
fix(Table): reverts unnecessary fix

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Body.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Body.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Body } from 'reactabular-table';
 import PropTypes from 'prop-types';
 import { TableContext } from './Table';
+import { isRowExpanded } from './utils';
 
 const propTypes = {
   /** Additional classes for table body. */
@@ -32,50 +33,33 @@ class ContextBody extends React.Component {
     };
   };
 
-  parentsExpanded(parentId) {
-    const { rows } = this.props;
-    return rows[parentId].hasOwnProperty('parent')
-      ? this.parentsExpanded(rows[parentId].parent)
-      : rows[parentId].isOpen;
-  }
+  mapCells = (headerData, row, rowKey) => {
+    // column indexes start after generated optional columns
+    let additionalColsIndexShift = headerData[0].extraParams.firstUserColumnIndex;
 
-  mapCells = (row, rowKey) => {
-    const { headerData } = this.props;
-    let shiftKey = Boolean(headerData[0] && headerData[0].extraParams.onSelect);
-    shiftKey += Boolean(headerData[0] && headerData[0].extraParams.onCollapse);
     return {
       ...(row &&
         (row.cells || row).reduce(
-          (acc, curr, key) => {
-            const currShift = shiftKey;
-            if (curr) {
-              if (curr.props && curr.props.colSpan) {
-                shiftKey += shiftKey + curr.props && curr.props.colSpan - 1;
-              }
-              return {
-                ...acc,
-                ...{
-                  [headerData[currShift + key].property]: {
-                    title: curr.title || curr,
-                    props: {
-                      isVisible: true,
-                      ...curr.props
-                    }
-                  }
+          (acc, cell, cellIndex) => {
+            const isCellObject = cell === Object(cell);
+
+            const mappedCell = {
+              [headerData[cellIndex + additionalColsIndexShift].property]: {
+                title: isCellObject ? cell.title : cell,
+                props: {
+                  isVisible: true,
+                  ...(isCellObject ? cell.props : null)
                 }
-              };
+              }
+            };
+
+            // increment the shift index when a cell spans multiple columns
+            if (isCellObject && cell.props && cell.props.colSpan) {
+              additionalColsIndexShift += cell.props.colSpan - 1;
             }
-            console.warn(`Cell value at [ ${rowKey}, ${key} ] should not be set to ${curr}`);
             return {
               ...acc,
-              ...{
-                [headerData[currShift + key].property]: {
-                  title: curr,
-                  props: {
-                    isVisible: true
-                  }
-                }
-              }
+              ...mappedCell
             };
           },
           { id: row.id !== undefined ? row.id : rowKey }
@@ -86,16 +70,13 @@ class ContextBody extends React.Component {
   render() {
     const { className, headerData, rows, rowKey, children, onRowClick, ...props } = this.props;
     const mappedRows =
-      headerData.length !== 0 &&
+      headerData.length > 0 &&
       rows.map((oneRow, oneRowKey) => ({
         ...oneRow,
-        ...this.mapCells(oneRow, oneRowKey),
-        ...(oneRow.parent !== undefined
-          ? {
-              isExpanded: this.parentsExpanded(oneRow.parent) && rows[oneRow.parent].isOpen
-            }
-          : {})
+        ...this.mapCells(headerData, oneRow, oneRowKey),
+        isExpanded: isRowExpanded(oneRow, rows)
       }));
+
     return (
       <React.Fragment>
         {mappedRows && (

--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
@@ -1471,6 +1471,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1511,6 +1512,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1551,6 +1553,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1591,6 +1594,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1631,6 +1635,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1671,6 +1676,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1711,6 +1717,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1751,6 +1758,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1791,6 +1799,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1837,6 +1846,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1877,6 +1887,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1917,6 +1928,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1957,6 +1969,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -1997,6 +2010,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -2037,6 +2051,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -2077,6 +2092,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -2117,6 +2133,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -2157,6 +2174,7 @@ exports[`Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -2204,6 +2222,7 @@ exports[`Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -2244,6 +2263,7 @@ exports[`Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 1,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -2284,6 +2304,7 @@ exports[`Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 2,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -2324,6 +2345,7 @@ exports[`Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -2364,6 +2386,7 @@ exports[`Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 4,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -2404,6 +2427,7 @@ exports[`Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -2444,6 +2468,7 @@ exports[`Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -2484,6 +2509,7 @@ exports[`Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -2524,6 +2550,7 @@ exports[`Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -2824,6 +2851,7 @@ exports[`Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -3032,6 +3060,7 @@ exports[`Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 0,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -3479,6 +3508,7 @@ exports[`Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -3687,6 +3717,7 @@ exports[`Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 1,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -4134,6 +4165,7 @@ exports[`Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 2,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -4342,6 +4374,7 @@ exports[`Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 2,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -4789,6 +4822,7 @@ exports[`Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -4997,6 +5031,7 @@ exports[`Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 3,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -5444,6 +5479,7 @@ exports[`Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 4,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -5652,6 +5688,7 @@ exports[`Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 4,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -6099,6 +6136,7 @@ exports[`Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -6307,6 +6345,7 @@ exports[`Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 5,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -6754,6 +6793,7 @@ exports[`Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -6962,6 +7002,7 @@ exports[`Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 6,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -7409,6 +7450,7 @@ exports[`Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -7617,6 +7659,7 @@ exports[`Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 7,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -8064,6 +8107,7 @@ exports[`Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -8272,6 +8316,7 @@ exports[`Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 8,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -9518,6 +9563,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -9558,6 +9604,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -9598,6 +9645,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -9638,6 +9686,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -9678,6 +9727,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -9718,6 +9768,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -9758,6 +9809,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -9798,6 +9850,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -9838,6 +9891,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -9884,6 +9938,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -9924,6 +9979,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -9964,6 +10020,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -10004,6 +10061,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -10044,6 +10102,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -10084,6 +10143,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -10124,6 +10184,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -10164,6 +10225,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -10204,6 +10266,7 @@ exports[`Cell header table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -10251,6 +10314,7 @@ exports[`Cell header table 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -10291,6 +10355,7 @@ exports[`Cell header table 1`] = `
                       "title": "one",
                     },
                     "id": 1,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -10331,6 +10396,7 @@ exports[`Cell header table 1`] = `
                       "title": "one",
                     },
                     "id": 2,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -10371,6 +10437,7 @@ exports[`Cell header table 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -10411,6 +10478,7 @@ exports[`Cell header table 1`] = `
                       "title": "one",
                     },
                     "id": 4,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -10451,6 +10519,7 @@ exports[`Cell header table 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -10491,6 +10560,7 @@ exports[`Cell header table 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -10531,6 +10601,7 @@ exports[`Cell header table 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -10571,6 +10642,7 @@ exports[`Cell header table 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -10831,6 +10903,7 @@ exports[`Cell header table 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -11168,6 +11241,7 @@ exports[`Cell header table 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -11505,6 +11579,7 @@ exports[`Cell header table 1`] = `
                         "title": "one",
                       },
                       "id": 2,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -11842,6 +11917,7 @@ exports[`Cell header table 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -12179,6 +12255,7 @@ exports[`Cell header table 1`] = `
                         "title": "one",
                       },
                       "id": 4,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -12516,6 +12593,7 @@ exports[`Cell header table 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -12853,6 +12931,7 @@ exports[`Cell header table 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -13190,6 +13269,7 @@ exports[`Cell header table 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -13527,6 +13607,7 @@ exports[`Cell header table 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -15023,6 +15104,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -15149,6 +15231,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -15232,6 +15315,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -15272,6 +15356,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -15312,6 +15397,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -15352,6 +15438,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -15398,6 +15485,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -15524,6 +15612,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -15607,6 +15696,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -15647,6 +15737,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -15687,6 +15778,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -15727,6 +15819,7 @@ exports[`Collapsible nested table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -15774,6 +15867,7 @@ exports[`Collapsible nested table 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "isOpen": false,
                     "last-commit": Object {
                       "props": Object {
@@ -15900,6 +15994,7 @@ exports[`Collapsible nested table 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "isOpen": false,
                     "last-commit": Object {
                       "props": Object {
@@ -15983,6 +16078,7 @@ exports[`Collapsible nested table 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -16023,6 +16119,7 @@ exports[`Collapsible nested table 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -16063,6 +16160,7 @@ exports[`Collapsible nested table 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -16103,6 +16201,7 @@ exports[`Collapsible nested table 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -16412,6 +16511,7 @@ exports[`Collapsible nested table 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "isOpen": false,
                       "last-commit": Object {
                         "props": Object {
@@ -17728,6 +17828,7 @@ exports[`Collapsible nested table 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "isOpen": false,
                       "last-commit": Object {
                         "props": Object {
@@ -18591,6 +18692,7 @@ exports[`Collapsible nested table 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -19001,6 +19103,7 @@ exports[`Collapsible nested table 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -19411,6 +19514,7 @@ exports[`Collapsible nested table 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -19821,6 +19925,7 @@ exports[`Collapsible nested table 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -21311,6 +21416,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "isOpen": true,
                   "last-commit": Object {
                     "props": Object {
@@ -21394,6 +21500,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -21434,6 +21541,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -21517,6 +21625,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -21557,6 +21666,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -21597,6 +21707,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -21637,6 +21748,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -21683,6 +21795,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "isOpen": true,
                   "last-commit": Object {
                     "props": Object {
@@ -21766,6 +21879,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -21806,6 +21920,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -21889,6 +22004,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -21929,6 +22045,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -21969,6 +22086,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -22009,6 +22127,7 @@ exports[`Collapsible table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -22056,6 +22175,7 @@ exports[`Collapsible table 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "isOpen": true,
                     "last-commit": Object {
                       "props": Object {
@@ -22139,6 +22259,7 @@ exports[`Collapsible table 1`] = `
                       "title": "one",
                     },
                     "id": 2,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -22179,6 +22300,7 @@ exports[`Collapsible table 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "isOpen": false,
                     "last-commit": Object {
                       "props": Object {
@@ -22262,6 +22384,7 @@ exports[`Collapsible table 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -22302,6 +22425,7 @@ exports[`Collapsible table 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -22342,6 +22466,7 @@ exports[`Collapsible table 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -22382,6 +22507,7 @@ exports[`Collapsible table 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -22691,6 +22817,7 @@ exports[`Collapsible table 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "isOpen": true,
                       "last-commit": Object {
                         "props": Object {
@@ -23554,6 +23681,7 @@ exports[`Collapsible table 1`] = `
                         "title": "one",
                       },
                       "id": 2,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -23964,6 +24092,7 @@ exports[`Collapsible table 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "isOpen": false,
                       "last-commit": Object {
                         "props": Object {
@@ -24827,6 +24956,7 @@ exports[`Collapsible table 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -25237,6 +25367,7 @@ exports[`Collapsible table 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -25647,6 +25778,7 @@ exports[`Collapsible table 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -26057,6 +26189,7 @@ exports[`Collapsible table 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -27253,6 +27386,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -27379,6 +27513,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -27462,6 +27597,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -27502,6 +27638,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -27542,6 +27679,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -27582,6 +27720,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -27628,6 +27767,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -27754,6 +27894,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -27837,6 +27978,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -27877,6 +28019,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -27917,6 +28060,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -27957,6 +28101,7 @@ exports[`Header width table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -28004,6 +28149,7 @@ exports[`Header width table 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "isOpen": false,
                     "last-commit": Object {
                       "props": Object {
@@ -28130,6 +28276,7 @@ exports[`Header width table 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "isOpen": false,
                     "last-commit": Object {
                       "props": Object {
@@ -28213,6 +28360,7 @@ exports[`Header width table 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -28253,6 +28401,7 @@ exports[`Header width table 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -28293,6 +28442,7 @@ exports[`Header width table 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -28333,6 +28483,7 @@ exports[`Header width table 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -28597,6 +28748,7 @@ exports[`Header width table 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "isOpen": false,
                       "last-commit": Object {
                         "props": Object {
@@ -29645,6 +29797,7 @@ exports[`Header width table 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "isOpen": false,
                       "last-commit": Object {
                         "props": Object {
@@ -30342,6 +30495,7 @@ exports[`Header width table 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -30688,6 +30842,7 @@ exports[`Header width table 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -31034,6 +31189,7 @@ exports[`Header width table 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -31380,6 +31536,7 @@ exports[`Header width table 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -32817,6 +32974,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -32943,6 +33101,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -33026,6 +33185,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -33066,6 +33226,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -33106,6 +33267,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -33146,6 +33308,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -33192,6 +33355,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -33318,6 +33482,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "isOpen": false,
                   "last-commit": Object {
                     "props": Object {
@@ -33401,6 +33566,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -33441,6 +33607,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -33481,6 +33648,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -33521,6 +33689,7 @@ exports[`Selectable table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -33568,6 +33737,7 @@ exports[`Selectable table 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "isOpen": false,
                     "last-commit": Object {
                       "props": Object {
@@ -33694,6 +33864,7 @@ exports[`Selectable table 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "isOpen": false,
                     "last-commit": Object {
                       "props": Object {
@@ -33777,6 +33948,7 @@ exports[`Selectable table 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -33817,6 +33989,7 @@ exports[`Selectable table 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -33857,6 +34030,7 @@ exports[`Selectable table 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -33897,6 +34071,7 @@ exports[`Selectable table 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -34200,6 +34375,7 @@ exports[`Selectable table 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "isOpen": false,
                       "last-commit": Object {
                         "props": Object {
@@ -35422,6 +35598,7 @@ exports[`Selectable table 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "isOpen": false,
                       "last-commit": Object {
                         "props": Object {
@@ -36241,6 +36418,7 @@ exports[`Selectable table 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -36657,6 +36835,7 @@ exports[`Selectable table 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -37073,6 +37252,7 @@ exports[`Selectable table 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -37489,6 +37669,7 @@ exports[`Selectable table 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -39500,6 +39681,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -39540,6 +39722,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -39580,6 +39763,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -39620,6 +39804,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -39660,6 +39845,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -39700,6 +39886,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -39740,6 +39927,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -39780,6 +39968,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -39820,6 +40009,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -39861,6 +40051,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 9,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -39907,6 +40098,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -39947,6 +40139,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -39987,6 +40180,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -40027,6 +40221,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -40067,6 +40262,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -40107,6 +40303,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -40147,6 +40344,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -40187,6 +40385,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -40227,6 +40426,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -40268,6 +40468,7 @@ exports[`Simple Actions table 1`] = `
                     "title": "one",
                   },
                   "id": 9,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -40315,6 +40516,7 @@ exports[`Simple Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -40355,6 +40557,7 @@ exports[`Simple Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 1,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -40395,6 +40598,7 @@ exports[`Simple Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 2,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -40435,6 +40639,7 @@ exports[`Simple Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -40475,6 +40680,7 @@ exports[`Simple Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 4,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -40515,6 +40721,7 @@ exports[`Simple Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -40555,6 +40762,7 @@ exports[`Simple Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -40595,6 +40803,7 @@ exports[`Simple Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -40635,6 +40844,7 @@ exports[`Simple Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -40676,6 +40886,7 @@ exports[`Simple Actions table 1`] = `
                       "title": "one",
                     },
                     "id": 9,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -41084,6 +41295,7 @@ exports[`Simple Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -41310,6 +41522,7 @@ exports[`Simple Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 0,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -41865,6 +42078,7 @@ exports[`Simple Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -42091,6 +42305,7 @@ exports[`Simple Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 1,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -42646,6 +42861,7 @@ exports[`Simple Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 2,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -42872,6 +43088,7 @@ exports[`Simple Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 2,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -43427,6 +43644,7 @@ exports[`Simple Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -43653,6 +43871,7 @@ exports[`Simple Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 3,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -44208,6 +44427,7 @@ exports[`Simple Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 4,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -44434,6 +44654,7 @@ exports[`Simple Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 4,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -44989,6 +45210,7 @@ exports[`Simple Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -45215,6 +45437,7 @@ exports[`Simple Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 5,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -45770,6 +45993,7 @@ exports[`Simple Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -45996,6 +46220,7 @@ exports[`Simple Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 6,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -46551,6 +46776,7 @@ exports[`Simple Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -46777,6 +47003,7 @@ exports[`Simple Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 7,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -47332,6 +47559,7 @@ exports[`Simple Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -47558,6 +47786,7 @@ exports[`Simple Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 8,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -48114,6 +48343,7 @@ exports[`Simple Actions table 1`] = `
                         "title": "one",
                       },
                       "id": 9,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -48341,6 +48571,7 @@ exports[`Simple Actions table 1`] = `
                                   "title": "one",
                                 },
                                 "id": 9,
+                                "isExpanded": undefined,
                                 "last-commit": Object {
                                   "props": Object {
                                     "isVisible": true,
@@ -49489,6 +49720,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -49529,6 +49761,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -49569,6 +49802,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -49609,6 +49843,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -49649,6 +49884,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -49689,6 +49925,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -49729,6 +49966,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -49769,6 +50007,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -49809,6 +50048,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -49855,6 +50095,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -49895,6 +50136,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -49935,6 +50177,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -49975,6 +50218,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -50015,6 +50259,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -50055,6 +50300,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -50095,6 +50341,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -50135,6 +50382,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -50175,6 +50423,7 @@ exports[`Simple table aria-label 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -50222,6 +50471,7 @@ exports[`Simple table aria-label 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -50262,6 +50512,7 @@ exports[`Simple table aria-label 1`] = `
                       "title": "one",
                     },
                     "id": 1,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -50302,6 +50553,7 @@ exports[`Simple table aria-label 1`] = `
                       "title": "one",
                     },
                     "id": 2,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -50342,6 +50594,7 @@ exports[`Simple table aria-label 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -50382,6 +50635,7 @@ exports[`Simple table aria-label 1`] = `
                       "title": "one",
                     },
                     "id": 4,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -50422,6 +50676,7 @@ exports[`Simple table aria-label 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -50462,6 +50717,7 @@ exports[`Simple table aria-label 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -50502,6 +50758,7 @@ exports[`Simple table aria-label 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -50542,6 +50799,7 @@ exports[`Simple table aria-label 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -50800,6 +51058,7 @@ exports[`Simple table aria-label 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -51135,6 +51394,7 @@ exports[`Simple table aria-label 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -51470,6 +51730,7 @@ exports[`Simple table aria-label 1`] = `
                         "title": "one",
                       },
                       "id": 2,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -51805,6 +52066,7 @@ exports[`Simple table aria-label 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -52140,6 +52402,7 @@ exports[`Simple table aria-label 1`] = `
                         "title": "one",
                       },
                       "id": 4,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -52475,6 +52738,7 @@ exports[`Simple table aria-label 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -52810,6 +53074,7 @@ exports[`Simple table aria-label 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -53145,6 +53410,7 @@ exports[`Simple table aria-label 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -53480,6 +53746,7 @@ exports[`Simple table aria-label 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -54559,6 +54826,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -54599,6 +54867,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -54639,6 +54908,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -54679,6 +54949,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -54719,6 +54990,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -54759,6 +55031,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -54799,6 +55072,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -54839,6 +55113,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -54879,6 +55154,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -54925,6 +55201,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -54965,6 +55242,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -55005,6 +55283,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -55045,6 +55324,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -55085,6 +55365,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -55125,6 +55406,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -55165,6 +55447,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -55205,6 +55488,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -55245,6 +55529,7 @@ exports[`Simple table caption 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -55292,6 +55577,7 @@ exports[`Simple table caption 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -55332,6 +55618,7 @@ exports[`Simple table caption 1`] = `
                       "title": "one",
                     },
                     "id": 1,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -55372,6 +55659,7 @@ exports[`Simple table caption 1`] = `
                       "title": "one",
                     },
                     "id": 2,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -55412,6 +55700,7 @@ exports[`Simple table caption 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -55452,6 +55741,7 @@ exports[`Simple table caption 1`] = `
                       "title": "one",
                     },
                     "id": 4,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -55492,6 +55782,7 @@ exports[`Simple table caption 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -55532,6 +55823,7 @@ exports[`Simple table caption 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -55572,6 +55864,7 @@ exports[`Simple table caption 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -55612,6 +55905,7 @@ exports[`Simple table caption 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -55870,6 +56164,7 @@ exports[`Simple table caption 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -56205,6 +56500,7 @@ exports[`Simple table caption 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -56540,6 +56836,7 @@ exports[`Simple table caption 1`] = `
                         "title": "one",
                       },
                       "id": 2,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -56875,6 +57172,7 @@ exports[`Simple table caption 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -57210,6 +57508,7 @@ exports[`Simple table caption 1`] = `
                         "title": "one",
                       },
                       "id": 4,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -57545,6 +57844,7 @@ exports[`Simple table caption 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -57880,6 +58180,7 @@ exports[`Simple table caption 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -58215,6 +58516,7 @@ exports[`Simple table caption 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -58550,6 +58852,7 @@ exports[`Simple table caption 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -59633,6 +59936,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -59673,6 +59977,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -59713,6 +60018,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -59753,6 +60059,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -59793,6 +60100,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -59833,6 +60141,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -59873,6 +60182,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -59913,6 +60223,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -59953,6 +60264,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -59999,6 +60311,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -60039,6 +60352,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -60079,6 +60393,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -60119,6 +60434,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -60159,6 +60475,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -60199,6 +60516,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -60239,6 +60557,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -60279,6 +60598,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -60319,6 +60639,7 @@ exports[`Simple table header 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -60366,6 +60687,7 @@ exports[`Simple table header 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -60406,6 +60728,7 @@ exports[`Simple table header 1`] = `
                       "title": "one",
                     },
                     "id": 1,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -60446,6 +60769,7 @@ exports[`Simple table header 1`] = `
                       "title": "one",
                     },
                     "id": 2,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -60486,6 +60810,7 @@ exports[`Simple table header 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -60526,6 +60851,7 @@ exports[`Simple table header 1`] = `
                       "title": "one",
                     },
                     "id": 4,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -60566,6 +60892,7 @@ exports[`Simple table header 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -60606,6 +60933,7 @@ exports[`Simple table header 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -60646,6 +60974,7 @@ exports[`Simple table header 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -60686,6 +61015,7 @@ exports[`Simple table header 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -60944,6 +61274,7 @@ exports[`Simple table header 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -61279,6 +61610,7 @@ exports[`Simple table header 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -61614,6 +61946,7 @@ exports[`Simple table header 1`] = `
                         "title": "one",
                       },
                       "id": 2,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -61949,6 +62282,7 @@ exports[`Simple table header 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -62284,6 +62618,7 @@ exports[`Simple table header 1`] = `
                         "title": "one",
                       },
                       "id": 4,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -62619,6 +62954,7 @@ exports[`Simple table header 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -62954,6 +63290,7 @@ exports[`Simple table header 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -63289,6 +63626,7 @@ exports[`Simple table header 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -63624,6 +63962,7 @@ exports[`Simple table header 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -64796,6 +65135,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -64836,6 +65176,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -64876,6 +65217,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -64916,6 +65258,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -64956,6 +65299,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -64996,6 +65340,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65036,6 +65381,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65076,6 +65422,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65116,6 +65463,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65162,6 +65510,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65202,6 +65551,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65242,6 +65592,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65282,6 +65633,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65322,6 +65674,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65362,6 +65715,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65402,6 +65756,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65442,6 +65797,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65482,6 +65838,7 @@ exports[`Sortable table 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -65529,6 +65886,7 @@ exports[`Sortable table 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -65569,6 +65927,7 @@ exports[`Sortable table 1`] = `
                       "title": "one",
                     },
                     "id": 1,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -65609,6 +65968,7 @@ exports[`Sortable table 1`] = `
                       "title": "one",
                     },
                     "id": 2,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -65649,6 +66009,7 @@ exports[`Sortable table 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -65689,6 +66050,7 @@ exports[`Sortable table 1`] = `
                       "title": "one",
                     },
                     "id": 4,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -65729,6 +66091,7 @@ exports[`Sortable table 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -65769,6 +66132,7 @@ exports[`Sortable table 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -65809,6 +66173,7 @@ exports[`Sortable table 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -65849,6 +66214,7 @@ exports[`Sortable table 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -66108,6 +66474,7 @@ exports[`Sortable table 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -66444,6 +66811,7 @@ exports[`Sortable table 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -66780,6 +67148,7 @@ exports[`Sortable table 1`] = `
                         "title": "one",
                       },
                       "id": 2,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -67116,6 +67485,7 @@ exports[`Sortable table 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -67452,6 +67822,7 @@ exports[`Sortable table 1`] = `
                         "title": "one",
                       },
                       "id": 4,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -67788,6 +68159,7 @@ exports[`Sortable table 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -68124,6 +68496,7 @@ exports[`Sortable table 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -68460,6 +68833,7 @@ exports[`Sortable table 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -68796,6 +69170,7 @@ exports[`Sortable table 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -69966,6 +70341,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70006,6 +70382,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70046,6 +70423,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70086,6 +70464,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70126,6 +70505,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70166,6 +70546,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70206,6 +70587,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70246,6 +70628,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70286,6 +70669,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70332,6 +70716,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70372,6 +70757,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70412,6 +70798,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70452,6 +70839,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70492,6 +70880,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70532,6 +70921,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70572,6 +70962,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70612,6 +71003,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70652,6 +71044,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -70699,6 +71092,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -70739,6 +71133,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       "title": "one",
                     },
                     "id": 1,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -70779,6 +71174,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       "title": "one",
                     },
                     "id": 2,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -70819,6 +71215,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -70859,6 +71256,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       "title": "one",
                     },
                     "id": 4,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -70899,6 +71297,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -70939,6 +71338,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -70979,6 +71379,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -71019,6 +71420,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -71278,6 +71680,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -71614,6 +72017,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -71950,6 +72354,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "title": "one",
                       },
                       "id": 2,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -72286,6 +72691,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -72622,6 +73028,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "title": "one",
                       },
                       "id": 4,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -72958,6 +73365,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -73294,6 +73702,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -73630,6 +74039,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -73966,6 +74376,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -75136,6 +75547,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75176,6 +75588,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75216,6 +75629,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75256,6 +75670,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75296,6 +75711,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75336,6 +75752,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75376,6 +75793,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75416,6 +75834,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75456,6 +75875,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75502,6 +75922,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75542,6 +75963,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75582,6 +76004,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75622,6 +76045,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75662,6 +76086,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75702,6 +76127,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75742,6 +76168,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75782,6 +76209,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75822,6 +76250,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -75869,6 +76298,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -75909,6 +76339,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       "title": "one",
                     },
                     "id": 1,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -75949,6 +76380,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       "title": "one",
                     },
                     "id": 2,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -75989,6 +76421,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -76029,6 +76462,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       "title": "one",
                     },
                     "id": 4,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -76069,6 +76503,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -76109,6 +76544,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -76149,6 +76585,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -76189,6 +76626,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -76448,6 +76886,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -76784,6 +77223,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -77120,6 +77560,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "title": "one",
                       },
                       "id": 2,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -77456,6 +77897,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -77792,6 +78234,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "title": "one",
                       },
                       "id": 4,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -78128,6 +78571,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -78464,6 +78908,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -78800,6 +79245,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -79136,6 +79582,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -80306,6 +80753,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80346,6 +80794,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80386,6 +80835,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80426,6 +80876,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80466,6 +80917,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80506,6 +80958,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80546,6 +80999,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80586,6 +81040,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80626,6 +81081,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80672,6 +81128,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80712,6 +81169,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80752,6 +81210,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80792,6 +81251,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80832,6 +81292,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80872,6 +81333,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80912,6 +81374,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80952,6 +81415,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -80992,6 +81456,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -81039,6 +81504,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -81079,6 +81545,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       "title": "one",
                     },
                     "id": 1,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -81119,6 +81586,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       "title": "one",
                     },
                     "id": 2,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -81159,6 +81627,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -81199,6 +81668,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       "title": "one",
                     },
                     "id": 4,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -81239,6 +81709,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -81279,6 +81750,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -81319,6 +81791,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -81359,6 +81832,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -81618,6 +82092,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -81954,6 +82429,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -82290,6 +82766,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "title": "one",
                       },
                       "id": 2,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -82626,6 +83103,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -82962,6 +83440,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "title": "one",
                       },
                       "id": 4,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -83298,6 +83777,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -83634,6 +84114,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -83970,6 +84451,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -84306,6 +84788,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -85476,6 +85959,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -85516,6 +86000,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -85556,6 +86041,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -85596,6 +86082,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -85636,6 +86123,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -85676,6 +86164,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -85716,6 +86205,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -85756,6 +86246,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -85796,6 +86287,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -85842,6 +86334,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 0,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -85882,6 +86375,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 1,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -85922,6 +86416,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 2,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -85962,6 +86457,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 3,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -86002,6 +86498,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 4,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -86042,6 +86539,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 5,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -86082,6 +86580,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 6,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -86122,6 +86621,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 7,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -86162,6 +86662,7 @@ exports[`Table variants Size - compact 1`] = `
                     "title": "one",
                   },
                   "id": 8,
+                  "isExpanded": undefined,
                   "last-commit": Object {
                     "props": Object {
                       "isVisible": true,
@@ -86209,6 +86710,7 @@ exports[`Table variants Size - compact 1`] = `
                       "title": "one",
                     },
                     "id": 0,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -86249,6 +86751,7 @@ exports[`Table variants Size - compact 1`] = `
                       "title": "one",
                     },
                     "id": 1,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -86289,6 +86792,7 @@ exports[`Table variants Size - compact 1`] = `
                       "title": "one",
                     },
                     "id": 2,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -86329,6 +86833,7 @@ exports[`Table variants Size - compact 1`] = `
                       "title": "one",
                     },
                     "id": 3,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -86369,6 +86874,7 @@ exports[`Table variants Size - compact 1`] = `
                       "title": "one",
                     },
                     "id": 4,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -86409,6 +86915,7 @@ exports[`Table variants Size - compact 1`] = `
                       "title": "one",
                     },
                     "id": 5,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -86449,6 +86956,7 @@ exports[`Table variants Size - compact 1`] = `
                       "title": "one",
                     },
                     "id": 6,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -86489,6 +86997,7 @@ exports[`Table variants Size - compact 1`] = `
                       "title": "one",
                     },
                     "id": 7,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -86529,6 +87038,7 @@ exports[`Table variants Size - compact 1`] = `
                       "title": "one",
                     },
                     "id": 8,
+                    "isExpanded": undefined,
                     "last-commit": Object {
                       "props": Object {
                         "isVisible": true,
@@ -86788,6 +87298,7 @@ exports[`Table variants Size - compact 1`] = `
                         "title": "one",
                       },
                       "id": 0,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -87124,6 +87635,7 @@ exports[`Table variants Size - compact 1`] = `
                         "title": "one",
                       },
                       "id": 1,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -87460,6 +87972,7 @@ exports[`Table variants Size - compact 1`] = `
                         "title": "one",
                       },
                       "id": 2,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -87796,6 +88309,7 @@ exports[`Table variants Size - compact 1`] = `
                         "title": "one",
                       },
                       "id": 3,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -88132,6 +88646,7 @@ exports[`Table variants Size - compact 1`] = `
                         "title": "one",
                       },
                       "id": 4,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -88468,6 +88983,7 @@ exports[`Table variants Size - compact 1`] = `
                         "title": "one",
                       },
                       "id": 5,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -88804,6 +89320,7 @@ exports[`Table variants Size - compact 1`] = `
                         "title": "one",
                       },
                       "id": 6,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -89140,6 +89657,7 @@ exports[`Table variants Size - compact 1`] = `
                         "title": "one",
                       },
                       "id": 7,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,
@@ -89476,6 +89994,7 @@ exports[`Table variants Size - compact 1`] = `
                         "title": "one",
                       },
                       "id": 8,
+                      "isExpanded": undefined,
                       "last-commit": Object {
                         "props": Object {
                           "isVisible": true,


### PR DESCRIPTION
https://github.com/patternfly/patternfly-react/pull/1520 already fixed https://github.com/patternfly/patternfly-react/issues/1371 with some other enhacements.

https://github.com/patternfly/patternfly-react/pull/1621 reverted these enhacements, so this PR reverts that PR

It also added 
```
`console.warn(`Cell value at [ ${rowKey}, ${key} ] should not be set to ${curr}`);` 
```

which I do not think is necessary, because there are multiple use cases when the row is represented as structured data and we render that data according to that and do not render cells. In this use case, I think it is not necessary to show warnings (especially one per each cell).