### PR TITLE
fix(charts): chart: wrong 'children' type

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
@@ -35,7 +35,7 @@ export interface ChartProps extends VictoryChartProps {
   /**
    * The children to render with the chart
    */
-  children?: React.ReactElement<any> | React.ReactElement<any>[];
+  children?: React.ReactNode;
   /**
    * The containerComponent prop takes an entire component which will be used to
    * create a container element for standalone charts.

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -5,7 +5,7 @@ typescript: true
 propComponents: ['Chart', 'ChartBar', 'ChartGroup']
 ---
 
-## Default Bar Chart
+## Simple Bar Chart
 
 import { Chart, ChartBar, ChartGroup, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
 import './chart-bar.scss';

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -50,7 +50,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * ChartGroup will be cloned and rendered with new props so that all children share common props such as domain and
    * scale.
    */
-  children?: React.ReactElement<any> | React.ReactElement<any>[];
+  children?: React.ReactNode;
   /**
    * The colorScale prop is an optional prop that defines the color scale the chart's bars
    * will be created on. This prop should be given as an array of CSS colors, or as a string


### PR DESCRIPTION
Modifies Chart & ChartStack to use ReactNode as `children` type.

Fixes https://github.com/patternfly/patternfly-react/issues/2152
