### PR TITLE
fix(types): Update @types/victory, victory, victory-core, and hoist-non-react-statics packages to latest

### DIFF
--- a/packages/patternfly-4/react-charts/package.json
+++ b/packages/patternfly-4/react-charts/package.json
@@ -41,10 +41,10 @@
     "develop": "yarn build:babel:esm --skip-initial-build --watch --verbose"
   },
   "optionalDependencies": {
-    "@types/victory": "^0.9.19",
-    "hoist-non-react-statics": "^3.1.0",
-    "victory": "^30.1.0",
-    "victory-core": "^31.1.0"
+    "@types/victory": "^31.0.15",
+    "hoist-non-react-statics": "^3.3.0",
+    "victory": "^32.2.0",
+    "victory-core": "^32.2.0"
   },
   "devDependencies": {
     "@patternfly/patternfly": "2.6.5",

--- a/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.js.snap
@@ -49,7 +49,6 @@ exports[`Chart 1`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -76,7 +75,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -268,7 +266,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -313,7 +310,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -392,7 +388,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -451,7 +446,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -487,7 +481,6 @@ exports[`Chart 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -522,7 +515,6 @@ exports[`Chart 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -581,7 +573,6 @@ exports[`Chart 1`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -608,7 +599,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -800,7 +790,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -845,7 +834,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -924,7 +912,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -983,7 +970,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1019,7 +1005,6 @@ exports[`Chart 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -1054,7 +1039,6 @@ exports[`Chart 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1131,7 +1115,6 @@ exports[`Chart 1`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -1159,7 +1142,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1351,7 +1333,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1396,7 +1377,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1475,7 +1455,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1534,7 +1513,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1570,7 +1548,6 @@ exports[`Chart 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -1605,7 +1582,6 @@ exports[`Chart 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1677,7 +1653,6 @@ exports[`Chart 1`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -1705,7 +1680,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1897,7 +1871,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1942,7 +1915,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2021,7 +1993,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2080,7 +2051,6 @@ exports[`Chart 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2116,7 +2086,6 @@ exports[`Chart 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -2151,7 +2120,6 @@ exports[`Chart 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2677,7 +2645,6 @@ exports[`Chart 2`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -2704,7 +2671,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2896,7 +2862,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2941,7 +2906,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3020,7 +2984,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3079,7 +3042,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3115,7 +3077,6 @@ exports[`Chart 2`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -3150,7 +3111,6 @@ exports[`Chart 2`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3209,7 +3169,6 @@ exports[`Chart 2`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -3236,7 +3195,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3428,7 +3386,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3473,7 +3430,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3552,7 +3508,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3611,7 +3566,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3647,7 +3601,6 @@ exports[`Chart 2`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -3682,7 +3635,6 @@ exports[`Chart 2`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3759,7 +3711,6 @@ exports[`Chart 2`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -3787,7 +3738,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3979,7 +3929,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -4024,7 +3973,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -4103,7 +4051,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -4162,7 +4109,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -4198,7 +4144,6 @@ exports[`Chart 2`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -4233,7 +4178,6 @@ exports[`Chart 2`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -4305,7 +4249,6 @@ exports[`Chart 2`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -4333,7 +4276,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -4525,7 +4467,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -4570,7 +4511,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -4649,7 +4589,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -4708,7 +4647,6 @@ exports[`Chart 2`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -4744,7 +4682,6 @@ exports[`Chart 2`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -4779,7 +4716,6 @@ exports[`Chart 2`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -5305,7 +5241,6 @@ exports[`renders axis and component children 1`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -5332,7 +5267,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -5524,7 +5458,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -5569,7 +5502,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -5648,7 +5580,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -5707,7 +5638,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -5743,7 +5673,6 @@ exports[`renders axis and component children 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -5778,7 +5707,6 @@ exports[`renders axis and component children 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -5837,7 +5765,6 @@ exports[`renders axis and component children 1`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -5864,7 +5791,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -6056,7 +5982,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -6101,7 +6026,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -6180,7 +6104,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -6239,7 +6162,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -6275,7 +6197,6 @@ exports[`renders axis and component children 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -6310,7 +6231,6 @@ exports[`renders axis and component children 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -6387,7 +6307,6 @@ exports[`renders axis and component children 1`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -6415,7 +6334,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -6607,7 +6525,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -6652,7 +6569,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -6731,7 +6647,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -6790,7 +6705,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -6826,7 +6740,6 @@ exports[`renders axis and component children 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -6861,7 +6774,6 @@ exports[`renders axis and component children 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -6933,7 +6845,6 @@ exports[`renders axis and component children 1`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -6961,7 +6872,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -7153,7 +7063,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -7198,7 +7107,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -7277,7 +7185,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -7336,7 +7243,6 @@ exports[`renders axis and component children 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -7372,7 +7278,6 @@ exports[`renders axis and component children 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -7407,7 +7312,6 @@ exports[`renders axis and component children 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.js.snap
@@ -35,7 +35,6 @@ exports[`Chart 1`] = `
     />
   }
   samples={50}
-  scale="linear"
   sortKey="x"
   sortOrder="ascending"
   standalone={true}
@@ -524,7 +523,6 @@ exports[`Chart 2`] = `
     />
   }
   samples={50}
-  scale="linear"
   sortKey="x"
   sortOrder="ascending"
   standalone={true}
@@ -1037,7 +1035,6 @@ exports[`renders component data 1`] = `
     />
   }
   samples={50}
-  scale="linear"
   sortKey="x"
   sortOrder="ascending"
   standalone={true}

--- a/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.js.snap
@@ -37,7 +37,6 @@ exports[`ChartAxis 1`] = `
       role="presentation"
     />
   }
-  scale="linear"
   standalone={true}
   theme={
     Object {
@@ -541,7 +540,6 @@ exports[`ChartAxis 2`] = `
       role="presentation"
     />
   }
-  scale="linear"
   standalone={true}
   theme={
     Object {
@@ -1057,7 +1055,6 @@ exports[`renders component data 1`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -1084,7 +1081,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1276,7 +1272,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1321,7 +1316,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1400,7 +1394,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1459,7 +1452,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1495,7 +1487,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -1530,7 +1521,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1589,7 +1579,6 @@ exports[`renders component data 1`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -1616,7 +1605,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1808,7 +1796,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1853,7 +1840,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1932,7 +1918,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1991,7 +1976,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2027,7 +2011,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -2062,7 +2045,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2139,7 +2121,6 @@ exports[`renders component data 1`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -2167,7 +2148,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2359,7 +2339,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2404,7 +2383,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2483,7 +2461,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2542,7 +2519,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2578,7 +2554,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -2613,7 +2588,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2685,7 +2659,6 @@ exports[`renders component data 1`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -2713,7 +2686,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2905,7 +2877,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2950,7 +2921,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3029,7 +2999,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3088,7 +3057,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3124,7 +3092,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -3159,7 +3126,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.js.snap
@@ -51,7 +51,6 @@ exports[`Chart 1`] = `
     />
   }
   samples={50}
-  scale="linear"
   sortOrder="ascending"
   standalone={true}
   theme={
@@ -555,7 +554,6 @@ exports[`Chart 2`] = `
     />
   }
   samples={50}
-  scale="linear"
   sortOrder="ascending"
   standalone={true}
   theme={
@@ -1057,7 +1055,6 @@ exports[`renders component data 1`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -1084,7 +1081,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1276,7 +1272,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1321,7 +1316,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1400,7 +1394,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1459,7 +1452,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1495,7 +1487,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -1530,7 +1521,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1589,7 +1579,6 @@ exports[`renders component data 1`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -1616,7 +1605,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1808,7 +1796,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1853,7 +1840,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1932,7 +1918,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1991,7 +1976,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2027,7 +2011,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -2062,7 +2045,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2139,7 +2121,6 @@ exports[`renders component data 1`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -2167,7 +2148,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2359,7 +2339,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2404,7 +2383,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2483,7 +2461,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2542,7 +2519,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2578,7 +2554,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -2613,7 +2588,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2685,7 +2659,6 @@ exports[`renders component data 1`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -2713,7 +2686,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2905,7 +2877,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2950,7 +2921,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3029,7 +2999,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3088,7 +3057,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3124,7 +3092,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -3159,7 +3126,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,

--- a/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.js.snap
@@ -12,7 +12,6 @@ exports[`ChartGroup 1`] = `
   }
   groupComponent={<g />}
   samples={50}
-  scale="linear"
   sortOrder="ascending"
   standalone={true}
   theme={
@@ -477,7 +476,6 @@ exports[`ChartGroup 2`] = `
   }
   groupComponent={<g />}
   samples={50}
-  scale="linear"
   sortOrder="ascending"
   standalone={true}
   theme={
@@ -943,7 +941,6 @@ exports[`renders container children 1`] = `
   groupComponent={<g />}
   height={200}
   samples={50}
-  scale="linear"
   sortOrder="ascending"
   standalone={true}
   theme={

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.d.ts
@@ -1,9 +1,6 @@
 import * as victory from 'victory';
-import { OneOf } from '../../typeUtils';
 
-export interface ChartLegendProps extends victory.VictoryLegendProps {
-  title?: OneOf<string, []>;
-}
+export interface ChartLegendProps extends victory.VictoryLegendProps {}
 
 declare const ChartLegend: React.ComponentClass<ChartLegendProps>;
 

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.js.snap
@@ -34,7 +34,6 @@ exports[`Chart 1`] = `
     />
   }
   samples={50}
-  scale="linear"
   sortKey="x"
   sortOrder="ascending"
   standalone={true}
@@ -522,7 +521,6 @@ exports[`Chart 2`] = `
     />
   }
   samples={50}
-  scale="linear"
   sortKey="x"
   sortOrder="ascending"
   standalone={true}
@@ -1025,7 +1023,6 @@ exports[`renders component data 1`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -1052,7 +1049,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1244,7 +1240,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1289,7 +1284,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1368,7 +1362,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1427,7 +1420,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1463,7 +1455,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -1498,7 +1489,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1557,7 +1547,6 @@ exports[`renders component data 1`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -1584,7 +1573,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1776,7 +1764,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1821,7 +1808,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1900,7 +1886,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1959,7 +1944,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1995,7 +1979,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -2030,7 +2013,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2107,7 +2089,6 @@ exports[`renders component data 1`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -2135,7 +2116,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2327,7 +2307,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2372,7 +2351,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2451,7 +2429,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2510,7 +2487,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2546,7 +2522,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -2581,7 +2556,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2653,7 +2627,6 @@ exports[`renders component data 1`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -2681,7 +2654,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2873,7 +2845,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2918,7 +2889,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2997,7 +2967,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3056,7 +3025,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3092,7 +3060,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -3127,7 +3094,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.js.snap
@@ -12,7 +12,6 @@ exports[`Chart 1`] = `
   }
   fillInMissingData={true}
   groupComponent={<g />}
-  scale="linear"
   standalone={true}
   theme={
     Object {
@@ -476,7 +475,6 @@ exports[`Chart 2`] = `
   }
   fillInMissingData={true}
   groupComponent={<g />}
-  scale="linear"
   standalone={true}
   theme={
     Object {
@@ -977,7 +975,6 @@ exports[`renders component data 1`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -1004,7 +1001,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1196,7 +1192,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1241,7 +1236,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1320,7 +1314,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1379,7 +1372,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1415,7 +1407,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -1450,7 +1441,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1509,7 +1499,6 @@ exports[`renders component data 1`] = `
             role="presentation"
           />
         }
-        scale="linear"
         standalone={true}
         theme={
           Object {
@@ -1536,7 +1525,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1728,7 +1716,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1773,7 +1760,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1852,7 +1838,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1911,7 +1896,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -1947,7 +1931,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -1982,7 +1965,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2059,7 +2041,6 @@ exports[`renders component data 1`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -2087,7 +2068,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2279,7 +2259,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2324,7 +2303,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2403,7 +2381,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2462,7 +2439,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2498,7 +2474,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -2533,7 +2508,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2605,7 +2579,6 @@ exports[`renders component data 1`] = `
           />
         }
         labelPlacement="parallel"
-        scale="linear"
         standalone={true}
         startAngle={0}
         theme={
@@ -2633,7 +2606,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2825,7 +2797,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2870,7 +2841,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -2949,7 +2919,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3008,7 +2977,6 @@ exports[`renders component data 1`] = `
                   "letterSpacing": "normal",
                   "padding": 10,
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,
@@ -3044,7 +3012,6 @@ exports[`renders component data 1`] = `
                 "padding": 5,
                 "pointerEvents": "none",
                 "stroke": "transparent",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -3079,7 +3046,6 @@ exports[`renders component data 1`] = `
                   "padding": 5,
                   "pointerEvents": "none",
                   "stroke": "transparent",
-                  "textAnchor": "middle",
                 },
               },
               "width": 450,

--- a/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.js.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.js.snap
@@ -34,7 +34,6 @@ exports[`ChartVoronoiContainer 1`] = `
     />
   }
   samples={50}
-  scale="linear"
   sortKey="x"
   sortOrder="ascending"
   standalone={true}
@@ -522,7 +521,6 @@ exports[`ChartVoronoiContainer 2`] = `
     />
   }
   samples={50}
-  scale="linear"
   sortKey="x"
   sortOrder="ascending"
   standalone={true}
@@ -982,7 +980,6 @@ exports[`renders container via ChartGroup 1`] = `
   groupComponent={<g />}
   height={200}
   samples={50}
-  scale="linear"
   sortOrder="ascending"
   standalone={true}
   theme={

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,9 +2326,10 @@
     "@types/unist" "*"
     "@types/vfile-message" "*"
 
-"@types/victory@^0.9.19":
-  version "0.9.21"
-  resolved "https://registry.yarnpkg.com/@types/victory/-/victory-0.9.21.tgz#debf9b816134b36631cec746927cda87b16815e7"
+"@types/victory@^31.0.15":
+  version "31.0.15"
+  resolved "https://registry.yarnpkg.com/@types/victory/-/victory-31.0.15.tgz#98bb7edb38c951121d08f4242ce4392cd163bae3"
+  integrity sha512-h56UDINKIgls7EZOP08BZw0O/jZFrzLR2H0tFe3Pk2cAlMon5M490wtiQVj7+RbfIx1cPTqb58wyPGYoBqRjGw==
   dependencies:
     "@types/react" "*"
 
@@ -10038,7 +10039,7 @@ hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
   dependencies:
@@ -19532,80 +19533,89 @@ vfile@^3.0.0:
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
 
-victory-area@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-30.6.1.tgz#03f19be259b1da78f9ab5f7c1297b9ef7eccacad"
+victory-area@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-32.2.0.tgz#6ca4573d53474cfb96d567f2b7ebcbaff1bec38d"
+  integrity sha512-+Sdio4uvUD4+QbW/3pohhgAvB74GIXH5Lpx4S/cwJLTIl/c77zuSn230fL7MDwyXu0xaixGXwOnvpkLXwEuj7g==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-axis@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-30.6.1.tgz#d9eae9b31ec8b78ad9f99383b54ab03f3bf7a0b2"
+victory-axis@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-32.2.0.tgz#140e4af4eab8d8df6c2ca58db604d760ebb178f5"
+  integrity sha512-wo1jgV8wm/hZIrKXowBxTF+hKAAwZQR7ZkAi3maNe9ch0q9Yk5vyLeIionYQHoIA0b/0cZhZjo+ye+7QLNsrOw==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-bar@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-30.6.1.tgz#04793a0c83cc77d695f94a92358a14eec5f1d657"
+victory-bar@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-32.2.0.tgz#8bdb27d778dbb6eb4d9b6c94135898e0b758c817"
+  integrity sha512-wzxQp7MN01H3g0LiLYCMBbxNSkNWIKPSQ07955uGLPC8m/7yX+E9DhE6prkvoTXaJ5ag58Z1xC23PslkpAObhQ==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-box-plot@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-30.6.1.tgz#d82e726069d891dd0e54fed04bc75f112a212df4"
+victory-box-plot@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-32.2.0.tgz#5113e8b535f9c919b6713a2fad32102108ea72a8"
+  integrity sha512-DsXCSwMpsxziJK8fIT42arRqh6pWylMnvqZPaF8Qf7vplcqVUVdR2rMcQ4cQvz38q9PqhxPLlQQ/AANmjVOHvA==
   dependencies:
     d3-array "^1.2.0"
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-brush-container@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-30.6.1.tgz#2db8c4f3d6e6facfafc69285e8cb6a2f94e2499e"
+victory-brush-container@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-32.2.0.tgz#769ca688523982f030373e9152eca1736dc71309"
+  integrity sha512-v0pkrcZICXJKJIkdOzVyJ53yaXYsV0ob6TjWwhatV+3Q+QpMaQ/j9IRnSnNzbld4rCTrpbDO5t0FknXFgVF9ZQ==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-brush-line@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-30.6.1.tgz#d0cf8c32f55674fda8c1fcd16d548ea4e1119361"
+victory-brush-line@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-32.2.0.tgz#2600c86339155444220f4e512cdaf3960d121158"
+  integrity sha512-Gppx3rXIHevilMt6c3vvttc1JQPJvX9AiXHMDPWIhmcjlqE65RozZmSmyyHTLM8apIJqYm6v9+24gEoVvp8T3g==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-candlestick@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-30.6.1.tgz#14fa5220ce2ee766c721a71eff0ecab80528e6d1"
+victory-candlestick@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-32.2.0.tgz#30d7af8be400afcb8ae46c40129945c301459d63"
+  integrity sha512-bQHFA25Erz4oKonQwswxr6LCrLIrFXnlrbQlI7ccaeeXSMyRqxEIk13yVBBwiEYCX46OSdmU4K6gVbkEFJHimg==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-chart@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-30.6.1.tgz#ee74341b6ec14ef7954161296e8f6e9f4e6c851f"
+victory-chart@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-32.2.0.tgz#103a9a15062c451a2e2cd90db16f6ffedad25148"
+  integrity sha512-KgVlrPgwJZZ7IMFiBiNcc4MADWr5fBqQX51OtxWVTfyq3uQ5IMKD9lPIToDDaQcb5WtznxsZsp8/oSU/KgE5/w==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-axis "^30.6.1"
-    victory-core "^30.6.1"
-    victory-polar-axis "^30.6.1"
-    victory-shared-events "^30.6.1"
+    victory-axis "^32.2.0"
+    victory-core "^32.2.0"
+    victory-polar-axis "^32.2.0"
+    victory-shared-events "^32.2.0"
 
-victory-core@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-30.6.1.tgz#edb3eb6f8d48dc9953273e7f77fafdedeadf1460"
+victory-core@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-32.2.0.tgz#8e8bbaa7cd1a9aec6148cf249498b35b636e3fdb"
+  integrity sha512-NgGRHluhSXBjYa/kc8rqlkDKvWEZshCsrLZqDnRTAgSRDDE4wMoy1fuZXewiQZJlN3RgF5lvwI4pll/8566yjA==
   dependencies:
     d3-ease "^1.0.0"
     d3-interpolate "^1.1.1"
@@ -19616,185 +19626,192 @@ victory-core@^30.6.1:
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
 
-victory-core@^31.1.0:
-  version "31.2.0"
-  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-31.2.0.tgz#c526abbeb8003460ac157419c13f9c1935a980f1"
+victory-create-container@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-32.2.0.tgz#a1786cb3f8133f1ffe246e628735f719d259e818"
+  integrity sha512-yvWennAFJIHVM/dpXh4+fUSL5lEdetE9sfebjPL1lOBDCs1sNje/mpDirvsClfjMdzt33YwR5cuOa1Xk9uyjSA==
   dependencies:
-    d3-ease "^1.0.0"
-    d3-interpolate "^1.1.1"
-    d3-scale "^1.0.0"
-    d3-shape "^1.2.0"
-    d3-timer "^1.0.0"
+    lodash "^4.17.5"
+    victory-brush-container "^32.2.0"
+    victory-core "^32.2.0"
+    victory-cursor-container "^32.2.0"
+    victory-selection-container "^32.2.0"
+    victory-voronoi-container "^32.2.0"
+    victory-zoom-container "^32.2.0"
+
+victory-cursor-container@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-32.2.0.tgz#f623034087dcde69751f6f1ed54db1196871a5c2"
+  integrity sha512-2lhCPg3UycRx2Uk/ZFWOhv3T1Rd0Q/YbxFhvm+WGxCgktBBsILhK5Q/HZPQqiDRvJN60n/VxqtPt1bQnysSMZQ==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.0"
+
+victory-errorbar@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-32.2.0.tgz#1a0c0e80d8b9c551f4d6254c7b4ba04dd04b6037"
+  integrity sha512-K1syVU4VK3z4oBhwX5lBbKTcTGxvKy25ZWEWFH/qi93TxEg34/gerOjwN+qm24YBYQFFhnKmLxg/mDeItHvdqQ==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.0"
+
+victory-group@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-32.2.0.tgz#3f8454cf1a336e12375d7fb43ca3734d41434202"
+  integrity sha512-nNJO5BlK9Sr0F2JcjyeWAwLupEyvuzMYc6OLzqIbXgzWoCYIWR1jBwF55AaQD1LwVxv7zdc4Zr6s3Pb8kGrODA==
+  dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
+    victory-core "^32.2.0"
 
-victory-create-container@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-30.6.1.tgz#f24f4f6269e11ef04a5f2d08831a347e5b01ccfc"
-  dependencies:
-    lodash "^4.17.5"
-    victory-brush-container "^30.6.1"
-    victory-core "^30.6.1"
-    victory-cursor-container "^30.6.1"
-    victory-selection-container "^30.6.1"
-    victory-voronoi-container "^30.6.1"
-    victory-zoom-container "^30.6.1"
-
-victory-cursor-container@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-30.6.1.tgz#054ba4a9caf3b32a4b467d77a9c0b0410f54a06e"
+victory-legend@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-32.2.0.tgz#62a29b1f418aaac39ba987db01cdbe9cf830ed76"
+  integrity sha512-XuDAnb+w9nvyKNmiid3LGfxtdEJ9qTTE5XVzKRjyCOwhwtZ7pGGJlcOZIsRf85XNfoSNErZS1dFja0AVV06txA==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-errorbar@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-30.6.1.tgz#bee14bf0c0853ad841454ec060b290f7588dd7a2"
-  dependencies:
-    lodash "^4.17.5"
-    prop-types "^15.5.8"
-    victory-core "^30.6.1"
-
-victory-group@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-30.6.1.tgz#59a55858750a3f880860ebe64faf0b21575f3da4"
-  dependencies:
-    lodash "^4.17.5"
-    prop-types "^15.5.8"
-    victory-core "^30.6.1"
-
-victory-legend@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-30.6.1.tgz#9f411b07915f058ed17b061e274c622b426e4c08"
-  dependencies:
-    lodash "^4.17.5"
-    prop-types "^15.5.8"
-    victory-core "^30.6.1"
-
-victory-line@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-30.6.1.tgz#ce43f4d68b0faea28025881580b6b3914b427950"
+victory-line@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-32.2.0.tgz#bfb60d8f469a2c1b8b7c0c6956a1907783387abd"
+  integrity sha512-e5K4VL+vfaz9Msgyka6/LGHYGFOY3N0SkiDoo2Q/V4qoqyQD2jU5De6+mrnqccdfEdYTf5ZXDYMrLqPeG+ziqw==
   dependencies:
     d3-shape "^1.2.0"
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-pie@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-30.6.1.tgz#f791286fb9e57b5e575ec51ea5b4275a4aa7d68d"
+victory-pie@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-32.2.0.tgz#1ee0f3cc531661bc91265e87232861f09f55a0eb"
+  integrity sha512-FdCl/XWfMfF3CIHgTh/+L9qo7zgY/vXgWmcIxsghbGODR9ZVPXHCCDNPw2/0LEK+OluaQ+DCOtpVxu+i2YMSRw==
   dependencies:
     d3-shape "^1.0.0"
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-polar-axis@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-30.6.1.tgz#a8b13e9210627abe70605bf7d8e11d34d66cf632"
+victory-polar-axis@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-32.2.0.tgz#e34d65735693f0dbd69846dac73e2b55fc5a5423"
+  integrity sha512-dIDkSvK1sQWnPOZlO0CqaG/q40IVep8/8BdCUoKbRCJ0iX/2tdHjSmyXjDWwxFRUYuAyAIzG/ZXB/mkOEOFP8g==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-scatter@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-30.6.1.tgz#96797fefff3d31ede944e95ac51682846705a1a8"
+victory-scatter@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-32.2.0.tgz#c65e6e9f9ef637e5aed0f551f8895e3a86b95647"
+  integrity sha512-dvdFJ6pbvOLYF1LbAQslO9OnRCxjGdLrIHQObmRPCStBjfjL0X/HuZTNOAIMOhWmSe/n0CgJJxlp0cTe07TbKg==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-selection-container@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-30.6.1.tgz#627148c84ae43472682c9f135487035cbdadf6d4"
+victory-selection-container@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-32.2.0.tgz#bde0e449823bcb08c4546d318f59fa1a1956fece"
+  integrity sha512-s6UWM2wPQFlMdz/1hqIGjquMQeXBZ2cvgI8byFtHV/LNWdDu74RNUzHG+4JGRHYtp8lCGUbail7gwFLafZK2GA==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-shared-events@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-30.6.1.tgz#788e6c45a752c521a3f067675b9b9196fcee552c"
+victory-shared-events@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-32.2.0.tgz#b0cb11d8958784f1b7ff79aff7be53b40eaff617"
+  integrity sha512-LbqhwstfIDMl4NsvJ9ouXOXWOX7T34ShTj3ZE3b9uR60z2bQPTLrYGq2x/tI/3Pddx8tYl4sl7ZyFU3dqp9RqA==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    react-fast-compare "^2.0.0"
+    victory-core "^32.2.0"
 
-victory-stack@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-30.6.1.tgz#873be79c492f0d7ed02ad03bd82e592d6f778ea8"
+victory-stack@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-32.2.0.tgz#3adbb26e60169add31e0e005e514ec10d41eb93d"
+  integrity sha512-8d86+EHiwfIKpO1CTAGRY5j/bHFQf+b6hAF/RSqbJx/K7aAtjpV6g9CZCkUFvG604IZfUdxZdeZKk/U//LTUdQ==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    react-fast-compare "^2.0.0"
+    victory-core "^32.2.0"
 
-victory-tooltip@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-30.6.1.tgz#234e23954c9b4543cee22ac45f9b91325207fe42"
+victory-tooltip@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-32.2.0.tgz#6aa3c22d0ab566ad9183c556fd4dc343c7a87cdb"
+  integrity sha512-LYMhAUhexqEWwBsOBFSf7ROdKUO3Uiw3bSAPQeEqK7LJ3uE3J7wa6uVQDKufL+jas5LXrmFW1MryEatiPFnvBg==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-voronoi-container@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-30.6.1.tgz#58a16af999e0c6ff528905aec812c2fdd5b93dff"
+victory-voronoi-container@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-32.2.0.tgz#1a5dfcc3c0e69bdf92b483abd7a14f8ce54367d0"
+  integrity sha512-26Z1CS/RCJQHGulICqfunaOkpAnzLIx3yuDMBB2C2yjXS2RCLc4FYDSCkAzRsxDMqK4Dj0JxkK9rpOx4a+Re1Q==
   dependencies:
     d3-voronoi "^1.1.2"
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
-    victory-tooltip "^30.6.1"
+    victory-core "^32.2.0"
+    victory-tooltip "^32.2.0"
 
-victory-voronoi@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-30.6.1.tgz#d3de9db4997778f2f8acd0427bab14898e137b9e"
+victory-voronoi@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-32.2.0.tgz#bec7da774856126e2ee00e9ccd56b7e1c051506a"
+  integrity sha512-2F9mWohz/zp/Shh8/LhaInR982Iy15oX7/YqLQBXPYDDx2rchzZtD/Uv9CO/m8j87p0wABSyjAa0Y63S5K6uOw==
   dependencies:
     d3-voronoi "^1.1.2"
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory-zoom-container@^30.6.1:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-30.6.1.tgz#41ee41e4168f311375508d2ed1b8581f2b437bb6"
+victory-zoom-container@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-32.2.0.tgz#6927ec06ea582f9e023189772e80fa3783506e50"
+  integrity sha512-xxdagazoS6eh1COxWONg2IC+f7BoYVxACeNVBYM/tmWYxccLdREBSQeACYMjsNLprz2tt0wsd05ouv+TPSxH+A==
   dependencies:
     lodash "^4.17.5"
     prop-types "^15.5.8"
-    victory-core "^30.6.1"
+    victory-core "^32.2.0"
 
-victory@^30.1.0:
-  version "30.6.1"
-  resolved "https://registry.yarnpkg.com/victory/-/victory-30.6.1.tgz#607a0ca643bf4f4a32a08a4a4e1a84d601611159"
+victory@^32.2.0:
+  version "32.2.0"
+  resolved "https://registry.yarnpkg.com/victory/-/victory-32.2.0.tgz#c42952fa72da299a844905b5880e54ca84f166f4"
+  integrity sha512-b+Idge6g771Azlvgefc0IGKPBibUSruyWFPGmxCdA5TjMEUeZ0Q1FV81FDfR0ZHQJ9a2ktG4p8dJrbsOnkcpfg==
   dependencies:
-    victory-area "^30.6.1"
-    victory-axis "^30.6.1"
-    victory-bar "^30.6.1"
-    victory-box-plot "^30.6.1"
-    victory-brush-container "^30.6.1"
-    victory-brush-line "^30.6.1"
-    victory-candlestick "^30.6.1"
-    victory-chart "^30.6.1"
-    victory-core "^30.6.1"
-    victory-create-container "^30.6.1"
-    victory-cursor-container "^30.6.1"
-    victory-errorbar "^30.6.1"
-    victory-group "^30.6.1"
-    victory-legend "^30.6.1"
-    victory-line "^30.6.1"
-    victory-pie "^30.6.1"
-    victory-polar-axis "^30.6.1"
-    victory-scatter "^30.6.1"
-    victory-selection-container "^30.6.1"
-    victory-shared-events "^30.6.1"
-    victory-stack "^30.6.1"
-    victory-tooltip "^30.6.1"
-    victory-voronoi "^30.6.1"
-    victory-voronoi-container "^30.6.1"
-    victory-zoom-container "^30.6.1"
+    victory-area "^32.2.0"
+    victory-axis "^32.2.0"
+    victory-bar "^32.2.0"
+    victory-box-plot "^32.2.0"
+    victory-brush-container "^32.2.0"
+    victory-brush-line "^32.2.0"
+    victory-candlestick "^32.2.0"
+    victory-chart "^32.2.0"
+    victory-core "^32.2.0"
+    victory-create-container "^32.2.0"
+    victory-cursor-container "^32.2.0"
+    victory-errorbar "^32.2.0"
+    victory-group "^32.2.0"
+    victory-legend "^32.2.0"
+    victory-line "^32.2.0"
+    victory-pie "^32.2.0"
+    victory-polar-axis "^32.2.0"
+    victory-scatter "^32.2.0"
+    victory-selection-container "^32.2.0"
+    victory-shared-events "^32.2.0"
+    victory-stack "^32.2.0"
+    victory-tooltip "^32.2.0"
+    victory-voronoi "^32.2.0"
+    victory-voronoi-container "^32.2.0"
+    victory-zoom-container "^32.2.0"
 
 vlq@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
fixes #1898

**What**:
Update `@types/victory`, `victory`, `victory-core`, and `hoist-non-react-statics` to latest and remove extra type definition for the `title` prop in `ChartLegend`. The latest victory types include an accurate definition for this prop.

Victory changelog for reference:
https://github.com/FormidableLabs/victory/blob/master/CHANGELOG.md