### PR TITLE
fix(Dropdown): handle on enter focusing when options are disabled

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
@@ -39,10 +39,14 @@ class DropdownMenu extends React.Component {
 
   componentDidMount() {
     if (this.props.openedOnEnter) {
-      if (this.props.component === 'ul') this.refsCollection[0].focus();
+      const focusTarget =
+        this.refsCollection.filter(
+          ref => ref && ((ref.current && !ref.current.hasAttribute('disabled')) || !ref.hasAttribute('disabled'))
+        )[0] || null;
+      if (this.props.component === 'ul') focusTarget && focusTarget.focus();
       else {
-        (this.refsCollection[0].current.focus && this.refsCollection[0].current.focus()) ||
-          ReactDOM.findDOMNode(this.refsCollection[0].current).focus();
+        (focusTarget.current.focus && focusTarget.current.focus()) ||
+          (focusTarget && ReactDOM.findDOMNode(focusTarget.current).focus());
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: fix for handling when options are disabled. Focus should be on the first non-disabled item.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Refer to issue**: Fixes #2017

<!-- feel free to add additional comments -->
