### PR TITLE
fix(react-table): collapse column icon behavior

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/CollapseColumn.js
+++ b/packages/patternfly-4/react-table/src/components/Table/CollapseColumn.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
+import { AngleDownIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { Button } from '@patternfly/react-core';
 import styles from '@patternfly/react-styles/css/components/Table/table';
@@ -29,7 +29,7 @@ const CollapseColumn = ({ children, onToggle, isOpen, className, ...props }) => 
         onClick={onToggle}
         aria-expanded={isOpen}
       >
-        {isOpen ? <AngleDownIcon /> : <AngleRightIcon />}
+        <AngleDownIcon />
       </Button>
     )}
     {children}

--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -763,8 +763,7 @@ class CollapsibleTable extends React.Component {
       columns: [
         {
           title: 'Header cell',
-          cellFormatters: [expandable],
-          cellTransforms: [headerCol()]
+          cellFormatters: [expandable]
         },
         'Branches',
         { title: 'Pull requests' },


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
fixes #1961 

> 1- For closed rows, the caret should point right, not up.

This was occurring b/c Core uses a 270 degree CSS rotation on the AngleDownIcon instead of an AngleRightIcon. In the future, this should animate the same way as the DataList expand icon in Core, but this resolves the icon issue. cc: @mcoker 

> 2- The Collapsible table example does not have the correct highlighting (blue bar on the left). The example for the Compact expandable table is correct.

This is just a miss in the docs on the Collapsible example. We should not be using `headerCol` transform on `cellTransform`.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:
(none)

<!-- feel free to add additional comments -->
