### PR TITLE
fix(tooltip): trigger tooltip by mouse click or other events

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.d.ts
@@ -12,6 +12,8 @@ export const TooltipPosition: {
 export interface TooltipProps extends Omit<HTMLProps<HTMLDivElement>, 'content' | 'children'> {
   /** Tooltip position */
   position?: BasicPlacement;
+  /** Tooltip trigger */
+  trigger?: string;
   /** If true, tries to keep the tooltip in view by flipping it if necessary */
   enableFlip?: boolean;
   /** Tooltip additional class */

--- a/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.js
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.js
@@ -21,6 +21,8 @@ export const TooltipPosition = {
 const propTypes = {
   /** Tooltip position */
   position: PropTypes.oneOf(Object.keys(TooltipPosition).map(key => TooltipPosition[key])),
+  /** Tooltip trigger: click, mouseenter, focus */
+  trigger: PropTypes.string,
   /** If true, tries to keep the tooltip in view by flipping it if necessary */
   enableFlip: PropTypes.bool,
   /** Tooltip additional class */
@@ -43,6 +45,7 @@ const propTypes = {
 
 const defaultProps = {
   position: 'top',
+  trigger: 'mouseenter focus',
   enableFlip: true,
   className: null,
   entryDelay: 500,
@@ -80,6 +83,7 @@ class Tooltip extends React.Component {
   render() {
     const {
       position,
+      trigger,
       enableFlip,
       children,
       className,
@@ -114,6 +118,7 @@ class Tooltip extends React.Component {
         theme="pf-tippy"
         performance
         placement={position}
+        trigger={trigger}
         delay={[entryDelay, exitDelay]}
         distance={15}
         flip={enableFlip}

--- a/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.test.js
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Tooltip } from './index';
+import Tippy from '@tippy.js/react';
 
 test('tooltip renders', () => {
   const view = shallow(
@@ -16,4 +17,17 @@ test('tooltip renders', () => {
     </Tooltip>
   );
   expect(view).toMatchSnapshot();
+});
+
+test('tooltip triggered by click', () => {
+  const view = shallow(
+    <Tooltip
+      position="top"
+      trigger="click"
+      content={<p>my content</p>}
+    >
+      <div>Toggle tooltip</div>
+    </Tooltip>
+  );
+  expect(view.find(Tippy).prop('trigger')).toBe('click');
 });

--- a/packages/patternfly-4/react-core/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/__snapshots__/Tooltip.test.js.snap
@@ -47,6 +47,7 @@ exports[`tooltip renders 1`] = `
     }
   }
   theme="pf-tippy"
+  trigger="mouseenter focus"
   zIndex={9999}
 >
   <div>


### PR DESCRIPTION
**What**:

closes #1564 

Adding the `trigger` props to display tooltip on mouse click.

//cc @keithjgrant