### PR TITLE
feat(Table): Add compact expandable table class and example

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.js
@@ -236,7 +236,7 @@ class Table extends React.Component {
           }}
           columns={headerData}
           role="grid"
-          className={css(styles.table, getModifier(stylesGrid, gridBreakPoint), getModifier(styles, variant), className)}
+          className={css(styles.table, getModifier(stylesGrid, gridBreakPoint), getModifier(styles, variant), onCollapse && variant === TableVariant.compact && styles.modifiers.expandable, className)}
         >
           {caption && <caption>{caption}</caption>}
           {children}

--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -345,6 +345,83 @@ class CompactTable extends React.Component {
 }
 ```
 
+## Compact Expandable Table
+```js
+import React from 'react';
+import { Table, TableHeader, TableBody, expandable, TableVariant } from '@patternfly/react-table';
+
+class ContactExpandableTable extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      columns: [
+        {
+          title: 'Header cell',
+          cellFormatters: [expandable]
+        },
+        'Branches',
+        { title: 'Pull requests' },
+        '' // deliberately empty
+      ],
+      rows: [
+        {
+          cells: ['one', 'two', 'three', 'four']
+        },
+        {
+          isOpen: true,
+          cells: ['parent - 1', 'two', 'three', 'four']
+        },
+        {
+          parent: 1,
+          cells: ['child - 1']
+        },
+        {
+          isOpen: false,
+          cells: ['parent - 2', 'two', 'three', 'four']
+        },
+        {
+          parent: 3,
+          cells: ['child - 2']
+        },
+        {
+          isOpen: false,
+          cells: ['parent - 3', 'two', 'three', 'four']
+        },
+        {
+          parent: 5,
+          cells: ['child - 3']
+        }
+      ]
+    };
+    this.onCollapse = this.onCollapse.bind(this);
+  }
+
+  onCollapse(event, rowKey, isOpen) {
+    const { rows } = this.state;
+    /**
+     * Please do not use rowKey as row index for more complex tables.
+     * Rather use some kind of identifier like ID passed with each row.
+     */
+    rows[rowKey].isOpen = isOpen;
+    this.setState({
+      rows
+    });
+  }
+
+  render() {
+    const { columns, rows } = this.state;
+
+    return (
+      <Table caption="Compact expandable table" variant={TableVariant.compact} onCollapse={this.onCollapse} rows={rows} cells={columns}>
+        <TableHeader />
+        <TableBody />
+      </Table>
+    );
+  }
+}
+
+```
+
 ## Table with Width Modifiers
 ```js
 import React from 'react';


### PR DESCRIPTION
Added support for compact expandable table (and example).

Using styles.modifiers instead of getModifier() because getModifier() wasn't finding the correct modifier.

Fixes #1684.
