### PR TITLE
fix(charts): labels should use the overpass font

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
@@ -9,11 +9,11 @@ exports[`Chart 1`] = `
     style={
       Array [
         Object {
-          "fontSize": 26,
+          "fontSize": 24,
         },
         Object {
           "fill": "#bbb",
-          "fontSize": 16,
+          "fontSize": 14,
         },
       ]
     }
@@ -948,11 +948,11 @@ exports[`Chart 2`] = `
     style={
       Array [
         Object {
-          "fontSize": 26,
+          "fontSize": 24,
         },
         Object {
           "fill": "#bbb",
-          "fontSize": 16,
+          "fontSize": 14,
         },
       ]
     }
@@ -1887,11 +1887,11 @@ exports[`renders component data 1`] = `
     style={
       Array [
         Object {
-          "fontSize": 26,
+          "fontSize": 24,
         },
         Object {
           "fill": "#bbb",
-          "fontSize": 16,
+          "fontSize": 14,
         },
       ]
     }

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
@@ -9,11 +9,11 @@ exports[`Chart 1`] = `
     style={
       Array [
         Object {
-          "fontSize": 26,
+          "fontSize": 24,
         },
         Object {
           "fill": "#bbb",
-          "fontSize": 16,
+          "fontSize": 14,
         },
       ]
     }
@@ -507,11 +507,11 @@ exports[`Chart 2`] = `
     style={
       Array [
         Object {
-          "fontSize": 26,
+          "fontSize": 24,
         },
         Object {
           "fill": "#bbb",
-          "fontSize": 16,
+          "fontSize": 14,
         },
       ]
     }
@@ -1005,11 +1005,11 @@ exports[`renders component data 1`] = `
     style={
       Array [
         Object {
-          "fontSize": 26,
+          "fontSize": 24,
         },
         Object {
           "fill": "#bbb",
-          "fontSize": 16,
+          "fontSize": 14,
         },
       ]
     }

--- a/packages/patternfly-4/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
+import { defaults } from 'lodash';
 import {
   StringOrNumberOrCallback,
-  // TextAnchorType,
-  // VerticalAnchorType,
   VictoryLabel,
   VictoryLabelProps
 } from 'victory';
+import { LabelStyles } from '../ChartTheme/themes/label-theme';
 
 export enum ChartLabelDirection {
   rtl = 'rtl',
@@ -132,7 +132,7 @@ export interface ChartLabelProps extends VictoryLabelProps {
   /**
    * The style prop applies CSS properties to the rendered `<text>` element.
    */
-  style?: React.CSSProperties;
+  style?: React.CSSProperties; // Todo: style accepts arrays, but TS definition is wrong
   /**
    * The text prop defines the text ChartLabel will render. The text prop may be given as a string, number, a function
    * of datum, or an array of any of these. Strings may include newline characters, which ChartLabel will split into
@@ -166,8 +166,14 @@ export interface ChartLabelProps extends VictoryLabelProps {
   y?: number;
 };
 
-export const ChartLabel: React.FunctionComponent<ChartLabelProps> = (props: ChartLabelProps) =>
-  <VictoryLabel {...props} />;
+export const ChartLabel: React.FunctionComponent<ChartLabelProps> = ({
+  style,
+  ...rest
+}: ChartLabelProps) => {
+  const applyDefaultStyle = (customStyle: React.CSSProperties) => defaults(customStyle, LabelStyles);
+  const newStyle = Array.isArray(style) ? style.map(applyDefaultStyle) : applyDefaultStyle(style);
+  return <VictoryLabel style={newStyle as any} {...rest} />;
+}
 
 // Note: VictoryLabel.role must be hoisted
 hoistNonReactStatics(ChartLabel, VictoryLabel);

--- a/packages/patternfly-4/react-charts/src/components/ChartLabel/__snapshots__/ChartLabel.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLabel/__snapshots__/ChartLabel.test.tsx.snap
@@ -5,6 +5,11 @@ exports[`Chart 1`] = `
   capHeight={0.71}
   direction="inherit"
   lineHeight={1}
+  style={
+    Object {
+      "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+    }
+  }
   textComponent={<Text />}
   tspanComponent={<TSpan />}
 />
@@ -15,6 +20,11 @@ exports[`Chart 2`] = `
   capHeight={0.71}
   direction="inherit"
   lineHeight={1}
+  style={
+    Object {
+      "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+    }
+  }
   textComponent={<Text />}
   tspanComponent={<TSpan />}
 />
@@ -25,6 +35,11 @@ exports[`renders component text 1`] = `
   capHeight={0.71}
   direction="inherit"
   lineHeight={1}
+  style={
+    Object {
+      "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+    }
+  }
   text="This is a test"
   textComponent={<Text />}
   tspanComponent={<TSpan />}

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-theme.ts
@@ -5,10 +5,10 @@ export const DonutStyles = {
   label: {
     subTitle: {
       fill: '#bbb',
-      fontSize: 16
+      fontSize: 14
     },
     title: {
-      fontSize: 26
+      fontSize: 24
     }
   }
 };

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-utilization-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-utilization-theme.ts
@@ -5,10 +5,10 @@ export const DonutUtilizationStyles = {
   label: {
     subTitle: {
       fill: '#bbb',
-      fontSize: 16
+      fontSize: 14
     },
     title: {
-      fontSize: 26
+      fontSize: 24
     }
   },
   legend: {

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/label-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/label-theme.ts
@@ -1,0 +1,7 @@
+/* eslint-disable camelcase */
+import { global_FontFamily_sans_serif } from '@patternfly/react-tokens';
+
+// Label styles
+export const LabelStyles = {
+  fontFamily: global_FontFamily_sans_serif.value
+};


### PR DESCRIPTION
The VictoryLabel is not part of the theme, so we must apply a default font via ChartLabel.

Fixes https://github.com/patternfly/patternfly-react/issues/2160
Fixes https://github.com/patternfly/patternfly-react/issues/2214

![Screen Shot 2019-06-12 at 11 22 51 AM](https://user-images.githubusercontent.com/17481322/59364195-6f684200-8d04-11e9-95a4-ef0c0c617c89.png)
