### PR TITLE
fix(aboutmodal): support isOpen initially set true in about modal

### DIFF
--- a/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.tsx
+++ b/packages/patternfly-4/react-core/src/components/AboutModal/AboutModal.tsx
@@ -59,7 +59,7 @@ export class AboutModal extends React.Component<AboutModalProps> {
     }
   };
 
-  componentDidMount() {
+  private appendContainer = () => {
     if (!this.container) {
       this.container = document.createElement('div');
       document.body.appendChild(this.container);
@@ -70,6 +70,10 @@ export class AboutModal extends React.Component<AboutModalProps> {
     } else {
       document.body.classList.remove(css(styles.backdropOpen));
     }
+  }
+
+  componentDidMount() {
+    this.appendContainer();
   }
 
   componentDidUpdate() {
@@ -88,8 +92,11 @@ export class AboutModal extends React.Component<AboutModalProps> {
   }
 
   render() {
-    if (!canUseDOM || !this.container) {
+    if (!canUseDOM) {
       return null;
+    }
+    if(canUseDOM && !this.container) {
+      this.appendContainer();
     }
 
     return ReactDOM.createPortal(


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Noticed this while release testing `@patternfly/react-core`  3.34.0 today. This will just ensure the about modal container exists on initial load if `isOpen` is passed `true` with children contents initially...

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
