### PR TITLE
chore(cleanup): fix dup heading level feature, relax title typedef

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Text/Text.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Text/Text.d.ts
@@ -2,12 +2,6 @@ import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 import { OneOf } from '../../helpers/typeUtils';
 
 export const TextVariants: {
-  h1: 'h1';
-  h2: 'h2';
-  h3: 'h3';
-  h4: 'h4';
-  h5: 'h5';
-  h6: 'h6';
   p: 'p';
   a: 'a';
   small: 'small';

--- a/packages/patternfly-4/react-core/src/components/Text/Text.js
+++ b/packages/patternfly-4/react-core/src/components/Text/Text.js
@@ -3,12 +3,6 @@ import PropTypes from 'prop-types';
 import { css } from '@patternfly/react-styles';
 
 export const TextVariants = {
-  h1: 'h1',
-  h2: 'h2',
-  h3: 'h3',
-  h4: 'h4',
-  h5: 'h5',
-  h6: 'h6',
   p: 'p',
   a: 'a',
   small: 'small',

--- a/packages/patternfly-4/react-core/src/components/Text/Text.md
+++ b/packages/patternfly-4/react-core/src/components/Text/Text.md
@@ -13,29 +13,6 @@ import {
   TextListItemVariants
 } from '@patternfly/react-core';
 
-## Headings
-```js
-import React from 'react';
-import {
-  TextContent,
-  Text,
-  TextVariants,
-  TextList,
-  TextListVariants,
-  TextListItem,
-  TextListItemVariants
-} from '@patternfly/react-core';
-
-<TextContent>
-  <Text component={TextVariants.h1}>Hello World</Text>
-  <Text component={TextVariants.h2}>Second level</Text>
-  <Text component={TextVariants.h3}>Third level</Text>
-  <Text component={TextVariants.h4}>Fourth level</Text>
-  <Text component={TextVariants.h5}>Fifth level</Text>
-  <Text component={TextVariants.h6}>Sixth level</Text>
-</TextContent>
-```
-
 ## Body text
 ```js
 import React from 'react';

--- a/packages/patternfly-4/react-core/src/components/Text/Text.test.js
+++ b/packages/patternfly-4/react-core/src/components/Text/Text.test.js
@@ -8,13 +8,11 @@ import TextListItem, { TextListItemVariants } from './TextListItem';
 test('Text example should match snapshot', () => {
   const view = mount(
     <TextContent>
-      <Text component={TextVariants.h1}>Hello World</Text>
       <Text component={TextVariants.p}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla accumsan, metus ultrices eleifend gravida, nulla
         nunc varius lectus, nec rutrum justo nibh eu lectus. Ut vulputate semper dui. Fusce erat odio, sollicitudin vel
         erat vel, interdum mattis neque. Sub works as well!
       </Text>
-      <Text component={TextVariants.h2}>Second level</Text>
       <Text component={TextVariants.p}>
         Curabitur accumsan turpis pharetra <strong>augue tincidunt</strong> blandit. Quisque condimentum maximus mi, sit
         amet commodo arcu rutrum id. Proin pretium urna vel cursus venenatis. Suspendisse potenti. Etiam mattis sem
@@ -32,7 +30,6 @@ test('Text example should match snapshot', () => {
         </TextListItem>
         <TextListItem>Ut non enim metus.</TextListItem>
       </TextList>
-      <Text component={TextVariants.h3}>Third level</Text>
       <Text component={TextVariants.p}>
         Quisque ante lacus, malesuada ac auctor vitae, congue{' '}
         <Text component={TextVariants.a} href="#">
@@ -75,7 +72,6 @@ test('Text example should match snapshot', () => {
         Suspendisse egestas sapien non felis placerat elementum. Morbi tortor nisl, suscipit sed mi sit amet, mollis
         malesuada nulla. Nulla facilisi. Nullam ac erat ante.
       </Text>
-      <Text component={TextVariants.h4}>Fourth level</Text>
       <Text component={TextVariants.p}>
         Nulla efficitur eleifend nisi, sit amet bibendum sapien fringilla ac. Mauris euismod metus a tellus laoreet, at
         elementum ex efficitur.
@@ -93,13 +89,11 @@ test('Text example should match snapshot', () => {
         nec nisl placerat, pretium metus vel, euismod ipsum. Proin tempor cursus nisl vel condimentum. Nam pharetra
         varius metus non pellentesque.
       </Text>
-      <Text component={TextVariants.h5}>Fifth level</Text>
       <Text component={TextVariants.p}>
         Aliquam sagittis rhoncus vulputate. Cras non luctus sem, sed tincidunt ligula. Vestibulum at nunc elit. Praesent
         aliquet ligula mi, in luctus elit volutpat porta. Phasellus molestie diam vel nisi sodales, a eleifend augue
         laoreet. Sed nec eleifend justo. Nam et sollicitudin odio.
       </Text>
-      <Text component={TextVariants.h6}>Sixth level</Text>
       <Text component={TextVariants.p}>
         Cras in nibh lacinia, venenatis nisi et, auctor urna. Donec pulvinar lacus sed diam dignissim, ut eleifend eros
         accumsan. Phasellus non tortor eros. Ut sed rutrum lacus. Etiam purus nunc, scelerisque quis enim vitae,

--- a/packages/patternfly-4/react-core/src/components/Text/__snapshots__/Text.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Text/__snapshots__/Text.test.js.snap
@@ -9,17 +9,6 @@ exports[`Text example should match snapshot 1`] = `
   >
     <Text
       className=""
-      component="h1"
-    >
-      <h1
-        className=""
-        data-pf-content={true}
-      >
-        Hello World
-      </h1>
-    </Text>
-    <Text
-      className=""
       component="p"
     >
       <p
@@ -28,17 +17,6 @@ exports[`Text example should match snapshot 1`] = `
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla accumsan, metus ultrices eleifend gravida, nulla nunc varius lectus, nec rutrum justo nibh eu lectus. Ut vulputate semper dui. Fusce erat odio, sollicitudin vel erat vel, interdum mattis neque. Sub works as well!
       </p>
-    </Text>
-    <Text
-      className=""
-      component="h2"
-    >
-      <h2
-        className=""
-        data-pf-content={true}
-      >
-        Second level
-      </h2>
     </Text>
     <Text
       className=""
@@ -141,17 +119,6 @@ exports[`Text example should match snapshot 1`] = `
         </TextListItem>
       </ul>
     </TextList>
-    <Text
-      className=""
-      component="h3"
-    >
-      <h3
-        className=""
-        data-pf-content={true}
-      >
-        Third level
-      </h3>
-    </Text>
     <Text
       className=""
       component="p"
@@ -391,17 +358,6 @@ exports[`Text example should match snapshot 1`] = `
     </Text>
     <Text
       className=""
-      component="h4"
-    >
-      <h4
-        className=""
-        data-pf-content={true}
-      >
-        Fourth level
-      </h4>
-    </Text>
-    <Text
-      className=""
       component="p"
     >
       <p
@@ -446,17 +402,6 @@ exports[`Text example should match snapshot 1`] = `
     </Text>
     <Text
       className=""
-      component="h5"
-    >
-      <h5
-        className=""
-        data-pf-content={true}
-      >
-        Fifth level
-      </h5>
-    </Text>
-    <Text
-      className=""
       component="p"
     >
       <p
@@ -465,17 +410,6 @@ exports[`Text example should match snapshot 1`] = `
       >
         Aliquam sagittis rhoncus vulputate. Cras non luctus sem, sed tincidunt ligula. Vestibulum at nunc elit. Praesent aliquet ligula mi, in luctus elit volutpat porta. Phasellus molestie diam vel nisi sodales, a eleifend augue laoreet. Sed nec eleifend justo. Nam et sollicitudin odio.
       </p>
-    </Text>
-    <Text
-      className=""
-      component="h6"
-    >
-      <h6
-        className=""
-        data-pf-content={true}
-      >
-        Sixth level
-      </h6>
     </Text>
     <Text
       className=""

--- a/packages/patternfly-4/react-core/src/components/Title/Title.tsx
+++ b/packages/patternfly-4/react-core/src/components/Title/Title.tsx
@@ -21,7 +21,7 @@ export interface TitleProps extends Omit<React.HTMLProps<HTMLHeadingElement>, 's
   /** Additional classes added to the Title */
   className?: string;
   /** the heading level to use */
-  headingLevel?: TitleLevel;
+  headingLevel?: TitleLevel | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
 
 const Title: React.FunctionComponent<TitleProps> = ({


### PR DESCRIPTION
**What**: Consolidate heading component implementations. Make Title headingLevel prop more flexible.

Currently, there are two ways to generate a heading. The preferred way is using the dedicated Title component, a secondary and legacy way is using the Text component. I don't think we need multiple implementations as it confuses the semantics of the component and makes searching/writing docs harder. This PR removes the heading capability from the `Text` component, deferring to `Title` which has more features and is further tested/documented.

On the note of Title, we had a small but important regression recently. The ability to supply string values for headingLevel in Title I think is important. It's a bit of a tripping hazard. As a developer, I expect to be able to write `<Title size="3xl" headingLevel="h2">...` and not forced to use the enum, for example `<Title size="3xl" headingLevel={TitleLevel.h2}>...`. This PR adds back that capability so developers can use either approach. Makes for smoother developer experience.

Before

<img width="749" alt="Screen Shot 2019-04-23 at 12 17 37 PM" src="https://user-images.githubusercontent.com/5942899/56608173-2a634180-65d8-11e9-901b-b0250c9b7d26.png">

After

<img width="644" alt="Screen Shot 2019-04-23 at 1 59 12 PM" src="https://user-images.githubusercontent.com/5942899/56608224-4830a680-65d8-11e9-9e45-01cf18dc2756.png">

