### PR TITLE
fix(react-table): Some props of IRow should not required

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
@@ -77,9 +77,9 @@ export interface IRowCell {
 
 export interface IRow {
   cells: Array<ReactNode | IRowCell>;
-  isOpen: Boolean;
-  parent: Number;
-  props: any;
+  isOpen?: Boolean;
+  parent?: Number;
+  props?: any;
   fullWidth?: Boolean;
   noPadding?: Boolean;
 }


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

Makes following props of `IRow` to optional

- isOpen
- parent
- props


https://github.com/patternfly/patternfly-react/blob/979f13f1525410f7bccc108480736d3898550333/packages/patternfly-4/react-table/src/components/Table/Table.js#L183

The `parent` props should not define anything to pass the check


<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
