### PR TITLE
[WIP] fix(imports): use a different import pattern

### DIFF
--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import AboutModalContainer from './AboutModalContainer';
-import { canUseDOM } from 'exenv';
+import * as ExecutionEnvironment from 'exenv';
 import { KEY_CODES } from '../../helpers/constants';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/patternfly/components/Backdrop/backdrop.css';
@@ -85,7 +85,7 @@ class AboutModal extends React.Component {
   }
 
   render() {
-    if (!canUseDOM) {
+    if (!ExecutionEnvironment.canUseDom) {
       return null;
     }
 

--- a/packages/patternfly-4/react-core/src/components/Modal/Modal.js
+++ b/packages/patternfly-4/react-core/src/components/Modal/Modal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import ModalContent from './ModalContent';
-import { canUseDOM } from 'exenv';
+import * as ExecutionEnvironment from 'exenv';
 import { KEY_CODES } from '../../helpers/constants';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/patternfly/components/Backdrop/backdrop.css';
@@ -98,7 +98,7 @@ class Modal extends React.Component {
   render() {
     const { ...props } = this.props;
 
-    if (!canUseDOM) {
+    if (!ExecutionEnvironment.canUseDOM) {
       return null;
     }
 
@@ -106,7 +106,7 @@ class Modal extends React.Component {
       this.container = document.createElement('div');
     }
 
-    return ReactDOM.createPortal(<ModalContent {...props} title={this.props.title} id={this.id} ariaDescribedById={this.props.ariaDescribedById}/>, this.container);
+    return ReactDOM.createPortal(<ModalContent {...props} title={this.props.title} id={this.id} ariaDescribedById={this.props.ariaDescribedById} />, this.container);
   }
 }
 

--- a/packages/patternfly-4/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/patternfly-4/react-core/src/components/Wizard/Wizard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { canUseDOM } from 'exenv';
+import * as ExecutionEnvironment from 'exenv';
 import { KEY_CODES } from '../../helpers/constants';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/patternfly/components/Wizard/wizard.css';
@@ -255,7 +255,7 @@ class Wizard extends React.Component<WizardProps> {
   }
 
   public render() {
-    if (!canUseDOM) {
+    if (!ExecutionEnvironment.canUseDOM) {
       return null;
     }
     if (!this.container) {


### PR DESCRIPTION
**What**: Fix an error I was seeing when importing react-core into a project. I don't see this in every project that uses `@patternfly/react-core`, and I haven't nailed down yet what the difference is in the project I'm seeing this in (https://github.com/syndesisio/syndesis-react), but figured I'd get these changes up so others who may know more about it could chime in.

<img width="1210" alt="Screen Shot 2019-04-10 at 2 42 17 PM" src="https://user-images.githubusercontent.com/5942899/56222515-31b7a780-603a-11e9-8601-7064492de770.png">


These changes fix the build issue I'm seeing, but it breaks the demo's that use the exenv pkg. WIP