### PR TITLE
fix(charts): Fix chart font stack to use PatternFly core sans-serif font stack

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.js.snap
@@ -2198,7 +2198,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2227,7 +2227,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -2241,7 +2241,7 @@ exports[`Chart 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2271,7 +2271,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2298,7 +2298,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2311,7 +2311,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2324,7 +2324,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2336,7 +2336,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2348,7 +2348,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2377,7 +2377,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2421,7 +2421,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2457,7 +2457,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2465,7 +2465,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -2491,7 +2491,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2517,7 +2517,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -2542,7 +2542,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2581,7 +2581,7 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -2612,7 +2612,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -4826,7 +4826,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4855,7 +4855,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -4869,7 +4869,7 @@ exports[`Chart 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4899,7 +4899,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4926,7 +4926,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4939,7 +4939,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4952,7 +4952,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4964,7 +4964,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4976,7 +4976,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -5005,7 +5005,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -5049,7 +5049,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -5085,7 +5085,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -5093,7 +5093,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -5119,7 +5119,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -5145,7 +5145,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -5170,7 +5170,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -5209,7 +5209,7 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -5240,7 +5240,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -7460,7 +7460,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7489,7 +7489,7 @@ exports[`renders axis and component children 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -7503,7 +7503,7 @@ exports[`renders axis and component children 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7533,7 +7533,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7560,7 +7560,7 @@ exports[`renders axis and component children 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7573,7 +7573,7 @@ exports[`renders axis and component children 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7586,7 +7586,7 @@ exports[`renders axis and component children 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7598,7 +7598,7 @@ exports[`renders axis and component children 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7610,7 +7610,7 @@ exports[`renders axis and component children 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7639,7 +7639,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7683,7 +7683,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7719,7 +7719,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7727,7 +7727,7 @@ exports[`renders axis and component children 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -7753,7 +7753,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7779,7 +7779,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -7804,7 +7804,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7843,7 +7843,7 @@ exports[`renders axis and component children 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -7874,7 +7874,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.js.snap
@@ -59,7 +59,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -88,7 +88,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -102,7 +102,7 @@ exports[`Chart 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -132,7 +132,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -159,7 +159,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -172,7 +172,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -185,7 +185,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -197,7 +197,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -209,7 +209,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -238,7 +238,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -282,7 +282,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -318,7 +318,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -326,7 +326,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -352,7 +352,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -378,7 +378,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -403,7 +403,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -442,7 +442,7 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -473,7 +473,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -548,7 +548,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -577,7 +577,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -591,7 +591,7 @@ exports[`Chart 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -621,7 +621,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -648,7 +648,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -661,7 +661,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -674,7 +674,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -686,7 +686,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -698,7 +698,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -727,7 +727,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -771,7 +771,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -807,7 +807,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -815,7 +815,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -841,7 +841,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -867,7 +867,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -892,7 +892,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -931,7 +931,7 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -962,7 +962,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1061,7 +1061,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1090,7 +1090,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1104,7 +1104,7 @@ exports[`renders component data 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1134,7 +1134,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1161,7 +1161,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1174,7 +1174,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1187,7 +1187,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1199,7 +1199,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1211,7 +1211,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1240,7 +1240,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1284,7 +1284,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1320,7 +1320,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1328,7 +1328,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1354,7 +1354,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1380,7 +1380,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1405,7 +1405,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1444,7 +1444,7 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -1475,7 +1475,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.js.snap
@@ -59,7 +59,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -88,7 +88,7 @@ exports[`ChartAxis 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -102,7 +102,7 @@ exports[`ChartAxis 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -132,7 +132,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -159,7 +159,7 @@ exports[`ChartAxis 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -172,7 +172,7 @@ exports[`ChartAxis 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -185,7 +185,7 @@ exports[`ChartAxis 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -197,7 +197,7 @@ exports[`ChartAxis 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -209,7 +209,7 @@ exports[`ChartAxis 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -238,7 +238,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -282,7 +282,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -318,7 +318,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -326,7 +326,7 @@ exports[`ChartAxis 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -352,7 +352,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -378,7 +378,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -403,7 +403,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -442,7 +442,7 @@ exports[`ChartAxis 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -473,7 +473,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -563,7 +563,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -592,7 +592,7 @@ exports[`ChartAxis 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -606,7 +606,7 @@ exports[`ChartAxis 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -636,7 +636,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -663,7 +663,7 @@ exports[`ChartAxis 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -676,7 +676,7 @@ exports[`ChartAxis 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -689,7 +689,7 @@ exports[`ChartAxis 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -701,7 +701,7 @@ exports[`ChartAxis 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -713,7 +713,7 @@ exports[`ChartAxis 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -742,7 +742,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -786,7 +786,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -822,7 +822,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -830,7 +830,7 @@ exports[`ChartAxis 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -856,7 +856,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -882,7 +882,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -907,7 +907,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -946,7 +946,7 @@ exports[`ChartAxis 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -977,7 +977,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3215,7 +3215,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3244,7 +3244,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -3258,7 +3258,7 @@ exports[`renders component data 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3288,7 +3288,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3315,7 +3315,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3328,7 +3328,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3341,7 +3341,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3353,7 +3353,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3365,7 +3365,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3394,7 +3394,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3438,7 +3438,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3474,7 +3474,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3482,7 +3482,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -3508,7 +3508,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3534,7 +3534,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3559,7 +3559,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3598,7 +3598,7 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -3629,7 +3629,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.js.snap
@@ -74,7 +74,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -103,7 +103,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -117,7 +117,7 @@ exports[`Chart 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -147,7 +147,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -174,7 +174,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -187,7 +187,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -200,7 +200,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -212,7 +212,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -224,7 +224,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -253,7 +253,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -297,7 +297,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -333,7 +333,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -341,7 +341,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -367,7 +367,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -393,7 +393,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -418,7 +418,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -457,7 +457,7 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -488,7 +488,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -578,7 +578,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -607,7 +607,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -621,7 +621,7 @@ exports[`Chart 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -651,7 +651,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -678,7 +678,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -691,7 +691,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -704,7 +704,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -716,7 +716,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -728,7 +728,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -757,7 +757,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -801,7 +801,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -837,7 +837,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -845,7 +845,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -871,7 +871,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -897,7 +897,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -922,7 +922,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -961,7 +961,7 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -992,7 +992,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3215,7 +3215,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3244,7 +3244,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -3258,7 +3258,7 @@ exports[`renders component data 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3288,7 +3288,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3315,7 +3315,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3328,7 +3328,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3341,7 +3341,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3353,7 +3353,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3365,7 +3365,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3394,7 +3394,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3438,7 +3438,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3474,7 +3474,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3482,7 +3482,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -3508,7 +3508,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3534,7 +3534,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3559,7 +3559,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3598,7 +3598,7 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -3629,7 +3629,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.js.snap
@@ -65,7 +65,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -94,7 +94,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -108,7 +108,7 @@ exports[`Chart 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -138,7 +138,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -165,7 +165,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -178,7 +178,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -191,7 +191,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -203,7 +203,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -215,7 +215,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -244,7 +244,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -288,7 +288,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -324,7 +324,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -332,7 +332,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -358,7 +358,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -384,7 +384,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -409,7 +409,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -448,7 +448,7 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -479,7 +479,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -560,7 +560,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -589,7 +589,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -603,7 +603,7 @@ exports[`Chart 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -633,7 +633,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -660,7 +660,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -673,7 +673,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -686,7 +686,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -698,7 +698,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -710,7 +710,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -739,7 +739,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -783,7 +783,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -819,7 +819,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -827,7 +827,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -853,7 +853,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -879,7 +879,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -904,7 +904,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -943,7 +943,7 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -974,7 +974,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1042,7 +1042,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1071,7 +1071,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1085,7 +1085,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1115,7 +1115,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1142,7 +1142,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1155,7 +1155,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1168,7 +1168,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1180,7 +1180,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1192,7 +1192,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1221,7 +1221,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1265,7 +1265,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1301,7 +1301,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1309,7 +1309,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1335,7 +1335,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1361,7 +1361,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1386,7 +1386,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1425,7 +1425,7 @@ exports[`renders container via ChartLegend 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -1456,7 +1456,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.js.snap
@@ -65,7 +65,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -94,7 +94,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -108,7 +108,7 @@ exports[`Chart 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -138,7 +138,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -165,7 +165,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -178,7 +178,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -191,7 +191,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -203,7 +203,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -215,7 +215,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -244,7 +244,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -288,7 +288,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -324,7 +324,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -332,7 +332,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -358,7 +358,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -384,7 +384,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -409,7 +409,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -448,7 +448,7 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -479,7 +479,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -560,7 +560,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -589,7 +589,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -603,7 +603,7 @@ exports[`Chart 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -633,7 +633,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -660,7 +660,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -673,7 +673,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -686,7 +686,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -698,7 +698,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -710,7 +710,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -739,7 +739,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -783,7 +783,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -819,7 +819,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -827,7 +827,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -853,7 +853,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -879,7 +879,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -904,7 +904,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -943,7 +943,7 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -974,7 +974,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1048,7 +1048,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1077,7 +1077,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1091,7 +1091,7 @@ exports[`renders component data 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1121,7 +1121,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1148,7 +1148,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1161,7 +1161,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1174,7 +1174,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1186,7 +1186,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1198,7 +1198,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1227,7 +1227,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1271,7 +1271,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1307,7 +1307,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1315,7 +1315,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1341,7 +1341,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1367,7 +1367,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1392,7 +1392,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1431,7 +1431,7 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -1462,7 +1462,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.js.snap
@@ -35,7 +35,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -64,7 +64,7 @@ exports[`ChartGroup 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -78,7 +78,7 @@ exports[`ChartGroup 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -108,7 +108,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -135,7 +135,7 @@ exports[`ChartGroup 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -148,7 +148,7 @@ exports[`ChartGroup 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -161,7 +161,7 @@ exports[`ChartGroup 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -173,7 +173,7 @@ exports[`ChartGroup 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -185,7 +185,7 @@ exports[`ChartGroup 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -214,7 +214,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -258,7 +258,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -294,7 +294,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -302,7 +302,7 @@ exports[`ChartGroup 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -328,7 +328,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -354,7 +354,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -379,7 +379,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -418,7 +418,7 @@ exports[`ChartGroup 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -449,7 +449,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -500,7 +500,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -529,7 +529,7 @@ exports[`ChartGroup 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -543,7 +543,7 @@ exports[`ChartGroup 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -573,7 +573,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -600,7 +600,7 @@ exports[`ChartGroup 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -613,7 +613,7 @@ exports[`ChartGroup 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -626,7 +626,7 @@ exports[`ChartGroup 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -638,7 +638,7 @@ exports[`ChartGroup 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -650,7 +650,7 @@ exports[`ChartGroup 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -679,7 +679,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -723,7 +723,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -759,7 +759,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -767,7 +767,7 @@ exports[`ChartGroup 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -793,7 +793,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -819,7 +819,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -844,7 +844,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -883,7 +883,7 @@ exports[`ChartGroup 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -914,7 +914,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -966,7 +966,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -995,7 +995,7 @@ exports[`renders container children 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1009,7 +1009,7 @@ exports[`renders container children 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1039,7 +1039,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1066,7 +1066,7 @@ exports[`renders container children 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1079,7 +1079,7 @@ exports[`renders container children 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1092,7 +1092,7 @@ exports[`renders container children 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1104,7 +1104,7 @@ exports[`renders container children 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1116,7 +1116,7 @@ exports[`renders container children 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1145,7 +1145,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1189,7 +1189,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1225,7 +1225,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1233,7 +1233,7 @@ exports[`renders container children 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1259,7 +1259,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1285,7 +1285,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1310,7 +1310,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1349,7 +1349,7 @@ exports[`renders container children 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -1380,7 +1380,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.js.snap
@@ -54,7 +54,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -83,7 +83,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -97,7 +97,7 @@ exports[`Chart 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -127,7 +127,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -154,7 +154,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -167,7 +167,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -180,7 +180,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -192,7 +192,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -204,7 +204,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -233,7 +233,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -277,7 +277,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -313,7 +313,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -321,7 +321,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -347,7 +347,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -373,7 +373,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -398,7 +398,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -437,7 +437,7 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -468,7 +468,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -547,7 +547,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -576,7 +576,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -590,7 +590,7 @@ exports[`Chart 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -620,7 +620,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -647,7 +647,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -660,7 +660,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -673,7 +673,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -685,7 +685,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -697,7 +697,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -726,7 +726,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -770,7 +770,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -806,7 +806,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -814,7 +814,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -840,7 +840,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -866,7 +866,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -891,7 +891,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -930,7 +930,7 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -961,7 +961,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1041,7 +1041,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1070,7 +1070,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1084,7 +1084,7 @@ exports[`renders component data 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1114,7 +1114,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1141,7 +1141,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1154,7 +1154,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1167,7 +1167,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1179,7 +1179,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1191,7 +1191,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1220,7 +1220,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1264,7 +1264,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1300,7 +1300,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1308,7 +1308,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1334,7 +1334,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1360,7 +1360,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1385,7 +1385,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1424,7 +1424,7 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -1455,7 +1455,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.js.snap
@@ -58,7 +58,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -87,7 +87,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -101,7 +101,7 @@ exports[`Chart 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -131,7 +131,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -158,7 +158,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -171,7 +171,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -184,7 +184,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -196,7 +196,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -208,7 +208,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -237,7 +237,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -281,7 +281,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -317,7 +317,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -325,7 +325,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -351,7 +351,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -377,7 +377,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -402,7 +402,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -441,7 +441,7 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -472,7 +472,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -546,7 +546,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -575,7 +575,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -589,7 +589,7 @@ exports[`Chart 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -619,7 +619,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -646,7 +646,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -659,7 +659,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -672,7 +672,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -684,7 +684,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -696,7 +696,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -725,7 +725,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -769,7 +769,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -805,7 +805,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -813,7 +813,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -839,7 +839,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -865,7 +865,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -890,7 +890,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -929,7 +929,7 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -960,7 +960,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3180,7 +3180,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3209,7 +3209,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -3223,7 +3223,7 @@ exports[`renders component data 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3253,7 +3253,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3280,7 +3280,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3293,7 +3293,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3306,7 +3306,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3318,7 +3318,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3330,7 +3330,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3359,7 +3359,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3403,7 +3403,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3439,7 +3439,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3447,7 +3447,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -3473,7 +3473,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3499,7 +3499,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3524,7 +3524,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3563,7 +3563,7 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -3594,7 +3594,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.js.snap
@@ -63,7 +63,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -92,7 +92,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -106,7 +106,7 @@ exports[`Chart 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -136,7 +136,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -163,7 +163,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -176,7 +176,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -189,7 +189,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -201,7 +201,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -213,7 +213,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -242,7 +242,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -286,7 +286,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -322,7 +322,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -330,7 +330,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -356,7 +356,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -382,7 +382,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -407,7 +407,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -446,7 +446,7 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -477,7 +477,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -556,7 +556,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -585,7 +585,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -599,7 +599,7 @@ exports[`Chart 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -629,7 +629,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -656,7 +656,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -669,7 +669,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -682,7 +682,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -694,7 +694,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -706,7 +706,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -735,7 +735,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -779,7 +779,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -815,7 +815,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -823,7 +823,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -849,7 +849,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -875,7 +875,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -900,7 +900,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -939,7 +939,7 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -970,7 +970,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1042,7 +1042,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1071,7 +1071,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1085,7 +1085,7 @@ exports[`renders component data 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1115,7 +1115,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1142,7 +1142,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1155,7 +1155,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1168,7 +1168,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1180,7 +1180,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1192,7 +1192,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1221,7 +1221,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1265,7 +1265,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1301,7 +1301,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1309,7 +1309,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1335,7 +1335,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1361,7 +1361,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1386,7 +1386,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1425,7 +1425,7 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -1456,7 +1456,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.js.snap
@@ -54,7 +54,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -83,7 +83,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -97,7 +97,7 @@ exports[`Chart 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -127,7 +127,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -154,7 +154,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -167,7 +167,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -180,7 +180,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -192,7 +192,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -204,7 +204,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -233,7 +233,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -277,7 +277,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -313,7 +313,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -321,7 +321,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -347,7 +347,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -373,7 +373,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -398,7 +398,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -437,7 +437,7 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -468,7 +468,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -547,7 +547,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -576,7 +576,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -590,7 +590,7 @@ exports[`Chart 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -620,7 +620,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -647,7 +647,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -660,7 +660,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -673,7 +673,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -685,7 +685,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -697,7 +697,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -726,7 +726,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -770,7 +770,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -806,7 +806,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -814,7 +814,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -840,7 +840,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -866,7 +866,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -891,7 +891,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -930,7 +930,7 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -961,7 +961,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1044,7 +1044,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1073,7 +1073,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1087,7 +1087,7 @@ exports[`renders component data 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1117,7 +1117,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1144,7 +1144,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1157,7 +1157,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1170,7 +1170,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1182,7 +1182,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1194,7 +1194,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1223,7 +1223,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1267,7 +1267,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1303,7 +1303,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1311,7 +1311,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1337,7 +1337,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1363,7 +1363,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1388,7 +1388,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1427,7 +1427,7 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -1458,7 +1458,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.js.snap
@@ -34,7 +34,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -63,7 +63,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -77,7 +77,7 @@ exports[`Chart 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -107,7 +107,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -134,7 +134,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -147,7 +147,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -160,7 +160,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -172,7 +172,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -184,7 +184,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -213,7 +213,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -257,7 +257,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -293,7 +293,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -301,7 +301,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -327,7 +327,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -353,7 +353,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -378,7 +378,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -417,7 +417,7 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -448,7 +448,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -498,7 +498,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -527,7 +527,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -541,7 +541,7 @@ exports[`Chart 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -571,7 +571,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -598,7 +598,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -611,7 +611,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -624,7 +624,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -636,7 +636,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -648,7 +648,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -677,7 +677,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -721,7 +721,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -757,7 +757,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -765,7 +765,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -791,7 +791,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -817,7 +817,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -842,7 +842,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -881,7 +881,7 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -912,7 +912,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3135,7 +3135,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3164,7 +3164,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -3178,7 +3178,7 @@ exports[`renders component data 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3208,7 +3208,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3235,7 +3235,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3248,7 +3248,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3261,7 +3261,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3273,7 +3273,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3285,7 +3285,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3314,7 +3314,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3358,7 +3358,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3394,7 +3394,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3402,7 +3402,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -3428,7 +3428,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3454,7 +3454,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3479,7 +3479,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3518,7 +3518,7 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -3549,7 +3549,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-common.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-common.js
@@ -16,9 +16,7 @@ export default props => {
     LABEL_CENTERED_PROPS,
     STROKE_LINE_CAP,
     STROKE_LINE_JOIN,
-    // TOPOGRAPHY_FONT_FAMILY,
-    // TOPOGRAPHY_LETTER_SPACING,
-    TOPOGRAPHY_FONT_SIZE
+    TYPOGRAPHY_FONT_SIZE
   } = props;
 
   return {
@@ -151,7 +149,7 @@ export default props => {
           type: 'square'
         },
         labels: LABEL_PROPS,
-        title: Object.assign({}, LABEL_PROPS, { fontSize: TOPOGRAPHY_FONT_SIZE, padding: 2 })
+        title: Object.assign({}, LABEL_PROPS, { fontSize: TYPOGRAPHY_FONT_SIZE, padding: 2 })
       }
     },
     line: Object.assign(

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-dark-blue.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-dark-blue.js
@@ -5,7 +5,8 @@ import {
   global_active_color_300,
   global_Color_dark_100,
   global_Color_dark_200,
-  global_Color_light_100
+  global_Color_light_100,
+  global_FontFamily_sans_serif
 } from '@patternfly/react-tokens';
 import Theme from './theme-common';
 
@@ -27,9 +28,9 @@ const COLOR_TOOLTIP_FLYOUT_FILL = global_Color_dark_100.value;
 const COLOR_TOOLTIP_FLYOUT_STROKE = global_Color_dark_100.value;
 
 // Typography
-const TOPOGRAPHY_FONT_FAMILY = "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif";
-const TOPOGRAPHY_LETTER_SPACING = 'normal';
-const TOPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
+const TYPOGRAPHY_FONT_FAMILY = global_FontFamily_sans_serif.value;
+const TYPOGRAPHY_LETTER_SPACING = 'normal';
+const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
 
 // Layout
 const LAYOUT_PROPS = {
@@ -41,9 +42,9 @@ const LAYOUT_PROPS = {
 
 // Labels
 const LABEL_PROPS = {
-  fontFamily: TOPOGRAPHY_FONT_FAMILY,
-  fontSize: TOPOGRAPHY_FONT_SIZE,
-  letterSpacing: TOPOGRAPHY_LETTER_SPACING,
+  fontFamily: TYPOGRAPHY_FONT_FAMILY,
+  fontSize: TYPOGRAPHY_FONT_SIZE,
+  letterSpacing: TYPOGRAPHY_LETTER_SPACING,
   padding: 10,
   fill: global_Color_light_100.value,
   stroke: 'transparent'
@@ -70,7 +71,7 @@ export default Theme({
   LABEL_CENTERED_PROPS,
   STROKE_LINE_CAP,
   STROKE_LINE_JOIN,
-  TOPOGRAPHY_FONT_FAMILY,
-  TOPOGRAPHY_LETTER_SPACING,
-  TOPOGRAPHY_FONT_SIZE
+  TYPOGRAPHY_FONT_FAMILY,
+  TYPOGRAPHY_LETTER_SPACING,
+  TYPOGRAPHY_FONT_SIZE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-dark-green.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-dark-green.js
@@ -4,7 +4,8 @@ import {
   global_Color_dark_200,
   global_Color_light_100,
   global_success_color_100,
-  global_success_color_200
+  global_success_color_200,
+  global_FontFamily_sans_serif
 } from '@patternfly/react-tokens';
 import Theme from './theme-common';
 
@@ -21,9 +22,9 @@ const COLOR_TOOLTIP_FLYOUT_FILL = global_Color_dark_100.value;
 const COLOR_TOOLTIP_FLYOUT_STROKE = global_Color_dark_100.value;
 
 // Typography
-const TOPOGRAPHY_FONT_FAMILY = "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif";
-const TOPOGRAPHY_LETTER_SPACING = 'normal';
-const TOPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
+const TYPOGRAPHY_FONT_FAMILY = global_FontFamily_sans_serif.value;
+const TYPOGRAPHY_LETTER_SPACING = 'normal';
+const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
 
 // Layout
 const LAYOUT_PROPS = {
@@ -35,9 +36,9 @@ const LAYOUT_PROPS = {
 
 // Labels
 const LABEL_PROPS = {
-  fontFamily: TOPOGRAPHY_FONT_FAMILY,
-  fontSize: TOPOGRAPHY_FONT_SIZE,
-  letterSpacing: TOPOGRAPHY_LETTER_SPACING,
+  fontFamily: TYPOGRAPHY_FONT_FAMILY,
+  fontSize: TYPOGRAPHY_FONT_SIZE,
+  letterSpacing: TYPOGRAPHY_LETTER_SPACING,
   padding: 10,
   fill: global_Color_light_100.value,
   stroke: 'transparent'
@@ -64,7 +65,7 @@ export default Theme({
   LABEL_CENTERED_PROPS,
   STROKE_LINE_CAP,
   STROKE_LINE_JOIN,
-  TOPOGRAPHY_FONT_FAMILY,
-  TOPOGRAPHY_LETTER_SPACING,
-  TOPOGRAPHY_FONT_SIZE
+  TYPOGRAPHY_FONT_FAMILY,
+  TYPOGRAPHY_LETTER_SPACING,
+  TYPOGRAPHY_FONT_SIZE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-dark-multi.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-dark-multi.js
@@ -4,7 +4,8 @@ import {
   global_active_color_300,
   global_Color_dark_100,
   global_Color_dark_200,
-  global_Color_light_100
+  global_Color_light_100,
+  global_FontFamily_sans_serif
 } from '@patternfly/react-tokens';
 import Theme from './theme-common';
 
@@ -21,9 +22,9 @@ const COLOR_TOOLTIP_FLYOUT_FILL = global_Color_dark_100.value;
 const COLOR_TOOLTIP_FLYOUT_STROKE = global_Color_dark_100.value;
 
 // Typography
-const TOPOGRAPHY_FONT_FAMILY = "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif";
-const TOPOGRAPHY_LETTER_SPACING = 'normal';
-const TOPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
+const TYPOGRAPHY_FONT_FAMILY = global_FontFamily_sans_serif.value;
+const TYPOGRAPHY_LETTER_SPACING = 'normal';
+const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
 
 // Layout
 const LAYOUT_PROPS = {
@@ -35,9 +36,9 @@ const LAYOUT_PROPS = {
 
 // Labels
 const LABEL_PROPS = {
-  fontFamily: TOPOGRAPHY_FONT_FAMILY,
-  fontSize: TOPOGRAPHY_FONT_SIZE,
-  letterSpacing: TOPOGRAPHY_LETTER_SPACING,
+  fontFamily: TYPOGRAPHY_FONT_FAMILY,
+  fontSize: TYPOGRAPHY_FONT_SIZE,
+  letterSpacing: TYPOGRAPHY_LETTER_SPACING,
   padding: 10,
   fill: global_Color_light_100.value,
   stroke: 'transparent'
@@ -64,7 +65,7 @@ export default Theme({
   LABEL_CENTERED_PROPS,
   STROKE_LINE_CAP,
   STROKE_LINE_JOIN,
-  TOPOGRAPHY_FONT_FAMILY,
-  TOPOGRAPHY_LETTER_SPACING,
-  TOPOGRAPHY_FONT_SIZE
+  TYPOGRAPHY_FONT_FAMILY,
+  TYPOGRAPHY_LETTER_SPACING,
+  TYPOGRAPHY_FONT_SIZE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-light-blue.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-light-blue.js
@@ -5,7 +5,8 @@ import {
   global_active_color_300,
   global_Color_dark_100,
   global_Color_dark_200,
-  global_Color_light_100
+  global_Color_light_100,
+  global_FontFamily_sans_serif
 } from '@patternfly/react-tokens';
 import Theme from './theme-common';
 
@@ -27,9 +28,9 @@ const COLOR_TOOLTIP_FLYOUT_FILL = global_Color_light_100.value;
 const COLOR_TOOLTIP_FLYOUT_STROKE = global_Color_dark_100.value;
 
 // Typography
-const TOPOGRAPHY_FONT_FAMILY = "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif";
-const TOPOGRAPHY_LETTER_SPACING = 'normal';
-const TOPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
+const TYPOGRAPHY_FONT_FAMILY = global_FontFamily_sans_serif.value;
+const TYPOGRAPHY_LETTER_SPACING = 'normal';
+const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
 
 // Layout
 const LAYOUT_PROPS = {
@@ -41,9 +42,9 @@ const LAYOUT_PROPS = {
 
 // Labels
 const LABEL_PROPS = {
-  fontFamily: TOPOGRAPHY_FONT_FAMILY,
-  fontSize: TOPOGRAPHY_FONT_SIZE,
-  letterSpacing: TOPOGRAPHY_LETTER_SPACING,
+  fontFamily: TYPOGRAPHY_FONT_FAMILY,
+  fontSize: TYPOGRAPHY_FONT_SIZE,
+  letterSpacing: TYPOGRAPHY_LETTER_SPACING,
   padding: 10,
   fill: global_Color_dark_100.value,
   stroke: 'transparent'
@@ -70,7 +71,7 @@ export default Theme({
   LABEL_CENTERED_PROPS,
   STROKE_LINE_CAP,
   STROKE_LINE_JOIN,
-  TOPOGRAPHY_FONT_FAMILY,
-  TOPOGRAPHY_LETTER_SPACING,
-  TOPOGRAPHY_FONT_SIZE
+  TYPOGRAPHY_FONT_FAMILY,
+  TYPOGRAPHY_LETTER_SPACING,
+  TYPOGRAPHY_FONT_SIZE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-light-green.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-light-green.js
@@ -4,7 +4,8 @@ import {
   global_Color_dark_200,
   global_Color_light_100,
   global_success_color_100,
-  global_success_color_200
+  global_success_color_200,
+  global_FontFamily_sans_serif
 } from '@patternfly/react-tokens';
 import Theme from './theme-common';
 
@@ -21,9 +22,9 @@ const COLOR_TOOLTIP_FLYOUT_FILL = global_Color_light_100.value;
 const COLOR_TOOLTIP_FLYOUT_STROKE = global_Color_dark_100.value;
 
 // Typography
-const TOPOGRAPHY_FONT_FAMILY = "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif";
-const TOPOGRAPHY_LETTER_SPACING = 'normal';
-const TOPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
+const TYPOGRAPHY_FONT_FAMILY = global_FontFamily_sans_serif.value;
+const TYPOGRAPHY_LETTER_SPACING = 'normal';
+const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
 
 // Layout
 const LAYOUT_PROPS = {
@@ -35,9 +36,9 @@ const LAYOUT_PROPS = {
 
 // Labels
 const LABEL_PROPS = {
-  fontFamily: TOPOGRAPHY_FONT_FAMILY,
-  fontSize: TOPOGRAPHY_FONT_SIZE,
-  letterSpacing: TOPOGRAPHY_LETTER_SPACING,
+  fontFamily: TYPOGRAPHY_FONT_FAMILY,
+  fontSize: TYPOGRAPHY_FONT_SIZE,
+  letterSpacing: TYPOGRAPHY_LETTER_SPACING,
   padding: 10,
   fill: global_Color_dark_100.value,
   stroke: 'transparent'
@@ -64,7 +65,7 @@ export default Theme({
   LABEL_CENTERED_PROPS,
   STROKE_LINE_CAP,
   STROKE_LINE_JOIN,
-  TOPOGRAPHY_FONT_FAMILY,
-  TOPOGRAPHY_LETTER_SPACING,
-  TOPOGRAPHY_FONT_SIZE
+  TYPOGRAPHY_FONT_FAMILY,
+  TYPOGRAPHY_LETTER_SPACING,
+  TYPOGRAPHY_FONT_SIZE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-light-multi.js
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/theme-light-multi.js
@@ -4,7 +4,8 @@ import {
   global_active_color_300,
   global_Color_dark_100,
   global_Color_dark_200,
-  global_Color_light_100
+  global_Color_light_100,
+  global_FontFamily_sans_serif
 } from '@patternfly/react-tokens';
 import Theme from './theme-common';
 
@@ -21,9 +22,9 @@ const COLOR_TOOLTIP_FLYOUT_FILL = global_Color_light_100.value;
 const COLOR_TOOLTIP_FLYOUT_STROKE = global_Color_dark_100.value;
 
 // Typography
-const TOPOGRAPHY_FONT_FAMILY = "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif";
-const TOPOGRAPHY_LETTER_SPACING = 'normal';
-const TOPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
+const TYPOGRAPHY_FONT_FAMILY = global_FontFamily_sans_serif.value;
+const TYPOGRAPHY_LETTER_SPACING = 'normal';
+const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
 
 // Layout
 const LAYOUT_PROPS = {
@@ -35,9 +36,9 @@ const LAYOUT_PROPS = {
 
 // Labels
 const LABEL_PROPS = {
-  fontFamily: TOPOGRAPHY_FONT_FAMILY,
-  fontSize: TOPOGRAPHY_FONT_SIZE,
-  letterSpacing: TOPOGRAPHY_LETTER_SPACING,
+  fontFamily: TYPOGRAPHY_FONT_FAMILY,
+  fontSize: TYPOGRAPHY_FONT_SIZE,
+  letterSpacing: TYPOGRAPHY_LETTER_SPACING,
   padding: 10,
   fill: global_Color_dark_100.value,
   stroke: 'transparent'
@@ -64,7 +65,7 @@ export default Theme({
   LABEL_CENTERED_PROPS,
   STROKE_LINE_CAP,
   STROKE_LINE_JOIN,
-  TOPOGRAPHY_FONT_FAMILY,
-  TOPOGRAPHY_LETTER_SPACING,
-  TOPOGRAPHY_FONT_SIZE
+  TYPOGRAPHY_FONT_FAMILY,
+  TYPOGRAPHY_LETTER_SPACING,
+  TYPOGRAPHY_FONT_SIZE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.js.snap
@@ -58,7 +58,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -87,7 +87,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -101,7 +101,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -131,7 +131,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -158,7 +158,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -171,7 +171,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -184,7 +184,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -196,7 +196,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -208,7 +208,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -237,7 +237,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -281,7 +281,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -317,7 +317,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -325,7 +325,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -351,7 +351,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -377,7 +377,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -402,7 +402,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -441,7 +441,7 @@ exports[`ChartVoronoiContainer 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -472,7 +472,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -546,7 +546,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -575,7 +575,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -589,7 +589,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -619,7 +619,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -646,7 +646,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -659,7 +659,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -672,7 +672,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -684,7 +684,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -696,7 +696,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -725,7 +725,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -769,7 +769,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -805,7 +805,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -813,7 +813,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -839,7 +839,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -865,7 +865,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -890,7 +890,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -929,7 +929,7 @@ exports[`ChartVoronoiContainer 2`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -960,7 +960,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1005,7 +1005,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1034,7 +1034,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1048,7 +1048,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1078,7 +1078,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1105,7 +1105,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1118,7 +1118,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1131,7 +1131,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1143,7 +1143,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1155,7 +1155,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1184,7 +1184,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1228,7 +1228,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1264,7 +1264,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1272,7 +1272,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1298,7 +1298,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1324,7 +1324,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1349,7 +1349,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1388,7 +1388,7 @@ exports[`renders container via ChartGroup 1`] = `
         "pointerLength": 10,
         "style": Object {
           "fill": "#fff",
-          "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 8,
@@ -1419,7 +1419,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "'Gill Sans', 'Gill Sans MT', 'Ser­avek', 'Trebuchet MS', sans-serif",
+            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,


### PR DESCRIPTION
Fixes #1864

**What**:
Use `global_FontFamily_sans_serif` variable for chart font stack. Also, correct misspelled 'TYPOGRAPHY' related variable names.