### PR TITLE
feat(page): add fill and no-fill modifiers to page sections

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Page/Page.md
+++ b/packages/patternfly-4/react-core/src/components/Page/Page.md
@@ -129,3 +129,52 @@ class VerticalPage extends React.Component {
   }
 }
 ```
+## Main section fill/no-fill modifiers
+```js
+import React from 'react';
+import { Page, PageHeader, PageSidebar, PageSection, PageSectionVariants } from '@patternfly/react-core';
+
+class FillPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isNavOpen: true
+    };
+    this.onNavToggle = () => {
+      this.setState({
+        isNavOpen: !this.state.isNavOpen
+      });
+    };
+  }
+
+  render() {
+    const { isNavOpen } = this.state;
+
+    const logoProps = {
+      href: 'https://patternfly.org',
+      onClick: () => console.log('clicked logo'),
+      target: '_blank'
+    };
+    const Header = (
+      <PageHeader
+        logo="Logo"
+        logoProps={logoProps}
+        toolbar="Toolbar"
+        avatar=" | Avatar"
+        showNavToggle
+        isNavOpen={isNavOpen}
+        onNavToggle={this.onNavToggle}
+      />
+    );
+    const Sidebar = <PageSidebar nav="Navigation" isNavOpen={isNavOpen} />;
+
+    return (
+      <Page header={Header} sidebar={Sidebar}>
+        <PageSection style={{height: '10em'}}>This section is set to the default fill variant</PageSection>
+        <PageSection style={{height: '10em'}} isFilled={true}>This section fills the available space.</PageSection>
+        <PageSection style={{height: '10em'}} isFilled={false}> This section does not fill the available space.</PageSection>
+      </Page>
+    );
+  }
+}
+```

--- a/packages/patternfly-4/react-core/src/components/Page/PageSection.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Page/PageSection.d.ts
@@ -12,6 +12,7 @@ export interface PageSectionProps extends HTMLProps<HTMLDivElement> {
   children?: ReactNode;
   className?: string;
   variant?: OneOf<typeof PageSectionVariants, keyof typeof PageSectionVariants>;
+  isFilled?: boolean;
   noPadding?: boolean;
   noPaddingMobile?: boolean;
 }

--- a/packages/patternfly-4/react-core/src/components/Page/PageSection.js
+++ b/packages/patternfly-4/react-core/src/components/Page/PageSection.js
@@ -19,6 +19,8 @@ const propTypes = {
   variant: PropTypes.oneOf(Object.values(PageSectionVariants)),
   /** Modifies a main page section to have no padding */
   noPadding: PropTypes.bool,
+  /** Enables the page section to fill the available vertical space */
+  isFilled: PropTypes.bool,
   /** Modifies a main page section to have no padding on mobile */
   noPaddingMobile: PropTypes.bool,
   /** Additional props are spread to the container <section> */
@@ -29,20 +31,20 @@ const defaultProps = {
   children: null,
   className: '',
   variant: 'default',
+  isFilled: undefined,
   noPadding: false,
   noPaddingMobile: false
 };
 
-const PageSection = ({ className, children, variant, noPadding, noPaddingMobile, ...props }) => {
+const PageSection = ({ className, children, variant, noPadding, noPaddingMobile, isFilled, ...props }) => {
   const variantStyle = {
     [PageSectionVariants.default]: '',
     [PageSectionVariants.light]: styles.modifiers.light,
     [PageSectionVariants.dark]: styles.modifiers.dark_200,
     [PageSectionVariants.darker]: styles.modifiers.dark_100
   };
-
   return (
-    <section {...props} className={css(styles.pageMainSection, noPadding && styles.modifiers.noPadding, noPaddingMobile && styles.modifiers.noPaddingMobile, variantStyle[variant], className)}>
+    <section {...props} className={css(styles.pageMainSection, noPadding && styles.modifiers.noPadding, noPaddingMobile && styles.modifiers.noPaddingMobile, variantStyle[variant], isFilled === false && styles.modifiers.noFill, isFilled === true && styles.modifiers.fill , className)}>
       {children}
     </section>
   );

--- a/packages/patternfly-4/react-core/src/components/Page/PageSection.test.js
+++ b/packages/patternfly-4/react-core/src/components/Page/PageSection.test.js
@@ -15,3 +15,22 @@ test('Check page section with no padding on mobile example against snapshot', ()
   const view = mount(Section);
   expect(view).toMatchSnapshot();
 });
+
+test('Check page section with no fill example against snapshot', () => {
+  const Section = <PageSection isFilled={false} />;
+  const view = mount(Section);
+  expect(view).toMatchSnapshot();
+});
+
+test('Check page section with fill example against snapshot', () => {
+  const Section = <PageSection isFilled={true} />;
+  const view = mount(Section);
+  expect(view).toMatchSnapshot();
+});
+
+test('Check page section with fill and no padding example against snapshot', () => {
+  const Section = <PageSection isFilled={true} noPadding={true} />;
+  const view = mount(Section);
+  expect(view).toMatchSnapshot();
+});
+

--- a/packages/patternfly-4/react-core/src/components/Page/__snapshots__/PageSection.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Page/__snapshots__/PageSection.test.js.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Check page section with fill and no padding example against snapshot 1`] = `
+<PageSection
+  className=""
+  isFilled={true}
+  noPadding={true}
+  noPaddingMobile={false}
+  variant="default"
+>
+  <section
+    className="pf-c-page__main-section pf-m-no-padding pf-m-fill"
+  />
+</PageSection>
+`;
+
+exports[`Check page section with fill example against snapshot 1`] = `
+<PageSection
+  className=""
+  isFilled={true}
+  noPadding={false}
+  noPaddingMobile={false}
+  variant="default"
+>
+  <section
+    className="pf-c-page__main-section pf-m-fill"
+  />
+</PageSection>
+`;
+
+exports[`Check page section with no fill example against snapshot 1`] = `
+<PageSection
+  className=""
+  isFilled={false}
+  noPadding={false}
+  noPaddingMobile={false}
+  variant="default"
+>
+  <section
+    className="pf-c-page__main-section pf-m-no-fill"
+  />
+</PageSection>
+`;
+
 exports[`Check page section with no padding example against snapshot 1`] = `
 <PageSection
   className=""


### PR DESCRIPTION
**What**:

closes #1707 

Added the `no-fill` and `fill` modifiers to the PageSection component + added an example to `Page.md`.

//cc @mcoker @mcarrano 
