### PR TITLE
fix(charts): Fix chart themes to prevent axis labels from overflowing parent

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.js.snap
@@ -2156,7 +2156,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -2184,11 +2183,10 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -2232,7 +2230,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -2257,7 +2254,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -2337,7 +2333,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -2363,7 +2358,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -2380,7 +2374,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -2407,7 +2400,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -2450,7 +2442,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -2501,7 +2492,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -2528,7 +2518,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -2566,7 +2555,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -4752,7 +4740,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -4780,11 +4767,10 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -4828,7 +4814,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -4853,7 +4838,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -4933,7 +4917,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -4959,7 +4942,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -4976,7 +4958,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -5003,7 +4984,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -5046,7 +5026,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -5097,7 +5076,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -5124,7 +5102,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -5162,7 +5139,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -7354,7 +7330,6 @@ exports[`renders axis and component children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -7382,11 +7357,10 @@ exports[`renders axis and component children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -7430,7 +7404,6 @@ exports[`renders axis and component children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -7455,7 +7428,6 @@ exports[`renders axis and component children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -7535,7 +7507,6 @@ exports[`renders axis and component children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -7561,7 +7532,6 @@ exports[`renders axis and component children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -7578,7 +7548,6 @@ exports[`renders axis and component children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -7605,7 +7574,6 @@ exports[`renders axis and component children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -7648,7 +7616,6 @@ exports[`renders axis and component children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -7699,7 +7666,6 @@ exports[`renders axis and component children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -7726,7 +7692,6 @@ exports[`renders axis and component children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -7764,7 +7729,6 @@ exports[`renders axis and component children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.js.snap
@@ -48,7 +48,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -76,11 +75,10 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -124,7 +122,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -149,7 +146,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -229,7 +225,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -255,7 +250,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -272,7 +266,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -299,7 +292,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -342,7 +334,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -393,7 +384,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -420,7 +410,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -458,7 +447,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -536,7 +524,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -564,11 +551,10 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -612,7 +598,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -637,7 +622,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -717,7 +701,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -743,7 +726,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -760,7 +742,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -787,7 +768,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -830,7 +810,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -881,7 +860,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -908,7 +886,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -946,7 +923,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1048,7 +1024,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1076,11 +1051,10 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -1124,7 +1098,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -1149,7 +1122,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -1229,7 +1201,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -1255,7 +1226,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -1272,7 +1242,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1299,7 +1268,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -1342,7 +1310,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1393,7 +1360,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1420,7 +1386,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -1458,7 +1423,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -44,7 +44,7 @@ class SimpleChart extends React.Component {
     return (
       <div ref={this.containerRef}>
         <div className="chart-overflow">
-          <ChartGroup containerComponent={container} height={100} width={width}>
+          <ChartGroup containerComponent={container} height={200} width={width}>
             <ChartArea
               data={[
                 { name: 'Cats', x: 1, y: 1 },
@@ -127,7 +127,7 @@ class CustomColorsChart extends React.Component {
     return (
       <div ref={this.containerRef}>
         <div className="chart-overflow">
-          <ChartGroup containerComponent={container} height={100} width={width}>
+          <ChartGroup containerComponent={container} height={200} width={width}>
             <ChartArea
               data={[
                 { name: 'Cats', x: 1, y: 1 },
@@ -200,7 +200,7 @@ class DarkGreenThemeChart extends React.Component {
     return (
       <div ref={this.containerRef}>
         <div className="chart-overflow">
-          <ChartGroup containerComponent={container} theme={ChartTheme.dark.green} height={100} width={width}>
+          <ChartGroup containerComponent={container} theme={ChartTheme.dark.green} height={200} width={width}>
             <ChartArea
               data={[
                 { name: 'Cats', x: 1, y: 1 },

--- a/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.js.snap
@@ -48,7 +48,6 @@ exports[`ChartAxis 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -76,11 +75,10 @@ exports[`ChartAxis 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -124,7 +122,6 @@ exports[`ChartAxis 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -149,7 +146,6 @@ exports[`ChartAxis 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -229,7 +225,6 @@ exports[`ChartAxis 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -255,7 +250,6 @@ exports[`ChartAxis 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -272,7 +266,6 @@ exports[`ChartAxis 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -299,7 +292,6 @@ exports[`ChartAxis 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -342,7 +334,6 @@ exports[`ChartAxis 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -393,7 +384,6 @@ exports[`ChartAxis 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -420,7 +410,6 @@ exports[`ChartAxis 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -458,7 +447,6 @@ exports[`ChartAxis 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -551,7 +539,6 @@ exports[`ChartAxis 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -579,11 +566,10 @@ exports[`ChartAxis 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -627,7 +613,6 @@ exports[`ChartAxis 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -652,7 +637,6 @@ exports[`ChartAxis 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -732,7 +716,6 @@ exports[`ChartAxis 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -758,7 +741,6 @@ exports[`ChartAxis 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -775,7 +757,6 @@ exports[`ChartAxis 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -802,7 +783,6 @@ exports[`ChartAxis 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -845,7 +825,6 @@ exports[`ChartAxis 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -896,7 +875,6 @@ exports[`ChartAxis 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -923,7 +901,6 @@ exports[`ChartAxis 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -961,7 +938,6 @@ exports[`ChartAxis 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -3171,7 +3147,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -3199,11 +3174,10 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -3247,7 +3221,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -3272,7 +3245,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -3352,7 +3324,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -3378,7 +3349,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -3395,7 +3365,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -3422,7 +3391,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -3465,7 +3433,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -3516,7 +3483,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -3543,7 +3509,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -3581,7 +3546,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.js.snap
@@ -63,7 +63,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -91,11 +90,10 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -139,7 +137,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -164,7 +161,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -244,7 +240,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -270,7 +265,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -287,7 +281,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -314,7 +307,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -357,7 +349,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -408,7 +399,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -435,7 +425,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -473,7 +462,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -566,7 +554,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -594,11 +581,10 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -642,7 +628,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -667,7 +652,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -747,7 +731,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -773,7 +756,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -790,7 +772,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -817,7 +798,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -860,7 +840,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -911,7 +890,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -938,7 +916,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -976,7 +953,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -3171,7 +3147,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -3199,11 +3174,10 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -3247,7 +3221,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -3272,7 +3245,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -3352,7 +3324,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -3378,7 +3349,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -3395,7 +3365,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -3422,7 +3391,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -3465,7 +3433,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -3516,7 +3483,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -3543,7 +3509,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -3581,7 +3546,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",

--- a/packages/patternfly-4/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.js.snap
@@ -55,7 +55,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -83,11 +82,10 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -131,7 +129,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -156,7 +153,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -236,7 +232,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -262,7 +257,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -279,7 +273,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -306,7 +299,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -349,7 +341,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -400,7 +391,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -427,7 +417,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -465,7 +454,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -550,7 +538,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -578,11 +565,10 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -626,7 +612,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -651,7 +636,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -731,7 +715,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -757,7 +740,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -774,7 +756,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -801,7 +782,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -844,7 +824,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -895,7 +874,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -922,7 +900,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -960,7 +937,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1032,7 +1008,6 @@ exports[`renders container via ChartLegend 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1060,11 +1035,10 @@ exports[`renders container via ChartLegend 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -1108,7 +1082,6 @@ exports[`renders container via ChartLegend 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -1133,7 +1106,6 @@ exports[`renders container via ChartLegend 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -1213,7 +1185,6 @@ exports[`renders container via ChartLegend 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -1239,7 +1210,6 @@ exports[`renders container via ChartLegend 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -1256,7 +1226,6 @@ exports[`renders container via ChartLegend 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1283,7 +1252,6 @@ exports[`renders container via ChartLegend 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -1326,7 +1294,6 @@ exports[`renders container via ChartLegend 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1377,7 +1344,6 @@ exports[`renders container via ChartLegend 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1404,7 +1370,6 @@ exports[`renders container via ChartLegend 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -1442,7 +1407,6 @@ exports[`renders container via ChartLegend 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.js.snap
@@ -55,7 +55,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -83,11 +82,10 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -131,7 +129,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -156,7 +153,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -236,7 +232,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -262,7 +257,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -279,7 +273,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -306,7 +299,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -349,7 +341,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -400,7 +391,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -427,7 +417,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -465,7 +454,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -550,7 +538,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -578,11 +565,10 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -626,7 +612,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -651,7 +636,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -731,7 +715,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -757,7 +740,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -774,7 +756,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -801,7 +782,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -844,7 +824,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -895,7 +874,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -922,7 +900,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -960,7 +937,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1038,7 +1014,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1066,11 +1041,10 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -1114,7 +1088,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -1139,7 +1112,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -1219,7 +1191,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -1245,7 +1216,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -1262,7 +1232,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1289,7 +1258,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -1332,7 +1300,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1383,7 +1350,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1410,7 +1376,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -1448,7 +1413,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",

--- a/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.js.snap
@@ -24,7 +24,6 @@ exports[`ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -52,11 +51,10 @@ exports[`ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -100,7 +98,6 @@ exports[`ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -125,7 +122,6 @@ exports[`ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -205,7 +201,6 @@ exports[`ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -231,7 +226,6 @@ exports[`ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -248,7 +242,6 @@ exports[`ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -275,7 +268,6 @@ exports[`ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -318,7 +310,6 @@ exports[`ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -369,7 +360,6 @@ exports[`ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -396,7 +386,6 @@ exports[`ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -434,7 +423,6 @@ exports[`ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -488,7 +476,6 @@ exports[`ChartGroup 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -516,11 +503,10 @@ exports[`ChartGroup 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -564,7 +550,6 @@ exports[`ChartGroup 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -589,7 +574,6 @@ exports[`ChartGroup 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -669,7 +653,6 @@ exports[`ChartGroup 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -695,7 +678,6 @@ exports[`ChartGroup 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -712,7 +694,6 @@ exports[`ChartGroup 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -739,7 +720,6 @@ exports[`ChartGroup 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -782,7 +762,6 @@ exports[`ChartGroup 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -833,7 +812,6 @@ exports[`ChartGroup 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -860,7 +838,6 @@ exports[`ChartGroup 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -898,7 +875,6 @@ exports[`ChartGroup 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -953,7 +929,6 @@ exports[`renders container children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -981,11 +956,10 @@ exports[`renders container children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -1029,7 +1003,6 @@ exports[`renders container children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -1054,7 +1027,6 @@ exports[`renders container children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -1134,7 +1106,6 @@ exports[`renders container children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -1160,7 +1131,6 @@ exports[`renders container children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -1177,7 +1147,6 @@ exports[`renders container children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1204,7 +1173,6 @@ exports[`renders container children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -1247,7 +1215,6 @@ exports[`renders container children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1298,7 +1265,6 @@ exports[`renders container children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1325,7 +1291,6 @@ exports[`renders container children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -1363,7 +1328,6 @@ exports[`renders container children 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.js.snap
@@ -44,7 +44,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -72,11 +71,10 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -120,7 +118,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -145,7 +142,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -225,7 +221,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -251,7 +246,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -268,7 +262,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -295,7 +288,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -338,7 +330,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -389,7 +380,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -416,7 +406,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -454,7 +443,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -537,7 +525,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -565,11 +552,10 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -613,7 +599,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -638,7 +623,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -718,7 +702,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -744,7 +727,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -761,7 +743,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -788,7 +769,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -831,7 +811,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -882,7 +861,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -909,7 +887,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -947,7 +924,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1031,7 +1007,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1059,11 +1034,10 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -1107,7 +1081,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -1132,7 +1105,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -1212,7 +1184,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -1238,7 +1209,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -1255,7 +1225,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1282,7 +1251,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -1325,7 +1293,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1376,7 +1343,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1403,7 +1369,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -1441,7 +1406,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.js.snap
@@ -47,7 +47,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -75,11 +74,10 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -123,7 +121,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -148,7 +145,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -228,7 +224,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -254,7 +249,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -271,7 +265,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -298,7 +291,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -341,7 +333,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -392,7 +383,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -419,7 +409,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -457,7 +446,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -534,7 +522,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -562,11 +549,10 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -610,7 +596,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -635,7 +620,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -715,7 +699,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -741,7 +724,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -758,7 +740,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -785,7 +766,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -828,7 +808,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -879,7 +858,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -906,7 +884,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -944,7 +921,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -3136,7 +3112,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -3164,11 +3139,10 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -3212,7 +3186,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -3237,7 +3210,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -3317,7 +3289,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -3343,7 +3314,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -3360,7 +3330,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -3387,7 +3356,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -3430,7 +3398,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -3481,7 +3448,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -3508,7 +3474,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -3546,7 +3511,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.js.snap
@@ -53,7 +53,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -81,11 +80,10 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -129,7 +127,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -154,7 +151,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -234,7 +230,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -260,7 +255,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -277,7 +271,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -304,7 +297,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -347,7 +339,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -398,7 +389,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -425,7 +415,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -463,7 +452,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -546,7 +534,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -574,11 +561,10 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -622,7 +608,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -647,7 +632,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -727,7 +711,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -753,7 +736,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -770,7 +752,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -797,7 +778,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -840,7 +820,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -891,7 +870,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -918,7 +896,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -956,7 +933,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1032,7 +1008,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1060,11 +1035,10 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -1108,7 +1082,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -1133,7 +1106,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -1213,7 +1185,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -1239,7 +1210,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -1256,7 +1226,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1283,7 +1252,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -1326,7 +1294,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1377,7 +1344,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1404,7 +1370,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -1442,7 +1407,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.js.snap
@@ -44,7 +44,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -72,11 +71,10 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -120,7 +118,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -145,7 +142,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -225,7 +221,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -251,7 +246,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -268,7 +262,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -295,7 +288,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -338,7 +330,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -389,7 +380,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -416,7 +406,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -454,7 +443,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -537,7 +525,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -565,11 +552,10 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -613,7 +599,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -638,7 +623,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -718,7 +702,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -744,7 +727,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -761,7 +743,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -788,7 +769,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -831,7 +811,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -882,7 +861,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -909,7 +887,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -947,7 +924,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1034,7 +1010,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1062,11 +1037,10 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -1110,7 +1084,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -1135,7 +1108,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -1215,7 +1187,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -1241,7 +1212,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -1258,7 +1228,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1285,7 +1254,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -1328,7 +1296,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1379,7 +1346,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1406,7 +1372,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -1444,7 +1409,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.js.snap
@@ -23,7 +23,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -51,11 +50,10 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -99,7 +97,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -124,7 +121,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -204,7 +200,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -230,7 +225,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -247,7 +241,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -274,7 +267,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -317,7 +309,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -368,7 +359,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -395,7 +385,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -433,7 +422,6 @@ exports[`Chart 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -486,7 +474,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -514,11 +501,10 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -562,7 +548,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -587,7 +572,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -667,7 +651,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -693,7 +676,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -710,7 +692,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -737,7 +718,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -780,7 +760,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -831,7 +810,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -858,7 +836,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -896,7 +873,6 @@ exports[`Chart 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -3091,7 +3067,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -3119,11 +3094,10 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -3167,7 +3141,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -3192,7 +3165,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -3272,7 +3244,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -3298,7 +3269,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -3315,7 +3285,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -3342,7 +3311,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -3385,7 +3353,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -3436,7 +3403,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -3463,7 +3429,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -3501,7 +3466,6 @@ exports[`renders component data 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -3,10 +3,6 @@ title: 'Stack chart'
 section: 'charts'
 ---
 
-### Known Problem
-
-All of the `<svg>` elements on this page need to have `overflow: 'visible'` set on them to display axes.
-
 ## Vertical blue themed stack chart
 
 import { Chart, ChartBar, ChartStack, ChartTheme } from '@patternfly/react-charts';

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-dark-blue.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-dark-blue.js
@@ -12,7 +12,7 @@ import Theme from './theme-common';
 
 // Colors
 const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = global_Color_dark_200.value;
+const COLOR_AXIS_STROKE = '#D1D1D1'; // TODO Replace with PF css variable when available
 const COLOR_FILL = global_active_color_200.value;
 const COLOR_SCALE = [
   global_active_color_100.value,
@@ -36,7 +36,6 @@ const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
 const LAYOUT_PROPS = {
   width: 451, // Todo: want to ensure the value is coming from theme
   height: 301,
-  padding: 8,
   colorScale: COLOR_SCALE
 };
 

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-dark-green.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-dark-green.js
@@ -11,7 +11,7 @@ import Theme from './theme-common';
 
 // Colors
 const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = global_Color_dark_100.value;
+const COLOR_AXIS_STROKE = '#D1D1D1'; // TODO Replace with PF css variable when available
 const COLOR_FILL = global_success_color_200.value;
 const COLOR_SCALE = [global_success_color_100.value, global_success_color_200.value, '#59C768'];
 const COLOR_STACK_STROKE = global_Color_dark_200.value;
@@ -30,7 +30,6 @@ const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
 const LAYOUT_PROPS = {
   width: 451, // Todo: want to ensure the value is coming from theme
   height: 301,
-  padding: 8,
   colorScale: COLOR_SCALE
 };
 

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-dark-multi.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-dark-multi.js
@@ -11,7 +11,7 @@ import Theme from './theme-common';
 
 // Colors
 const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = global_Color_dark_100.value;
+const COLOR_AXIS_STROKE = '#D1D1D1'; // TODO Replace with PF css variable when available
 const COLOR_FILL = global_active_color_200.value;
 const COLOR_SCALE = ['#39a5dc', '#9C92F5', '#59C768', '#FFD47D'];
 const COLOR_STACK_STROKE = global_Color_dark_200.value;
@@ -30,7 +30,6 @@ const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
 const LAYOUT_PROPS = {
   width: 451, // Todo: want to ensure the value is coming from theme
   height: 301,
-  padding: 8,
   colorScale: COLOR_SCALE
 };
 

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-light-blue.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-light-blue.js
@@ -4,7 +4,6 @@ import {
   global_active_color_200,
   global_active_color_300,
   global_Color_dark_100,
-  global_Color_dark_200,
   global_Color_light_100,
   global_FontFamily_sans_serif
 } from '@patternfly/react-tokens';
@@ -12,7 +11,7 @@ import Theme from './theme-common';
 
 // Colors
 const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = global_Color_dark_200.value;
+const COLOR_AXIS_STROKE = '#D1D1D1'; // TODO Replace with PF css variable when available
 const COLOR_FILL = global_active_color_200.value;
 const COLOR_SCALE = [
   global_active_color_100.value,
@@ -36,7 +35,6 @@ const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
 const LAYOUT_PROPS = {
   width: 451, // Todo: want to ensure the value is coming from theme
   height: 301,
-  padding: 8,
   colorScale: COLOR_SCALE
 };
 

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-light-green.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-light-green.js
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 import {
   global_Color_dark_100,
-  global_Color_dark_200,
   global_Color_light_100,
   global_success_color_100,
   global_success_color_200,
@@ -11,7 +10,7 @@ import Theme from './theme-common';
 
 // Colors
 const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = global_Color_dark_200.value;
+const COLOR_AXIS_STROKE = '#D1D1D1'; // TODO Replace with PF css variable when available
 const COLOR_FILL = global_success_color_200.value;
 const COLOR_SCALE = [global_success_color_100.value, global_success_color_200.value, '#59C768'];
 const COLOR_STACK_STROKE = global_Color_light_100.value;
@@ -30,7 +29,6 @@ const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
 const LAYOUT_PROPS = {
   width: 451, // Todo: want to ensure the value is coming from theme
   height: 301,
-  padding: 8,
   colorScale: COLOR_SCALE
 };
 

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-light-multi.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-light-multi.js
@@ -3,7 +3,6 @@ import {
   global_active_color_200,
   global_active_color_300,
   global_Color_dark_100,
-  global_Color_dark_200,
   global_Color_light_100,
   global_FontFamily_sans_serif
 } from '@patternfly/react-tokens';
@@ -11,7 +10,7 @@ import Theme from './theme-common';
 
 // Colors
 const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = global_Color_dark_200.value;
+const COLOR_AXIS_STROKE = '#D1D1D1'; // TODO Replace with PF css variable when available
 const COLOR_FILL = global_active_color_200.value;
 const COLOR_SCALE = ['#39a5dc', '#9C92F5', '#59C768', '#FFD47D'];
 const COLOR_STACK_STROKE = global_Color_light_100.value;
@@ -30,7 +29,6 @@ const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
 const LAYOUT_PROPS = {
   width: 451, // Todo: want to ensure the value is coming from theme
   height: 301,
-  padding: 8,
   colorScale: COLOR_SCALE
 };
 

--- a/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.js.snap
@@ -47,7 +47,6 @@ exports[`ChartVoronoiContainer 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -75,11 +74,10 @@ exports[`ChartVoronoiContainer 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -123,7 +121,6 @@ exports[`ChartVoronoiContainer 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -148,7 +145,6 @@ exports[`ChartVoronoiContainer 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -228,7 +224,6 @@ exports[`ChartVoronoiContainer 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -254,7 +249,6 @@ exports[`ChartVoronoiContainer 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -271,7 +265,6 @@ exports[`ChartVoronoiContainer 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -298,7 +291,6 @@ exports[`ChartVoronoiContainer 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -341,7 +333,6 @@ exports[`ChartVoronoiContainer 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -392,7 +383,6 @@ exports[`ChartVoronoiContainer 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -419,7 +409,6 @@ exports[`ChartVoronoiContainer 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -457,7 +446,6 @@ exports[`ChartVoronoiContainer 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -534,7 +522,6 @@ exports[`ChartVoronoiContainer 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -562,11 +549,10 @@ exports[`ChartVoronoiContainer 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -610,7 +596,6 @@ exports[`ChartVoronoiContainer 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -635,7 +620,6 @@ exports[`ChartVoronoiContainer 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -715,7 +699,6 @@ exports[`ChartVoronoiContainer 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -741,7 +724,6 @@ exports[`ChartVoronoiContainer 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -758,7 +740,6 @@ exports[`ChartVoronoiContainer 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -785,7 +766,6 @@ exports[`ChartVoronoiContainer 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -828,7 +808,6 @@ exports[`ChartVoronoiContainer 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -879,7 +858,6 @@ exports[`ChartVoronoiContainer 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -906,7 +884,6 @@ exports[`ChartVoronoiContainer 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -944,7 +921,6 @@ exports[`ChartVoronoiContainer 2`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -992,7 +968,6 @@ exports[`renders container via ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1020,11 +995,10 @@ exports[`renders container via ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#72767b",
+            "stroke": "#D1D1D1",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
@@ -1068,7 +1042,6 @@ exports[`renders container via ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "none",
@@ -1093,7 +1066,6 @@ exports[`renders container via ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "max": Object {
             "padding": 8,
@@ -1173,7 +1145,6 @@ exports[`renders container via ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#73bcf7",
@@ -1199,7 +1170,6 @@ exports[`renders container via ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "parent": Object {
             "border": "1px solid #bee1f4",
@@ -1216,7 +1186,6 @@ exports[`renders container via ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1243,7 +1212,6 @@ exports[`renders container via ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "width": 451,
       },
       "legend": Object {
@@ -1286,7 +1254,6 @@ exports[`renders container via ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",
@@ -1337,7 +1304,6 @@ exports[`renders container via ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
@@ -1364,7 +1330,6 @@ exports[`renders container via ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "stroke": "#fff",
@@ -1402,7 +1367,6 @@ exports[`renders container via ChartGroup 1`] = `
           "#0066ff",
         ],
         "height": 301,
-        "padding": 8,
         "style": Object {
           "data": Object {
             "fill": "transparent",


### PR DESCRIPTION
Fixes #1819

**What**:

Removed padding prop from the default layout and updated axis stroke color. Victory's default padding allows room for axis tick labels. The color for axis stroke will be included in PF core variables soon, but for now, just hardcoded the hex value.