### PR TITLE
fix(AboutModal): provide a way to set the background using props

### DIFF
--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.d.ts
@@ -8,8 +8,7 @@ export interface AboutModalProps extends HTMLProps<HTMLDivElement> {
   trademark?: string;
   brandImageSrc: string;
   brandImageAlt: string;
-  logoImageSrc?: string;
-  logoImageAlt?: string;
+  backgroundImageSrc?: string;
   noAboutModalBoxContentContainer?: boolean;
 }
 

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.js
@@ -24,20 +24,14 @@ const propTypes = {
   brandImageSrc: PropTypes.string.isRequired,
   /** The alternate text of the brand image */
   brandImageAlt: PropTypes.string.isRequired,
-  /** The URL of the image for the logo */
-  logoImageSrc: PropTypes.string,
-  /** The alternate text of the logo image */
-  logoImageAlt: props => {
-    if (props.logoImageSrc && !props.logoImageAlt) {
-      return new Error('logoImageAlt is required when a logoImageSrc is specified');
-    }
-    return null;
-  },
+  /** The URL of the image for the background */
+  backgroundImageSrc: PropTypes.string,
   /** Prevents the about modal from rendering content inside a container; allows for more flexible layouts */
   noAboutModalBoxContentContainer: PropTypes.bool,
   /** Additional props are passed and spread to the modal content container <div> */
   '': PropTypes.any
 };
