### PR TITLE
Updated collapsable table demo for issue #1678

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -541,6 +541,8 @@ class CollapsibleTable extends React.Component {
         },
         {
           parent: 5,
+          fullWidth: true,
+          noPadding: true,
           cells: ['child - 3']
         }
       ]

--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -525,6 +525,7 @@ class CollapsibleTable extends React.Component {
         },
         {
           parent: 1,
+          fullWidth: true,
           cells: ['child - 1']
         },
         {


### PR DESCRIPTION
Added no padding example to collapsable table demo.  Fix for issue #1678 