### PR TITLE
fix(Charts): Fix type definitions for chart themes

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/ChartTheme.d.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/ChartTheme.d.ts
@@ -1,15 +1,19 @@
-export const ChartBaseTheme = any;
-export const ChartDonutTheme = any;
+import { VictoryThemeInterface, VictoryThemeDefinition } from "victory";
 
-export interface ChartThemeColor {
+interface ChartBaseThemeInterface extends VictoryThemeDefinition {}
+interface ChartDonutThemeInterface extends VictoryThemeDefinition {}
+
+interface ChartThemeColorInterface {
   blue: string;
   default: string;
   green: string;
   multi: string;
-};
+}
 
-export interface ChartThemeVariant {
+interface ChartThemeVariantInterface {
   dark: string;
   default: string;
   light: string;
-};
+}
+
+export declare const ChartThemeColor: ChartThemeColorInterface, ChartThemeVariant: ChartThemeVariantInterface, ChartBaseTheme: ChartBaseThemeInterface, ChartDonutTheme: ChartDonutThemeInterface;


### PR DESCRIPTION
Fixes #2061

**What**:
- ChartBaseTheme and ChartDonutTheme type definitions were using `const` instead of `type` or `interface`. Update to interfaces which extend VictoryThemeInterface.
 - None of the types in ChartTheme.d.ts were associated with variable declarations, so module imports did not work as expected. Declare variables to associate types with instances.
