### PR TITLE
fix(charts): remove ChartThemeDefinition export from index.ts

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -12,7 +12,7 @@ import {
   VictoryAxisProps,
 } from 'victory';
 import { getTheme } from '../ChartUtils/chart-theme';
-import { ChartThemeDefinition } from "../ChartTheme";
+import { ChartThemeDefinition } from "../ChartTheme/ChartTheme";
 
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -10,7 +10,7 @@ import { Data } from 'victory-core';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { ChartContainer } from '../ChartContainer/ChartContainer';
 import { ChartPie, ChartPieProps } from '../ChartPie/ChartPie';
-import { ChartThemeDefinition } from "../ChartTheme";
+import { ChartThemeDefinition } from "../ChartTheme/ChartTheme";
 import { getChartOrigin } from '../ChartUtils/chart-origin';
 import { getDonutThresholdDynamicTheme, getDonutThresholdStaticTheme } from '../ChartUtils/chart-theme';
 

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/ChartTheme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/ChartTheme.ts
@@ -10,7 +10,7 @@ import {
   DonutUtilizationStaticTheme
 } from './themes/donut-utilization-theme';
 
-export interface ChartThemeDefinition extends VictoryThemeDefinition {
+export interface ChartThemeDefinitionInterface extends VictoryThemeDefinition {
   area?: any;
   axis?: any;
   bar?: any;
@@ -42,13 +42,6 @@ interface ChartThemeVariantInterface {
   light: string;
 }
 
-export const ChartBaseTheme: ChartThemeDefinition = BaseTheme;
-export const ChartDonutUtilizationDynamicTheme: ChartThemeDefinition = DonutUtilizationDynamicTheme;
-export const ChartDonutUtilizationStaticTheme: ChartThemeDefinition = DonutUtilizationStaticTheme;
-export const ChartDonutTheme: ChartThemeDefinition = DonutTheme;
-export const ChartDonutThresholdDynamicTheme: ChartThemeDefinition = DonutThresholdDynamicTheme;
-export const ChartDonutThresholdStaticTheme: ChartThemeDefinition = DonutThresholdStaticTheme;
-
 export const ChartThemeColor: ChartThemeColorInterface = {
   blue: 'blue',
   default: 'blue',
@@ -62,3 +55,12 @@ export const ChartThemeVariant: ChartThemeVariantInterface = {
   default: 'light',
   light: 'light'
 };
+
+export type ChartThemeDefinition = ChartThemeDefinitionInterface;
+
+export const ChartBaseTheme: ChartThemeDefinition = BaseTheme;
+export const ChartDonutUtilizationDynamicTheme: ChartThemeDefinition = DonutUtilizationDynamicTheme;
+export const ChartDonutUtilizationStaticTheme: ChartThemeDefinition = DonutUtilizationStaticTheme;
+export const ChartDonutTheme: ChartThemeDefinition = DonutTheme;
+export const ChartDonutThresholdDynamicTheme: ChartThemeDefinition = DonutThresholdDynamicTheme;
+export const ChartDonutThresholdStaticTheme: ChartThemeDefinition = DonutThresholdStaticTheme;

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/index.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/index.ts
@@ -6,6 +6,5 @@ export {
   ChartDonutUtilizationDynamicTheme,
   ChartDonutUtilizationStaticTheme,
   ChartThemeColor,
-  ChartThemeDefinition,
   ChartThemeVariant
 } from './ChartTheme';

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-theme.ts
@@ -14,10 +14,10 @@ import {
   ChartDonutUtilizationStaticTheme,
   ChartDonutThresholdDynamicTheme,
   ChartDonutThresholdStaticTheme,
-  ChartThemeColor,
   ChartThemeDefinition,
+  ChartThemeColor,
   ChartThemeVariant
-} from '../ChartTheme';
+} from '../ChartTheme/ChartTheme';
 
 // Apply custom properties to color and base themes
 export const getCustomTheme = (themeColor: string, themeVariant: string,


### PR DESCRIPTION
A simple fix to remove the ChartThemeDefinition export from the ChartTheme index.ts file.

Fixes https://github.com/patternfly/patternfly-react/issues/2148
