### PR TITLE
fix(popover): Enable highlighting and selecting text in popover.

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Tooltip/styles.js
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/styles.js
@@ -18,6 +18,10 @@ export const tippyStyles = () => {
       -webkit-font-smoothing: unset;
       text-align: unset;
       padding: unset;
+      cursor: text;
+      .tippy-content {
+        pointer-events: none;
+      }
     }
     .pf-c-tooltip, .pf-c-popover {
       max-width: unset;


### PR DESCRIPTION
**Previously,** cursor does turn to I-Beam (text), but cannot highlight or select the text in the Popover:
![popover_not_working](https://user-images.githubusercontent.com/12733153/56048213-0456bb00-5d15-11e9-9124-b25ef684d834.gif)

**With fix**, can now highlight and select text:
![popover_working](https://user-images.githubusercontent.com/12733153/56048247-10427d00-5d15-11e9-82b6-fbd9353810d5.gif)

Fixes #1735