### PR TITLE
fix(popover): make PopoverPosition an enum

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.md
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.md
@@ -10,11 +10,11 @@ import { Popover, PopoverPosition, Checkbox, Button } from '@patternfly/react-co
 ## Simple popover
 ```js
 import React from 'react';
-import { Popover, Button } from '@patternfly/react-core';
+import { Popover, PopoverPosition, Button } from '@patternfly/react-core';
 
 SimplePopover = () => (
   <Popover
-    position="right"
+    position={PopoverPosition.right}
     headerContent={<div>Popover Header</div>}
     bodyContent={
       <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.</div>
@@ -120,7 +120,7 @@ import { Popover, PopoverPosition, Checkbox, Button } from '@patternfly/react-co
 
 HeadlessPopover = () => (
   <Popover
-    position="right"
+    position={PopoverPosition.right}
     bodyContent={
       <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.</div>
     }

--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.test.tsx
@@ -1,11 +1,30 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { Popover } from './Popover';
+import { Popover, PopoverPosition } from './Popover';
 
 test('popover renders close-button, header and body', () => {
   const view = shallow(
     <Popover
       position="top"
+      isVisible
+      hideOnOutsideClick
+      headerContent={<div>Popover Header</div>}
+      bodyContent={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle Popover</div>
+    </Popover>
+  );
+  expect(view).toMatchSnapshot();
+});
+
+test('popover can specify position as object value', () => {
+  const view = shallow(
+    <Popover
+      position={PopoverPosition.right}
       isVisible
       hideOnOutsideClick
       headerContent={<div>Popover Header</div>}

--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
@@ -20,11 +20,11 @@ import { ReactElement } from 'react';
 const FocusTrap: any = require('focus-trap-react');
 tippyStyles();
 
-export const PopoverPosition = {
-  top: 'top',
-  bottom: 'bottom',
-  left: 'left',
-  right: 'right'
+export enum PopoverPosition {
+  top = 'top',
+  bottom = 'bottom',
+  left = 'left',
+  right = 'right'
 };
 
 export interface PopoverProps {

--- a/packages/patternfly-4/react-core/src/components/Popover/__snapshots__/Popover.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Popover/__snapshots__/Popover.test.tsx.snap
@@ -1,5 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`popover can specify position as object value 1`] = `
+<Tippy
+  animateFill={false}
+  appendTo={[Function]}
+  content={
+    <GenerateId
+      prefix="pf-random-id-"
+    >
+      [Function]
+    </GenerateId>
+  }
+  distance={25}
+  flip={true}
+  hideOnClick={false}
+  interactive={true}
+  interactiveBorder={0}
+  isVisible={true}
+  lazy={true}
+  maxWidth="calc(1.5rem + 18.75rem)"
+  onCreate={[Function]}
+  onHidden={[Function]}
+  onHide={[Function]}
+  onMount={[Function]}
+  onShow={[Function]}
+  onShown={[Function]}
+  performance={true}
+  placement="right"
+  popperOptions={
+    Object {
+      "modifiers": Object {
+        "hide": Object {
+          "enabled": true,
+        },
+        "preventOverflow": Object {
+          "enabled": true,
+        },
+      },
+    }
+  }
+  theme="pf-tippy"
+  trigger="manual"
+  zIndex={9999}
+>
+  <div>
+    Toggle Popover
+  </div>
+</Tippy>
+`;
+
 exports[`popover renders close-button, header and body 1`] = `
 <Tippy
   animateFill={false}


### PR DESCRIPTION
**What**: This PR changes PopoverPosition from a const to an enum. This allows users to specify their choice of a string or object property for the `position` property value on Popover component. Also adds a test that exercises this method to ensure it doesn't regress going forward.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: https://github.com/patternfly/patternfly-react/issues/2099
