### PR TITLE
fix(demo-app): remove demo-app from build

### DIFF
--- a/packages/patternfly-4/react-integration/demo-app-ts/package.json
+++ b/packages/patternfly-4/react-integration/demo-app-ts/package.json
@@ -3,11 +3,11 @@
   "private": true,
   "version": "1.1.2",
   "scripts": {
-    "build": "react-scripts build",
+    "build:demo-app": "react-scripts build",
     "start:demo-app": "react-scripts start"
   },
   "dependencies": {
-    "@patternfly/react-core": "file:../../react-core",
+    "@patternfly/react-core": "^3.18.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-router": "^4.3.1",

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/NavDemo/NavDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/NavDemo/NavDemo.tsx
@@ -1,16 +1,12 @@
 import { Nav, NavList, NavItem, NavProps } from '@patternfly/react-core';
 import React, { Component } from 'react';
 
-class myProps implements NavProps {
-  'aria-label': string = 'Test Nav Props';
-}
-
 export class NavDemo extends Component {
   render() {
     // Nav onToggle and onSelect should be optional
     // https://github.com/patternfly/patternfly-react/issues/1234
     return (
-      <Nav aria-label={new myProps()['aria-label']}>
+      <Nav aria-label={'Test Nav Props'}>
         <NavList>
           <NavItem preventDefault={false}>Link 1</NavItem>
           <NavItem>Link 2</NavItem>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/NavDemo/NavDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/NavDemo/NavDemo.tsx
@@ -1,12 +1,16 @@
 import { Nav, NavList, NavItem, NavProps } from '@patternfly/react-core';
 import React, { Component } from 'react';
 
+const myProps: NavProps = {
+  "aria-label": 'Test Nav Props'
+};
+
 export class NavDemo extends Component {
   render() {
     // Nav onToggle and onSelect should be optional
     // https://github.com/patternfly/patternfly-react/issues/1234
     return (
-      <Nav aria-label={'Test Nav Props'}>
+      <Nav aria-label={myProps["aria-label"]}>
         <NavList>
           <NavItem preventDefault={false}>Link 1</NavItem>
           <NavItem>Link 2</NavItem>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TitleDemo/TitleDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TitleDemo/TitleDemo.tsx
@@ -1,16 +1,11 @@
-import { Title,  TitleProps, TitleLevel } from '@patternfly/react-core';
+import { Title,  TitleLevel } from '@patternfly/react-core';
 import React, { Component } from 'react';
 
 export class TitleDemo extends Component {
-  myTitleProps: TitleProps = {
-    size: 'md',
-    headingLevel: TitleLevel.h1
-  };
-
   render() {
     return (
     <React.Fragment>
-      <Title size={this.myTitleProps.size} headingLevel={this.myTitleProps.headingLevel}>
+      <Title size={'md'} headingLevel={TitleLevel.h1}>
         Integration Demo App
       </Title>
     </React.Fragment>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TitleDemo/TitleDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TitleDemo/TitleDemo.tsx
@@ -1,11 +1,16 @@
-import { Title,  TitleLevel } from '@patternfly/react-core';
+import { Title,  TitleLevel, TitleProps } from '@patternfly/react-core';
 import React, { Component } from 'react';
+
+const myProps: TitleProps = {
+  size: 'md',
+  headingLevel: TitleLevel.h1
+};
 
 export class TitleDemo extends Component {
   render() {
     return (
     <React.Fragment>
-      <Title size={'md'} headingLevel={TitleLevel.h1}>
+      <Title size={myProps.size} headingLevel={myProps.headingLevel}>
         Integration Demo App
       </Title>
     </React.Fragment>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TooltipDemo/TooltipDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TooltipDemo/TooltipDemo.tsx
@@ -1,11 +1,16 @@
-import { Tooltip } from '@patternfly/react-core';
+import { Tooltip, TooltipProps } from '@patternfly/react-core';
 import React, { Component } from 'react';
+
+const myProps: TooltipProps = {
+  content: <div>World</div>,
+  children: <div>Hello</div>
+};
 
 export class TooltipDemo extends Component {
   render() {
     return (
-      <Tooltip content={<div>World</div>}>
-        <div>Hello</div>
+      <Tooltip content={myProps.content}>
+        {myProps.children}
       </Tooltip>
     );
   };

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TooltipDemo/TooltipDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TooltipDemo/TooltipDemo.tsx
@@ -2,7 +2,7 @@ import { Tooltip } from '@patternfly/react-core';
 import React, { Component } from 'react';
 
 export class TooltipDemo extends Component {
-  render = () => {
+  render() {
     return (
       <Tooltip content={<div>World</div>}>
         <div>Hello</div>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TooltipDemo/TooltipDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TooltipDemo/TooltipDemo.tsx
@@ -1,15 +1,12 @@
-import { Tooltip, TooltipProps } from '@patternfly/react-core';
+import { Tooltip } from '@patternfly/react-core';
 import React, { Component } from 'react';
 
 export class TooltipDemo extends Component {
-  myTooltipProps: TooltipProps = {
-    content: <div>World</div>,
-    children: <div>Hello</div>
-  };
-
   render = () => {
-    return <Tooltip content={this.myTooltipProps.content}>
-      {this.myTooltipProps.children}
-    </Tooltip>;
+    return (
+      <Tooltip content={<div>World</div>}>
+        <div>Hello</div>
+      </Tooltip>
+    );
   };
 }

--- a/packages/patternfly-4/react-integration/package.json
+++ b/packages/patternfly-4/react-integration/package.json
@@ -29,12 +29,10 @@
     "lint:ts": "tslint -p tsconfig.json",
     "test:integration": "node ./scripts/server.js"
   },
-  "dependencies": {
-    "local-web-server": "^2.6.1"
-  },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^4.0.3",
     "cypress": "^3.2.0",
+    "local-web-server": "^2.6.1",
     "rimraf": "^2.6.2",
     "ts-loader": "^5.3.3",
     "typescript": "3.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,17 +1884,6 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.6.5.tgz#6e4f22f0e7ac6d06bd42473b8282ce92a1cab8e1"
   integrity sha512-L0k+ea2N679ytQwTqYJ7RewVDx6FDpm9burtHgD8fhcIN0UJJo7v2IkhLya2WzH2/O7L7TiF45lb/ZVoFVckDA==
 
-"@patternfly/react-core@file:packages/patternfly-4/react-core":
-  version "3.16.16"
-  dependencies:
-    "@patternfly/react-icons" "^3.9.2"
-    "@patternfly/react-styles" "^3.2.1"
-    "@patternfly/react-tokens" "^2.5.2"
-    "@tippy.js/react" "^1.1.1"
-    emotion "^9.2.9"
-    exenv "^1.2.2"
-    focus-trap-react "^4.0.1"
-
 "@pieh/friendly-errors-webpack-plugin@1.7.0-chalk-2":
   version "1.7.0-chalk-2"
   resolved "https://registry.yarnpkg.com/@pieh/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.0-chalk-2.tgz#2e9da9d3ade9d18d013333eb408c457d04eabac0"


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Fixes common build issues with react-demo-app. TypeChecking still happens through `tsc`, so the passed props are still getting checked (like in the Jest tests). If we really want consumers to be able to import our types easier, we should look into exporting a single types file and maybe even hosting it in [@types](https://github.com/DefinitelyTyped/DefinitelyTyped)!

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
