### PR TITLE
feat(About modal): Added support for more user control over content

### DIFF
--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.d.ts
@@ -10,6 +10,7 @@ export interface AboutModalProps extends HTMLProps<HTMLDivElement> {
   brandImageAlt: string;
   logoImageSrc?: string;
   logoImageAlt?: string;
+  noAboutModalBoxContentContainer?: boolean;
 }
 
 declare const AboutModal: FunctionComponent<AboutModalProps>;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.js
@@ -33,6 +33,8 @@ const propTypes = {
     }
     return null;
   },
+  /** prevents AboutModal from rendering content inside AboutModalContentBox; allows for more flexible layouts */
+  noAboutModalBoxContentContainer: PropTypes.bool,
   /** Additional props are passed and spread to Modal content container <div> */
   '': PropTypes.any
 };
@@ -44,7 +46,8 @@ const defaultProps = {
   productName: '',
   trademark: '',
   logoImageSrc: '',
-  logoImageAlt: ''
+  logoImageAlt: '',
+  noAboutModalBoxContentContainer: false
 };
 
 let currentId = 0;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.js
@@ -8,34 +8,34 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/patternfly/components/Backdrop/backdrop.css';
 
 const propTypes = {
-  /** content rendered inside the About Modal. */
+  /** Content rendered inside the about modal */
   children: PropTypes.node.isRequired,
-  /** additional classes added to the About Modal */
+  /** Additional classes added to the about modal */
   className: PropTypes.string,
-  /** Flag to show the  About modal */
+  /** Flag to show the about modal */
   isOpen: PropTypes.bool,
   /** A callback for when the close button is clicked */
   onClose: PropTypes.func,
-  /** Product Name */
+  /** Product name */
   productName: PropTypes.string,
   /** Trademark information */
   trademark: PropTypes.string,
-  /** the URL of the image for the Brand. */
+  /** The URL of the image for the brand */
   brandImageSrc: PropTypes.string.isRequired,
-  /** the alternate text of the Brand image. */
+  /** The alternate text of the brand image */
   brandImageAlt: PropTypes.string.isRequired,
-  /** the URL of the image for the Logo. */
+  /** The URL of the image for the logo */
   logoImageSrc: PropTypes.string,
-  /** the alternate text of the Logo image. */
+  /** The alternate text of the logo image */
   logoImageAlt: props => {
     if (props.logoImageSrc && !props.logoImageAlt) {
       return new Error('logoImageAlt is required when a logoImageSrc is specified');
     }
     return null;
   },
-  /** prevents AboutModal from rendering content inside AboutModalContentBox; allows for more flexible layouts */
+  /** Prevents the about modal from rendering content inside a container; allows for more flexible layouts */
   noAboutModalBoxContentContainer: PropTypes.bool,
-  /** Additional props are passed and spread to Modal content container <div> */
+  /** Additional props are passed and spread to the modal content container <div> */
   '': PropTypes.any
 };
 

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.md
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.md
@@ -2,12 +2,11 @@
 title: 'About modal'
 cssPrefix: 'pf-c-about-modal-box'
 ---
-## Simple about modal
-
 import { AboutModal, Button, TextContent, TextList, TextListItem } from '@patternfly/react-core';
 import brandImg from './examples/brandImg.svg';
 import logoImg from './examples/logoImg.svg';
 
+## Simple about modal
 ```js
 import React from 'react';
 import { AboutModal, Button, TextContent, TextList, TextListItem } from '@patternfly/react-core';
@@ -132,3 +131,74 @@ class SimpleAboutModal extends React.Component {
   }
 }
 ```
