### PR TITLE
add bodyWrapper type def

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
@@ -104,6 +104,8 @@ export interface TableProps extends Omit<Omit<HTMLProps<HTMLTableElement>, 'onSe
   dropdownDirection?: OneOf<typeof DropdownDirection, keyof typeof DropdownDirection>;
   rows: Array<IRow | Array<String>>;
   cells: Array<ICell | String>;
+  bodyWrapper?: Function;
+  rowWrapper?: Function;
 }
 
 declare const Table: FunctionComponent<TableProps>;


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Discovered these were missed in #1227 today while testing downstream
```
ERROR in /Users/priley/GitHub/web-ui/frontend/public/components/factory/table.tsx(386,12):
TS2322: Type '{ children: Element[]; cells: any[]; rows: any; onSelect: (event: MouseEvent<Element>, isSelected...' is not assignable to type 'IntrinsicAttributes & TableProps & { children?: ReactNode; }'.
  Type '{ children: Element[]; cells: any[]; rows: any; onSelect: (event: MouseEvent<Element>, isSelected...' is not assignable to type 'TableProps'.
    Property 'bodyWrapper' is missing in type '{ children: Element[]; cells: any[]; rows: any; onSelect: (event: MouseEvent<Element>, isSelected...'.
```

do these work OK for now @suomiy  or did you have something else in mind? 

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:
none

<!-- feel free to add additional comments -->
