### PR TITLE
feat(Button): add icon property and wrapper css

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Button/Button.md
+++ b/packages/patternfly-4/react-core/src/components/Button/Button.md
@@ -28,8 +28,8 @@ ButtonVariants = () => (
   <React.Fragment>
     <Button variant="primary">Primary</Button> <Button variant="secondary">Secondary</Button>{' '}
     <Button variant="tertiary">Tertiary</Button> <Button variant="danger">Danger</Button>{' '}
-    <Button variant="link">
-      <PlusCircleIcon /> Link button
+    <Button variant="link" icon={<PlusCircleIcon />}>
+      Link button
     </Button>{' '}
     <Button variant="plain" aria-label="Action">
       <TimesIcon />

--- a/packages/patternfly-4/react-core/src/components/Button/Button.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Button/Button.test.tsx
@@ -1,6 +1,7 @@
 import { Button, ButtonVariant } from './Button';
 import React from 'react';
 import { shallow } from 'enzyme';
+import { CartArrowDownIcon } from '@patternfly/react-icons';
 
 Object.values(ButtonVariant).forEach(variant => {
   test(`${variant} button`, () => {
@@ -17,6 +18,15 @@ test('it adds an aria-label to plain buttons', () => {
   const label = 'aria-label test';
   const view = shallow(<Button aria-label={label} />);
   expect(view.find('button').props()['aria-label']).toBe(label);
+});
+
+test('link with icon', () => {
+  const view = shallow(
+    <Button variant={ButtonVariant.link} icon={<CartArrowDownIcon />}>
+      Block Button
+    </Button>
+  );
+  expect(view).toMatchSnapshot();
 });
 
 test('isBlock', () => {

--- a/packages/patternfly-4/react-core/src/components/Button/Button.tsx
+++ b/packages/patternfly-4/react-core/src/components/Button/Button.tsx
@@ -41,6 +41,8 @@ export interface ButtonProps extends React.HTMLProps<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'tertiary' | 'danger' | 'link' | 'plain' ;
   /** Adds accessible text to the button. */
   'aria-label'?: string; 
+  /** Icon for the button */
+  icon?: React.ReactType | null;
 }
 
 export const Button: React.FunctionComponent<ButtonProps> = ({
@@ -56,6 +58,7 @@ export const Button: React.FunctionComponent<ButtonProps> = ({
   type = ButtonType.button,
   variant = ButtonVariant.primary,
   'aria-label': ariaLabel = null, 
+  icon = null,
   ...props
 }: ButtonProps) => {
   const Component = component as any;
@@ -80,6 +83,7 @@ export const Button: React.FunctionComponent<ButtonProps> = ({
     tabIndex={isDisabled && !isButtonElement ? -1 : null}
     type={isButtonElement ? type : null}
   >
+    {(icon && variant === ButtonVariant.link) && <span className="pf-c-button__icon">{icon}</span>}
     {children}
   </Component>
   );

--- a/packages/patternfly-4/react-core/src/components/Button/Button.tsx
+++ b/packages/patternfly-4/react-core/src/components/Button/Button.tsx
@@ -41,8 +41,8 @@ export interface ButtonProps extends React.HTMLProps<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'tertiary' | 'danger' | 'link' | 'plain' ;
   /** Adds accessible text to the button. */
   'aria-label'?: string; 
-  /** Icon for the button */
-  icon?: React.ReactType | null;
+  /** Icon for the button if variant is a link */
+  icon?: React.ReactNode | null;
 }
 
 export const Button: React.FunctionComponent<ButtonProps> = ({

--- a/packages/patternfly-4/react-core/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -106,6 +106,29 @@ exports[`link button 1`] = `
 </button>
 `;
 
+exports[`link with icon 1`] = `
+<button
+  aria-disabled={null}
+  aria-label={null}
+  className="pf-c-button pf-m-link"
+  disabled={false}
+  tabIndex={null}
+  type="button"
+>
+  <span
+    className="pf-c-button__icon"
+  >
+    <CartArrowDownIcon
+      color="currentColor"
+      noVerticalAlign={false}
+      size="sm"
+      title={null}
+    />
+  </span>
+  Block Button
+</button>
+`;
+
 exports[`plain button 1`] = `
 <button
   aria-disabled={null}


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Adds an optional icon property. When present, wraps the icon in the new margin css class and displays the icon before the text.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Refer to issue**: #2145

<!-- feel free to add additional comments -->
