### PR TITLE
fix(ClipboardCopy): update imports and clean up

### DIFF
--- a/packages/patternfly-4/react-core/src/components/ClipboardCopy/ClipboardCopy.d.ts
+++ b/packages/patternfly-4/react-core/src/components/ClipboardCopy/ClipboardCopy.d.ts
@@ -1,16 +1,18 @@
-import { FunctionComponent, HTMLProps, MouseEvent, ReactNode, HTMLDivElement } from 'react';
-import { OneOf } from '../../typeUtils';
+import { ClipboardEvent, FunctionComponent, HTMLProps, ReactNode } from 'react';
+import { OneOf, Omit } from '../../helpers/typeUtils';
 import { PopoverPosition } from '../Popover';
 
-export const ClipboardCopyVariant = {
-  inline: 'inline',
-  expansion: 'expansion'
-};
+export enum ClipboardCopyVariant {
+  inline = 'inline',
+  expansion = 'expansion'
+}
 
-export interface ClipboardCopyProps extends HTMLProps<HTMLDivElement> {
+export interface ClipboardCopyProps extends Omit<HTMLProps<HTMLDivElement>, 'onChange'> {
   className?: string;
   hoverTip?: string;
   clickTip?: string;
+  textAriaLabel?: string;
+  toggleAriaLabel?: string;
   isReadOnly?: boolean;
   variant?: OneOf<typeof ClipboardCopyVariant, keyof typeof ClipboardCopyVariant>;
   position?: OneOf<typeof PopoverPosition, keyof typeof PopoverPosition>;
@@ -18,8 +20,8 @@ export interface ClipboardCopyProps extends HTMLProps<HTMLDivElement> {
   exitDelay?: number;
   entryDelay?: number;
   switchDelay?: number;
-  onCopy?: (event: MouseEvent, text?: string) => void;
-  onChange?: (text: string) => void;
+  onCopy?: (event: ClipboardEvent<HTMLDivElement>, text?: string) => void;
+  onChange?: (text?: string) => void;
   children?: ReactNode;
 }
 

--- a/packages/patternfly-4/react-core/src/components/ClipboardCopy/ClipboardCopy.js
+++ b/packages/patternfly-4/react-core/src/components/ClipboardCopy/ClipboardCopy.js
@@ -56,18 +56,16 @@ class ClipboardCopy extends React.Component {
       onCopy,
       hoverTip,
       clickTip,
-      'aria-label': ariaLabel,
-      'toggle-aria-label': toggleAriaLabel,
+      textAriaLabel,
+      toggleAriaLabel,
       variant,
       position,
       className,
-      onChange,
       ...props
     } = this.props;
     const textIdPrefix = 'text-input-';
     const toggleIdPrefix = 'toggle-';
     const contentIdPrefix = 'content-';
-    const copyButtonIdPrefix = 'copy-button-';
     return (
       <div
         className={css(styles.clipboardCopy, this.state.expanded && styles.modifiers.expanded, className)}
@@ -92,7 +90,7 @@ class ClipboardCopy extends React.Component {
                   onChange={this.updateText}
                   value={this.state.text}
                   id={`text-input-${id}`}
-                  aria-label={ariaLabel}
+                  aria-label={textAriaLabel}
                 />
                 <CopyButton
                   exitDelay={exitDelay}
@@ -140,9 +138,9 @@ ClipboardCopy.propTypes = {
   /** Tooltip message to display when clicking the copy button */
   clickTip: PropTypes.string,
   /** Custom flag to show that the input requires an associated id or aria-label. */
-  'aria-label': PropTypes.string,
+  textAriaLabel: PropTypes.string,
   /** Custom flag to show that the toggle button requires an associated id or aria-label. */
-  'toggle-aria-label': PropTypes.string,
+  toggleAriaLabel: PropTypes.string,
   /** Flag to show if the input is read only. */
   isReadOnly: PropTypes.bool,
   /** Adds Clipboard Copy variant styles. */
@@ -179,8 +177,8 @@ ClipboardCopy.defaultProps = {
   switchDelay: 2000,
   onCopy: clipboardCopyFunc,
   onChange: () => {},
-  'aria-label': 'Copyable input',
-  'toggle-aria-label': 'Show content'
+  textAriaLabel: 'Copyable input',
+  toggleAriaLabel: 'Show content'
 };
 
 export default ClipboardCopy;


### PR DESCRIPTION
Fixes issue [#1871](https://github.com/patternfly/patternfly-react/issues/1871)

Note: the issue states that the onChange prop is not used in ClipboardCopy.js but it is used on line 46. It is not used in the render function.

Tested by adding component to index.tsx on patternfly-react-seed (locally)

