### PR TITLE
Table type adjustments

### DIFF
--- a/packages/patternfly-4/react-table/README.md
+++ b/packages/patternfly-4/react-table/README.md
@@ -48,7 +48,7 @@ class SimpleTable extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      columns: [{ title: 'Repositories' }, 'Branches', { title: 'Pull requests' }, 'Workspaces', 'Last Commit'],
+      columns: [{ title: 'Repositories', props: null }, 'Branches', { title: 'Pull requests', props: null }, 'Workspaces', 'Last Commit'],
       rows: [['one', 'two', 'three', 'four', 'five']]
     };
   }

--- a/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.d.ts
@@ -48,12 +48,12 @@ export interface IExtra extends IExtraData {
 }
 
 export interface ISortBy {
-  index?: Number;
+  index?: number;
   direction?: OneOf<typeof SortByDirection, keyof typeof SortByDirection>;
 }
 
 export interface IAction {
-  title: String;
+  title: string;
   onClick: (event: MouseEvent, rowIndex: number, rowData: IRowData, extraData: IExtraData) => void;
 }
 
@@ -61,13 +61,18 @@ export interface ISeparator {
   isSeparator: Boolean
 }
 
+export interface IDecorator extends HTMLProps<HTMLElement> {
+  isVisible: boolean;
+  children?: React.ReactNode;
+}
+
 export interface ICell {
-  title: String;
-  transforms?: Array<Function>;
-  cellTransforms?: Array<Function>;
-  columnTransforms?: Array<Function>;
-  formatters?: Array<Function>;
-  cellFormatters?: Array<Function>;
+  title: string;
+  transforms?: ((value: any) => IDecorator)[];
+  cellTransforms?: ((value: any) => IDecorator)[];
+  columnTransforms?: ((value: any) => IDecorator)[];
+  formatters?: ((value: any) => IDecorator)[];
+  cellFormatters?: ((value: any) => IDecorator)[];
   props: any;
 }
 
@@ -79,7 +84,7 @@ export interface IRowCell {
 export interface IRow {
   cells: Array<ReactNode | IRowCell>;
   isOpen?: Boolean;
-  parent?: Number;
+  parent?: number;
   props?: any;
   fullWidth?: Boolean;
   noPadding?: Boolean;
@@ -101,13 +106,13 @@ export interface TableProps extends Omit<Omit<HTMLProps<HTMLTableElement>, 'onSe
   areActionsDisabled?: (rowData: IRowData, extraData: IExtraData) => boolean;
   header?: ReactNode;
   caption?: ReactNode;
-  rowLabeledBy?: String;
-  expandId?: String;
-  contentId?: String;
+  rowLabeledBy?: string;
+  expandId?: string;
+  contentId?: string;
   dropdownPosition?: OneOf<typeof DropdownPosition, keyof typeof DropdownPosition>;
   dropdownDirection?: OneOf<typeof DropdownDirection, keyof typeof DropdownDirection>;
-  rows: Array<IRow | Array<String>>;
-  cells: Array<ICell | String>;
+  rows: Array<IRow | Array<string>>;
+  cells: Array<ICell | string>;
   bodyWrapper?: Function;
   rowWrapper?: Function;
 }

--- a/packages/patternfly-4/react-table/src/components/Table/index.d.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/index.d.ts
@@ -10,6 +10,7 @@ export {
   IRow,
   IRowData,
   IColumn,
+  IDecorator,
   IExtra,
   IExtraData,
   IExtraColumnData


### PR DESCRIPTION
**What**: This PR updates the type used in react-table to be a little more explicit. Also updates the example code in the readme, following along as-is in a TypeScript application leads to the following error

![Screen Shot 2019-06-12 at 10 52 42 AM](https://user-images.githubusercontent.com/5942899/59380419-1362e500-8d27-11e9-88ef-9fa91b381d35.png)

I took a stab at using better types for `transforms`, what do people think about this new type? I'd like to use something more specific than `Array<Function>` if possible as this doesn't inform of what the inputs and outputs should or can be. Might be good to wait until this is converted fully to TS to address the others, but I'm curious what others think.