### PR TITLE
fix(ChartDonutThreshold): Don't show static threshold donut tooltips by default.

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Chart 1`] = `
     }
     height={230}
     innerRadius={98}
+    labels={Array []}
     origin={
       Object {
         "x": 115,
@@ -494,6 +495,7 @@ exports[`Chart 2`] = `
     }
     height={230}
     innerRadius={98}
+    labels={Array []}
     origin={
       Object {
         "x": 115,
@@ -967,24 +969,25 @@ exports[`renders component data 1`] = `
     data={
       Array [
         Object {
+          "x": "Birds",
+          "y": 10,
+        },
+        Object {
           "x": "Cats",
-          "y": 35,
+          "y": 25,
         },
         Object {
           "x": "Dogs",
           "y": 20,
         },
         Object {
-          "x": "Birds",
           "y": 45,
-        },
-        Object {
-          "y": 90,
         },
       ]
     }
     height={200}
     innerRadius={83}
+    labels={Array []}
     origin={
       Object {
         "x": 100,


### PR DESCRIPTION
Pie chart tooltips display the x value of each slice as a tooltip label by default. Because we are
doing calculations to mutate the data, this can lead to array indices being displayed as slice labels. Change defaults so that no slice labels are displayed for the static threshold donut. Also, fix a bug where ChartDonutThreshold accessors were being used to format child ChartDonutUtilization data.

Fixes #2258 and #2259 