### PR TITLE
fix(popover): maxWidth typescript error

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
@@ -72,7 +72,7 @@ export interface PopoverProps {
   /** z-index of the popover */
   zIndex?: number;
   /** Maximum width of the tooltip (default 18.75rem) */
-  maxWidth: string;
+  maxWidth?: string;
   /** Aria label for the Close button */
   closeBtnAriaLabel?: string;
 }


### PR DESCRIPTION
Fixes https://github.com/patternfly/patternfly-react/issues/2108

There is already a default value for maxWidth, so we just need to make this optional. Tested with the Cost Management UI.