### PR TITLE
fix(modal): do not render title when hideTitle is true 

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Modal/Modal.md
+++ b/packages/patternfly-4/react-core/src/components/Modal/Modal.md
@@ -241,7 +241,6 @@ class NoHeader extends React.Component {
         </Button>
         <Modal
           isLarge
-          title="Modal Header"
           isOpen={isModalOpen}
           hideTitle={true}
           ariaDescribedById="no-header-example"

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalBoxHeader.tsx
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalBoxHeader.tsx
@@ -22,11 +22,9 @@ export const ModalBoxHeader: React.FunctionComponent<ModalBoxHeaderProps> = ({
   headingLevel = TitleLevel.h1,
   ...props
 }: ModalBoxHeaderProps) => {
-  const hidden = hideTitle ? css(accessibleStyles.screenReader) : '';
-
-  return (
+  return hideTitle ? null : (
     <React.Fragment>
-      <Title size="2xl" headingLevel={headingLevel} className={className + hidden} {...props}>
+      <Title size="2xl" headingLevel={headingLevel} className={className} {...props}>
         {children}
       </Title>
     </React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Modal/__snapshots__/ModalBoxHeader.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Modal/__snapshots__/ModalBoxHeader.test.tsx.snap
@@ -12,17 +12,7 @@ exports[`ModalBoxHeader Test 1`] = `
 </Fragment>
 `;
 
-exports[`ModalBoxHeader Test hideTitle 1`] = `
-<Fragment>
-  <Component
-    className="pf-u-screen-reader"
-    headingLevel="h1"
-    size="2xl"
-  >
-    This is a ModalBox header
-  </Component>
-</Fragment>
-`;
+exports[`ModalBoxHeader Test hideTitle 1`] = `""`;
 
 exports[`ModalBoxHeader Test with H3 1`] = `
 <Fragment>


### PR DESCRIPTION
**What**:

In core, the no header modal doesn't have title or a screen-reader element.
This PR is supposed to be aligned to that change.

This PR closes #2056

// cc @jeff-phillips-18 