### PR TITLE
fix(Table): Add ability to center-align header and cell text

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/BodyCell.js
+++ b/packages/patternfly-4/react-table/src/components/Table/BodyCell.js
@@ -1,24 +1,45 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/patternfly/components/Table/table.css';
 
-const BodyCell = ({ 'data-label': dataLabel, parentId, isVisible, component: Component, colSpan, ...props }) => {
+const BodyCell = ({
+  'data-label': dataLabel,
+  className,
+  colSpan,
+  component: Component,
+  isVisible,
+  parentId,
+  textCenter,
+  ...props
+}) => {
   const mappedProps = {
     ...(dataLabel ? { 'data-label': dataLabel } : {}),
     ...props
   };
   return (parentId !== undefined && colSpan === undefined) || !isVisible ? null : (
-    <Component {...mappedProps} colSpan={colSpan} />
+    <Component {...mappedProps} className={css(className, textCenter && styles.modifiers.center)} colSpan={colSpan} />
   );
 };
 
 BodyCell.propTypes = {
   'data-label': PropTypes.string,
-  component: PropTypes.node
+  className: PropTypes.string,
+  colSpan: PropTypes.number,
+  component: PropTypes.node,
+  isVisible: PropTypes.bool,
+  parentId: PropTypes.number,
+  textCenter: PropTypes.bool
 };
 
 BodyCell.defaultProps = {
+  'data-label': '',
+  className: undefined,
+  colSpan: undefined,
   component: 'td',
-  'data-label': ''
+  isVisible: undefined,
+  parentId: undefined,
+  textCenter: false
 };
 
 export default BodyCell;

--- a/packages/patternfly-4/react-table/src/components/Table/HeaderCell.js
+++ b/packages/patternfly-4/react-table/src/components/Table/HeaderCell.js
@@ -1,24 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/patternfly/components/Table/table.css';
 
-const HeaderCell = ({ 'data-label': dataLabel, isVisible, scope, component: Component, ...props }) => {
+const HeaderCell = ({
+  'data-label': dataLabel,
+  className,
+  component: Component,
+  isVisible,
+  scope,
+  textCenter,
+  ...props
+}) => {
   const mappedProps = {
     ...(scope ? { scope } : {}),
     ...props
   };
-  return <Component {...mappedProps} />;
+  return <Component {...mappedProps} className={css(className, textCenter && styles.modifiers.center)} />;
 };
 
 HeaderCell.propTypes = {
   'data-label': PropTypes.string,
+  className: PropTypes.string,
+  component: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.number]),
+  isVisible: PropTypes.bool,
   scope: PropTypes.string,
-  component: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.number])
+  textCenter: PropTypes.bool
 };
 
 HeaderCell.defaultProps = {
-  scope: '',
+  'data-label': '',
+  className: undefined,
   component: 'th',
-  'data-label': ''
+  isVisible: undefined,
+  scope: '',
+  textCenter: false
 };
 
 export default HeaderCell;

--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -14,7 +14,8 @@ import {
   headerCol,
   TableVariant,
   expandable,
-  cellWidth
+  cellWidth,
+  textCenter,
 } from '@patternfly/react-table';
 
 ## Simple Table
@@ -30,14 +31,25 @@ import {
   headerCol,
   TableVariant,
   expandable,
-  cellWidth
+  cellWidth,
+  textCenter,
 } from '@patternfly/react-table';
 
 class SimpleTable extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      columns: [{ title: 'Repositories' }, 'Branches', { title: 'Pull requests' }, 'Workspaces', 'Last Commit'],
+      columns: [
+        { title: 'Repositories' },
+        'Branches',
+        { title: 'Pull requests' },
+        'Workspaces',
+        {
+          title: 'Last Commit',
+          transforms: [textCenter],
+          cellTransforms: [textCenter]
+        }
+      ],
       rows: [
         ['one', 'two', 'three', 'four', 'five'],
         [
@@ -47,6 +59,16 @@ class SimpleTable extends React.Component {
           },
           'four - 2',
           'five - 2'
+        ],
+        [
+          'one - 3',
+          'two - 3',
+          'three - 3',
+          'four - 3',
+          {
+            title: 'five - 3 (not centered)',
+            props: { textCenter: false }
+          }
         ]
       ]
     };

