### PR TITLE
feat(docs): allow hot-reloading react-core changes with babel --watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "prettier": "prettier --write 'storybook/**/*.js' 'packages/**/*.js' 'scripts/**/*.js'",
     "start": "yarn start:pf3",
     "start:pf3": "concurrently 'yarn storybook' 'yarn storybook:openurl'",
-    "start:pf4": "lerna run develop --scope=@patternfly/react-docs --stream",
+    "start:pf4": "lerna run develop --scope='@patternfly/react-docs' --scope='@patternfly/react-core' --parallel --stream",
     "storybook:openurl": "node ./storybook/openBrowser.js",
     "storybook": "start-storybook -c storybook -p 6006",
     "test": "jest packages",

--- a/packages/patternfly-4/react-core/package.json
+++ b/packages/patternfly-4/react-core/package.json
@@ -34,6 +34,7 @@
     "build:babel:esm": "cross-env BABEL_ENV=production:esm babel src --out-dir dist/esm --extensions '.js,jsx,.ts,.tsx'",
     "build:babel:umd": "cross-env BABEL_ENV=production:umd babel dist/esm --out-dir dist/umd --plugins transform-es2015-modules-umd  --extensions '.js,jsx,.ts,.tsx'",
     "build:types": "tsc -p tsconfig.gen-dts.json",
+    "develop": "yarn build:babel:esm --skip-initial-build --watch --verbose",
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "clean": "rimraf dist",
     "lint": "tslint -p tsconfig.typecheck.json"

--- a/packages/patternfly-4/react-docs/src/helpers/dynamicImports.js
+++ b/packages/patternfly-4/react-docs/src/helpers/dynamicImports.js
@@ -1,35 +1,32 @@
-// Dynamic imports. Yep, this is as ghetto as it looks.
 // We cannot use `"@patternfly/react-core": "file:../react-core"` in package.json and then
 // use the normal require("@patternfly/react-core") here because we need to use a *locked*
 // version of react-core for other component _inside_ our website (like the nav) in case
 // they break during local development. This is so the website won't fall apart if you break
 // the code for react-core/src/components/Button locally.
-const reactCharts = require("../../../react-charts/dist/esm");
-const reactCore = require("../../../react-core/dist/esm");
-const reactIcons = require("../../../../react-icons/dist/esm");
-const reactStyled = require("../../../react-styled-system/dist/esm");
-const reactStyles = require("../../../react-styles/dist/esm");
-const reactTable = require("../../../react-table/dist/esm");
-const reactTokens = require("../../../react-tokens/dist/esm");
-const reactStyledSystem = require("../../../react-styled-system/dist/esm")
-const reactInlineEdit = require("../../../react-inline-edit-extension/dist/esm")
+import * as reactCharts from "../../../react-charts/dist/esm";
+import * as reactCore from "../../../react-core/dist/esm";
+import * as reactIcons from "../../../../react-icons/dist/esm";
+import * as reactInlineEdit from "../../../react-inline-edit-extension/dist/esm";
+import * as reactStyledSystem from "../../../react-styled-system/dist/esm";
+import * as reactStyles from "../../../react-styles/dist/esm";
+import * as reactTable from "../../../react-table/dist/esm";
+import * as reactTokens from "../../../react-tokens/dist/esm";
 // This is from our gatsby-transformer-react-examples plugin
-const exampleComponents = require("../../.cache/example_index");
+import * as exampleComponents from "../../.cache/example_index";
 
 
 let imports = {
   "@patternfly/react-charts": reactCharts,
   "@patternfly/react-core": reactCore,
   "@patternfly/react-icons": reactIcons,
-  "@patternfly/react-styled-system": reactStyled,
+  "@patternfly/react-styled-system": reactStyledSystem,
   "@patternfly/react-styles": reactStyles,
   "@patternfly/react-table": reactTable,
   "@patternfly/react-tokens": reactTokens,
-  "@patternfly/react-styled-system": reactStyledSystem,
   "@patternfly/react-inline-edit-extension": reactInlineEdit
 };
 
-exports.getScope = (sourceCode, exampleResources) => {
+export const getScope = (sourceCode, exampleResources) => {
   let res = {};
   Object.entries(imports).forEach(([key, value]) => {
     if (sourceCode.indexOf(key) !== -1) {
@@ -46,4 +43,4 @@ exports.getScope = (sourceCode, exampleResources) => {
   return res;
 };
 
-exports.getTokens = () => imports["@patternfly/react-tokens"];
+export const getTokens = () => imports["@patternfly/react-tokens"];


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Let react-core keep its own build system this time instead of having react-docs also transpile react-core.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
