### PR TITLE
fix(Button): Fix Button component atttribute to let set component like element 'a'

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Button/Button.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Button/Button.d.ts
@@ -17,7 +17,7 @@ export const ButtonType: {
 
 export interface ButtonProps extends HTMLProps<HTMLButtonElement> {
   children?: ReactNode;
-  component?: ReactType<ButtonProps>;
+  component?: ReactType;
   isActive?: boolean;
   isBlock?: boolean;
   isDisabled?: boolean;


### PR DESCRIPTION
fix #1824

```typescript
(95,17): Type '"a"' is not assignable to type '"big" | "small" | "sub" | "sup" | "abbr" | "address" | "article" | "aside" | "b" | "bdo" | "blockquote" | "button" | "caption" | "cite" | "code" | "data" | "dd" | "del" | "details" | ... 39 more ... | undefined'.
```
cc @priley86 