### PR TITLE
fix(Table): fix type-o in ICell Interface transform (from transfrom)

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
@@ -60,7 +60,7 @@ export interface ISeparator {
 
 export interface ICell {
   title: String;
-  transfroms: Array<Function>;
+  transforms: Array<Function>;
   cellTransforms: Array<Function>;
   formatters: Array<Function>;
   cellFormatters: Array<Function>;


### PR DESCRIPTION
Add a fix found by a user to change the type-o of property transfrom to transform

Will only break for typescript users using the type definition files.

fix #1662

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
