### PR TITLE
fix(index.js): [PF3] Export BreadcrumbSwitcher from patternfly-react index

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/index.js
+++ b/packages/patternfly-3/patternfly-react/src/index.js
@@ -57,3 +57,4 @@ export * from './components/Wizard';
 export { patternfly, layout } from './common/patternfly';
 export * from './components/ExpandCollapse';
 export * from './components/Overlay';
+export * from './components/BreadcrumbSwitcher';


### PR DESCRIPTION


<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

In https://github.com/patternfly/patternfly-react/pull/1109, the new `BreadcrumbSwitcher` component was added, but it was never exported in the main `index.js` file, so it can't be imported by name from the package like `import { BreadcrumbSwitcher } from 'patternfly-react';`, instead it can only be imported from `node_modules/patternfly-react/dist/js/components/BreadcrumbSwitcher`. This PR just adds it to `index.js` so it can be imported normally.

Needed downstream for https://github.com/ManageIQ/manageiq-v2v/issues/865.

<!-- Are there any upstream issues or separate issues you need to reference? -->

<!-- feel free to add additional comments -->
