### PR TITLE
chore(title): headingLevel => level and make it required

### DIFF
--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxHeader.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxHeader.js
@@ -21,7 +21,7 @@ const defaultProps = {
 
 const AboutModalBoxHeader = ({ className, productName, id, ...props }) => (
   <div {...props} className={css(styles.aboutModalBoxHeader, className)}>
-    <Title headingLevel="h1" size="4xl" id={id}>
+    <Title level="h1" size="4xl" id={id}>
       {productName}
     </Title>
   </div>

--- a/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalBoxHeader.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalBoxHeader.test.js.snap
@@ -5,8 +5,8 @@ exports[`AboutModalBoxHeader Test 1`] = `
   className="pf-c-about-modal-box__header"
 >
   <Title
-    headingLevel="h1"
     id="id"
+    level="h1"
     size="4xl"
   >
     Product Name

--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.md
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.md
@@ -18,7 +18,7 @@ import { CubesIcon } from '@patternfly/react-icons';
 SimpleEmptyState = () => (
   <EmptyState>
     <EmptyStateIcon icon={CubesIcon} />
-    <Title headingLevel="h5" size="lg">Empty State</Title>
+    <Title level="h5" size="lg">Empty State</Title>
     <EmptyStateBody>
       This represents an the empty state pattern in Patternfly 4. Hopefully it's simple enough to use but flexible
       enough to meet a variety of needs.

--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.test.js
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.test.js
@@ -12,7 +12,7 @@ describe('EmptyState', () => {
   test('Main', () => {
     const view = shallow(
       <EmptyState>
-        <Title headingLevel="h5" size="lg">HTTP Proxies</Title>
+        <Title level="h5" size="lg">HTTP Proxies</Title>
         <EmptyStateBody>
           Defining HTTP Proxies that exist on your network allows you to perform various actions through those proxies.
         </EmptyStateBody>

--- a/packages/patternfly-4/react-core/src/components/EmptyState/__snapshots__/EmptyState.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/__snapshots__/EmptyState.test.js.snap
@@ -5,7 +5,7 @@ exports[`EmptyState Main 1`] = `
   className="pf-c-empty-state"
 >
   <Title
-    headingLevel="h5"
+    level="h5"
     size="lg"
   >
     HTTP Proxies

--- a/packages/patternfly-4/react-core/src/components/LoginPage/LoginMainHeader.js
+++ b/packages/patternfly-4/react-core/src/components/LoginPage/LoginMainHeader.js
@@ -26,7 +26,7 @@ const defaultProps = {
 
 const LoginMainHeader = ({ children, className, title, subtitle, ...props }) => (
   <header className={css(styles.loginMainHeader, className)} {...props}>
-    {title && <Title headingLevel="h2" size="3xl">{title}</Title>}
+    {title && <Title level="h2" size="3xl">{title}</Title>}
     {subtitle && <p>{subtitle}</p>}
     {children}
   </header>

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxHeader.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxHeader.js
@@ -24,7 +24,7 @@ const ModalBoxHeader = ({ hideTitle, children, className, ...props }) => {
   const hidden = hideTitle ? css(accessibleStyles.screenReader) : '';
 
   return <React.Fragment>
-    <Title size="2xl" headingLevel="h3" className={className + hidden} {...props}>
+    <Title size="2xl" level="h3" className={className + hidden} {...props}>
       {children}
     </Title>
   </React.Fragment>;

--- a/packages/patternfly-4/react-core/src/components/Modal/__snapshots__/ModalBoxHeader.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Modal/__snapshots__/ModalBoxHeader.test.js.snap
@@ -4,7 +4,7 @@ exports[`ModalBoxHeader Test 1`] = `
 <Fragment>
   <Title
     className=""
-    headingLevel="h3"
+    level="h3"
     size="2xl"
   >
     This is a ModalBox header

--- a/packages/patternfly-4/react-core/src/components/Popover/PopoverHeader.js
+++ b/packages/patternfly-4/react-core/src/components/Popover/PopoverHeader.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Title, TitleSize } from '../Title';
 
 const PopoverHeader = ({ children, id, ...rest }) => (
-  <Title headingLevel="h6" size={TitleSize.xl} id={id} {...rest}>
+  <Title level="h6" size={TitleSize.xl} id={id} {...rest}>
     {children}
   </Title>
 );

--- a/packages/patternfly-4/react-core/src/components/Title/Title.md
+++ b/packages/patternfly-4/react-core/src/components/Title/Title.md
@@ -9,11 +9,11 @@ import { Title } from '@patternfly/react-core';
 
 
 <React.Fragment>
-  <Title headingLevel="h1" size="4xl">4xl Title</Title>
-  <Title headingLevel="h2" size="3xl">3xl Title</Title>
-  <Title headingLevel="h3" size="2xl">2xl Title</Title>
-  <Title headingLevel="h4" size="xl">xl Title</Title>
-  <Title headingLevel="h5" size="lg">lg Title</Title>
-  <Title headingLevel="h6" size="md">md Title</Title>
+  <Title level="h1" size="4xl">4xl Title</Title>
+  <Title level="h2" size="3xl">3xl Title</Title>
+  <Title level="h3" size="2xl">2xl Title</Title>
+  <Title level="h4" size="xl">xl Title</Title>
+  <Title level="h5" size="lg">lg Title</Title>
+  <Title level="h6" size="md">md Title</Title>
 </React.Fragment>
 ```

--- a/packages/patternfly-4/react-core/src/components/Title/Title.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Title/Title.test.tsx
@@ -4,14 +4,14 @@ import { Title, TitleSize } from '.';
 
 Object.values(TitleSize).forEach(size => {
   test(`${size} Title`, () => {
-    const view = shallow(<Title size={size} headingLevel="h1">{size} Title</Title>);
+    const view = shallow(<Title size={size} level="h1">{size} Title</Title>);
     expect(view).toMatchSnapshot();
   });
 });
 
 test('Heading level can be set using a string value', () => {
   const view = shallow(
-    <Title size="lg" headingLevel="h3">
+    <Title size="lg" level="h3">
       H3 Heading
     </Title>
   );

--- a/packages/patternfly-4/react-core/src/components/Title/Title.tsx
+++ b/packages/patternfly-4/react-core/src/components/Title/Title.tsx
@@ -12,14 +12,14 @@ export interface TitleProps extends Omit<React.HTMLProps<HTMLHeadingElement>, 's
   /** Additional classes added to the Title */
   className?: string;
   /** the heading level to use */
-  headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  level: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
 
 const Title: React.FunctionComponent<TitleProps> = ({
   size,
   className = '',
   children = '',
-  headingLevel: HeadingLevel = 'h1',
+  level: HeadingLevel = 'h1',
   ...props
 }: TitleProps) => {
   return (

--- a/packages/patternfly-4/react-core/src/components/Wizard/WizardHeader.tsx
+++ b/packages/patternfly-4/react-core/src/components/Wizard/WizardHeader.tsx
@@ -26,7 +26,7 @@ const WizardHeader: React.FunctionComponent<WizardHeaderProps> = ({
       <Button variant="plain" className={css(styles.wizardClose)} aria-label={ariaLabel} onClick={onClose}>
         <TimesIcon aria-hidden="true" />
       </Button>
-      <Title size="3xl" className={css(styles.wizardTitle)} aria-label={title} id={titleId}>{title}</Title>
+      <Title level="h1" size="3xl" className={css(styles.wizardTitle)} aria-label={title} id={titleId}>{title}</Title>
       {description && <p className={css(styles.wizardDescription)} id={descriptionId}>
         {description}
       </p>}

--- a/packages/patternfly-4/react-docs/src/pages/icons/icons.js
+++ b/packages/patternfly-4/react-docs/src/pages/icons/icons.js
@@ -37,7 +37,7 @@ const Icons = () => {
   return (
     <SidebarLayout>
       <PageSection>
-        <Title size="4xl" headingLevel="h1">Icons</Title>
+        <Title size="4xl" level="h1">Icons</Title>
         <Text>
           These are all Patternfly React Icons.
         </Text>

--- a/packages/patternfly-4/react-docs/src/pages/index.js
+++ b/packages/patternfly-4/react-docs/src/pages/index.js
@@ -27,8 +27,8 @@ const IndexPage = ({ data }) => {
       <div style={containerStyle}>
         <PageSection style={centerStyle}>
           <div style={{ flex: "none", textAlign: "center" }}>
-            <Title size="4xl">PatternFly 4 React Docs</Title>
-            <Title size="2xl">
+            <Title size="4xl" level="h1">PatternFly 4 React Docs</Title>
+            <Title size="2xl" level="h3">
               {prInfo.num ? <a href={prInfo.url}>PR #{prInfo.num}</a> : "Hi people!"}
             </Title>
             <p>Welcome to Patternfly 4 React docs.</p>

--- a/packages/patternfly-4/react-docs/src/pages/tokens/global-css-variables.js
+++ b/packages/patternfly-4/react-docs/src/pages/tokens/global-css-variables.js
@@ -6,7 +6,7 @@ import { Title, PageSection } from '@patternfly/react-core';
 const GlobalCSSVars = () => (
   <SidebarLayout>
     <PageSection>
-      <Title size="4xl" headingLevel="h1">Global CSS Icons</Title>
+      <Title size="4xl" level="h1">Global CSS Icons</Title>
       <CSSVars cssPrefix="global" />
     </PageSection>
   </SidebarLayout>

--- a/packages/patternfly-4/react-docs/src/templates/markdownTemplate.js
+++ b/packages/patternfly-4/react-docs/src/templates/markdownTemplate.js
@@ -55,7 +55,7 @@ const MarkdownTemplate = ({ data }) => {
   return (
     <SidebarLayout>
       <PageSection>
-        <Title size="4xl" style={{ textTransform: 'capitalize' }}>
+        <Title size="4xl" level="h1" style={{ textTransform: 'capitalize' }}>
           {data.markdownRemark.frontmatter.title} {section.indexOf('-') === -1 ? section : ''}
         </Title>
         {renderAst(data.markdownRemark.htmlAst)}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/App.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/App.tsx
@@ -91,7 +91,7 @@ class App extends Component<AppState> {
     return (
       <div className="App">
         <header className="App-header">
-          <Title style={{ color: '#fff', padding: '12px 0' }} headingLevel="h1" size="4xl">
+          <Title style={{ color: '#fff', padding: '12px 0' }} level="h1" size="4xl">
             PF4 Integration Sandbox
           </Title>
           <Avatar src={logo} alt={'avatar'} />
@@ -163,11 +163,11 @@ class App extends Component<AppState> {
         </InputGroup>
         <ContextSelector
           toggleText="My Project"
-          onSearchInputChange={() => {}}
+          onSearchInputChange={() => { }}
           isOpen={true}
           searchInputValue=""
-          onToggle={() => {}}
-          onSelect={() => {}}
+          onToggle={() => { }}
+          onSelect={() => { }}
           screenReaderLabel="screenReader Label"
           searchInputPlaceholder="test"
           searchButtonAriaLabel="Aria Lable"


### PR DESCRIPTION
**What**: This PR renames the prop `headingLevel` to simply `level` for the Title component. It also makes this a required prop. It should be required because otherwise, users are inclined to use the default value of h1 which leads to applications with IA that misrepresent the semantics of the content.

Fixes https://github.com/patternfly/patternfly-react/issues/1439
