### PR TITLE
fix(charts): align label vertically and add donutHeight/Width defaults

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -61,6 +61,13 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
    */
   animate?: AnimatePropTypeInterface;
   /**
+   * The capHeight prop defines a text metric for the font being used: the expected height of capital letters.
+   * This is necessary because of SVG, which (a) positions the *bottom* of the text at `y`, and (b) has no notion of
+   * line height. The value should ideally use the same units as `lineHeight` and `dy`, preferably ems. If given a
+   * unitless number, it is assumed to be ems.
+   */
+  capHeight?: StringOrNumberOrCallback;
+  /**
    * The categories prop specifies how categorical data for a chart should be ordered.
    * This prop should be given as an array of string values, or an object with
    * these arrays of values specified for x and y. If this prop is not set,
@@ -134,8 +141,14 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
    * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
    * pixels will depend on the size of the container the chart is rendered into.
    *
-   * Note: The parent container must be set to the same height in order to maintain the aspect ratio. Otherwise, the
-   * innerRadius may need to be set when using this property.
+   * Note: When adding a legend, height (the overall SVG height) may need to be larger than donutHeight (the donut size)
+   * in order to accommodate the extra legend.
+   *
+   * By default, donutHeight is the min. of either height or width. This covers most use cases in order to accommodate
+   * legends within the same SVG. However, donutHeight (not height) may need to be set in order to adjust the donut
+   * height.
+   *
+   * The innerRadius may also need to be set when changing the donut size.
    */
   donutHeight?: number;
   /**
@@ -150,8 +163,13 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
    * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
    * pixels will depend on the size of the container the chart is rendered into.
    *
-   * Note: The parent container must be set to the same height in order to maintain the aspect ratio. Otherwise, the
-   * innerRadius may need to be set when using this property.
+   * Note: When adding a legend, width (the overall SVG width) may need to be larger than donutWidth (the donut size)
+   * in order to accommodate the extra legend.
+   *
+   * By default, donutWidth is the min. of either height or width. This covers most use cases in order to accommodate
+   * legends within the same SVG. However, donutWidth (not width) may need to be set in order to adjust the donut width.
+   *
+   * The innerRadius may also need to be set when changing the donut size.
    */
   donutWidth?: number;
   /**
@@ -223,7 +241,10 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
    * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
    * pixels will depend on the size of the container the chart is rendered into.
    *
-   * Note: innerRadius may need to be set when using this property.
+   * Note: When adding a legend, height (the overall SVG height) may need to be larger than donutHeight (the donut size)
+   * in order to accommodate the extra legend.
+   *
+   * Typically, the parent container is set to the same height in order to maintain the aspect ratio.
    */
   height?: number;
   /**
@@ -402,7 +423,10 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
    * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
    * pixels will depend on the size of the container the chart is rendered into.
    *
-   * Note: innerRadius may need to be set when using this property.
+   * Note: When adding a legend, width (the overall SVG width) may need to be larger than donutWidth (the donut size)
+   * in order to accommodate the extra legend.
+   *
+   * Typically, the parent container is set to the same width in order to maintain the aspect ratio.
    */
   width?: number;
   /**
@@ -449,11 +473,12 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
 
   // destructure last
   theme = getDonutUtilizationTheme(themeColor, themeVariant),
-  donutHeight = theme.pie.height,
-  donutWidth = theme.pie.width,
+  capHeight = title && subTitle ? 1.1 : undefined,
   height = theme.pie.height,
-  innerRadius = ((donutHeight || donutWidth) - 34) / 2,
   width = theme.pie.width,
+  donutHeight = Math.min(height, width),
+  donutWidth = Math.min(height, width),
+  innerRadius = (Math.min(donutHeight, donutWidth) - 34) / 2,
   ...rest
 }: ChartDonutUtilizationProps) => {
   // Returns computed data representing pie chart slices
@@ -555,6 +580,7 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
   const chart = (
     <React.Fragment>
       <ChartLabel
+        capHeight={capHeight}
         style={[DonutUtilizationStyles.label.title, DonutUtilizationStyles.label.subTitle] as any} // Todo: Array supported, but @types/victory is wrong
         text={title && subTitle ? [title, subTitle] : title}
         textAnchor="middle"

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
@@ -983,12 +983,12 @@ exports[`renders component data 1`] = `
         },
       ]
     }
-    height={230}
-    innerRadius={98}
+    height={200}
+    innerRadius={83}
     origin={
       Object {
-        "x": 115,
-        "y": 115,
+        "x": 100,
+        "y": 100,
       }
     }
     standalone={false}
@@ -1444,7 +1444,7 @@ exports[`renders component data 1`] = `
         },
       }
     }
-    width={230}
+    width={200}
   />
 </Component>
 `;

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
@@ -1015,8 +1015,8 @@ exports[`renders component data 1`] = `
     }
     textAnchor="middle"
     verticalAnchor="middle"
-    x={115}
-    y={115}
+    x={100}
+    y={100}
   />
   <Component
     data={
@@ -1030,12 +1030,12 @@ exports[`renders component data 1`] = `
         },
       ]
     }
-    height={230}
-    innerRadius={98}
+    height={200}
+    innerRadius={83}
     origin={
       Object {
-        "x": 115,
-        "y": 115,
+        "x": 100,
+        "y": 100,
       }
     }
     standalone={false}
@@ -1489,7 +1489,7 @@ exports[`renders component data 1`] = `
         },
       }
     }
-    width={230}
+    width={200}
   />
 </Component>
 `;

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -58,7 +58,7 @@ class UtilizationChart extends React.Component {
     const { spacer, used } = this.state;
     return (
       <div>
-        <div className="donut-utilization-chart-horz">
+        <div className="donut-utilization-chart-legend-right">
           <ChartDonutUtilization
             data={{ x: 'GBps capacity', y: used }}
             labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
@@ -108,7 +108,7 @@ class UtilizationChart extends React.Component {
     const { spacer, used } = this.state;
     return (
       <div>
-        <div className="donut-utilization-chart-horz">
+        <div className="donut-utilization-chart-legend-right">
           <ChartDonutUtilization
             data={{ x: 'GBps capacity', y: used }}
             labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
@@ -133,9 +133,10 @@ import React from 'react';
 import { ChartDonutUtilization } from '@patternfly/react-charts';
 
 <div>
-  <div className="donut-utilization-chart-vert">
+  <div className="donut-utilization-chart-legend-bottom">
     <ChartDonutUtilization
       data={{ x: 'GBps capacity', y: 45 }}
+      donutHeight={230}
       donutOrientation="top"
       height={275}
       labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
@@ -157,7 +158,7 @@ import React from 'react';
 import { ChartDonutUtilization } from '@patternfly/react-charts';
 
 <div>
-  <div className="donut-utilization-chart-horz-sm">
+  <div className="donut-utilization-chart-legend-left">
     <ChartDonutUtilization
       data={{ x: 'GBps capacity', y: 45 }}
       donutOrientation="right"
@@ -178,11 +179,10 @@ import React from 'react';
 import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
 
 <div>
-  <div className="donut-threshold-chart-horz">
+  <div className="donut-threshold-chart">
     <ChartDonutThreshold
       data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
       labels={datum => datum.x ? datum.x : null}
-      width={475}
     >
       <ChartDonutUtilization
         data={{ x: 'GBps capacity', y: 45 }}
@@ -223,7 +223,7 @@ class ThresholdChart extends React.Component {
     const { used } = this.state;
     return (
       <div>
-        <div className="donut-threshold-chart-horz">
+        <div className="donut-threshold-chart-legend-right">
           <ChartDonutThreshold
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
             labels={datum => datum.x ? datum.x : null}
@@ -273,7 +273,7 @@ class ThresholdChart extends React.Component {
     const { used } = this.state;
     return (
       <div>
-        <div className="donut-threshold-chart-horz">
+        <div className="donut-threshold-chart-legend-right">
           <ChartDonutThreshold
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
             labels={datum => datum.x ? datum.x : null}
@@ -303,13 +303,13 @@ import React from 'react';
 import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
 
 <div>
-  <div className="donut-threshold-chart-vert">
+  <div className="donut-threshold-chart-legend-bottom">
     <ChartDonutThreshold
       data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
       donutOrientation="top"
       height={325}
       labels={datum => datum.x ? datum.x : null}
-      width={275}
+      width={230}
     >
       <ChartDonutUtilization
         data={{ x: 'GBps capacity', y: 45 }}
@@ -329,7 +329,7 @@ import React from 'react';
 import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
 
 <div>
-  <div className="donut-threshold-chart-horz-sm">
+  <div className="donut-threshold-chart-legend-left">
     <ChartDonutThreshold
       data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
       donutOrientation="right"
@@ -346,4 +346,149 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     </ChartDonutThreshold>
   </div>
 </div>
+```
+
+## Small donut utilization chart
+```js
+import React from 'react';
+import { ChartDonutUtilization } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-utilization-chart-sm">
+    <ChartDonutUtilization
+      data={{ x: 'GBps capacity', y: 75 }}
+      height={150}
+      labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
+      subTitle="of 100 GBps"
+      title="75%"
+      width={150}
+    />
+  </div>
+</div>
+```
+
+## Small donut utilization chart with right-aligned legend
+```js
+import React from 'react';
+import { ChartDonutUtilization } from '@patternfly/react-charts';
+
+class UtilizationChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      spacer: '',
+      used: 0
+    };
+  }
+
+  componentDidMount() {
+    this.interval = setInterval(() => {
+      const { used } = this.state;
+      const val = (used + 10) % 100;
+      this.setState({
+        spacer: val < 10 ? ' ' : '',
+        used: val
+      });
+    }, 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
+
+  render() {
+    const { spacer, used } = this.state;
+    return (
+      <div>
+        <div className="donut-utilization-chart-legend-right-sm">
+          <ChartDonutUtilization
+            data={{ x: 'GBps capacity', y: used }}
+            height={150}
+            labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
+            legendData={[{ name: `GBps capacity - ${spacer}${used}%` }, { name: 'Unused' }]}
+            subTitle="of 100 GBps"
+            title={`${used}%`}
+            thresholds={[{ value: 60 }, { value: 90 }]}
+            width={350}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+```
+
+## Small donut utilization chart with static thresholds
+```js
+import React from 'react';
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-threshold-chart-sm">
+    <ChartDonutThreshold
+      data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
+      height={175}
+      labels={datum => datum.x ? datum.x : null}
+      width={175}
+    >
+      <ChartDonutUtilization
+        data={{ x: 'GBps capacity', y: 45 }}
+        labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
+        subTitle="of 100 GBps"
+        title="45%"
+      />
+    </ChartDonutThreshold>
+  </div>
+</div>
+```
+
+## Small donut utilization chart with static thresholds and right-aligned legend
+```js
+import React from 'react';
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
+
+class ThresholdChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      used: 0
+    };
+  }
+
+  componentDidMount() {
+    this.interval = setInterval(() => {
+      const { used } = this.state;
+      this.setState({ used: (used + 10) % 100 });
+    }, 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
+
+  render() {
+    const { used } = this.state;
+    return (
+      <div>
+        <div className="donut-threshold-chart-legend-right-sm">
+          <ChartDonutThreshold
+            data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
+            height={175}
+            labels={datum => datum.x ? datum.x : null}
+            width={425}
+          >
+            <ChartDonutUtilization
+              data={{ x: 'GBps capacity', y: used }}
+              labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
+              legendData={[{ name: `GBps capacity - ${used}%` }, { name: 'Warning threshold at - 60%' }, { name: 'Danger threshold at - 90%' }]}
+              subTitle="of 100 GBps"
+              title={`${used}%`}
+              thresholds={[{ value: 60 }, { value: 90 }]}
+            />
+          </ChartDonutThreshold>
+        </div>
+      </div>
+    );
+  }
+}
 ```

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -245,7 +245,7 @@ class ThresholdChart extends React.Component {
 }
 ```
 
-## Green donut utilization chart with static thresholds and right-aligned legend
+## Green donut utilization chart with static thresholds and right-aligned (custom) legend
 ```js
 import React from 'react';
 import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
@@ -282,7 +282,11 @@ class ThresholdChart extends React.Component {
             <ChartDonutUtilization
               data={{ x: 'GBps capacity', y: used }}
               labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
-              legendData={[{ name: `GBps capacity - ${used}%` }, { name: 'Warning threshold at - 60%' }, { name: 'Danger threshold at - 90%' }]}
+              legendComponent={
+                <ChartLegend
+                  data={[{ name: `GBps capacity - ${used}%` }, { name: 'Warning threshold at - 60%' }, { name: 'Danger threshold at - 90%' }]}
+                />
+              }
               subTitle="of 100 GBps"
               title={`${used}%`}
               themeColor={ChartThemeColor.green}

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/chart-donut-utilization.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/chart-donut-utilization.scss
@@ -1,18 +1,33 @@
 .ws-preview {
   & > * {
-    .donut-threshold-chart-horz {
+    .donut-threshold-chart {
       height: 230px;
-      width: 492px;
+      width: 230px;
     }
 
-    .donut-threshold-chart-horz-sm {
+    .donut-threshold-chart-sm {
+      height: 175px;
+      width: 175px;
+    }
+
+    .donut-threshold-chart-legend-bottom {
+      height: 325px;
+      width: 230px;
+    }
+
+    .donut-threshold-chart-legend-left {
       height: 230px;
       width: 475px;
     }
 
-    .donut-threshold-chart-vert {
-      height: 325px;
-      width: 275px;
+    .donut-threshold-chart-legend-right {
+      height: 230px;
+      width: 492px;
+    }
+
+    .donut-threshold-chart-legend-right-sm {
+      height: 175px;
+      width: 425px;
     }
 
     .donut-utilization-chart {
@@ -20,19 +35,29 @@
       width: 230px;
     }
 
-    .donut-utilization-chart-horz {
-      height: 230px;
-      width: 435px;
+    .donut-utilization-chart-sm {
+      height: 150px;
+      width: 150px;
     }
 
-    .donut-utilization-chart-horz-sm {
+    .donut-utilization-chart-legend-bottom {
+      height: 275px;
+      width: 300px;
+    }
+
+    .donut-utilization-chart-legend-left {
       height: 230px;
       width: 425px;
     }
 
-    .donut-utilization-chart-vert {
-      height: 275px;
-      width: 300px;
+    .donut-utilization-chart-legend-right {
+      height: 230px;
+      width: 435px;
+    }
+
+    .donut-utilization-chart-legend-right-sm {
+      height: 150px;
+      width: 350px;
     }
   }
 }


### PR DESCRIPTION
This PR is for donut utilization changes requested by @TheRealJon for use in OpenShift.

Fixes https://github.com/patternfly/patternfly-react/issues/2191
Fixes https://github.com/patternfly/patternfly-react/issues/2192
Fixes https://github.com/patternfly/patternfly-react/issues/2194

I was able to fix #2191 by setting capHeight (using a rem value) in order to help center the label vertically. I only use this when both title and subtitle are available -- not necessary for a single label. I've added a property so it may be overridden.

<img width="229" alt="Screen Shot 2019-06-07 at 8 39 09 PM" src="https://user-images.githubusercontent.com/17481322/59141035-e0f66800-8973-11e9-8a95-45aae2f7e389.png">

I was able to address #2192 by changing the default donutHeight and donutWidth properties to use the min. of the given SVG height or width. If height & width are not provided, the default theme property would be used.

With these changes, the user can just set the height and width properties. Similar to other charts, we'll set the donut size to match that.

This also works with the threshold chart. I've modified the dynamic chart to be 28px smaller than the static (threshold) chart by default. This is similar to innerRadius, where we set a default regardless of the chart size.

This probably covers most use cases where the width is larger to accommodate either a left or right aligned legend. Of course, it also works without any legends at all. Thus, allowing the user to more easily create different size charts.

![small-donuts](https://user-images.githubusercontent.com/17481322/59141195-90343e80-8976-11e9-9c16-588b56f0af3a.gif)

For edge cases, the user can still override the donutHeight and donutWidth properties. There an example of this (below), where the overall SVG height and width are larger than donutHeight and donutWidth. In this particular example, the horizontal legend is wider than the chart's donutWidth, while the SVG is sized appropriately to accommodate both the chart and legend.

<img width="438" alt="Screen Shot 2019-06-08 at 9 17 37 AM" src="https://user-images.githubusercontent.com/17481322/59147817-4bd48d00-89ce-11e9-8af1-cc0fb4fd7e56.png">
