### PR TITLE
chore(build): Fix MaxEventListenersExceeded

### DIFF
--- a/scripts/hashDir.js
+++ b/scripts/hashDir.js
@@ -3,17 +3,17 @@ const path = require('path');
 const crypto = require('crypto');
 
 // http://stackoverflow.com/a/5827895/4241030
-function filewalker(dir, done) {
+function filewalker(dir) {
   let results = [];
 
 	fs.readdirSync(dir).forEach(file => {
     filePath = path.resolve(dir, file);
 
-    const stat = fs.statSync(filePath)
+    const stat = fs.statSync(filePath);
     // If directory, execute a recursive call
-    if (stat && stat.isDirectory()) {
-      results.concat(filewalker(filePath));
-    } else {
+    if (stat && stat.isDirectory() && !stat.isSymbolicLink()) {
+      results = results.concat(filewalker(filePath));
+    } else if (stat && stat.isFile()) {
       results.push(filePath);
     }
   });

--- a/scripts/incrementalBuild.js
+++ b/scripts/incrementalBuild.js
@@ -1,3 +1,5 @@
+// This script should be replaced by some standard incremental build system
+// `tsc` is a pretty good example...
 const fs = require('fs');
 const { hashDir } = require("./hashDir");
 const Project = require('@lerna/project');
@@ -39,8 +41,7 @@ async function getInvalidPackages() {
       : true) // Based off argv
 
   for (let p of packages) {
-    const watchDir = getDir(p.name);
-    p.hash = hashDir(`${p.location}/${watchDir}`);
+    p.hash = hashDir(`${p.location}/${getDir(p.name)}`);
     p.valid = cache && cache[p.name] === p.hash;
     if (p.valid) {
       console.info('Skipping', p.name, '(already built).');
@@ -50,25 +51,21 @@ async function getInvalidPackages() {
   return packages.filter(p => !p.valid);
 }
 
-async function incrementalBuild() {
-  const packages = await getInvalidPackages();
-
+getInvalidPackages().then(packages => {
   if (packages.length > 0) {
     // Run for all invalid packages
-    await RunCommand({
+    RunCommand({
       cwd: '.',
       script: 'build',
       npmClient: 'yarn',
-      scope: packages.map(p => p.name),
-      stream: true
-    });
-    // Mark as valid
-    packages.forEach(p => cache[p.name] = p.hash);
-    if (!fs.existsSync('.cache')) {
-      fs.mkdirSync('.cache');
-    }
-    fs.writeFileSync(cacheFile, JSON.stringify(cache, null, 2));
+      scope: packages.map(p => p.name)
+    }).then(() => {
+      // Mark as valid
+      packages.forEach(p => cache[p.name] = p.hash);
+      if (!fs.existsSync('.cache')) {
+        fs.mkdirSync('.cache');
+      }
+      fs.writeFileSync(cacheFile, JSON.stringify(cache, null, 2));
+    })
   }
-}
-
-incrementalBuild().then();
+});

--- a/scripts/incrementalBuild.js
+++ b/scripts/incrementalBuild.js
@@ -40,7 +40,7 @@ async function getInvalidPackages() {
 
   for (let p of packages) {
     const watchDir = getDir(p.name);
-    p.hash = await hashDir(`${p.location}/${watchDir}`);
+    p.hash = hashDir(`${p.location}/${watchDir}`);
     p.valid = cache && cache[p.name] === p.hash;
     if (p.valid) {
       console.info('Skipping', p.name, '(already built).');


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Passing `stream: true` to lerna caused it to call `process.stdout.setMaxListeners(children);` with one too few children, since our wrapper program is also listening to `process.stdout`. Since there is no way to close `stdout` in NodeJS that I know of, for now we can just not pass `stream: true` to lerna and be patient with output that doesn't flush until after 30s.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: I prettied up the script files while I was debugging.

<!-- feel free to add additional comments -->
