### PR TITLE
 feat(Table): Allow passing TableGridBreakpoint.none for gridBreakPoint prop to disable grid layout

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
@@ -7,6 +7,7 @@ interface OnSort {
 }
 
 export const TableGridBreakpoint: {
+  none: null,
   grid: 'grid',
   gridMd: 'grid-md',
   gridLg: 'grid-lg',

--- a/packages/patternfly-4/react-table/src/components/Table/Table.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.js
@@ -13,6 +13,7 @@ import BodyWrapper from './BodyWrapper';
 import { calculateColumns } from './utils/headerUtils';
 
 export const TableGridBreakpoint = {
+  none: null,
   grid: 'grid',
   gridMd: 'grid-md',
   gridLg: 'grid-lg',
@@ -251,7 +252,7 @@ class Table extends React.Component {
           role="grid"
           className={css(
             styles.table,
-            getModifier(stylesGrid, gridBreakPoint),
+            gridBreakPoint && getModifier(stylesGrid, gridBreakPoint),
             getModifier(styles, variant),
             ((onCollapse && variant === TableVariant.compact) || onExpand) && styles.modifiers.expandable,
             variant === TableVariant.compact && borders === false ? styles.modifiers.noBorderRows : null,


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Closes #1890

Passing `TableGridBreakpoint.none` (or just `null` directly) to the `gridBreakPoint` prop of a `Table` will prevent a `pf-m-grid-` modifier class from being rendered.