### PR TITLE
fix(HorizontalNav): Horizontal nav is not exported for build.

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/index.js
+++ b/packages/patternfly-3/patternfly-react/src/index.js
@@ -17,6 +17,7 @@ export * from './components/Filter';
 export * from './components/Form';
 export * from './components/Grid';
 export * from './components/HintBlock';
+export * from './components/HorizontalNav';
 export * from './components/Icon';
 export * from './components/InfoTip';
 export * from './components/InlineEdit';


### PR DESCRIPTION
fix #2040

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Added `HorizontalNav` to `src/index` in PF3
<!-- Are there any upstream issues or separate issues you need to reference? -->
