### PR TITLE
feat(Tab): Render Tab as <a> instead of <button> if it contains an href prop

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Tabs/Tab.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tab.d.ts
@@ -4,6 +4,7 @@ import { Omit } from '../../helpers/typeUtils';
 export interface TabProps extends Omit<HTMLProps<HTMLDivElement>, 'id'> {
   children?: ReactNode;
   className?: string;
+  href?: string;
   eventKey: number;
   id?: string;
   tabContentId?: string | number;

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tab.js
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tab.js
@@ -4,8 +4,10 @@ import PropTypes from 'prop-types';
 const propTypes = {
   /** content rendered inside the Tab content area. */
   children: PropTypes.node,
-  /** additional classes added to the Modal */
+  /** additional classes added to the Tab */
   className: PropTypes.string,
+  /** URL associated with the Tab. A Tab with an href will render as an <a> instead of a <button>. A Tab inside a <Tabs variant="nav"> should have an href. */
+  href: PropTypes.string,
   /** Tab title */
   title: PropTypes.string.isRequired,
   /** uniquely identifies the tab */
@@ -22,6 +24,7 @@ const propTypes = {
 const defaultProps = {
   children: null,
   className: '',
+  href: null,
   tabContentId: null,
   tabContentRef: null,
 };
@@ -42,7 +45,8 @@ class Tab extends React.Component {
   render() {
     // destructuring to prevent console warnings for applying eventKey, forwardRef, and tabContentId to a DOM element and remove title from the DOM element
     const { children, eventKey, tabContentId, tabContentRef, forwardRef, title, ...props } = this.props;
-    return <button {...props} ref={tabContentRef}>{children}</button>;
+    const Component = props.href ? 'a' : 'button';
+    return <Component {...props} ref={tabContentRef}>{children}</Component>;
   }
 }
 

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tabs.md
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tabs.md
@@ -201,12 +201,12 @@ class FilledTabs extends React.Component {
 }
 ```
 
-## Accessible secondary tabs
+## Secondary tabs using the nav element
 ```js
 import React from 'react';
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
 
-class AccessibleSecondaryTabs extends React.Component {
+class SecondaryTabsNavVariant extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -237,7 +237,7 @@ class AccessibleSecondaryTabs extends React.Component {
         aria-label="Local"
         variant={TabsVariant.nav}
       >
-        <Tab eventKey={0} title="Tab item 1">
+        <Tab eventKey={0} title="Tab item 1" href="#">
           <Tabs
             activeKey={this.state.activeTabKey2}
             isSecondary
@@ -245,21 +245,21 @@ class AccessibleSecondaryTabs extends React.Component {
             aria-label="Local secondary"
             variant={TabsVariant.nav}
           >
-            <Tab eventKey={10} title="Secondary tab item 1">
+            <Tab eventKey={10} title="Secondary tab item 1" href="#">
               Secondary tab item 1 item section
             </Tab>
-            <Tab eventKey={11} title="Secondary tab item 2">
+            <Tab eventKey={11} title="Secondary tab item 2" href="#">
               Secondary tab item 2 section
             </Tab>
-            <Tab eventKey={12} title="Secondary tab item 3">
+            <Tab eventKey={12} title="Secondary tab item 3" href="#">
               Secondary tab item 3 section
             </Tab>
           </Tabs>
         </Tab>
-        <Tab eventKey={1} title="Tab item 2">
+        <Tab eventKey={1} title="Tab item 2" href="#">
           Tab 2 section
         </Tab>
-        <Tab eventKey={2} title="Tab item 3">
+        <Tab eventKey={2} title="Tab item 3" href="#">
           Tab 3 section
         </Tab>
       </Tabs>
@@ -268,12 +268,12 @@ class AccessibleSecondaryTabs extends React.Component {
 }
 ```
 
-## Accessible tabs
+## Tabs using the nav element
 ```js
 import React from 'react';
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
 
-class AccessibleTabs extends React.Component {
+class TabsNavVariant extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -296,13 +296,13 @@ class AccessibleTabs extends React.Component {
         aria-label="Local"
         variant={TabsVariant.nav}
       >
-        <Tab eventKey={0} title="Tab item 1">
+        <Tab eventKey={0} title="Tab item 1" href="#">
           Tab 1 section
         </Tab>
-        <Tab eventKey={1} title="Tab item 2">
+        <Tab eventKey={1} title="Tab item 2" href="#">
           Tab 2 section
         </Tab>
-        <Tab eventKey={2} title="Tab item 3">
+        <Tab eventKey={2} title="Tab item 3" href="#">
           Tab 3 section
         </Tab>
       </Tabs>

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tabs.test.js
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tabs.test.js
@@ -23,13 +23,13 @@ test('should render simple tabs', () => {
 test('should render accessible tabs', () => {
   const view = shallow(
     <Tabs id="accessibleTabs" aria-label="accessible Tabs example" variant="nav">
-      <Tab id="tab1" eventKey={0} title="Tab item 1">
+      <Tab id="tab1" eventKey={0} title="Tab item 1" href="#/items/1">
         Tab 1 section
       </Tab>
-      <Tab id="tab2" eventKey={1} title="Tab item 2">
+      <Tab id="tab2" eventKey={1} title="Tab item 2" href="#/items/2">
         Tab 2 section
       </Tab>
-      <Tab id="tab3" eventKey={2} title="Tab item 3">
+      <Tab id="tab3" eventKey={2} title="Tab item 3" href="#/items/3">
         Tab 3 section
       </Tab>
     </Tabs>

--- a/packages/patternfly-4/react-core/src/components/Tabs/__snapshots__/Tabs.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Tabs/__snapshots__/Tabs.test.js.snap
@@ -101,6 +101,7 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
                   className="pf-c-tabs__button"
                   eventKey={0}
                   forwardRef={[Function]}
+                  href={null}
                   id="pf-tab-0-tab1"
                   onClick={[Function]}
                   tabContentId={null}
@@ -110,6 +111,7 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
                   <button
                     aria-controls="pf-tab-section-0-tab1"
                     className="pf-c-tabs__button"
+                    href={null}
                     id="pf-tab-0-tab1"
                     onClick={[Function]}
                   >
@@ -145,6 +147,7 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
                   className="pf-c-tabs__button"
                   eventKey={1}
                   forwardRef={[Function]}
+                  href={null}
                   id="pf-tab-1-tab2"
                   onClick={[Function]}
                   tabContentId={null}
@@ -154,6 +157,7 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
                   <button
                     aria-controls="pf-tab-section-1-tab2"
                     className="pf-c-tabs__button"
+                    href={null}
                     id="pf-tab-1-tab2"
                     onClick={[Function]}
                   >
@@ -189,6 +193,7 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
                   className="pf-c-tabs__button"
                   eventKey={2}
                   forwardRef={[Function]}
+                  href={null}
                   id="pf-tab-2-tab3"
                   onClick={[Function]}
                   tabContentId={null}
@@ -198,6 +203,7 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
                   <button
                     aria-controls="pf-tab-section-2-tab3"
                     className="pf-c-tabs__button"
+                    href={null}
                     id="pf-tab-2-tab3"
                     onClick={[Function]}
                   >
@@ -482,6 +488,7 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
                   className="pf-c-tabs__button"
                   eventKey={0}
                   forwardRef={[Function]}
+                  href={null}
                   id="pf-tab-0-tab1"
                   onClick={[Function]}
                   tabContentId={null}
@@ -491,6 +498,7 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
                   <button
                     aria-controls="pf-tab-section-0-tab1"
                     className="pf-c-tabs__button"
+                    href={null}
                     id="pf-tab-0-tab1"
                     onClick={[Function]}
                   >
@@ -526,6 +534,7 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
                   className="pf-c-tabs__button"
                   eventKey={1}
                   forwardRef={[Function]}
+                  href={null}
                   id="pf-tab-1-tab2"
                   onClick={[Function]}
                   tabContentId={null}
@@ -535,6 +544,7 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
                   <button
                     aria-controls="pf-tab-section-1-tab2"
                     className="pf-c-tabs__button"
+                    href={null}
                     id="pf-tab-1-tab2"
                     onClick={[Function]}
                   >
@@ -570,6 +580,7 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
                   className="pf-c-tabs__button"
                   eventKey={2}
                   forwardRef={[Function]}
+                  href={null}
                   id="pf-tab-2-tab3"
                   onClick={[Function]}
                   tabContentId={null}
@@ -579,6 +590,7 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
                   <button
                     aria-controls="pf-tab-section-2-tab3"
                     className="pf-c-tabs__button"
+                    href={null}
                     id="pf-tab-2-tab3"
                     onClick={[Function]}
                   >
@@ -863,6 +875,7 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
                   className="pf-c-tabs__button"
                   eventKey={0}
                   forwardRef={[Function]}
+                  href={null}
                   id="pf-tab-0-tab1"
                   onClick={[Function]}
                   tabContentId={null}
@@ -872,6 +885,7 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
                   <button
                     aria-controls="pf-tab-section-0-tab1"
                     className="pf-c-tabs__button"
+                    href={null}
                     id="pf-tab-0-tab1"
                     onClick={[Function]}
                   >
@@ -907,6 +921,7 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
                   className="pf-c-tabs__button"
                   eventKey={1}
                   forwardRef={[Function]}
+                  href={null}
                   id="pf-tab-1-tab2"
                   onClick={[Function]}
                   tabContentId={null}
@@ -916,6 +931,7 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
                   <button
                     aria-controls="pf-tab-section-1-tab2"
                     className="pf-c-tabs__button"
+                    href={null}
                     id="pf-tab-1-tab2"
                     onClick={[Function]}
                   >
@@ -951,6 +967,7 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
                   className="pf-c-tabs__button"
                   eventKey={2}
                   forwardRef={[Function]}
+                  href={null}
                   id="pf-tab-2-tab3"
                   onClick={[Function]}
                   tabContentId={null}
@@ -960,6 +977,7 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
                   <button
                     aria-controls="pf-tab-section-2-tab3"
                     className="pf-c-tabs__button"
+                    href={null}
                     id="pf-tab-2-tab3"
                     onClick={[Function]}
                   >
@@ -1157,6 +1175,7 @@ exports[`should render accessible tabs 1`] = `
 >
   <ForwardRef
     eventKey={0}
+    href="#/items/1"
     id="tab1"
     title="Tab item 1"
   >
@@ -1164,6 +1183,7 @@ exports[`should render accessible tabs 1`] = `
   </ForwardRef>
   <ForwardRef
     eventKey={1}
+    href="#/items/2"
     id="tab2"
     title="Tab item 2"
   >
@@ -1171,6 +1191,7 @@ exports[`should render accessible tabs 1`] = `
   </ForwardRef>
   <ForwardRef
     eventKey={2}
+    href="#/items/3"
     id="tab3"
     title="Tab item 3"
   >


### PR DESCRIPTION
Closes #1805

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Adds a prop `href` to the `Tab` component that causes it to render `<a>` instead of `<button>`. Adds a note to the props table explaining that this should be done if the consumer is using the `"nav"` variant for their `Tabs` container.

<!-- feel free to add additional comments -->
