### PR TITLE
fix(Alert): set the variant prop to info by default

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Alert/Alert.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Alert/Alert.test.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 import { Alert, AlertVariant } from './Alert';
 import { AlertActionLink }  from './AlertActionLink';
 import { AlertActionCloseButton } from './AlertActionCloseButton';
+
+test('default Alert variant is info', () => {
+  const view = shallow(<Alert title="this is a test">Alert testing</Alert>)
+  expect(view.props().className).toMatch(/pf-m-info/);
+})
 
 Object.values(AlertVariant).forEach(variant => {
   describe(`Alert - ${variant}`, () => {

--- a/packages/patternfly-4/react-core/src/components/Alert/Alert.tsx
+++ b/packages/patternfly-4/react-core/src/components/Alert/Alert.tsx
@@ -16,7 +16,7 @@ export enum AlertVariant {
 export interface AlertProps
   extends Omit<React.HTMLProps<HTMLDivElement>, 'action' | 'title'> {
   /** Adds Alert variant styles  */
-  variant: 'success' | 'danger' | 'warning' | 'info';
+  variant?: 'success' | 'danger' | 'warning' | 'info';
   /** Flag to indicate if the Alert is inline */
   isInline?: boolean;
   /** Title of the Alert  */
@@ -34,7 +34,7 @@ export interface AlertProps
 };
 
 export const Alert: React.FunctionComponent<AlertProps> = ({
-  variant,
+  variant = AlertVariant.info,
   isInline = false,
   variantLabel = `${capitalize(variant)} alert:`,
   'aria-label': ariaLabel = `${capitalize(variant)} Alert`,


### PR DESCRIPTION
**What**:

Setting `Alert` to info if not specified differently.

//cc @jgiardino @ssilvert
What: #2154