+
 
 const defaultProps = {
   className: '',
@@ -45,8 +39,7 @@ const defaultProps = {
   onClose: () => undefined,
   productName: '',
   trademark: '',
-  logoImageSrc: '',
-  logoImageAlt: '',
+  backgroundImageSrc: '',
   noAboutModalBoxContentContainer: false
 };
 

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.md
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.md
@@ -4,14 +4,13 @@ cssPrefix: 'pf-c-about-modal-box'
 ---
 import { AboutModal, Button, TextContent, TextList, TextListItem } from '@patternfly/react-core';
 import brandImg from './examples/brandImg.svg';
-import logoImg from './examples/logoImg.svg';
+import bgImg from './examples/patternfly-orb.svg';
 
 ## Simple about modal
 ```js
 import React from 'react';
 import { AboutModal, Button, TextContent, TextList, TextListItem } from '@patternfly/react-core';
 import brandImg from './examples/brandImg.svg';
-import logoImg from './examples/logoImg.svg';
 
 class SimpleAboutModal extends React.Component {
   constructor(props) {
@@ -40,8 +39,6 @@ class SimpleAboutModal extends React.Component {
           trademark="Trademark and copyright information here"
           brandImageSrc={brandImg}
           brandImageAlt="Patternfly Logo"
-          logoImageSrc={logoImg}
-          logoImageAlt="Patternfly Logo"
           productName="Product Name"
         >
           <TextContent>
@@ -75,7 +72,6 @@ class SimpleAboutModal extends React.Component {
 import React from 'react';
 import { AboutModal, Button, TextContent, TextList, TextListItem } from '@patternfly/react-core';
 import brandImg from './examples/brandImg.svg';
-import logoImg from './examples/logoImg.svg';
 
 class SimpleAboutModal extends React.Component {
   constructor(props) {
@@ -104,8 +100,6 @@ class SimpleAboutModal extends React.Component {
           trademark="Trademark and copyright information here"
           brandImageSrc={brandImg}
           brandImageAlt="Patternfly Logo"
-          logoImageSrc={logoImg}
-          logoImageAlt="Patternfly Logo"
         >
           <TextContent>
             <TextList component="dl">
@@ -138,7 +132,6 @@ class SimpleAboutModal extends React.Component {
 import React from 'react';
 import { AboutModal, Alert, Button, TextContent, TextList, TextListItem } from '@patternfly/react-core';
 import brandImg from './examples/brandImg.svg';
-import logoImg from './examples/logoImg.svg';
 
 class ContentRichAboutModal extends React.Component {
   constructor(props) {
@@ -167,8 +160,6 @@ class ContentRichAboutModal extends React.Component {
           trademark="Trademark and copyright information here"
           brandImageSrc={brandImg}
           brandImageAlt="Patternfly Logo"
-          logoImageSrc={logoImg}
-          logoImageAlt="Patternfly Logo"
           noAboutModalBoxContentContainer={true}
           productName="Product Name"
         >
@@ -202,3 +193,52 @@ class ContentRichAboutModal extends React.Component {
 }
 ```
 
+## About modal with custom background image
+
+```js
+import React from 'react';
+import { AboutModal, Button, TextContent, TextList, TextListItem } from '@patternfly/react-core';
+import brandImg from './examples/brandImg.svg';
+import bgImg from './examples/patternfly-orb.svg';
+
+class SimpleAboutModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isModalOpen: false
+    };
+    this.handleModalToggle = () => {
+      this.setState(({ isModalOpen }) => ({
+        isModalOpen: !isModalOpen
+      }));
+    };
+  }
+
+  render() {
+    const { isModalOpen } = this.state;
+
+    return (
+      <React.Fragment>
+        <Button variant="primary" onClick={this.handleModalToggle}>
+          Show About Modal
+        </Button>
+        <AboutModal
+          isOpen={isModalOpen}
+          onClose={this.handleModalToggle}
+          trademark="Trademark and copyright information here"
+          brandImageSrc={brandImg}
+          brandImageAlt="Patternfly Logo"
+          backgroundImageSrc={bgImg}
+        >
+          <TextContent>
+            <TextList component="dl">
+              <TextListItem component="dt">CFME Version</TextListItem>
+              <TextListItem component="dd">5.5.3.4.20102789036450</TextListItem>
+            </TextList>
+          </TextContent>
+        </AboutModal>
+      </React.Fragment>
+    );
+  }
+}
+```

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.test.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.test.js
@@ -17,8 +17,7 @@ const props = {
   trademark: 'Trademark and copyright information here',
   brandImageSrc: 'brandImg...',
   brandImageAlt: 'Brand Image',
-  logoImageSrc: 'logoImg...',
-  logoImageAlt: 'AboutModal Logo'
+  backgroundImageSrc: 'background-image-src'
 };
 
 test('AboutModal creates a container element once for div', () => {
@@ -55,15 +54,13 @@ test('Each modal is given new ariaDescribedById and ariaLablledbyId', () => {
   expect(first.props().ariaDescribedById).not.toBe(second.props().ariaDescribedById);
 });
 
-test('Console error is generated when the logoImageSrc is provided without logoImageAlt', () => {
+test('Console error is generated when the brandImageSrc is provided without brandImageAlt', () => {
   const noImgAltrops = {
     onClose: jest.fn(),
     children: 'modal content',
     productName: 'Product Name',
     trademark: 'Trademark and copyright information here',
-    brandImageSrc: 'brandImg...',
-    brandImageAlt: 'Brand Image',
-    logoImageSrc: 'logoImg...'
+    brandImageSrc: 'brandImg...'
   };
   const myMock = jest.fn();
   global.console = { error: myMock };

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxHero.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxHero.d.ts
@@ -1,5 +1,7 @@
 import { FunctionComponent, HTMLProps } from 'react';
 
-export interface AboutModalBoxHeroProps extends HTMLProps<HTMLImageElement> {}
+export interface AboutModalBoxHeroProps extends HTMLProps<HTMLImageElement> {
+  backgroundImageSrc?: string;
+}
 declare const AboutModalBoxHero: FunctionComponent<AboutModalBoxHeroProps>;
 export default AboutModalBoxHero;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxHero.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalBoxHero.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import { css } from '@patternfly/react-styles';
+import { c_about_modal_box__hero_sm_BackgroundImage } from '@patternfly/react-tokens'
 import PropTypes from 'prop-types';
 import styles from '@patternfly/patternfly/components/AboutModalBox/about-modal-box.css';
 
 const propTypes = {
   /** additional classes added to the About Modal Hero */
   className: PropTypes.string,
+  /** background image data or file path */
+  backgroundImageSrc: PropTypes.string,
   /** Additional props are spread to the container <div> */
   '': PropTypes.any
 };
@@ -14,9 +17,14 @@ const defaultProps = {
   className: ''
 };
 
-const AboutModalBoxHero = ({ className, ...props }) => (
-  <div {...props} className={css(styles.aboutModalBoxHero, className)} />
-);
+const AboutModalBoxHero = ({ className, backgroundImageSrc, ...props }) => {
+  const bgStyle = (backgroundImageSrc !== '') ? {
+    [c_about_modal_box__hero_sm_BackgroundImage.name]: `url(${backgroundImageSrc})`
+  } : {};
+  return (
+    <div {...props} style={bgStyle} className={css(styles.aboutModalBoxHero, className)} />
+  )
+};
 
 AboutModalBoxHero.propTypes = propTypes;
 AboutModalBoxHero.defaultProps = defaultProps;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalContainer.d.ts
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalContainer.d.ts
@@ -10,8 +10,7 @@ export interface AboutModalContainerProps extends HTMLProps<HTMLDivElement> {
   trademark: string;
   brandImageSrc: string;
   brandImageAlt: string;
-  logoImageSrc: string;
-  logoImageAlt: string;
+  backgroundImageSrc?: string;
 }
 
 declare const AboutModalContainer: FunctionComponent<AboutModalContainerProps>;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalContainer.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalContainer.js
@@ -26,10 +26,8 @@ const propTypes = {
   brandImageSrc: PropTypes.string.isRequired,
   /** the alternate text of the Brand image. */
   brandImageAlt: PropTypes.string.isRequired,
-  /** the URL of the image for the Logo. */
-  logoImageSrc: PropTypes.string.isRequired,
-  /** the alternate text of the Logo image. */
-  logoImageAlt: PropTypes.string.isRequired,
+  /** the URL of the image for the background. */
+  backgroundImageSrc: PropTypes.string,
   /** id to use for About Modal Box aria labeled by */
   ariaLabelledbyId: PropTypes.string.isRequired,
   /** id to use for About Modal Box aria described by */
@@ -54,8 +52,7 @@ const ModalContent = ({
   trademark,
   brandImageSrc,
   brandImageAlt,
-  logoImageSrc,
-  logoImageAlt,
+  backgroundImageSrc,
   ariaLabelledbyId,
   ariaDescribedById,
   ...props
@@ -73,7 +70,7 @@ const ModalContent = ({
           <AboutModalBoxContent {...props} trademark={trademark} id={ariaDescribedById}>
             {children}
           </AboutModalBoxContent>
-          <AboutModalBoxHero />
+          <AboutModalBoxHero backgroundImageSrc={backgroundImageSrc} />
         </AboutModalBox>
       </Bullseye>
     </Backdrop>

--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalContainer.test.js
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModalContainer.test.js
@@ -8,8 +8,7 @@ const props = {
   trademark: 'Trademark and copyright information here',
   brandImageSrc: 'brandImg...',
   brandImageAlt: 'Brand Image',
-  logoImageSrc: 'logoImg...',
-  logoImageAlt: 'AboutModal Logo',
+  backgroundImageSrc: 'backgroundImageSrc...',
   ariaLabelledbyId: 'ariaLablledbyId',
   ariaDescribedById: 'ariaDescribedById'
 };

--- a/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalBoxHero.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalBoxHero.test.js.snap
@@ -3,5 +3,10 @@
 exports[`test About Modal Box SHero 1`] = `
 <div
   className="pf-c-about-modal-box__hero"
+  style={
+    Object {
+      "--pf-c-about-modal-box__hero--sm--BackgroundImage": "url(undefined)",
+    }
+  }
 />
 `;

--- a/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalContainer.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/__snapshots__/AboutModalContainer.test.js.snap
@@ -36,6 +36,7 @@ exports[`About Modal Container Test isOpen 1`] = `
         This is ModalBox content
       </AboutModalBoxContent>
       <AboutModalBoxHero
+        backgroundImageSrc="backgroundImageSrc..."
         className=""
       />
     </AboutModalBox>

--- a/packages/patternfly-4/react-core/src/components/AboutModal/examples/patternfly-orb.svg
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/examples/patternfly-orb.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="320px" height="320px" viewBox="0 0 320 320" enable-background="new 0 0 320 320" xml:space="preserve">
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="160" y1="320" x2="160" y2="0">
+	<stop  offset="0" style="stop-color:#E6E6E6"/>
+	<stop  offset="0.75" style="stop-color:#FFFFFF"/>
+</linearGradient>
+<circle fill="url(#SVGID_1_)" cx="160" cy="160" r="160"/>
+<g>
+	<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="160" y1="54.8711" x2="160" y2="272.935">
+		<stop  offset="0" style="stop-color:#54EEFF"/>
+		<stop  offset="1" style="stop-color:#1C75BC"/>
+	</linearGradient>
+	<path fill="url(#SVGID_2_)" d="M160.27,48.269l0.022-0.206l-0.102,0.126l-0.04-0.039l0.034-0.328l-0.184,0.181l-0.188-0.181
+		l0.035,0.328l-0.04,0.039l-0.102-0.126l0.022,0.206L41.296,164.039L88.2,230.485l36.231-8.319l35.569,50.012l35.568-50.012
+		l36.231,8.319l29.053-41.16l17.851-25.287L160.27,48.269z M156.403,61.86l-16.178,151.596l-31.613-43.118L156.403,61.86z
+		 M107.062,168.225l-19.895-27.136l69.065-84.474L107.062,168.225z M139.543,216.366l-14.142,3.245l-23.771-33.421l5.924-13.449
+		L139.543,216.366z M159.627,54.544l0.374-0.848l0.372,0.844l16.728,162.987l-0.051-0.034l-16.39,24.219l-17.733-24.254
+		l-0.021,0.016L159.627,54.544z M179.774,213.458L163.597,61.856l47.79,108.482L179.774,213.458z M212.445,172.741l5.926,13.449
+		L194.6,219.611l-14.143-3.245L212.445,172.741z M163.77,56.619l69.063,84.47l-19.894,27.136L163.77,56.619z M89.178,227.93
+		l-44.909-63.619l104.499-102.15l-64.473,78.853l21.711,29.61l-6.974,15.831l23.974,33.708L89.178,227.93z M160.001,268.26
+		l-33.176-46.645l14.181-3.256l0.238,0.327l-0.152,0.112l19.64,26.859l18.199-26.891l-0.155-0.105l0.221-0.302l14.179,3.256
+		L160.001,268.26z M258.999,188.017l-28.177,39.913l-33.826-7.767l23.972-33.708l-6.972-15.831l21.711-29.61l-64.473-78.852
+		L275.73,164.311L258.999,188.017z"/>
+</g>
+</svg>


### PR DESCRIPTION
**What**: This PR removes the `logoImageSrc` and `logoImageAlt` props from about modal as they were never actually used. Beyond removing these dead API parts, I've replaced them with a single prop, `bgImgSrc` which I believe fulfills the original intent - which is making the background graphic on the right side of the modal configurable.

I've added a new example for AboutModal, one that illustrates how to set a custom background image.

The value passed for `backgroundImageSrc` is used to set the value for the css variable "--pf-c-about-modal-box__hero--sm--BackgroundImage". This is different than how we typically set CSS vars, and the need for it is described here https://github.com/patternfly/patternfly-react/issues/1919. In a nutshell, the need is driven by having assets served by a caching service or using generated asset filenames of which you don't know the exact name of a file, which in turn prevents you from setting this in a stylesheet.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: https://github.com/patternfly/patternfly-react/issues/1919

<img width="1627" alt="Screen Shot 2019-05-06 at 3 33 55 PM" src="https://user-images.githubusercontent.com/5942899/57251450-da44a000-7017-11e9-97df-d299a1b9c3b9.png">

