### PR TITLE
fix(Table): Update expanded row to span over all cells and remove padding

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
@@ -78,6 +78,8 @@ export interface IRow {
   isOpen: Boolean;
   parent: Number;
   props: any;
+  fullWidth?: Boolean;
+  noPadding?: Boolean;
 }
 
 export interface TableProps extends Omit<Omit<HTMLProps<HTMLTableElement>, 'onSelect'>, 'rows'> {

--- a/packages/patternfly-4/react-table/src/components/Table/Table.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.js
@@ -82,6 +82,8 @@ const propTypes = {
         ),
         isOpen: PropTypes.bool,
         parent: PropTypes.number,
+        fullWidth: PropTypes.bool,
+        noPadding: PropTypes.bool,
         props: PropTypes.any
       }),
       PropTypes.arrayOf(

--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -406,6 +406,7 @@ class ContactExpandableTable extends React.Component {
         },
         {
           parent: 1,
+          fullWidth: true,
           cells: ['child - 1']
         },
         {
@@ -422,6 +423,8 @@ class ContactExpandableTable extends React.Component {
         },
         {
           parent: 5,
+          fullWidth: true,
+          noPadding: true,
           cells: ['child - 3']
         }
       ]

--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/Table.test.js.snap
@@ -18197,6 +18197,7 @@ exports[`Collapsible nested table 1`] = `
                         </td>
                       </BodyCell>
                       <BodyCell
+                        className=""
                         colSpan={5}
                         component="td"
                         data-key={1}
@@ -18207,6 +18208,7 @@ exports[`Collapsible nested table 1`] = `
                         parentId={0}
                       >
                         <td
+                          className=""
                           colSpan={5}
                           data-key={1}
                           data-label="Header cell"
@@ -18636,7 +18638,7 @@ exports[`Collapsible nested table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -18644,7 +18646,7 @@ exports[`Collapsible nested table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn
@@ -18655,6 +18657,7 @@ exports[`Collapsible nested table 1`] = `
                         </td>
                       </BodyCell>
                       <BodyCell
+                        className=""
                         colSpan={5}
                         component="td"
                         data-key={1}
@@ -18665,6 +18668,7 @@ exports[`Collapsible nested table 1`] = `
                         parentId={1}
                       >
                         <td
+                          className=""
                           colSpan={5}
                           data-key={1}
                           data-label="Header cell"
@@ -19628,7 +19632,7 @@ exports[`Collapsible nested table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -19636,7 +19640,7 @@ exports[`Collapsible nested table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn
@@ -19647,6 +19651,7 @@ exports[`Collapsible nested table 1`] = `
                         </td>
                       </BodyCell>
                       <BodyCell
+                        className=""
                         colSpan={5}
                         component="td"
                         data-key={1}
@@ -19657,6 +19662,7 @@ exports[`Collapsible nested table 1`] = `
                         parentId={3}
                       >
                         <td
+                          className=""
                           colSpan={5}
                           data-key={1}
                           data-label="Header cell"
@@ -20090,7 +20096,7 @@ exports[`Collapsible nested table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -20098,7 +20104,7 @@ exports[`Collapsible nested table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn
@@ -20565,7 +20571,7 @@ exports[`Collapsible nested table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -20573,7 +20579,7 @@ exports[`Collapsible nested table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn
@@ -21040,7 +21046,7 @@ exports[`Collapsible nested table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -21048,7 +21054,7 @@ exports[`Collapsible nested table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn
@@ -21515,7 +21521,7 @@ exports[`Collapsible nested table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -21523,7 +21529,7 @@ exports[`Collapsible nested table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn
@@ -24947,7 +24953,7 @@ exports[`Collapsible table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -24955,7 +24961,7 @@ exports[`Collapsible table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn
@@ -24966,6 +24972,7 @@ exports[`Collapsible table 1`] = `
                         </td>
                       </BodyCell>
                       <BodyCell
+                        className=""
                         colSpan={5}
                         component="td"
                         data-key={1}
@@ -24976,6 +24983,7 @@ exports[`Collapsible table 1`] = `
                         parentId={0}
                       >
                         <td
+                          className=""
                           colSpan={5}
                           data-key={1}
                           data-label="Header cell"
@@ -25409,7 +25417,7 @@ exports[`Collapsible table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -25417,7 +25425,7 @@ exports[`Collapsible table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn
@@ -26414,7 +26422,7 @@ exports[`Collapsible table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -26422,7 +26430,7 @@ exports[`Collapsible table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn
@@ -26433,6 +26441,7 @@ exports[`Collapsible table 1`] = `
                         </td>
                       </BodyCell>
                       <BodyCell
+                        className=""
                         colSpan={5}
                         component="td"
                         data-key={1}
@@ -26443,6 +26452,7 @@ exports[`Collapsible table 1`] = `
                         parentId={3}
                       >
                         <td
+                          className=""
                           colSpan={5}
                           data-key={1}
                           data-label="Header cell"
@@ -26876,7 +26886,7 @@ exports[`Collapsible table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -26884,7 +26894,7 @@ exports[`Collapsible table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn
@@ -27351,7 +27361,7 @@ exports[`Collapsible table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -27359,7 +27369,7 @@ exports[`Collapsible table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn
@@ -27826,7 +27836,7 @@ exports[`Collapsible table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -27834,7 +27844,7 @@ exports[`Collapsible table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn
@@ -28301,7 +28311,7 @@ exports[`Collapsible table 1`] = `
                       onMouseDown={[Function]}
                     >
                       <BodyCell
-                        className="pf-c-table__toggle"
+                        className=""
                         component="td"
                         data-key={0}
                         data-label=""
@@ -28309,7 +28319,7 @@ exports[`Collapsible table 1`] = `
                         key="0-cell"
                       >
                         <td
-                          className="pf-c-table__toggle"
+                          className=""
                           data-key={0}
                         >
                           <CollapseColumn

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/collapsible.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/collapsible.js
@@ -19,8 +19,8 @@ export const collapsible = (value, { rowIndex, columnIndex, rowData, column, pro
     onCollapse && onCollapse(event, rowIndex, rowData && !rowData.isOpen, rowData, extraData);
   }
   return {
-    className: css(styles.tableToggle),
-    isVisible: true,
+    className: rowData.isOpen !== undefined && css(styles.tableToggle),
+    isVisible: !rowData.fullWidth,
     children: (
       <CollapseColumn
         aria-labelledby={`${rowLabeledBy}${rowIndex} ${expandId}${rowIndex}`}
@@ -49,8 +49,9 @@ export const expandedRow = colSpan => {
     }
   ) =>
     rowData.hasOwnProperty('parent') && {
-      colSpan,
-      id: contentId + rowIndex
+      colSpan: colSpan + !!rowData.fullWidth,
+      id: contentId + rowIndex,
+      className: rowData.noPadding && css(styles.modifiers.noPadding)
     };
   return expandedRowFormatter;
 };

--- a/packages/patternfly-4/react-table/src/components/Table/utils/transformers.test.js
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/transformers.test.js
@@ -184,6 +184,18 @@ describe('Transformer functions', () => {
     expect(onCollapse.mock.calls).toHaveLength(1);
   });
 
+  test('collapsible full width', () => {
+    const onCollapse = jest.fn();
+    const rowData = {
+      fullWidth: true
+    };
+    const column = {
+      extraParams: { onCollapse }
+    };
+    const returnedData = collapsible('', { rowIndex: 0, rowData, column });
+    expect(returnedData).toMatchObject({ className: false, isVisible: false });
+  });
+
   describe('expandable', () => {
     test('with parent', () => {
       const returned = expandable('test', { rowIndex: 2, rowData: { parent: 1 }, column: { extraParams: {} } });
@@ -209,6 +221,22 @@ describe('Transformer functions', () => {
     test('no parent', () => {
       expect(expandedRow(5)({ title: 'test' }, { rowData: {}, column: { extraParams: {} } })).toBe(false);
     });
+
+    test('full width', () => {
+      const returned = expandedRow(5)(
+        { title: 'test' },
+        { rowIndex: 2, rowData: { parent: 1, fullWidth: true }, column: { extraParams: {} } }
+      );
+      expect(returned).toMatchObject({ colSpan: 6, id: 'expanded-content2' });
+    });
+
+    test('no padding', () => {
+      const returned = expandedRow(5)(
+        { title: 'test' },
+        { rowIndex: 2, rowData: { parent: 1, noPadding: true }, column: { extraParams: {} } }
+      );
+      expect(returned).toMatchObject({ colSpan: 5, id: 'expanded-content2', className: 'pf-m-no-padding' });
+    })
   });
 
   test('scopeColTransformer', () => {


### PR DESCRIPTION
**What**:
Adds two optional fields to row definition
* `fullWidth` -  to span expanded row over all cells (removing first cell) fixes #1376
* `noPadding` - adds specific class `pf-m-no-padding` fixes #1678 

Fixes issue that first cell of expanded row had class `pf-c-table__toggle`, now first cell has no class at all.

<!-- feel free to add additional comments -->
