### PR TITLE
fix(Select): account for direct JSX children

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Select/Select.js
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import SingleSelect from './SingleSelect';
 import CheckboxSelect from './CheckboxSelect';
 import SelectToggle from './SelectToggle';
+import SelectOption from './SelectOption';
 import { SelectContext, SelectVariant } from './selectConstants';
 import { Chip, ChipGroup } from '../ChipGroup';
 
@@ -101,10 +102,10 @@ class Select extends React.Component {
     }
     const filteredChildren =
       e.target.value !== ''
-        ? this.props.children.filter(child => child.props.value.search(input) === 0)
+        ? React.Children.toArray(this.props.children).filter(child => child.props.value.search(input) === 0)
         : this.props.children;
     if (filteredChildren.length === 0) {
-      filteredChildren.push(<div className={css(styles.selectMenuItem)}>No results found</div>);
+      filteredChildren.push(<SelectOption isDisabled key={0} value="No results found" />);
     }
     this.setState({
       typeaheadValue: e.target.value,
@@ -149,7 +150,7 @@ class Select extends React.Component {
     const selectToggleId = `pf-toggle-id-${currentId++}`;
     let childPlaceholderText = null;
     if (!selections && !placeholderText) {
-      const childPlaceholder = children.filter(child => child.props.isPlaceholder === true);
+      const childPlaceholder = React.Children.toArray(children).filter(child => child.props.isPlaceholder === true);
       childPlaceholderText =
         (childPlaceholder[0] && childPlaceholder[0].props.value) || (children[0] && children[0].props.value);
     }

--- a/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.js.snap
@@ -1976,12 +1976,16 @@ exports[`typeahead multi select test onChange 1`] = `
             class="pf-c-select__menu"
             role="listbox"
           >
-            <div
-              class="pf-c-select__menu-item"
-              index="0"
+            <li
+              role="presentation"
             >
-              No results found
-            </div>
+              <button
+                class="pf-c-select__menu-item pf-m-disabled"
+                role="option"
+              >
+                No results found
+              </button>
+            </li>
           </ul>
         </div>
       }
@@ -2060,16 +2064,32 @@ exports[`typeahead multi select test onChange 1`] = `
         className="pf-c-select__menu"
         role="listbox"
       >
-        <div
-          className="pf-c-select__menu-item"
+        <SelectOption
+          className=""
           index={0}
+          isDisabled={true}
+          isPlaceholder={false}
           isSelected={false}
-          key=".0"
+          key=".$0"
           keyHandler={[Function]}
+          onClick={[Function]}
           sendRef={[Function]}
+          value="No results found"
         >
-          No results found
-        </div>
+          <li
+            role="presentation"
+          >
+            <button
+              aria-selected={null}
+              className="pf-c-select__menu-item pf-m-disabled"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="option"
+            >
+              No results found
+            </button>
+          </li>
+        </SelectOption>
       </ul>
     </SingleSelect>
   </div>
@@ -2777,12 +2797,16 @@ exports[`typeahead select test onChange 1`] = `
             class="pf-c-select__menu"
             role="listbox"
           >
-            <div
-              class="pf-c-select__menu-item"
-              index="0"
+            <li
+              role="presentation"
             >
-              No results found
-            </div>
+              <button
+                class="pf-c-select__menu-item pf-m-disabled"
+                role="option"
+              >
+                No results found
+              </button>
+            </li>
           </ul>
         </div>
       }
@@ -2861,16 +2885,32 @@ exports[`typeahead select test onChange 1`] = `
         className="pf-c-select__menu"
         role="listbox"
       >
-        <div
-          className="pf-c-select__menu-item"
+        <SelectOption
+          className=""
           index={0}
+          isDisabled={true}
+          isPlaceholder={false}
           isSelected={false}
-          key=".0"
+          key=".$0"
           keyHandler={[Function]}
+          onClick={[Function]}
           sendRef={[Function]}
+          value="No results found"
         >
-          No results found
-        </div>
+          <li
+            role="presentation"
+          >
+            <button
+              aria-selected={null}
+              className="pf-c-select__menu-item pf-m-disabled"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="option"
+            >
+              No results found
+            </button>
+          </li>
+        </SelectOption>
       </ul>
     </SingleSelect>
   </div>


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Fix for children operations to account for a direct list of JSX children (opposed to current examples, which map an array). Also updated no results found state for Typeahead to account for console warnings.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Refer to issue**: #2039 

<!-- feel free to add additional comments -->
