### PR TITLE
fix(PF4 Table): Export RowWrapper implementation

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/RowWrapper.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/RowWrapper.d.ts
@@ -1,11 +1,11 @@
-import { UIEventHandler } from 'react';
+import { FunctionComponent, UIEventHandler } from 'react';
 
 export interface RowWrapperRow {
   isOpen: Boolean;
   isExpanded: Boolean;
 }
 
-export interface RowWrapper {
+export interface RowWrapperProps {
   trRef?: Function;
   onScroll?: UIEventHandler;
   onResize?: UIEventHandler;
@@ -13,4 +13,7 @@ export interface RowWrapper {
   rowProps?: Object;
 }
 
+declare const RowWrapper: FunctionComponent<RowWrapperProps>;
+
 export default RowWrapper;
+

--- a/packages/patternfly-4/react-table/src/components/Table/index.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/index.d.ts
@@ -16,7 +16,7 @@ export {
 } from './Table';
 export { default as TableHeader, HeaderProps } from './Header';
 export { default as TableBody, TableBodyProps } from './Body';
-export { RowWrapper, RowWrapperRow } from './RowWrapper';
+export { default as RowWrapper, RowWrapperRow, RowWrapperProps } from './RowWrapper';
 export { default as ExpandableRowContent } from './ExpandableRowContent';
 export { sortable, headerCol, cellWidth, ISortable, expandable, isRowExpanded } from './utils';
 export { SortByDirection } from './SortColumn';


### PR DESCRIPTION
**What**:
When using react table in typescript project there is no way how to import `RowWrapper` implementation and copy pasting parts of it is bad. So this PR fixes this problem by exporting `RowWrapperProps` as interface and `RowWrapper` as implementation.

**Additional issues**:
There might be problems because we are changing interface to implementation, but this is not that greatly used interface so it should be fine. @suomiy, @priley86 are you using this interface somewhere?

Fixes: https://github.com/patternfly/patternfly-react/issues/2109
