### PR TITLE
fix(Tabs): Use TabsVariant.nav and fix a minor HTML issue

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Tabs/Tabs.js
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tabs.js
@@ -58,7 +58,7 @@ const Tabs = ({ 'aria-label': ariaLabel, id, variant, ...props }) => {
     : <TabsWithDiv id={unique_id} {...props} />;
 }
 
-const TabsWithNav = ({ activeKey, ariaLabel, className, id, isFilled, isSecondary, showLeftScrollButton, showRightScrollButton, highlightLeftScrollButton, highlightRightScrollButton, ...props }) => (
+const TabsWithNav = ({ activeKey, ariaLabel, className, id, isFilled, isSecondary, leftScrollAriaLabel, rightScrollAriaLabel, showLeftScrollButton, showRightScrollButton, highlightLeftScrollButton, highlightRightScrollButton, ...props }) => (
   <nav {...props}
     aria-label={ariaLabel}
     className={css(
@@ -71,12 +71,12 @@ const TabsWithNav = ({ activeKey, ariaLabel, className, id, isFilled, isSecondar
       highlightRightScrollButton && styles.modifiers.endCurrent,
       className)}
   >
-    <InternalTabs id={id} activeKey={activeKey} {...props} />
+    <InternalTabs id={id} activeKey={activeKey} leftScrollAriaLabel={leftScrollAriaLabel} rightScrollAriaLabel={rightScrollAriaLabel} {...props} />
     <InternalTabContainer id={id} activeKey={activeKey} {...props} />
   </nav>
 );
 
-const TabsWithDiv = ({ activeKey, className, id, isFilled, isSecondary, showLeftScrollButton, showRightScrollButton, highlightLeftScrollButton, highlightRightScrollButton, ...props }) => (
+const TabsWithDiv = ({ activeKey, className, id, isFilled, isSecondary, leftScrollAriaLabel, rightScrollAriaLabel, showLeftScrollButton, showRightScrollButton, highlightLeftScrollButton, highlightRightScrollButton, ...props }) => (
   <div {...props}
     className={css(
       styles.tabs,
@@ -88,7 +88,7 @@ const TabsWithDiv = ({ activeKey, className, id, isFilled, isSecondary, showLeft
       highlightRightScrollButton && styles.modifiers.endCurrent,
       className)}
   >
-    <InternalTabs id={id} activeKey={activeKey} {...props} />
+    <InternalTabs id={id} activeKey={activeKey} leftScrollAriaLabel={leftScrollAriaLabel} rightScrollAriaLabel={rightScrollAriaLabel} {...props} />
     <InternalTabContainer id={id} activeKey={activeKey} {...props} />
   </div>
 );

--- a/packages/patternfly-4/react-core/src/components/Tabs/__snapshots__/Tabs.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Tabs/__snapshots__/Tabs.test.js.snap
@@ -166,9 +166,7 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
   >
     <div
       className="pf-c-tabs pf-m-fill"
-      leftScrollAriaLabel="Scroll left"
       onSelect={[Function]}
-      rightScrollAriaLabel="Scroll Right"
     >
       <InternalTabs
         activeKey={0}
@@ -387,9 +385,7 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
       <InternalTabContainer
         activeKey={0}
         id="handleScrollButtons"
-        leftScrollAriaLabel="Scroll left"
         onSelect={[Function]}
-        rightScrollAriaLabel="Scroll Right"
       >
         <ForwardRef
           activeKey={0}
@@ -692,9 +688,7 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
   >
     <div
       className="pf-c-tabs pf-m-fill"
-      leftScrollAriaLabel="Scroll left"
       onSelect={[Function]}
-      rightScrollAriaLabel="Scroll Right"
     >
       <InternalTabs
         activeKey={0}
@@ -913,9 +907,7 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
       <InternalTabContainer
         activeKey={0}
         id="scrollLeft"
-        leftScrollAriaLabel="Scroll left"
         onSelect={[Function]}
-        rightScrollAriaLabel="Scroll Right"
       >
         <ForwardRef
           activeKey={0}
@@ -1218,9 +1210,7 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
   >
     <div
       className="pf-c-tabs pf-m-fill"
-      leftScrollAriaLabel="Scroll left"
       onSelect={[Function]}
-      rightScrollAriaLabel="Scroll Right"
     >
       <InternalTabs
         activeKey={0}
@@ -1439,9 +1429,7 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
       <InternalTabContainer
         activeKey={0}
         id="scrollRight"
-        leftScrollAriaLabel="Scroll left"
         onSelect={[Function]}
-        rightScrollAriaLabel="Scroll Right"
       >
         <ForwardRef
           activeKey={0}

--- a/packages/patternfly-4/react-core/src/components/Tabs/examples/AccessibleSecondaryTabs.js
+++ b/packages/patternfly-4/react-core/src/components/Tabs/examples/AccessibleSecondaryTabs.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tabs, Tab } from '@patternfly/react-core';
+import { Tabs, TabsVariant, Tab } from '@patternfly/react-core';
 
 class AccessibleSecondaryTabs extends React.Component {
   state = {
@@ -23,9 +23,9 @@ class AccessibleSecondaryTabs extends React.Component {
 
   render() {
     return (
-      <Tabs activeKey={this.state.activeTabKey1} onSelect={this.handleTabClickFirst} aria-label="Local" variant="nav">
+      <Tabs activeKey={this.state.activeTabKey1} onSelect={this.handleTabClickFirst} aria-label="Local" variant={TabsVariant.nav}>
         <Tab eventKey={0} title="Tab item 1">
-          <Tabs activeKey={this.state.activeTabKey2} isSecondary onSelect={this.handleTabClickSecond} aria-label="Local secondary" variant="nav">
+          <Tabs activeKey={this.state.activeTabKey2} isSecondary onSelect={this.handleTabClickSecond} aria-label="Local secondary" variant={TabsVariant.nav}>
             <Tab eventKey={10} title="Secondary tab item 1">
               Secondary tab item 1 item section
             </Tab>

--- a/packages/patternfly-4/react-core/src/components/Tabs/examples/AccessibleTabs.js
+++ b/packages/patternfly-4/react-core/src/components/Tabs/examples/AccessibleTabs.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tabs, Tab } from '@patternfly/react-core';
+import { Tabs, TabsVariant, Tab } from '@patternfly/react-core';
 
 class AccessibleTabs extends React.Component {
   state = {
@@ -15,7 +15,7 @@ class AccessibleTabs extends React.Component {
 
   render() {
     return (
-      <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick} aria-label="Local" variant="nav">
+      <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick} aria-label="Local" variant={TabsVariant.nav}>
         <Tab eventKey={0} title="Tab item 1">
           Tab 1 section
         </Tab>

--- a/packages/patternfly-4/react-core/src/components/Tabs/index.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Tabs/index.d.ts
@@ -1,3 +1,3 @@
 export { default as Tab, TabProps } from './Tab';
-export { default as Tabs, TabsProps } from './Tabs';
+export { default as Tabs, TabsProps, TabsVariant } from './Tabs';
 export { default as TabContent, TabContentProps } from './TabContent';

--- a/packages/patternfly-4/react-core/src/components/Tabs/index.js
+++ b/packages/patternfly-4/react-core/src/components/Tabs/index.js
@@ -1,3 +1,3 @@
 export { default as Tab } from './Tab';
-export { default as Tabs } from './Tabs';
+export { default as Tabs, TabsVariant } from './Tabs';
 export { default as TabContent } from './TabContent';


### PR DESCRIPTION
Instead of using variant="nav," we now use variant={TabsVariant.nav} in the accessible Tabs examples. I also fixed an HTML issue where the `<nav>` and `<div>` containers were displaying the scroll button aria-label props in the HTML for the nav/div. We're now explicitly passing those props to the child that needs it so it won't show up there.

Fixes #1689.