### PR TITLE
fix(Select): onSelect prop TypeScript definition

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Select/Select.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.d.ts
@@ -11,9 +11,10 @@ export interface SelectProps extends HTMLProps<HTMLOptionElement> {
   isExpanded?: boolean;
   isGrouped?: boolean;
   onToggle(value: boolean): void;
+  onSelect(event: ReactEventHandler<HTMLOptionElement, Event>, element: string, isPlaceholder: boolean): void;
   onClear?() : void;
   placeholderText?: string | ReactNode;
-  selections?: string | Array<string>;
+  selections?: string | Array<string> | null;
   variant?: string;
   width?: string | number;
   ariaLabelledBy?: string;


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: TypeScript definition file of Select component. This makes the `onSelect` prop required, and now has the correct parameters. Selections can now also take in null, which is the default value used within the Select component

From:
```js
onSelect(event: ReactEventHandler<HTMLOptionElement, Event>)
//...
selections?: string | Array<string>;
```
to
```js
onSelect(event: ReactEventHandler<HTMLOptionElement, Event>, element: string, isPlaceholder: boolean): void;
//...
selections?: string | Array<string> | null;
```

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: None

<!-- feel free to add additional comments -->
