### PR TITLE
Fixed PF4 link in README

### DIFF
--- a/packages/patternfly-4/react-core/README.md
+++ b/packages/patternfly-4/react-core/README.md
@@ -103,5 +103,5 @@ Testing is done at the root of this repo. To only run the patternfly-react tests
 yarn test packages/patternfly-4/react-core
 ```
 
-[patternfly-4]: https://github.com/patternfly/-next
+[patternfly-4]: https://github.com/patternfly/patternfly-next
 [docs]: https://patternfly-react.surge.sh/patternfly-4


### PR DESCRIPTION
**What**: The link to the PF4 page in the README.md file is broken. This PR fixes the link.

**Additional issues**: None