+
+## About modal with more complex user-positioned content
+
+```js
+import React from 'react';
+import { AboutModal, Alert, Button, TextContent, TextList, TextListItem } from '@patternfly/react-core';
+import brandImg from './examples/brandImg.svg';
+import logoImg from './examples/logoImg.svg';
+
+class ContentRichAboutModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isModalOpen: false
+    };
+    this.handleModalToggle = () => {
+      this.setState(({ isModalOpen }) => ({
+        isModalOpen: !isModalOpen
+      }));
+    };
+  }
+
+  render() {
+    const { isModalOpen } = this.state;
+
+    return (
+      <React.Fragment>
+        <Button variant="primary" onClick={this.handleModalToggle}>
+          Show About Modal
+        </Button>
+        <AboutModal
+          isOpen={isModalOpen}
+          onClose={this.handleModalToggle}
+          trademark="Trademark and copyright information here"
+          brandImageSrc={brandImg}
+          brandImageAlt="Patternfly Logo"
+          logoImageSrc={logoImg}
+          logoImageAlt="Patternfly Logo"
+          noAboutModalBoxContentContainer={true}
+          productName="Product Name"
+        >
+          <TextContent id="test1" className="pf-u-py-xl">
+            <h4>About</h4>
+            <p>Content here</p>
+          </TextContent>
+          <Alert variant="info" title="Updates available" />
+          <TextContent id="test2" className="pf-u-py-xl">
+            <TextList component="dl">
+              <TextListItem component="dt">CFME Version</TextListItem>
+              <TextListItem component="dd">5.5.3.4.20102789036450</TextListItem>
+              <TextListItem component="dt">Cloudforms Version</TextListItem>
+              <TextListItem component="dd">4.1</TextListItem>
+              <TextListItem component="dt">Server Name</TextListItem>
+              <TextListItem component="dd">40DemoMaster</TextListItem>
+              <TextListItem component="dt">User Name</TextListItem>
+              <TextListItem component="dd">Administrator</TextListItem>
+              <TextListItem component="dt">User Role</TextListItem>
+              <TextListItem component="dd">EvmRole-super_administrator</TextListItem>
+              <TextListItem component="dt">Browser Version</TextListItem>
+              <TextListItem component="dd">601.2</TextListItem>
+              <TextListItem component="dt">Browser OS</TextListItem>
+              <TextListItem component="dd">Mac</TextListItem>
+            </TextList>
+          </TextContent>
+        </AboutModal>
+      </React.Fragment>
+    );
+  }
+}
+```
+

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxContent.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxContent.d.ts
@@ -1,11 +1,11 @@
 import { FunctionComponent, HTMLProps, ReactNode } from 'react';
 
-export interface ModalBoxBodyProps extends HTMLProps<HTMLDivElement> {
+export interface AboutModalBoxContentProps extends HTMLProps<HTMLDivElement> {
   children: ReactNode;
-  tradeMark: string;
+  trademark: string;
   id: string;
 }
 
-declare const ModalBoxBody: FunctionComponent<ModalBoxBodyProps>;
+declare const AboutModalBoxContent: FunctionComponent<AboutModalBoxContentProps>;
 
-export default ModalBoxBody;
+export default AboutModalBoxContent;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxContent.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxContent.js
@@ -22,9 +22,9 @@ const defaultProps = {
   className: ''
 };
 
-const AboutModalBoxContent = ({ children, className, trademark, id, ...props }) => (
+const AboutModalBoxContent = ({ children, className, trademark, id, noAboutModalBoxContentContainer, ...props }) => (
   <div {...props} className={css(styles.aboutModalBoxContent, className)} id={id}>
-    <div className={css(contentStyles.content)}>{children}</div>
+    {noAboutModalBoxContentContainer ? children : <div className={css(contentStyles.content)}>{children}</div>}
     <div className={css(styles.aboutModalBoxStrapline)}>
       <p className={css(titleStyles.title)}>{trademark}</p>
     </div>

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxContent.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxContent.js
@@ -24,9 +24,14 @@ const defaultProps = {
 
 const AboutModalBoxContent = ({ children, className, trademark, id, noAboutModalBoxContentContainer, ...props }) => (
   <div {...props} className={css(styles.aboutModalBoxContent, className)} id={id}>
-    {noAboutModalBoxContentContainer ? children : <div className={css(contentStyles.content)}>{children}</div>}
+    <div className={css('pf-c-about-modal-box__body')}>
+      {noAboutModalBoxContentContainer
+        ? children
+        : <div className={css(contentStyles.content)}>{children}</div>
+      }
+    </div>
     <div className={css(styles.aboutModalBoxStrapline)}>
-      <p className={css(titleStyles.title)}>{trademark}</p>
+      <p className={css(titleStyles.title, titleStyles.modifiers.md)}>{trademark}</p>
     </div>
   </div>
 );

--- a/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalBoxContent.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalBoxContent.test.js.snap
@@ -6,15 +6,19 @@ exports[`AboutModalBoxContent Test 1`] = `
   id="id"
 >
   <div
-    className="pf-c-content"
+    className="pf-c-about-modal-box__body"
   >
-    This is a AboutModalBoxContent
+    <div
+      className="pf-c-content"
+    >
+      This is a AboutModalBoxContent
+    </div>
   </div>
   <div
     className="pf-c-about-modal-box__strapline"
   >
     <p
-      className="pf-c-title"
+      className="pf-c-title pf-m-md"
     >
       trademark
     </p>


### PR DESCRIPTION
Users can specify an optional prop that prevents the component from automatically nesting all content inside a  .pf-c-content div. Users can now use non-text components like Alert in the About modal.

I also fixed a messed up .d.ts file while I was in there (name and prop name were off).

Fixes #1853.