### PR TITLE
fix(Select): update SelectProps interface, clean up demos

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.md
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.md
@@ -10,7 +10,7 @@ import { Popover, PopoverPosition, Checkbox, Button } from '@patternfly/react-co
 ## Simple popover
 ```js
 import React from 'react';
-import { Popover, PopoverPosition, Checkbox, Button } from '@patternfly/react-core';
+import { Popover, Button } from '@patternfly/react-core';
 
 SimplePopover = () => (
   <Popover

--- a/packages/patternfly-4/react-core/src/components/Select/Select.d.ts
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.d.ts
@@ -1,4 +1,5 @@
 import { HTMLProps, FormEvent, ReactNode } from 'react';
+import { Omit } from '../../helpers/typeUtils';
 
 export const SelectVariant: {
   single: 'single';
@@ -7,11 +8,11 @@ export const SelectVariant: {
   typeaheadMulti: 'typeaheadmulti';
 };
 
-export interface SelectProps extends HTMLProps<HTMLOptionElement> {
+export interface SelectProps extends Omit<React.HTMLProps<HTMLOptionElement>, 'onSelect'> {
   isExpanded?: boolean;
   isGrouped?: boolean;
   onToggle(value: boolean): void;
-  onSelect(event: ReactEventHandler<HTMLOptionElement, Event>, element: string, isPlaceholder: boolean): void;
+  onSelect(event: React.SyntheticEvent<HTMLOptionElement, Event>, element: string, isPlaceholder: boolean): void;
   onClear?() : void;
   placeholderText?: string | ReactNode;
   selections?: string | Array<string> | null;

--- a/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.md
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.md
@@ -9,7 +9,7 @@ import { Tooltip, TooltipPosition, Checkbox } from '@patternfly/react-core';
 ## Simple tooltip
 ```js
 import React from 'react';
-import { Tooltip, TooltipPosition, Checkbox } from '@patternfly/react-core';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 
 <Tooltip
   position="right"

--- a/packages/patternfly-4/react-core/src/demos/ToolbarDemo.md
+++ b/packages/patternfly-4/react-core/src/demos/ToolbarDemo.md
@@ -83,7 +83,6 @@ class ComplexToolbarDemo extends React.Component {
       const { isDropDownOpen } = this.state;
       return (
         <Dropdown
-            onToggle={this.onDropDownToggle}
             onSelect={this.onDropDownSelect}
             position={DropdownPosition.right}
             toggle={<DropdownToggle onToggle={this.onDropDownToggle}>All</DropdownToggle>}
@@ -105,7 +104,6 @@ class ComplexToolbarDemo extends React.Component {
 
       return (
         <Dropdown
-            onToggle={this.onKebabToggle}
             onSelect={this.onKebabSelect}
             position={DropdownPosition.right}
             toggle={<KebabToggle onToggle={this.onKebabToggle} />}


### PR DESCRIPTION
**What**: This PR updates the SelectProps interface to avoid a type error when importing react-core into a TypeScript application. I also removed some unnecessary code in a couple of the demo's I followed recently. Copying the code as is was creating an error. I think they were safe deletions but worth double checking.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: https://github.com/patternfly/patternfly-react/issues/2106


