### PR TITLE
chore(react-docs): clean mdx cache before develop

### DIFF
--- a/packages/patternfly-4/react-docs/package.json
+++ b/packages/patternfly-4/react-docs/package.json
@@ -9,7 +9,8 @@
     "build:docs": "yarn build:static && gatsby build --prefix-paths",
     "build:static": "shx cp -r ../react-core/dist/styles/* static",
     "clean": "rimraf .cache public static/assets static/base.css",
-    "develop": "yarn build:static && gatsby develop",
+    "clean:mdx": "rimraf .cache/caches/gatsby-mdx",
+    "develop": "yarn build:static && yarn clean:mdx && gatsby develop",
     "serve": "gatsby serve --prefix-paths"
   },
   "dependencies": {


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: If you add new imports to your MDX file, rerun `yarn develop` which now clears the gatsby-mdx cache and lets you be on your merry way.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
