### PR TITLE
fix(dropdown-toggle): toggle props, allow null iconComponent

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggle.d.ts
@@ -11,7 +11,7 @@ export interface DropdownToggleProps extends HTMLProps<HTMLButtonElement> {
   isActive?: boolean;
   isPlain?: boolean;
   isDisabled?: boolean;
-  iconComponent?: ReactType;
+  iconComponent?: ReactType | null;
 }
 
 declare const DropdownToggle: FunctionComponent<DropdownToggleProps>;


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Slight tweak to  `DropdownToggleProps` found while testing Kiali today. We currently allow passing `null` to the `iconComponent` to remove the caret icon from the dropdown. If `strictNullChecks` is set true, this will give a TypeScript error to the user. Making the slight adjustment here to the definition to allow `null`.

<img width="772" alt="Screen Shot 2019-03-25 at 10 17 16 AM" src="https://user-images.githubusercontent.com/4237045/54927302-4942bb00-4ee8-11e9-9d3e-2e7448ab2a7f.png">

cc: @aljesusg 

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
