### PR TITLE
Improved function typings for PF4 <Pagination> component

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Pagination/Pagination.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Pagination/Pagination.d.ts
@@ -39,13 +39,13 @@ export interface PaginationProps extends HTMLProps<HTMLDivElement> {
   widgetId?: string;
   dropDirection?: OneOf<typeof DropdownDirection, keyof typeof DropdownDirection>;
   titles?: PaginationTitles;
-  onSetPage?: Function;
-  onFirstClick?: Function;
-  onPreviousClick?: Function;
-  onNextClick?: Function;
-  onLastClick?: Function;
-  onPageInput?: Function;
-  onPerPageSelect?: Function;
+  onSetPage?(event: React.SyntheticEvent<HTMLButtonElement>, page: number): void;
+  onFirstClick?(event: React.SyntheticEvent<HTMLButtonElement>, page: number): void;
+  onPreviousClick?(event: React.SyntheticEvent<HTMLButtonElement>, page: number): void;
+  onNextClick?(event: React.SyntheticEvent<HTMLButtonElement>, page: number): void;
+  onLastClick?(event: React.SyntheticEvent<HTMLButtonElement>, page: number): void;
+  onPageInput?(event: React.SyntheticEvent<HTMLButtonElement>, page: number): void;
+  onPerPageSelect?(event: React.SyntheticEvent<HTMLDivElement>, perPage: number): void;
 }
 
 declare const Pagination: FunctionComponent<PaginationProps>;


### PR DESCRIPTION
**What**: The TypeScript type definition for the `<Pagination>` currently define all the callbacks as simple `Function` types, giving users no clue about the actual arguments. This pull request provides more fine-grained types for these callbacks.

**Additional issues**: I'm not 100% sure about the type of the events provided to the callbacks. I just checked the components used by the `<Pagination>` component to get these types. However, this could be considered to be an implementation detail!?!

Fixes #1633