### PR TITLE
fix(Nav): change onSelect and onToggle arg types from positional to single obj

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Nav/Nav.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Nav/Nav.d.ts
@@ -4,8 +4,8 @@ import { Omit } from '../../helpers/typeUtils';
 export interface NavProps extends Omit<HTMLProps<HTMLDivElement>, 'onSelect'> {
   children?: ReactNode;
   className?: string;
-  onSelect?(groupId: number, itemId: number, event: FormEvent<HTMLInputElement>): void;
-  onToggle?(groupId: number, expanded: boolean, event: FormEvent<HTMLInputElement>): void;
+  onSelect?(selectedItem: {groupId: number; itemId:number; event: FormEvent<HTMLInputElement>}): void;
+  onToggle?(toggledItem: {groupId: number; expanded: boolean; event: FormEvent<HTMLInputElement>}): void;
   'aria-label'?: string;
 }
 


### PR DESCRIPTION

the onSelect and onToggle functions take a single js object of params rather than the same prams as
positional params to the both functions

fix #1391

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