--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
@@ -668,6 +668,7 @@ exports[`Actions table 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       aria-sort="none"
@@ -725,8 +726,10 @@ exports[`Actions table 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -739,8 +742,10 @@ exports[`Actions table 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -753,8 +758,10 @@ exports[`Actions table 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -767,8 +774,10 @@ exports[`Actions table 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -781,8 +790,10 @@ exports[`Actions table 1`] = `
                     data-label=""
                     key="5-header"
                     scope=""
+                    textCenter={false}
                   >
                     <td
+                      className=""
                       data-key={5}
                     />
                   </HeaderCell>
@@ -2749,8 +2760,10 @@ exports[`Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -2763,8 +2776,10 @@ exports[`Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -2777,8 +2792,10 @@ exports[`Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -2791,8 +2808,10 @@ exports[`Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -2805,8 +2824,10 @@ exports[`Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -2820,6 +2841,7 @@ exports[`Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -3475,8 +3497,10 @@ exports[`Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -3489,8 +3513,10 @@ exports[`Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -3503,8 +3529,10 @@ exports[`Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -3517,8 +3545,10 @@ exports[`Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -3531,8 +3561,10 @@ exports[`Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -3546,6 +3578,7 @@ exports[`Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -4201,8 +4234,10 @@ exports[`Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -4215,8 +4250,10 @@ exports[`Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -4229,8 +4266,10 @@ exports[`Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -4243,8 +4282,10 @@ exports[`Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -4257,8 +4298,10 @@ exports[`Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -4272,6 +4315,7 @@ exports[`Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -4927,8 +4971,10 @@ exports[`Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -4941,8 +4987,10 @@ exports[`Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -4955,8 +5003,10 @@ exports[`Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -4969,8 +5019,10 @@ exports[`Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -4983,8 +5035,10 @@ exports[`Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -4998,6 +5052,7 @@ exports[`Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -5653,8 +5708,10 @@ exports[`Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -5667,8 +5724,10 @@ exports[`Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -5681,8 +5740,10 @@ exports[`Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -5695,8 +5756,10 @@ exports[`Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -5709,8 +5772,10 @@ exports[`Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -5724,6 +5789,7 @@ exports[`Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -6379,8 +6445,10 @@ exports[`Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -6393,8 +6461,10 @@ exports[`Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -6407,8 +6477,10 @@ exports[`Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -6421,8 +6493,10 @@ exports[`Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -6435,8 +6509,10 @@ exports[`Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -6450,6 +6526,7 @@ exports[`Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -7105,8 +7182,10 @@ exports[`Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -7119,8 +7198,10 @@ exports[`Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -7133,8 +7214,10 @@ exports[`Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -7147,8 +7230,10 @@ exports[`Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -7161,8 +7246,10 @@ exports[`Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -7176,6 +7263,7 @@ exports[`Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -7831,8 +7919,10 @@ exports[`Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -7845,8 +7935,10 @@ exports[`Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -7859,8 +7951,10 @@ exports[`Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -7873,8 +7967,10 @@ exports[`Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -7887,8 +7983,10 @@ exports[`Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -7902,6 +8000,7 @@ exports[`Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -8557,8 +8656,10 @@ exports[`Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -8571,8 +8672,10 @@ exports[`Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -8585,8 +8688,10 @@ exports[`Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -8599,8 +8704,10 @@ exports[`Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -8613,8 +8720,10 @@ exports[`Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -8628,6 +8737,7 @@ exports[`Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -9505,6 +9615,7 @@ exports[`Cell header table 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       aria-sort="none"
@@ -9562,8 +9673,10 @@ exports[`Cell header table 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -9576,8 +9689,10 @@ exports[`Cell header table 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -9590,8 +9705,10 @@ exports[`Cell header table 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -9604,8 +9721,10 @@ exports[`Cell header table 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -11493,8 +11612,10 @@ exports[`Cell header table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -11507,8 +11628,10 @@ exports[`Cell header table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -11521,8 +11644,10 @@ exports[`Cell header table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -11535,8 +11660,10 @@ exports[`Cell header table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -11549,8 +11676,10 @@ exports[`Cell header table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -11894,8 +12023,10 @@ exports[`Cell header table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -11908,8 +12039,10 @@ exports[`Cell header table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -11922,8 +12055,10 @@ exports[`Cell header table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -11936,8 +12071,10 @@ exports[`Cell header table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -11950,8 +12087,10 @@ exports[`Cell header table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -12295,8 +12434,10 @@ exports[`Cell header table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -12309,8 +12450,10 @@ exports[`Cell header table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -12323,8 +12466,10 @@ exports[`Cell header table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -12337,8 +12482,10 @@ exports[`Cell header table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -12351,8 +12498,10 @@ exports[`Cell header table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -12696,8 +12845,10 @@ exports[`Cell header table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -12710,8 +12861,10 @@ exports[`Cell header table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -12724,8 +12877,10 @@ exports[`Cell header table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -12738,8 +12893,10 @@ exports[`Cell header table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -12752,8 +12909,10 @@ exports[`Cell header table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -13097,8 +13256,10 @@ exports[`Cell header table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -13111,8 +13272,10 @@ exports[`Cell header table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -13125,8 +13288,10 @@ exports[`Cell header table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -13139,8 +13304,10 @@ exports[`Cell header table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -13153,8 +13320,10 @@ exports[`Cell header table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -13498,8 +13667,10 @@ exports[`Cell header table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -13512,8 +13683,10 @@ exports[`Cell header table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -13526,8 +13699,10 @@ exports[`Cell header table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -13540,8 +13715,10 @@ exports[`Cell header table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -13554,8 +13731,10 @@ exports[`Cell header table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -13899,8 +14078,10 @@ exports[`Cell header table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -13913,8 +14094,10 @@ exports[`Cell header table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -13927,8 +14110,10 @@ exports[`Cell header table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -13941,8 +14126,10 @@ exports[`Cell header table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -13955,8 +14142,10 @@ exports[`Cell header table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -14300,8 +14489,10 @@ exports[`Cell header table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -14314,8 +14505,10 @@ exports[`Cell header table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -14328,8 +14521,10 @@ exports[`Cell header table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -14342,8 +14537,10 @@ exports[`Cell header table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -14356,8 +14553,10 @@ exports[`Cell header table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -14701,8 +14900,10 @@ exports[`Cell header table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -14715,8 +14916,10 @@ exports[`Cell header table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -14729,8 +14932,10 @@ exports[`Cell header table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -14743,8 +14948,10 @@ exports[`Cell header table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -14757,8 +14964,10 @@ exports[`Cell header table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -15470,8 +15679,10 @@ exports[`Collapsible nested table 1`] = `
                     data-label=""
                     key="0-header"
                     scope=""
+                    textCenter={false}
                   >
                     <td
+                      className=""
                       data-key={0}
                     />
                   </HeaderCell>
@@ -15483,6 +15694,7 @@ exports[`Collapsible nested table 1`] = `
                     data-label="Header cell"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       aria-sort="none"
@@ -15540,8 +15752,10 @@ exports[`Collapsible nested table 1`] = `
                     data-label="Branches"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -15554,8 +15768,10 @@ exports[`Collapsible nested table 1`] = `
                     data-label="Pull requests"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -15568,8 +15784,10 @@ exports[`Collapsible nested table 1`] = `
                     data-label="Workspaces"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -15582,8 +15800,10 @@ exports[`Collapsible nested table 1`] = `
                     data-label="Last Commit"
                     key="5-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={5}
                       scope="col"
                     >
@@ -17597,6 +17817,7 @@ exports[`Collapsible nested table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__toggle"
@@ -17672,8 +17893,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -17686,8 +17909,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -17700,8 +17925,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -17714,8 +17941,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -17728,8 +17957,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -18127,6 +18358,7 @@ exports[`Collapsible nested table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__toggle"
@@ -18206,6 +18438,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="1-cell"
                         parentId={0}
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -18230,6 +18463,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="2-cell"
                         parentId={0}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -18238,6 +18472,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="3-cell"
                         parentId={0}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -18246,6 +18481,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="4-cell"
                         parentId={0}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -18254,6 +18490,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="5-cell"
                         parentId={0}
+                        textCenter={false}
                       />
                     </tr>
                   </RowWrapper>
@@ -18644,6 +18881,7 @@ exports[`Collapsible nested table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -18666,6 +18904,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="1-cell"
                         parentId={1}
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -18690,6 +18929,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="2-cell"
                         parentId={1}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -18698,6 +18938,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="3-cell"
                         parentId={1}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -18706,6 +18947,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="4-cell"
                         parentId={1}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -18714,6 +18956,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="5-cell"
                         parentId={1}
+                        textCenter={false}
                       />
                     </tr>
                   </RowWrapper>
@@ -19110,6 +19353,7 @@ exports[`Collapsible nested table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__toggle"
@@ -19185,8 +19429,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -19199,8 +19445,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -19213,8 +19461,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -19227,8 +19477,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -19241,8 +19493,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -19638,6 +19892,7 @@ exports[`Collapsible nested table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -19660,6 +19915,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="1-cell"
                         parentId={3}
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -19684,6 +19940,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="2-cell"
                         parentId={3}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -19692,6 +19949,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="3-cell"
                         parentId={3}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -19700,6 +19958,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="4-cell"
                         parentId={3}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -19708,6 +19967,7 @@ exports[`Collapsible nested table 1`] = `
                         isVisible={true}
                         key="5-cell"
                         parentId={3}
+                        textCenter={false}
                       />
                     </tr>
                   </RowWrapper>
@@ -20102,6 +20362,7 @@ exports[`Collapsible nested table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -20120,8 +20381,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -20134,8 +20397,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -20148,8 +20413,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -20162,8 +20429,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -20176,8 +20445,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -20577,6 +20848,7 @@ exports[`Collapsible nested table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -20595,8 +20867,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -20609,8 +20883,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -20623,8 +20899,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -20637,8 +20915,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -20651,8 +20931,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -21052,6 +21334,7 @@ exports[`Collapsible nested table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -21070,8 +21353,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -21084,8 +21369,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -21098,8 +21385,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -21112,8 +21401,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -21126,8 +21417,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -21527,6 +21820,7 @@ exports[`Collapsible nested table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -21545,8 +21839,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -21559,8 +21855,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -21573,8 +21871,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -21587,8 +21887,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -21601,8 +21903,10 @@ exports[`Collapsible nested table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -22312,8 +22616,10 @@ exports[`Collapsible table 1`] = `
                     data-label=""
                     key="0-header"
                     scope=""
+                    textCenter={false}
                   >
                     <td
+                      className=""
                       data-key={0}
                     />
                   </HeaderCell>
@@ -22325,6 +22631,7 @@ exports[`Collapsible table 1`] = `
                     data-label="Header cell"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       aria-sort="none"
@@ -22382,8 +22689,10 @@ exports[`Collapsible table 1`] = `
                     data-label="Branches"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -22396,8 +22705,10 @@ exports[`Collapsible table 1`] = `
                     data-label="Pull requests"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -22410,8 +22721,10 @@ exports[`Collapsible table 1`] = `
                     data-label="Workspaces"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -22424,8 +22737,10 @@ exports[`Collapsible table 1`] = `
                     data-label="Last Commit"
                     key="5-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={5}
                       scope="col"
                     >
@@ -24431,6 +24746,7 @@ exports[`Collapsible table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__toggle"
@@ -24506,8 +24822,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -24520,8 +24838,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -24534,8 +24854,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -24548,8 +24870,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -24562,8 +24886,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -24959,6 +25285,7 @@ exports[`Collapsible table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -24981,6 +25308,7 @@ exports[`Collapsible table 1`] = `
                         isVisible={true}
                         key="1-cell"
                         parentId={0}
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -25005,6 +25333,7 @@ exports[`Collapsible table 1`] = `
                         isVisible={true}
                         key="2-cell"
                         parentId={0}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -25013,6 +25342,7 @@ exports[`Collapsible table 1`] = `
                         isVisible={true}
                         key="3-cell"
                         parentId={0}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -25021,6 +25351,7 @@ exports[`Collapsible table 1`] = `
                         isVisible={true}
                         key="4-cell"
                         parentId={0}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -25029,6 +25360,7 @@ exports[`Collapsible table 1`] = `
                         isVisible={true}
                         key="5-cell"
                         parentId={0}
+                        textCenter={false}
                       />
                     </tr>
                   </RowWrapper>
@@ -25423,6 +25755,7 @@ exports[`Collapsible table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -25441,8 +25774,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -25455,8 +25790,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -25469,8 +25806,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -25483,8 +25822,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -25497,8 +25838,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -25900,6 +26243,7 @@ exports[`Collapsible table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__toggle"
@@ -25975,8 +26319,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -25989,8 +26335,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -26003,8 +26351,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -26017,8 +26367,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -26031,8 +26383,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -26428,6 +26782,7 @@ exports[`Collapsible table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -26450,6 +26805,7 @@ exports[`Collapsible table 1`] = `
                         isVisible={true}
                         key="1-cell"
                         parentId={3}
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -26474,6 +26830,7 @@ exports[`Collapsible table 1`] = `
                         isVisible={true}
                         key="2-cell"
                         parentId={3}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -26482,6 +26839,7 @@ exports[`Collapsible table 1`] = `
                         isVisible={true}
                         key="3-cell"
                         parentId={3}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -26490,6 +26848,7 @@ exports[`Collapsible table 1`] = `
                         isVisible={true}
                         key="4-cell"
                         parentId={3}
+                        textCenter={false}
                       />
                       <BodyCell
                         component="td"
@@ -26498,6 +26857,7 @@ exports[`Collapsible table 1`] = `
                         isVisible={true}
                         key="5-cell"
                         parentId={3}
+                        textCenter={false}
                       />
                     </tr>
                   </RowWrapper>
@@ -26892,6 +27252,7 @@ exports[`Collapsible table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -26910,8 +27271,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -26924,8 +27287,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -26938,8 +27303,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -26952,8 +27319,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -26966,8 +27335,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -27367,6 +27738,7 @@ exports[`Collapsible table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -27385,8 +27757,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -27399,8 +27773,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -27413,8 +27789,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -27427,8 +27805,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -27441,8 +27821,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -27842,6 +28224,7 @@ exports[`Collapsible table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -27860,8 +28243,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -27874,8 +28259,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -27888,8 +28275,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -27902,8 +28291,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -27916,8 +28307,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -28317,6 +28710,7 @@ exports[`Collapsible table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
                           className=""
@@ -28335,8 +28729,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -28349,8 +28745,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -28363,8 +28761,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -28377,8 +28777,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -28391,8 +28793,10 @@ exports[`Collapsible table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -29019,6 +29423,7 @@ exports[`Header width table 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       className="pf-m-width-10"
@@ -29034,8 +29439,10 @@ exports[`Header width table 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -29049,6 +29456,7 @@ exports[`Header width table 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       className="pf-m-width-30"
@@ -29064,8 +29472,10 @@ exports[`Header width table 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -29079,6 +29489,7 @@ exports[`Header width table 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       className="pf-m-width-max"
@@ -31002,8 +31413,10 @@ exports[`Header width table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -31016,8 +31429,10 @@ exports[`Header width table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -31030,8 +31445,10 @@ exports[`Header width table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -31044,8 +31461,10 @@ exports[`Header width table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -31058,8 +31477,10 @@ exports[`Header width table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -31410,8 +31831,10 @@ exports[`Header width table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -31430,8 +31853,10 @@ exports[`Header width table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -31444,8 +31869,10 @@ exports[`Header width table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -31458,8 +31885,10 @@ exports[`Header width table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -31472,8 +31901,10 @@ exports[`Header width table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -31822,8 +32253,10 @@ exports[`Header width table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -31842,8 +32275,10 @@ exports[`Header width table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -31856,8 +32291,10 @@ exports[`Header width table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -31870,8 +32307,10 @@ exports[`Header width table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -31884,8 +32323,10 @@ exports[`Header width table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -32240,8 +32681,10 @@ exports[`Header width table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -32254,8 +32697,10 @@ exports[`Header width table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -32268,8 +32713,10 @@ exports[`Header width table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -32282,8 +32729,10 @@ exports[`Header width table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -32296,8 +32745,10 @@ exports[`Header width table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -32646,8 +33097,10 @@ exports[`Header width table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -32666,8 +33119,10 @@ exports[`Header width table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -32680,8 +33135,10 @@ exports[`Header width table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -32694,8 +33151,10 @@ exports[`Header width table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -32708,8 +33167,10 @@ exports[`Header width table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -33062,8 +33523,10 @@ exports[`Header width table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -33076,8 +33539,10 @@ exports[`Header width table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -33090,8 +33555,10 @@ exports[`Header width table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -33104,8 +33571,10 @@ exports[`Header width table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -33118,8 +33587,10 @@ exports[`Header width table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -33472,8 +33943,10 @@ exports[`Header width table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -33486,8 +33959,10 @@ exports[`Header width table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -33500,8 +33975,10 @@ exports[`Header width table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -33514,8 +33991,10 @@ exports[`Header width table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -33528,8 +34007,10 @@ exports[`Header width table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -33882,8 +34363,10 @@ exports[`Header width table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -33896,8 +34379,10 @@ exports[`Header width table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -33910,8 +34395,10 @@ exports[`Header width table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -33924,8 +34411,10 @@ exports[`Header width table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -33938,8 +34427,10 @@ exports[`Header width table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -34292,8 +34783,10 @@ exports[`Header width table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -34306,8 +34799,10 @@ exports[`Header width table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -34320,8 +34815,10 @@ exports[`Header width table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -34334,8 +34831,10 @@ exports[`Header width table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -34348,8 +34847,10 @@ exports[`Header width table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -35052,6 +35553,7 @@ exports[`Selectable table 1`] = `
                     isVisible={true}
                     key="0-header"
                     scope=""
+                    textCenter={false}
                   >
                     <td
                       className="pf-c-table__check"
@@ -35082,6 +35584,7 @@ exports[`Selectable table 1`] = `
                     data-label="Header cell"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       aria-sort="none"
@@ -35139,8 +35642,10 @@ exports[`Selectable table 1`] = `
                     data-label="Branches"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -35153,8 +35658,10 @@ exports[`Selectable table 1`] = `
                     data-label="Pull requests"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -35167,8 +35674,10 @@ exports[`Selectable table 1`] = `
                     data-label="Workspaces"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -35181,8 +35690,10 @@ exports[`Selectable table 1`] = `
                     data-label="Last Commit"
                     key="5-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={5}
                       scope="col"
                     >
@@ -37185,6 +37696,7 @@ exports[`Selectable table 1`] = `
                         isVisible={true}
                         key="0-cell"
                         scope=""
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__check"
@@ -37214,8 +37726,10 @@ exports[`Selectable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -37228,8 +37742,10 @@ exports[`Selectable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -37242,8 +37758,10 @@ exports[`Selectable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -37256,8 +37774,10 @@ exports[`Selectable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -37270,8 +37790,10 @@ exports[`Selectable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -37663,8 +38185,10 @@ exports[`Selectable table 1`] = `
                         isVisible={true}
                         key="0-cell"
                         scope=""
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           scope=""
                         />
@@ -37675,8 +38199,10 @@ exports[`Selectable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -37695,8 +38221,10 @@ exports[`Selectable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -37709,8 +38237,10 @@ exports[`Selectable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -37723,8 +38253,10 @@ exports[`Selectable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -37737,8 +38269,10 @@ exports[`Selectable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -38128,8 +38662,10 @@ exports[`Selectable table 1`] = `
                         isVisible={true}
                         key="0-cell"
                         scope=""
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           scope=""
                         />
@@ -38140,8 +38676,10 @@ exports[`Selectable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -38160,8 +38698,10 @@ exports[`Selectable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -38174,8 +38714,10 @@ exports[`Selectable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -38188,8 +38730,10 @@ exports[`Selectable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -38202,8 +38746,10 @@ exports[`Selectable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -38600,6 +39146,7 @@ exports[`Selectable table 1`] = `
                         isVisible={true}
                         key="0-cell"
                         scope=""
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__check"
@@ -38629,8 +39176,10 @@ exports[`Selectable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -38643,8 +39192,10 @@ exports[`Selectable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -38657,8 +39208,10 @@ exports[`Selectable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -38671,8 +39224,10 @@ exports[`Selectable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -38685,8 +39240,10 @@ exports[`Selectable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -39076,8 +39633,10 @@ exports[`Selectable table 1`] = `
                         isVisible={true}
                         key="0-cell"
                         scope=""
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           scope=""
                         />
@@ -39088,8 +39647,10 @@ exports[`Selectable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -39108,8 +39669,10 @@ exports[`Selectable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -39122,8 +39685,10 @@ exports[`Selectable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -39136,8 +39701,10 @@ exports[`Selectable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -39150,8 +39717,10 @@ exports[`Selectable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -39546,6 +40115,7 @@ exports[`Selectable table 1`] = `
                         isVisible={true}
                         key="0-cell"
                         scope=""
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__check"
@@ -39575,8 +40145,10 @@ exports[`Selectable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -39589,8 +40161,10 @@ exports[`Selectable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -39603,8 +40177,10 @@ exports[`Selectable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -39617,8 +40193,10 @@ exports[`Selectable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -39631,8 +40209,10 @@ exports[`Selectable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -40027,6 +40607,7 @@ exports[`Selectable table 1`] = `
                         isVisible={true}
                         key="0-cell"
                         scope=""
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__check"
@@ -40056,8 +40637,10 @@ exports[`Selectable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -40070,8 +40653,10 @@ exports[`Selectable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -40084,8 +40669,10 @@ exports[`Selectable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -40098,8 +40685,10 @@ exports[`Selectable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -40112,8 +40701,10 @@ exports[`Selectable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -40508,6 +41099,7 @@ exports[`Selectable table 1`] = `
                         isVisible={true}
                         key="0-cell"
                         scope=""
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__check"
@@ -40537,8 +41129,10 @@ exports[`Selectable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -40551,8 +41145,10 @@ exports[`Selectable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -40565,8 +41161,10 @@ exports[`Selectable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -40579,8 +41177,10 @@ exports[`Selectable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -40593,8 +41193,10 @@ exports[`Selectable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -40989,6 +41591,7 @@ exports[`Selectable table 1`] = `
                         isVisible={true}
                         key="0-cell"
                         scope=""
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__check"
@@ -41018,8 +41621,10 @@ exports[`Selectable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Header cell"
                         >
@@ -41032,8 +41637,10 @@ exports[`Selectable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Branches"
                         >
@@ -41046,8 +41653,10 @@ exports[`Selectable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Pull requests"
                         >
@@ -41060,8 +41669,10 @@ exports[`Selectable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Workspaces"
                         >
@@ -41074,8 +41685,10 @@ exports[`Selectable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={5}
                           data-label="Last Commit"
                         >
@@ -42008,6 +42621,7 @@ exports[`Simple Actions table 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       aria-sort="none"
@@ -42065,8 +42679,10 @@ exports[`Simple Actions table 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -42079,8 +42695,10 @@ exports[`Simple Actions table 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -42093,8 +42711,10 @@ exports[`Simple Actions table 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -42107,8 +42727,10 @@ exports[`Simple Actions table 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -42121,8 +42743,10 @@ exports[`Simple Actions table 1`] = `
                     data-label=""
                     key="5-header"
                     scope=""
+                    textCenter={false}
                   >
                     <td
+                      className=""
                       data-key={5}
                     />
                   </HeaderCell>
@@ -44453,8 +45077,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -44467,8 +45093,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -44481,8 +45109,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -44495,8 +45125,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -44509,8 +45141,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -44524,6 +45158,7 @@ exports[`Simple Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -45305,8 +45940,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -45319,8 +45956,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -45333,8 +45972,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -45347,8 +45988,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -45361,8 +46004,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -45376,6 +46021,7 @@ exports[`Simple Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -46157,8 +46803,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -46171,8 +46819,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -46185,8 +46835,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -46199,8 +46851,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -46213,8 +46867,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -46228,6 +46884,7 @@ exports[`Simple Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -47009,8 +47666,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -47023,8 +47682,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -47037,8 +47698,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -47051,8 +47714,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -47065,8 +47730,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -47080,6 +47747,7 @@ exports[`Simple Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -47861,8 +48529,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -47875,8 +48545,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -47889,8 +48561,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -47903,8 +48577,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -47917,8 +48593,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -47932,6 +48610,7 @@ exports[`Simple Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -48713,8 +49392,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -48727,8 +49408,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -48741,8 +49424,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -48755,8 +49440,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -48769,8 +49456,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -48784,6 +49473,7 @@ exports[`Simple Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -49565,8 +50255,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -49579,8 +50271,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -49593,8 +50287,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -49607,8 +50303,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -49621,8 +50319,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -49636,6 +50336,7 @@ exports[`Simple Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -50417,8 +51118,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -50431,8 +51134,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -50445,8 +51150,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -50459,8 +51166,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -50473,8 +51182,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -50488,6 +51199,7 @@ exports[`Simple Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -51269,8 +51981,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -51283,8 +51997,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -51297,8 +52013,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -51311,8 +52029,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -51325,8 +52045,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -51340,6 +52062,7 @@ exports[`Simple Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -52123,8 +52846,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -52137,8 +52862,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -52151,8 +52878,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -52165,8 +52894,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -52179,8 +52910,10 @@ exports[`Simple Actions table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -52194,6 +52927,7 @@ exports[`Simple Actions table 1`] = `
                         data-label=""
                         isVisible={true}
                         key="5-cell"
+                        textCenter={false}
                       >
                         <td
                           className="pf-c-table__action"
@@ -53078,8 +53812,10 @@ exports[`Simple table aria-label 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={0}
                       scope="col"
                     >
@@ -53092,8 +53828,10 @@ exports[`Simple table aria-label 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -53106,8 +53844,10 @@ exports[`Simple table aria-label 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -53120,8 +53860,10 @@ exports[`Simple table aria-label 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -53134,8 +53876,10 @@ exports[`Simple table aria-label 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -55019,8 +55763,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -55033,8 +55779,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -55047,8 +55795,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -55061,8 +55811,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -55075,8 +55827,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -55418,8 +56172,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -55432,8 +56188,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -55446,8 +56204,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -55460,8 +56220,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -55474,8 +56236,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -55817,8 +56581,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -55831,8 +56597,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -55845,8 +56613,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -55859,8 +56629,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -55873,8 +56645,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -56216,8 +56990,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -56230,8 +57006,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -56244,8 +57022,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -56258,8 +57038,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -56272,8 +57054,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -56615,8 +57399,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -56629,8 +57415,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -56643,8 +57431,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -56657,8 +57447,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -56671,8 +57463,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -57014,8 +57808,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -57028,8 +57824,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -57042,8 +57840,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -57056,8 +57856,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -57070,8 +57872,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -57413,8 +58217,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -57427,8 +58233,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -57441,8 +58249,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -57455,8 +58265,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -57469,8 +58281,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -57812,8 +58626,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -57826,8 +58642,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -57840,8 +58658,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -57854,8 +58674,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -57868,8 +58690,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -58211,8 +59035,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -58225,8 +59051,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -58239,8 +59067,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -58253,8 +59083,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -58267,8 +59099,10 @@ exports[`Simple table aria-label 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -58864,8 +59698,10 @@ exports[`Simple table caption 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={0}
                       scope="col"
                     >
@@ -58878,8 +59714,10 @@ exports[`Simple table caption 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -58892,8 +59730,10 @@ exports[`Simple table caption 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -58906,8 +59746,10 @@ exports[`Simple table caption 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -58920,8 +59762,10 @@ exports[`Simple table caption 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -60805,8 +61649,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -60819,8 +61665,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -60833,8 +61681,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -60847,8 +61697,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -60861,8 +61713,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -61204,8 +62058,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -61218,8 +62074,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -61232,8 +62090,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -61246,8 +62106,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -61260,8 +62122,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -61603,8 +62467,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -61617,8 +62483,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -61631,8 +62499,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -61645,8 +62515,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -61659,8 +62531,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -62002,8 +62876,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -62016,8 +62892,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -62030,8 +62908,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -62044,8 +62924,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -62058,8 +62940,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -62401,8 +63285,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -62415,8 +63301,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -62429,8 +63317,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -62443,8 +63333,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -62457,8 +63349,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -62800,8 +63694,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -62814,8 +63710,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -62828,8 +63726,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -62842,8 +63742,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -62856,8 +63758,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -63199,8 +64103,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -63213,8 +64119,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -63227,8 +64135,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -63241,8 +64151,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -63255,8 +64167,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -63598,8 +64512,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -63612,8 +64528,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -63626,8 +64544,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -63640,8 +64560,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -63654,8 +64576,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -63997,8 +64921,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -64011,8 +64937,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -64025,8 +64953,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -64039,8 +64969,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -64053,8 +64985,10 @@ exports[`Simple table caption 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -64654,8 +65588,10 @@ exports[`Simple table header 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={0}
                       scope="col"
                     >
@@ -64668,8 +65604,10 @@ exports[`Simple table header 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -64682,8 +65620,10 @@ exports[`Simple table header 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -64696,8 +65636,10 @@ exports[`Simple table header 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -64710,8 +65652,10 @@ exports[`Simple table header 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -66595,8 +67539,10 @@ exports[`Simple table header 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -66609,8 +67555,10 @@ exports[`Simple table header 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -66623,8 +67571,10 @@ exports[`Simple table header 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -66637,8 +67587,10 @@ exports[`Simple table header 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -66651,8 +67603,10 @@ exports[`Simple table header 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -66994,8 +67948,10 @@ exports[`Simple table header 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -67008,8 +67964,10 @@ exports[`Simple table header 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -67022,8 +67980,10 @@ exports[`Simple table header 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -67036,8 +67996,10 @@ exports[`Simple table header 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -67050,8 +68012,10 @@ exports[`Simple table header 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -67393,8 +68357,10 @@ exports[`Simple table header 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -67407,8 +68373,10 @@ exports[`Simple table header 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -67421,8 +68389,10 @@ exports[`Simple table header 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -67435,8 +68405,10 @@ exports[`Simple table header 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -67449,8 +68421,10 @@ exports[`Simple table header 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -67792,8 +68766,10 @@ exports[`Simple table header 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -67806,8 +68782,10 @@ exports[`Simple table header 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -67820,8 +68798,10 @@ exports[`Simple table header 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -67834,8 +68814,10 @@ exports[`Simple table header 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -67848,8 +68830,10 @@ exports[`Simple table header 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -68191,8 +69175,10 @@ exports[`Simple table header 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -68205,8 +69191,10 @@ exports[`Simple table header 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -68219,8 +69207,10 @@ exports[`Simple table header 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -68233,8 +69223,10 @@ exports[`Simple table header 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -68247,8 +69239,10 @@ exports[`Simple table header 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -68590,8 +69584,10 @@ exports[`Simple table header 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -68604,8 +69600,10 @@ exports[`Simple table header 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -68618,8 +69616,10 @@ exports[`Simple table header 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -68632,8 +69632,10 @@ exports[`Simple table header 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -68646,8 +69648,10 @@ exports[`Simple table header 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -68989,8 +69993,10 @@ exports[`Simple table header 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -69003,8 +70009,10 @@ exports[`Simple table header 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -69017,8 +70025,10 @@ exports[`Simple table header 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -69031,8 +70041,10 @@ exports[`Simple table header 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -69045,8 +70057,10 @@ exports[`Simple table header 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -69388,8 +70402,10 @@ exports[`Simple table header 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -69402,8 +70418,10 @@ exports[`Simple table header 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -69416,8 +70434,10 @@ exports[`Simple table header 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -69430,8 +70450,10 @@ exports[`Simple table header 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -69444,8 +70466,10 @@ exports[`Simple table header 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -69787,8 +70811,10 @@ exports[`Simple table header 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -69801,8 +70827,10 @@ exports[`Simple table header 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -69815,8 +70843,10 @@ exports[`Simple table header 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -69829,8 +70859,10 @@ exports[`Simple table header 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -69843,8 +70875,10 @@ exports[`Simple table header 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -70448,6 +71482,7 @@ exports[`Sortable table 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       aria-sort="none"
@@ -70505,8 +71540,10 @@ exports[`Sortable table 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -70519,8 +71556,10 @@ exports[`Sortable table 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -70533,8 +71572,10 @@ exports[`Sortable table 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -70547,8 +71588,10 @@ exports[`Sortable table 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -72434,8 +73477,10 @@ exports[`Sortable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -72448,8 +73493,10 @@ exports[`Sortable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -72462,8 +73509,10 @@ exports[`Sortable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -72476,8 +73525,10 @@ exports[`Sortable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -72490,8 +73541,10 @@ exports[`Sortable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -72834,8 +73887,10 @@ exports[`Sortable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -72848,8 +73903,10 @@ exports[`Sortable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -72862,8 +73919,10 @@ exports[`Sortable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -72876,8 +73935,10 @@ exports[`Sortable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -72890,8 +73951,10 @@ exports[`Sortable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -73234,8 +74297,10 @@ exports[`Sortable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -73248,8 +74313,10 @@ exports[`Sortable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -73262,8 +74329,10 @@ exports[`Sortable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -73276,8 +74345,10 @@ exports[`Sortable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -73290,8 +74361,10 @@ exports[`Sortable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -73634,8 +74707,10 @@ exports[`Sortable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -73648,8 +74723,10 @@ exports[`Sortable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -73662,8 +74739,10 @@ exports[`Sortable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -73676,8 +74755,10 @@ exports[`Sortable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -73690,8 +74771,10 @@ exports[`Sortable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -74034,8 +75117,10 @@ exports[`Sortable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -74048,8 +75133,10 @@ exports[`Sortable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -74062,8 +75149,10 @@ exports[`Sortable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -74076,8 +75165,10 @@ exports[`Sortable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -74090,8 +75181,10 @@ exports[`Sortable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -74434,8 +75527,10 @@ exports[`Sortable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -74448,8 +75543,10 @@ exports[`Sortable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -74462,8 +75559,10 @@ exports[`Sortable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -74476,8 +75575,10 @@ exports[`Sortable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -74490,8 +75591,10 @@ exports[`Sortable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -74834,8 +75937,10 @@ exports[`Sortable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -74848,8 +75953,10 @@ exports[`Sortable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -74862,8 +75969,10 @@ exports[`Sortable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -74876,8 +75985,10 @@ exports[`Sortable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -74890,8 +76001,10 @@ exports[`Sortable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -75234,8 +76347,10 @@ exports[`Sortable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -75248,8 +76363,10 @@ exports[`Sortable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -75262,8 +76379,10 @@ exports[`Sortable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -75276,8 +76395,10 @@ exports[`Sortable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -75290,8 +76411,10 @@ exports[`Sortable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -75634,8 +76757,10 @@ exports[`Sortable table 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -75648,8 +76773,10 @@ exports[`Sortable table 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -75662,8 +76789,10 @@ exports[`Sortable table 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -75676,8 +76805,10 @@ exports[`Sortable table 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -75690,8 +76821,10 @@ exports[`Sortable table 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -76293,6 +77426,7 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       aria-sort="none"
@@ -76350,8 +77484,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -76364,8 +77500,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -76378,8 +77516,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -76392,8 +77532,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -78279,8 +79421,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -78293,8 +79437,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -78307,8 +79453,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -78321,8 +79469,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -78335,8 +79485,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -78679,8 +79831,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -78693,8 +79847,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -78707,8 +79863,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -78721,8 +79879,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -78735,8 +79895,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -79079,8 +80241,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -79093,8 +80257,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -79107,8 +80273,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -79121,8 +80289,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -79135,8 +80305,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -79479,8 +80651,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -79493,8 +80667,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -79507,8 +80683,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -79521,8 +80699,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -79535,8 +80715,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -79879,8 +81061,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -79893,8 +81077,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -79907,8 +81093,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -79921,8 +81109,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -79935,8 +81125,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -80279,8 +81471,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -80293,8 +81487,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -80307,8 +81503,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -80321,8 +81519,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -80335,8 +81535,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -80679,8 +81881,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -80693,8 +81897,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -80707,8 +81913,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -80721,8 +81929,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -80735,8 +81945,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -81079,8 +82291,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -81093,8 +82307,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -81107,8 +82323,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -81121,8 +82339,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -81135,8 +82355,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -81479,8 +82701,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -81493,8 +82717,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -81507,8 +82733,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -81521,8 +82749,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -81535,8 +82765,10 @@ exports[`Table variants Breakpoint - grid 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -82138,6 +83370,7 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       aria-sort="none"
@@ -82195,8 +83428,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -82209,8 +83444,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -82223,8 +83460,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -82237,8 +83476,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -84124,8 +85365,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -84138,8 +85381,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -84152,8 +85397,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -84166,8 +85413,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -84180,8 +85429,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -84524,8 +85775,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -84538,8 +85791,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -84552,8 +85807,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -84566,8 +85823,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -84580,8 +85839,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -84924,8 +86185,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -84938,8 +86201,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -84952,8 +86217,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -84966,8 +86233,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -84980,8 +86249,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -85324,8 +86595,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -85338,8 +86611,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -85352,8 +86627,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -85366,8 +86643,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -85380,8 +86659,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -85724,8 +87005,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -85738,8 +87021,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -85752,8 +87037,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -85766,8 +87053,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -85780,8 +87069,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -86124,8 +87415,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -86138,8 +87431,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -86152,8 +87447,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -86166,8 +87463,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -86180,8 +87479,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -86524,8 +87825,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -86538,8 +87841,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -86552,8 +87857,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -86566,8 +87873,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -86580,8 +87889,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -86924,8 +88235,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -86938,8 +88251,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -86952,8 +88267,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -86966,8 +88283,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -86980,8 +88299,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -87324,8 +88645,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -87338,8 +88661,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -87352,8 +88677,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -87366,8 +88693,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -87380,8 +88709,10 @@ exports[`Table variants Breakpoint - grid-lg 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -87983,6 +89314,7 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       aria-sort="none"
@@ -88040,8 +89372,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -88054,8 +89388,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -88068,8 +89404,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -88082,8 +89420,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -89969,8 +91309,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -89983,8 +91325,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -89997,8 +91341,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -90011,8 +91357,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -90025,8 +91373,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -90369,8 +91719,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -90383,8 +91735,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -90397,8 +91751,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -90411,8 +91767,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -90425,8 +91783,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -90769,8 +92129,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -90783,8 +92145,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -90797,8 +92161,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -90811,8 +92177,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -90825,8 +92193,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -91169,8 +92539,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -91183,8 +92555,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -91197,8 +92571,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -91211,8 +92587,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -91225,8 +92603,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -91569,8 +92949,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -91583,8 +92965,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -91597,8 +92981,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -91611,8 +92997,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -91625,8 +93013,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -91969,8 +93359,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -91983,8 +93375,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -91997,8 +93391,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -92011,8 +93407,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -92025,8 +93423,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -92369,8 +93769,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -92383,8 +93785,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -92397,8 +93801,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -92411,8 +93817,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -92425,8 +93833,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -92769,8 +94179,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -92783,8 +94195,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -92797,8 +94211,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -92811,8 +94227,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -92825,8 +94243,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -93169,8 +94589,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -93183,8 +94605,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -93197,8 +94621,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -93211,8 +94637,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -93225,8 +94653,10 @@ exports[`Table variants Breakpoint - grid-md 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -93828,6 +95258,7 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       aria-sort="none"
@@ -93885,8 +95316,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -93899,8 +95332,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -93913,8 +95348,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -93927,8 +95364,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -95814,8 +97253,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -95828,8 +97269,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -95842,8 +97285,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -95856,8 +97301,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -95870,8 +97317,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -96214,8 +97663,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -96228,8 +97679,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -96242,8 +97695,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -96256,8 +97711,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -96270,8 +97727,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -96614,8 +98073,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -96628,8 +98089,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -96642,8 +98105,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -96656,8 +98121,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -96670,8 +98137,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -97014,8 +98483,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -97028,8 +98499,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -97042,8 +98515,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -97056,8 +98531,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -97070,8 +98547,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -97414,8 +98893,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -97428,8 +98909,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -97442,8 +98925,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -97456,8 +98941,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -97470,8 +98957,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -97814,8 +99303,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -97828,8 +99319,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -97842,8 +99335,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -97856,8 +99351,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -97870,8 +99367,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -98214,8 +99713,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -98228,8 +99729,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -98242,8 +99745,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -98256,8 +99761,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -98270,8 +99777,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -98614,8 +100123,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -98628,8 +100139,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -98642,8 +100155,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -98656,8 +100171,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -98670,8 +100187,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -99014,8 +100533,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -99028,8 +100549,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -99042,8 +100565,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -99056,8 +100581,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -99070,8 +100597,10 @@ exports[`Table variants Breakpoint - grid-xl 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -99673,6 +101202,7 @@ exports[`Table variants Size - compact 1`] = `
                     data-label="Header cell"
                     key="0-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
                       aria-sort="none"
@@ -99730,8 +101260,10 @@ exports[`Table variants Size - compact 1`] = `
                     data-label="Branches"
                     key="1-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={1}
                       scope="col"
                     >
@@ -99744,8 +101276,10 @@ exports[`Table variants Size - compact 1`] = `
                     data-label="Pull requests"
                     key="2-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={2}
                       scope="col"
                     >
@@ -99758,8 +101292,10 @@ exports[`Table variants Size - compact 1`] = `
                     data-label="Workspaces"
                     key="3-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={3}
                       scope="col"
                     >
@@ -99772,8 +101308,10 @@ exports[`Table variants Size - compact 1`] = `
                     data-label="Last Commit"
                     key="4-header"
                     scope="col"
+                    textCenter={false}
                   >
                     <th
+                      className=""
                       data-key={4}
                       scope="col"
                     >
@@ -101659,8 +103197,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -101673,8 +103213,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -101687,8 +103229,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -101701,8 +103245,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -101715,8 +103261,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -102059,8 +103607,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -102073,8 +103623,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -102087,8 +103639,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -102101,8 +103655,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -102115,8 +103671,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -102459,8 +104017,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -102473,8 +104033,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -102487,8 +104049,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -102501,8 +104065,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -102515,8 +104081,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -102859,8 +104427,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -102873,8 +104443,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -102887,8 +104459,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -102901,8 +104475,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -102915,8 +104491,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -103259,8 +104837,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -103273,8 +104853,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -103287,8 +104869,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -103301,8 +104885,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -103315,8 +104901,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -103659,8 +105247,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -103673,8 +105263,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -103687,8 +105279,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -103701,8 +105295,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -103715,8 +105311,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -104059,8 +105657,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -104073,8 +105673,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -104087,8 +105689,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -104101,8 +105705,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -104115,8 +105721,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -104459,8 +106067,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -104473,8 +106083,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -104487,8 +106099,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -104501,8 +106115,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -104515,8 +106131,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >
@@ -104859,8 +106477,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Header cell"
                         isVisible={true}
                         key="0-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={0}
                           data-label="Header cell"
                         >
@@ -104873,8 +106493,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Branches"
                         isVisible={true}
                         key="1-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={1}
                           data-label="Branches"
                         >
@@ -104887,8 +106509,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Pull requests"
                         isVisible={true}
                         key="2-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={2}
                           data-label="Pull requests"
                         >
@@ -104901,8 +106525,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Workspaces"
                         isVisible={true}
                         key="3-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={3}
                           data-label="Workspaces"
                         >
@@ -104915,8 +106541,10 @@ exports[`Table variants Size - compact 1`] = `
                         data-label="Last Commit"
                         isVisible={true}
                         key="4-cell"
+                        textCenter={false}
                       >
                         <td
+                          className=""
                           data-key={4}
                           data-label="Last Commit"
                         >

--- a/packages/patternfly-4/react-table/src/components/Table/index.js
+++ b/packages/patternfly-4/react-table/src/components/Table/index.js
@@ -4,5 +4,5 @@ export { default as TableBody } from './Body';
 export { default as BodyWrapper } from './BodyWrapper';
 export { default as RowWrapper } from './RowWrapper';
 export { default as ExpandableRowContent } from './ExpandableRowContent';
-export { sortable, headerCol, cellWidth, expandable, isRowExpanded } from './utils';
+export { sortable, headerCol, cellWidth, expandable, isRowExpanded, textCenter } from './utils';
 export { SortByDirection } from './SortColumn';

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/textCenter.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/textCenter.js
@@ -1,0 +1,1 @@
+export default () => ({ textCenter: true });

--- a/packages/patternfly-4/react-table/src/components/Table/utils/headerUtils.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/headerUtils.js
@@ -37,9 +37,9 @@ const generateHeader = ({ transforms: origTransforms, formatters: origFormatters
 const generateCell = ({ cellFormatters, cellTransforms, cell }) => ({
   ...cell,
   transforms: [
-    mapProps,
     ...(cellTransforms || []),
-    ...(cell && cell.hasOwnProperty('transforms') ? cell.transforms : [])
+    ...(cell && cell.hasOwnProperty('transforms') ? cell.transforms : []),
+    mapProps // This transform should be applied last so that props that are manually defined at the cell level will override all other transforms.
   ],
   formatters: [
     defaultTitle,

--- a/packages/patternfly-4/react-table/src/components/Table/utils/transformers.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/transformers.js
@@ -2,6 +2,7 @@ export { default as selectable } from './decorators/selectable';
 export { default as sortable } from './decorators/sortable';
 export { default as cellActions } from './decorators/cellActions';
 export { default as cellWidth } from './decorators/cellWidth';
+export { default as textCenter } from './decorators/textCenter';
 export { collapsible, expandedRow, expandable } from './decorators/collapsible';
 export { default as headerCol } from './decorators/headerCol';
 

--- a/packages/patternfly-4/react-table/src/components/Table/utils/transformers.test.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/transformers.test.js
@@ -10,7 +10,8 @@ import {
   emptyCol,
   mapProps,
   expandable,
-  expandedRow
+  expandedRow,
+  textCenter
 } from './transformers';
 import { DropdownDirection, DropdownPosition } from '@patternfly/react-core';
 
@@ -261,5 +262,9 @@ describe('Transformer functions', () => {
     };
     expect(mapProps(undefined, { property: 'some', rowData })).toEqual({ one: 1 });
     expect(mapProps(undefined, { property: 'wrong', rowData })).toEqual({});
+  });
+
+  test('textCenter', () => {
+    expect(textCenter()).toEqual({ textCenter: true });
   });
 });


### PR DESCRIPTION
fix #1482

**What**:

- Add a `textCenter` transform which applies `textCenter=true` prop to header and body cells. This prop conditionally adds the `pf-m-center` css class to header and body cells. This allows the transform to be easily overridden by applying `textCenter=false` prop to an individual cell definition.

- Change the order in which transforms are applied in `components/Table/utils/headerUtils.js:generateCell` function. Previously, props that were defined at the individual cell level were used as the default, then any transforms applied at the column level were overriding those values. This is the reverse of expected behavior. Transforms applied at the column level should be considered the default, then props/transforms should override each other as specificity increases (with the cell level being most specific, overriding all others).

- Add `textCenter` transform and `textCenter` prop override to Simple Table example.

- Fix some lint and prop validation errors in the files that were touched