### PR TITLE
chore(dependencies): Add "shx" package to root dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react-dom": "~16.8.4",
     "react-scripts": "2.1.3",
     "sass-loader": "^6.0.6",
+    "shx": "^0.3.2",
     "style-loader": "^0.20.3",
     "stylelint": "^9.10.1",
     "stylelint-config-standard": "^18.2.0",


### PR DESCRIPTION
Add "shx" package to root dev dependencies since it is used in the root npm scripts