### PR TITLE
fix(pagination): remove size attr from type="number" input

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Pagination/Navigation.js
+++ b/packages/patternfly-4/react-core/src/components/Pagination/Navigation.js
@@ -91,7 +91,6 @@ const Navigation = ({
           type="number"
           min="1"
           max={lastPage}
-          size="2"
           value={page}
           onChange={(event) => {
             let inputPage = Number.parseInt(event.target.value);

--- a/packages/patternfly-4/react-core/src/components/Pagination/__snapshots__/Pagination.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Pagination/__snapshots__/Pagination.test.js.snap
@@ -522,7 +522,6 @@ exports[`component render custom pagination toggle 1`] = `
             max={4}
             min="1"
             onChange={[Function]}
-            size="2"
             type="number"
             value={1}
           />
@@ -1101,7 +1100,6 @@ exports[`component render custom perPageOptions 1`] = `
             max={4}
             min="1"
             onChange={[Function]}
-            size="2"
             type="number"
             value={1}
           />
@@ -1763,7 +1761,6 @@ exports[`component render custom start end 1`] = `
             max={4}
             min="1"
             onChange={[Function]}
-            size="2"
             type="number"
             value={1}
           />
@@ -2423,7 +2420,6 @@ exports[`component render last page 1`] = `
             max={2}
             min="1"
             onChange={[Function]}
-            size="2"
             type="number"
             value={2}
           />
@@ -3087,7 +3083,6 @@ exports[`component render limited number of pages 1`] = `
             max={1}
             min="1"
             onChange={[Function]}
-            size="2"
             type="number"
             value={1}
           />
@@ -3747,7 +3742,6 @@ exports[`component render no items 1`] = `
             max={0}
             min="1"
             onChange={[Function]}
-            size="2"
             type="number"
             value={1}
           />
@@ -4399,7 +4393,6 @@ exports[`component render should render correctly bottom 1`] = `
             max={2}
             min="1"
             onChange={[Function]}
-            size="2"
             type="number"
             value={1}
           />
@@ -5059,7 +5052,6 @@ exports[`component render should render correctly top 1`] = `
             max={2}
             min="1"
             onChange={[Function]}
-            size="2"
             type="number"
             value={1}
           />
@@ -5710,7 +5702,6 @@ exports[`component render titles 1`] = `
             max={4}
             min="1"
             onChange={[Function]}
-            size="2"
             type="number"
             value={1}
           />
@@ -6370,7 +6361,6 @@ exports[`component render up drop direction 1`] = `
             max={4}
             min="1"
             onChange={[Function]}
-            size="2"
             type="number"
             value={1}
           />


### PR DESCRIPTION
**What**:
closes #1676
 
`type="number` inputs don't have the `size` attribute. 
Nevertheless, using `width: auto` (which is the default) the browser determines the right size of the input.