### PR TITLE
feat(PF Checkbox): Add 3rd state to checkbox controlled by consumer

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.md
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.md
@@ -17,7 +17,8 @@ class ControlledCheckbox extends React.Component {
     super(props);
     this.state = {
       check1: false,
-      check2: false
+      check2: false,
+      check3: null
     };
     this.handleChange = (checked, event) => {
       const target = event.target;
@@ -45,6 +46,14 @@ class ControlledCheckbox extends React.Component {
           aria-label="controlled checkbox example"
           id="check-2"
           name="check2"
+        />
+        <Checkbox
+          label="Controlled CheckBox"
+          isChecked={this.state.check3}
+          onChange={this.handleChange}
+          aria-label="controlled checkbox example"
+          id="check-3"
+          name="check3"
         />
       </React.Fragment>
     );

--- a/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.test.tsx
@@ -12,6 +12,11 @@ test('controlled', () => {
   expect(view).toMatchSnapshot();
 });
 
+test('controlled - 3rd state', () => {
+  const view = shallow(<Checkbox isChecked={null} id="check" aria-label="check" />);
+  expect(view).toMatchSnapshot();
+});
+
 test('uncontrolled', () => {
   const view = shallow(<Checkbox id="check" aria-label="check" />);
   expect(view).toMatchSnapshot();

--- a/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.tsx
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/Checkbox.tsx
@@ -21,7 +21,7 @@ export interface CheckboxProps
   /** Id of the checkbox. */
   id: string;
   /** Aria-label of the checkbox. */
-  'aria-label': string;
+  'aria-label'?: string;
 }
 
 // tslint:disable-next-line:no-empty
@@ -67,6 +67,8 @@ export class Checkbox extends React.Component<CheckboxProps> {
     if ([false, true].includes(defaultChecked)) {
       checkedProps.defaultChecked = defaultChecked;
     }
+
+    checkedProps.checked = checkedProps.checked === null ? false : checkedProps.checked;
     return (
       <div className={css(styles.check, className)}>
         <input
@@ -77,6 +79,7 @@ export class Checkbox extends React.Component<CheckboxProps> {
           aria-invalid={!isValid}
           aria-label={ariaLabel}
           disabled={isDisabled}
+          ref={elem => elem && (elem.indeterminate = isChecked === null)}
           {...checkedProps}
         />
         {label && (

--- a/packages/patternfly-4/react-core/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`controlled - 3rd state 1`] = `
+<div
+  className="pf-c-check"
+>
+  <input
+    aria-invalid={false}
+    aria-label="check"
+    className="pf-c-check__input"
+    disabled={false}
+    id="check"
+    onChange={[Function]}
+    type="checkbox"
+  />
+</div>
+`;
+
 exports[`controlled 1`] = `
 <div
   className="pf-c-check"

--- a/packages/patternfly-4/react-core/src/components/Checkbox/examples/Checkbox.md
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/examples/Checkbox.md
@@ -6,6 +6,7 @@ propComponents: ['Checkbox']
 ---
 
 import { Checkbox } from '@patternfly/react-core';
+import './checkbox.scss';
 
 ## Controlled checkbox
 ```js
@@ -18,7 +19,8 @@ class ControlledCheckbox extends React.Component {
     this.state = {
       check1: false,
       check2: false,
-      check3: null
+      check3: false,
+      check4: false
     };
     this.handleChange = (checked, event) => {
       const target = event.target;
@@ -28,11 +30,26 @@ class ControlledCheckbox extends React.Component {
     };
   }
 
+  componentDidUpdate(_prevProps, prevState) {
+    if (prevState.check1 !== this.state.check1 && this.state.check1 !== null) {
+      this.setState({
+        check2: this.state.check1,
+        check3: this.state.check1,
+      })
+    }
+
+    if (prevState.check2 !== this.state.check2 || prevState.check3 !== this.state.check3) {
+      this.setState({
+        check1: (this.state.check2 && this.state.check3) || (this.state.check2 || this.state.check3 ? null : false)
+      })
+    }
+  }
+
   render() {
     return (
       <React.Fragment>
         <Checkbox
-          label="Controlled CheckBox"
+          label="Parent CheckBox"
           isChecked={this.state.check1}
           onChange={this.handleChange}
           aria-label="controlled checkbox example"
@@ -40,7 +57,8 @@ class ControlledCheckbox extends React.Component {
           name="check1"
         />
         <Checkbox
-          label="Controlled CheckBox"
+          className="nested"
+          label="Child CheckBox 1"
           isChecked={this.state.check2}
           onChange={this.handleChange}
           aria-label="controlled checkbox example"
@@ -48,12 +66,21 @@ class ControlledCheckbox extends React.Component {
           name="check2"
         />
         <Checkbox
-          label="Controlled CheckBox"
+          className="nested"
+          label="Child CheckBox 2"
           isChecked={this.state.check3}
           onChange={this.handleChange}
           aria-label="controlled checkbox example"
           id="check-3"
           name="check3"
+        />
+        <Checkbox
+          label="Controlled CheckBox"
+          isChecked={this.state.check4}
+          onChange={this.handleChange}
+          aria-label="controlled checkbox example"
+          id="check-4"
+          name="check4"
         />
       </React.Fragment>
     );

--- a/packages/patternfly-4/react-core/src/components/Checkbox/examples/checkbox.scss
+++ b/packages/patternfly-4/react-core/src/components/Checkbox/examples/checkbox.scss
@@ -1,0 +1,5 @@
+.ws-preview {
+  & .pf-c-check.nested {
+    padding-left: var(--pf-global--spacer--md);
+  }
+}


### PR DESCRIPTION
**What**:
When using checkbox as hierarchical checkbox (parent checkbox with child checkboxes) and user selects only some of child checkboxes parent one should go to 3rd state to indicate user that only some checkboxes were selected.

**Additional issues**:

<!-- feel free to add additional comments -->
