### PR TITLE
Fixed TabContent errors

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Tabs/Tab.js
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tab.js
@@ -16,7 +16,7 @@ const propTypes = {
     PropTypes.number
   ]),
   /** child reference for case in which a TabContent section is defined outside of a Tabs component */
-  tabContentRef: PropTypes.elementType,
+  tabContentRef: PropTypes.node,
 };
 
 const defaultProps = {

--- a/packages/patternfly-4/react-core/src/components/Tabs/TabContent.js
+++ b/packages/patternfly-4/react-core/src/components/Tabs/TabContent.js
@@ -24,20 +24,24 @@ const defaultProps = {
 class TabContent extends React.Component {
   render() {
     const { id, activeKey, 'aria-label': ariaLabel, child, children, className, eventKey, innerRef, ...props } = this.props;
-    return <section
-      ref={innerRef}
-      index={eventKey}
-      hidden={children ? null : child.props.eventKey !== activeKey}
-      className={children ? css('pf-c-tab-content', className) : css('pf-c-tab-content', child.props.className)}
-      id={children ? id : `pf-tab-section-${child.props.eventKey}-${id}`}
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabel ? null : children ? `pf-tab-${eventKey}-${id}` : `pf-tab-${child.props.eventKey}-${id}`}
-      role="tabpanel"
-      tabIndex="0"
-      {...props}
-    >
-      {children ? children : child.props.children}
-    </section>;
+    if (children || child) {
+      return <section
+        ref={ innerRef }
+        index={ eventKey }
+        hidden={ children ? null : child.props.eventKey !== activeKey }
+        className={ children ? css('pf-c-tab-content', className) : css('pf-c-tab-content', child.props.className) }
+        id={ children ? id : `pf-tab-section-${child.props.eventKey}-${id}` }
+        aria-label={ ariaLabel }
+        aria-labelledby={ ariaLabel ? null : children ? `pf-tab-${eventKey}-${id}` : `pf-tab-${child.props.eventKey}-${id}` }
+        role="tabpanel"
+        tabIndex="0"
+        {...props}
+       >
+         {children ? children : child.props.children}
+       </section>;
+    } else {
+      return null;
+    }
   }
 }
 


### PR DESCRIPTION
This addresses the undefined child/children error seen with TabContent in the Cost Management UI. It also fixes a Typescript error encountered in the same UI.

Built and tested with the Cost Management UI and all is well.

Fixes https://github.com/patternfly/patternfly-react/issues/1698
