### PR TITLE
fix(Checkbox): Set checked value correctly

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.md
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.md
@@ -17,7 +17,7 @@ class ControlledCheckbox extends React.Component {
       check1: false,
       check2: false
     };
-    this.handleChange = checked => {
+    this.handleChange = (checked, event) => {
       const target = event.target;
       const value = target.type === 'checkbox' ? target.checked : target.value;
       const name = target.name;
@@ -34,6 +34,7 @@ class ControlledCheckbox extends React.Component {
           onChange={this.handleChange}
           aria-label="controlled checkbox example"
           id="check-1"
+          name="check1"
         />
         <Checkbox
           label="Controlled CheckBox"
@@ -41,6 +42,7 @@ class ControlledCheckbox extends React.Component {
           onChange={this.handleChange}
           aria-label="controlled checkbox example"
           id="check-2"
+          name="check2"
         />
       </React.Fragment>
     );

--- a/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.tsx
@@ -58,6 +58,13 @@ export class Checkbox extends React.Component<CheckboxProps> {
       checked,
       ...props
     } = this.props;
+    let value = undefined
+    if (isChecked === false || checked === false) {
+      value = false
+    }
+    if (isChecked === true || checked === true) {
+      value = true
+    }
     return (
       <div className={css(styles.check, className)}>
         <input
@@ -68,7 +75,7 @@ export class Checkbox extends React.Component<CheckboxProps> {
           aria-invalid={!isValid}
           aria-label={ariaLabel}
           disabled={isDisabled}
-          checked={isChecked || checked}
+          checked={value}
         />
         {label && (
           <label


### PR DESCRIPTION
**What**:

closes #1959 

I first realized that the controlled Checkbox example is wrong: `event.target.name` is not set and so the state can be `{check1: false, check2: false, '': false}` or `{check1: false, check2: false, '': true}`.

After fixing it by adding the `name` attribute to the Checkbox components the first time I checked one of the boxes I got the following error/warning message:
```
Warning: A component is changing an uncontrolled input of type checkbox to be controlled.
Input elements should not switch from uncontrolled to controlled (or vice versa).
Decide between using a controlled or uncontrolled input element for 
the lifetime of the component. More info: https://fb.me/react-controlled-components
    in input (created by Checkbox)
    in div (created by Checkbox)
    in Checkbox (created by ControlledCheckbox)
    in ControlledCheckbox (created by ErrorBoundary)
    in ErrorBoundary (created by Context.Consumer)
```

It looks like the expression `isChecked || checked` will return undefined if `isChecked` is false and so when checking the box that expression changed to `true` which causes the component to turn to be controlled.

//cc @dlabrecq 
fixes https://github.com/project-koku/koku-ui/issues/841