### PR TITLE
fix(react-core): Fixes console error with perPageSuffix (Issue #1784)

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Pagination/OptionsMenu.js
+++ b/packages/patternfly-4/react-core/src/components/Pagination/OptionsMenu.js
@@ -90,6 +90,7 @@ class OptionsMenu extends Component {
       firstIndex,
       lastIndex,
       perPage,
+      perPageSuffix,
       onPerPageSelect,
       toggleTemplate,
       ...props

--- a/packages/patternfly-4/react-core/src/components/Pagination/__snapshots__/Pagination.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Pagination/__snapshots__/Pagination.test.js.snap
@@ -96,7 +96,6 @@ exports[`component render custom pagination toggle 1`] = `
     >
       <div
         className="pf-c-options-menu"
-        perPageSuffix="per page"
       >
         <span
           hidden={true}
@@ -596,7 +595,6 @@ exports[`component render custom perPageOptions 1`] = `
     >
       <div
         className="pf-c-options-menu"
-        perPageSuffix="per page"
       >
         <span
           hidden={true}
@@ -1082,7 +1080,6 @@ exports[`component render custom start end 1`] = `
     >
       <div
         className="pf-c-options-menu"
-        perPageSuffix="per page"
       >
         <span
           hidden={true}
@@ -1623,7 +1620,6 @@ exports[`component render last page 1`] = `
     >
       <div
         className="pf-c-options-menu"
-        perPageSuffix="per page"
       >
         <span
           hidden={true}
@@ -2164,7 +2160,6 @@ exports[`component render limited number of pages 1`] = `
     >
       <div
         className="pf-c-options-menu"
-        perPageSuffix="per page"
       >
         <span
           hidden={true}
@@ -2705,7 +2700,6 @@ exports[`component render no items 1`] = `
     >
       <div
         className="pf-c-options-menu"
-        perPageSuffix="per page"
       >
         <span
           hidden={true}
@@ -3241,7 +3235,6 @@ exports[`component render should render correctly bottom 1`] = `
     >
       <div
         className="pf-c-options-menu"
-        perPageSuffix="per page"
       >
         <span
           hidden={true}
@@ -3782,7 +3775,6 @@ exports[`component render should render correctly top 1`] = `
     >
       <div
         className="pf-c-options-menu"
-        perPageSuffix="per page"
       >
         <span
           hidden={true}
@@ -4314,7 +4306,6 @@ exports[`component render titles 1`] = `
     >
       <div
         className="pf-c-options-menu"
-        perPageSuffix="per page"
       >
         <span
           hidden={true}
@@ -4855,7 +4846,6 @@ exports[`component render up drop direction 1`] = `
     >
       <div
         className="pf-c-options-menu"
-        perPageSuffix="per page"
       >
         <span
           hidden={true}


### PR DESCRIPTION
Destructured perPageSuffix from props prior to spreading.  Updated snapshots.

fix #1784

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
