### PR TITLE
fix(React Icons documentation): fix link in Icons documentation  

### DIFF
--- a/packages/react-icons/README.md
+++ b/packages/react-icons/README.md
@@ -11,7 +11,7 @@ import { TimesIcon } from '@patternfly/react-icons';
 const closeIcon = <TimesIcon />;
 ```
 
-For a list of the available icons please refer to the [PatternFly React Docs](https://patternfly-react.surge.sh/patternfly-4/styles/icons)
+For a list of the available icons please refer to the [PatternFly React Docs](https://patternfly-react.surge.sh/patternfly-4/icons/Icons/)
 
 Every icon component has the following props:
 


### PR DESCRIPTION
fix #1841
