### PR TITLE
react-charts: position subtitle center, right, bottom for small charts

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -147,11 +147,11 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   donutHeight?: number;
   /**
-   * Defines a horizontal shift from the x coordinate. This should not be set manually.
+   * Defines a horizontal shift from the x coordinate. It should not be set manually.
    */
   donutDx?: number;
   /**
-   * Defines a vertical shift from the y coordinate. This should not be set manually.
+   * Defines a vertical shift from the y coordinate. It should not be set manually.
    */
   donutDy?: number;
   /**
@@ -299,11 +299,11 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   legendData?: any[];
   /**
-   * Defines a horizontal shift from the x coordinate. This should not be set manually.
+   * Defines a horizontal shift from the x coordinate. It should not be set manually.
    */
   legendDx?: number;
   /**
-   * Defines a vertical shift from the y coordinate. This should not be set manually.
+   * Defines a vertical shift from the y coordinate. It should not be set manually.
    */
   legendDy?: number;
   /**
@@ -390,11 +390,11 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   subTitleComponent?: React.ReactElement<any>;
   /**
-   * Defines a horizontal shift from the x coordinate. This should not be set manually.
+   * Defines a horizontal shift from the x coordinate. It should not be set manually.
    */
   subTitleDx?: number;
   /**
-   * Defines a vertical shift from the y coordinate. This should not be set manually.
+   * Defines a vertical shift from the y coordinate. It should not be set manually.
    */
   subTitleDy?: number;
   /**
@@ -506,12 +506,6 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
       return null;
     }
     const props = legendComponent.props ? legendComponent.props : {};
-    const legendDimensions = getLegendDimensions({
-      legendData,
-      legendOrientation,
-      legendProps: props,
-      theme
-    });
     return React.cloneElement(legendComponent, {
       data: legendData,
       orientation: legendOrientation,
@@ -523,7 +517,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
         legendData,
         legendOrientation: props.legendOrientation ? props.legendOrientation : legendOrientation,
         legendPosition,
-        legendWidth: legendDimensions.width,
+        legendProps: props,
         theme,
         svgWidth: width
       }),
@@ -532,7 +526,8 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
         chartType: 'pie',
         dy: legendDy,
         legendData: props.data ? props.data : legendData,
-        legendHeight: legendDimensions.height,
+        legendOrientation: props.legendOrientation ? props.legendOrientation : legendOrientation,
+        legendProps: props,
         legendPosition,
         theme
       }),

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -492,7 +492,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
   // destructure last
   theme = getDonutTheme(themeColor, themeVariant),
   legendOrientation = theme.legend.orientation as ChartDonutLegendOrientation,
-  capHeight = title && subTitle ? 1.1 : undefined,
+  capHeight = 1.1,
   height = theme.pie.height,
   width = theme.pie.width,
   donutHeight = Math.min(height, width),
@@ -575,7 +575,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     const props = titleComponent ? titleComponent.props : {};
     const showBoth = title && subTitle && subTitlePosition == ChartDonutSubTitlePosition.center;
     return React.cloneElement(titleComponent, {
-      capHeight: showBoth ? capHeight : undefined,
+      ...showBoth && { capHeight },
       style: [DonutStyles.label.title, DonutStyles.label.subTitle],
       text: showBoth ? [title, subTitle] : title,
       textAnchor: 'middle',

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -8,16 +8,19 @@ import {
   EventPropTypeInterface,
   PaddingProps,
   StringOrNumberOrCallback,
-  VictoryPieProps,
   VictoryStyleInterface
 } from 'victory';
 import { getDonutTheme } from '../ChartUtils/chart-theme';
 import { ChartContainer } from '../ChartContainer/ChartContainer';
 import { ChartLabel } from '../ChartLabel/ChartLabel';
+import { ChartLegend } from "../ChartLegend/ChartLegend";
 import { ChartPie, ChartPieProps } from '../ChartPie/ChartPie';
 import { ChartThemeDefinition } from '../ChartTheme/ChartTheme';
-import { DonutStyles, DonutTheme } from '../ChartTheme/themes/donut-theme';
+import { DonutStyles } from '../ChartTheme/themes/donut-theme';
 import { ChartTooltip } from '../ChartTooltip/ChartTooltip';
+import { getLabelX, getLabelY } from "../ChartUtils/chart-label";
+import { getLegendDimensions, getLegendX, getLegendY } from "../ChartUtils/chart-legend";
+import { getChartOrigin } from '../ChartUtils/chart-origin';
 
 export enum ChartDonutLabelPosition {
   centroid = 'centroid',
@@ -25,10 +28,26 @@ export enum ChartDonutLabelPosition {
   startAngle = 'startAngle'
 };
 
+export enum ChartDonutLegendOrientation {
+  horizontal = 'horizontal',
+  vertical = 'vertical'
+};
+
+export enum ChartDonutLegendPosition {
+  bottom = 'bottom',
+  right = 'right'
+};
+
 export enum ChartDonutSortOrder {
   ascending = 'ascending',
   descending = 'descending'
 };
+
+export enum ChartDonutSubTitlePosition {
+  bottom = 'bottom',
+  center = 'center',
+  right = 'right'
+}
 
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
@@ -46,6 +65,13 @@ export interface ChartDonutProps extends ChartPieProps {
    * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
   animate?: AnimatePropTypeInterface;
+  /**
+   * The capHeight prop defines a text metric for the font being used: the expected height of capital letters.
+   * This is necessary because of SVG, which (a) positions the *bottom* of the text at `y`, and (b) has no notion of
+   * line height. The value should ideally use the same units as `lineHeight` and `dy`, preferably ems. If given a
+   * unitless number, it is assumed to be ems.
+   */
+  capHeight?: StringOrNumberOrCallback;
   /**
    * The categories prop specifies how categorical data for a chart should be ordered.
    * This prop should be given as an array of string values, or an object with
@@ -102,6 +128,49 @@ export interface ChartDonutProps extends ChartPieProps {
    * If a dataComponent is not provided, ChartDonut's Slice component will be used.
    */
   dataComponent?: React.ReactElement<any>;
+  /**
+   * Specifies the height of the donut chart. This value should be given as a
+   * number of pixels.
+   *
+   * Because Victory renders responsive containers, the width and height props do not determine the width and
+   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
+   * pixels will depend on the size of the container the chart is rendered into.
+   *
+   * Note: When adding a legend, height (the overall SVG height) may need to be larger than donutHeight (the donut size)
+   * in order to accommodate the extra legend.
+   *
+   * By default, donutHeight is the min. of either height or width. This covers most use cases in order to accommodate
+   * legends within the same SVG. However, donutHeight (not height) may need to be set in order to adjust the donut
+   * height.
+   *
+   * The innerRadius may also need to be set when changing the donut size.
+   */
+  donutHeight?: number;
+  /**
+   * Defines a horizontal shift from the x coordinate. This should not be set manually.
+   */
+  donutDx?: number;
+  /**
+   * Defines a vertical shift from the y coordinate. This should not be set manually.
+   */
+  donutDy?: number;
+  /**
+   * Specifies the width of the donut chart. This value should be given as a
+   * number of pixels.
+   *
+   * Because Victory renders responsive containers, the width and height props do not determine the width and
+   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
+   * pixels will depend on the size of the container the chart is rendered into.
+   *
+   * Note: When adding a legend, width (the overall SVG width) may need to be larger than donutWidth (the donut size)
+   * in order to accommodate the extra legend.
+   *
+   * By default, donutWidth is the min. of either height or width. This covers most use cases in order to accommodate
+   * legends within the same SVG. However, donutWidth (not width) may need to be set in order to adjust the donut width.
+   *
+   * The innerRadius may also need to be set when changing the donut size.
+   */
+  donutWidth?: number;
   /**
    * The overall end angle of the pie in degrees. This prop is used in conjunction with
    * startAngle to create a pie that spans only a segment of a circle.
@@ -212,6 +281,46 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   labels?: string[] | ((data: any) => string);
   /**
+   * The legend component to render with chart.
+   *
+   * Note: Use legendData so the legend width can be calculated and positioned properly.
+   * Default legend properties may be applied
+   */
+  legendComponent?: React.ReactElement<any>;
+  /**
+   * The data prop specifies the data to be plotted,
+   * where data X-value is the slice label (string or number),
+   * and Y-value is the corresponding number value represented by the slice
+   * Data should be in the form of an array of data points.
+   * Each data point may be any format you wish (depending on the `x` and `y` accessor props),
+   * but by default, an object with x and y properties is expected.
+   *
+   * @example legendData={[{ name: `GBps capacity - 45%` }, { name: 'Unused' }]}
+   */
+  legendData?: any[];
+  /**
+   * Defines a horizontal shift from the x coordinate. This should not be set manually.
+   */
+  legendDx?: number;
+  /**
+   * Defines a vertical shift from the y coordinate. This should not be set manually.
+   */
+  legendDy?: number;
+  /**
+   * The orientation prop takes a string that defines whether legend data
+   * are displayed in a row or column. When orientation is "horizontal",
+   * legend items will be displayed in a single row. When orientation is
+   * "vertical", legend items will be displayed in a single column. Line
+   * and text-wrapping is not currently supported, so "vertical"
+   * orientation is both the default setting and recommended for
+   * displaying many series of data.
+   */
+  legendOrientation?: 'horizontal' | 'vertical';
+  /**
+   * The legend position relation to the donut chart. Valid values are 'bottom' and 'right'
+   */
+  legendPosition?: 'bottom' | 'right';
+  /**
    * The name prop is used to reference a component instance when defining shared events.
    */
   name?: string;
@@ -275,6 +384,24 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   subTitle?: string;
   /**
+   * The label component to render the chart subTitle.
+   *
+   * Note: Default label properties may be applied
+   */
+  subTitleComponent?: React.ReactElement<any>;
+  /**
+   * Defines a horizontal shift from the x coordinate. This should not be set manually.
+   */
+  subTitleDx?: number;
+  /**
+   * Defines a vertical shift from the y coordinate. This should not be set manually.
+   */
+  subTitleDy?: number;
+  /**
+   * The orientation of the donut chart in relation to the legend. Valid values are 'bottom', 'center', and 'right'
+   */
+  subTitlePosition?: 'bottom' | 'center' | 'right';
+  /**
    * The theme prop takes a style object with nested data, labels, and parent objects.
    * You can create this object yourself, or you can use a theme provided by
    * When using ChartDonut as a solo component, implement the theme directly on
@@ -302,6 +429,12 @@ export interface ChartDonutProps extends ChartPieProps {
    * The title for the donut chart
    */
   title?: string;
+  /**
+   * The label component to render the chart title.
+   *
+   * Note: Default label properties may be applied
+   */
+  titleComponent?: React.ReactElement<any>;
   /**
    * Specifies the width of the svg viewBox of the chart container. This value should be given as a
    * number of pixels.
@@ -338,49 +471,169 @@ export interface ChartDonutProps extends ChartPieProps {
 }
 
 export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
-  height = DonutTheme.pie.height,
+  donutDx = 0,
+  donutDy = 0,
+  legendComponent = <ChartLegend />,
+  legendData,
+  legendDx = 0,
+  legendDy = 0,
+  legendPosition = DonutStyles.legend.position as ChartDonutLegendPosition,
   standalone = true,
   subTitle,
+  subTitleComponent = <ChartLabel />,
+  subTitleDx = 0,
+  subTitleDy = 0,
+  subTitlePosition = DonutStyles.label.subTitlePosition as ChartDonutSubTitlePosition,
   themeColor,
   themeVariant,
   title,
-  width = DonutTheme.pie.width,
+  titleComponent = <ChartLabel />,
 
   // destructure last
-  innerRadius = ((height || width) - 34) / 2,
   theme = getDonutTheme(themeColor, themeVariant),
+  legendOrientation = theme.legend.orientation as ChartDonutLegendOrientation,
+  capHeight = title && subTitle ? 1.1 : undefined,
+  height = theme.pie.height,
+  width = theme.pie.width,
+  donutHeight = Math.min(height, width),
+  donutWidth = Math.min(height, width, donutHeight),
+  innerRadius = (Math.min(donutHeight, donutWidth) - 34) / 2,
   ...rest
 }: ChartDonutProps) => {
+  // Returns legend
+  const getLegend = () => {
+    if (!legendData && !legendComponent.props.data) {
+      return null;
+    }
+    const props = legendComponent.props ? legendComponent.props : {};
+    const legendDimensions = getLegendDimensions({
+      legendData,
+      legendOrientation,
+      legendProps: props,
+      theme
+    });
+    return React.cloneElement(legendComponent, {
+      data: legendData,
+      orientation: legendOrientation,
+      standalone: false,
+      theme: theme,
+      x: getLegendX({
+        chartWidth: donutWidth,
+        dx: legendDx,
+        legendData,
+        legendOrientation: props.legendOrientation ? props.legendOrientation : legendOrientation,
+        legendPosition,
+        legendWidth: legendDimensions.width,
+        theme,
+        svgWidth: width
+      }),
+      y: getLegendY({
+        chartHeight: donutHeight,
+        chartType: 'pie',
+        dy: legendDy,
+        legendData: props.data ? props.data : legendData,
+        legendHeight: legendDimensions.height,
+        legendPosition,
+        theme
+      }),
+      ...props
+    });
+  };
+
+  // Returns subtitle
+  const getSubTitle = () => {
+    if (!subTitle || subTitlePosition === ChartDonutSubTitlePosition.center) {
+      return null;
+    }
+    const props = titleComponent.props ? titleComponent.props : {};
+    return React.cloneElement(titleComponent, {
+      style: DonutStyles.label.subTitle,
+      text: subTitle,
+      textAnchor: subTitlePosition === 'right' ? 'start' : 'middle',
+      verticalAnchor: 'middle',
+      x: getLabelX({
+        chartWidth: donutWidth,
+        dx: subTitleDx,
+        labelPosition: subTitlePosition,
+        legendPosition,
+        svgWidth: width
+      }),
+      y: getLabelY({
+        chartHeight: donutHeight,
+        dy: subTitleDy,
+        labelPosition: subTitlePosition
+      }),
+      ...props
+    });
+  };
+
+  // Returns title
+  const getTitle = () => {
+    if (!title) {
+      return null;
+    }
+    const props = titleComponent ? titleComponent.props : {};
+    const showBoth = title && subTitle && subTitlePosition == ChartDonutSubTitlePosition.center;
+    return React.cloneElement(titleComponent, {
+      capHeight: showBoth ? capHeight : undefined,
+      style: [DonutStyles.label.title, DonutStyles.label.subTitle],
+      text: showBoth ? [title, subTitle] : title,
+      textAnchor: 'middle',
+      verticalAnchor: 'middle',
+      x: getLabelX({
+        chartWidth: donutWidth,
+        dx: donutDx,
+        labelPosition: 'center',
+        legendPosition,
+        svgWidth: width
+      }),
+      y: getLabelY({
+        chartHeight: donutHeight,
+        dy: donutDy,
+        labelPosition: 'center'
+      }),
+      ...props
+    });
+  };
+
   const chart = (
     <React.Fragment>
-      <ChartLabel
-        style={[DonutStyles.label.title, DonutStyles.label.subTitle] as any} // Todo: Array supported, but @types/victory is wrong
-        text={title && subTitle ? [title, subTitle] : title}
-        textAnchor="middle"
-        verticalAnchor="middle"
-        x={width / 2}
-        y={height / 2}
-      />
       <ChartPie
-        height={height}
+        height={donutHeight}
         innerRadius={innerRadius > 0 ? innerRadius : 0}
         labelComponent={<ChartTooltip theme={theme} />}
+        origin={getChartOrigin({
+          chartHeight: donutHeight,
+          chartWidth: donutWidth,
+          dx: donutDx,
+          dy: donutDy,
+          legendPosition,
+          svgWidth: width
+        })}
         standalone={false}
         theme={theme}
-        width={width}
+        width={donutWidth}
         {...rest}
       />
     </React.Fragment>
   );
 
   return standalone ? (
-    <ChartContainer width={width} height={height}>
+    <ChartContainer height={height} width={width}>
       {chart}
+      {getLegend()}
+      {getTitle()}
+      {getSubTitle()}
     </ChartContainer>
   ) : (
-    chart
+    <React.Fragment>
+      {chart}
+      {getLegend()}
+      {getTitle()}
+      {getSubTitle()}
+    </React.Fragment>
   );
 };
 
-// Note: VictoryPie.role must be hoisted
+// Note: ChartPie.role must be hoisted
 hoistNonReactStatics(ChartDonut, ChartPie);

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
@@ -6,23 +6,6 @@ exports[`Chart 1`] = `
   width={230}
 >
   <Component
-    style={
-      Array [
-        Object {
-          "fontSize": 24,
-        },
-        Object {
-          "fill": "#bbb",
-          "fontSize": 14,
-        },
-      ]
-    }
-    textAnchor="middle"
-    verticalAnchor="middle"
-    x={115}
-    y={115}
-  />
-  <Component
     height={230}
     innerRadius={98}
     labelComponent={
@@ -480,6 +463,12 @@ exports[`Chart 1`] = `
           }
         }
       />
+    }
+    origin={
+      Object {
+        "x": 115,
+        "y": 115,
+      }
     }
     standalone={false}
     theme={
@@ -945,23 +934,6 @@ exports[`Chart 2`] = `
   width={230}
 >
   <Component
-    style={
-      Array [
-        Object {
-          "fontSize": 24,
-        },
-        Object {
-          "fill": "#bbb",
-          "fontSize": 14,
-        },
-      ]
-    }
-    textAnchor="middle"
-    verticalAnchor="middle"
-    x={115}
-    y={115}
-  />
-  <Component
     height={230}
     innerRadius={98}
     labelComponent={
@@ -1419,6 +1391,12 @@ exports[`Chart 2`] = `
           }
         }
       />
+    }
+    origin={
+      Object {
+        "x": 115,
+        "y": 115,
+      }
     }
     standalone={false}
     theme={
@@ -1883,23 +1861,6 @@ exports[`renders component data 1`] = `
   height={200}
   width={200}
 >
-  <Component
-    style={
-      Array [
-        Object {
-          "fontSize": 24,
-        },
-        Object {
-          "fill": "#bbb",
-          "fontSize": 14,
-        },
-      ]
-    }
-    textAnchor="middle"
-    verticalAnchor="middle"
-    x={100}
-    y={100}
-  />
   <Component
     data={
       Array [
@@ -2374,6 +2335,12 @@ exports[`renders component data 1`] = `
           }
         }
       />
+    }
+    origin={
+      Object {
+        "x": 100,
+        "y": 100,
+      }
     }
     standalone={false}
     theme={

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -2,63 +2,181 @@
 title: 'Donut'
 section: 'charts'
 typescript: true
-propComponents: ['ChartDonut', 'ChartLegend']
+propComponents: ['ChartDonut']
 ---
 
-import { ChartDonut, ChartLegend, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
+import { ChartDonut, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
 import './chart-donut.scss';
 
-## Blue donut chart
-
+## Simple donut chart
 ```js
 import React from 'react';
-import { ChartDonut, ChartLegend } from '@patternfly/react-charts';
+import { ChartDonut } from '@patternfly/react-charts';
 
 <div>
-  <div className="donut-chart-inline">
-    <div className="donut-chart-container">
-      <ChartDonut
-        data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-        labels={datum => `${datum.x}: ${datum.y}`}
-        subTitle="Pets"
-        title="100"
-      />
-    </div>
-    <ChartLegend
-      data={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
-      height={230}
-      orientation="vertical"
-      responsive={false}
-      y={70}
+  <div className="donut-chart">
+    <ChartDonut
+      data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+      labels={datum => `${datum.x}: ${datum.y}%`}
+      subTitle="Pets"
+      title="100"
     />
   </div>
 </div>
 ```
 
-## Multi-color donut chart
+## Donut chart with right-aligned legend
 ```js
 import React from 'react';
-import { ChartDonut, ChartLegend, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
+import { ChartDonut } from '@patternfly/react-charts';
 
 <div>
-  <div className="donut-chart-container">
+  <div className="donut-chart-legend-right">
     <ChartDonut
       data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-      labels={datum => `${datum.x}: ${datum.y}`}
+      labels={datum => `${datum.x}: ${datum.y}%`}
+      legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+      legendOrientation="vertical"
+      legendPosition="right"
       subTitle="Pets"
-      themeColor={ChartThemeColor.multi}
-      themeVariant={ChartThemeVariant.light}
       title="100"
+      width={350}
     />
   </div>
-  <ChartLegend
-    data={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
-    height={35}
-    orientation={'horizontal'}
-    responsive={false}
-    themeColor={ChartThemeColor.multi}
-    themeVariant={ChartThemeVariant.light}
-    x={8}
-  />
+</div>
+```
+
+## Multi-color donut chart with right-aligned legend
+```js
+import React from 'react';
+import { ChartDonut } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-chart-legend-right">
+    <ChartDonut
+      data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+      labels={datum => `${datum.x}: ${datum.y}%`}
+      legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+      legendOrientation="vertical"
+      legendPosition="right"
+      subTitle="Pets"
+      title="100"
+      themeColor={ChartThemeColor.multi}
+      themeVariant={ChartThemeVariant.light}
+      width={350}
+    />
+  </div>
+</div>
+```
+
+## Donut chart with bottom-aligned legend
+```js
+import React from 'react';
+import { ChartDonut } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-chart-legend-bottom">
+    <ChartDonut
+      data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+      donutHeight={230}
+      donutOrientation="top"
+      height={275}
+      labels={datum => `${datum.x}: ${datum.y}%`}
+      legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+      legendPosition="bottom"
+      legendWidth={225}
+      subTitle="Pets"
+      title="100"
+      width={300}
+    />
+  </div>
+</div>
+```
+
+## Small donut chart
+```js
+import React from 'react';
+import { ChartDonut } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-chart-sm">
+    <ChartDonut
+      data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+      height={150}
+      labels={datum => `${datum.x}: ${datum.y}%`}
+      subTitle="Pets"
+      title="100"
+      width={150}
+    />
+  </div>
+</div>
+```
+
+## Small donut chart with right-aligned legend
+```js
+import React from 'react';
+import { ChartDonut } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-chart-legend-right-sm">
+    <ChartDonut
+      data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+      height={150}
+      labels={datum => `${datum.x}: ${datum.y}%`}
+      legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+      legendOrientation="vertical"
+      legendPosition="right"
+      subTitle="Pets"
+      title="100"
+      width={275}
+    />
+  </div>
+</div>
+```
+
+## Small donut chart with right-aligned legend and bottom-aligned subtitle
+```js
+import React from 'react';
+import { ChartDonut } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-chart-legend-right-subtitle-bottom-sm">
+    <ChartDonut
+      data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+      donutHeight={150}
+      height={175}
+      labels={datum => `${datum.x}: ${datum.y}%`}
+      legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+      legendOrientation="vertical"
+      legendPosition="right"
+      subTitle="Pets"
+      subTitlePosition="bottom"
+      title="100"
+      width={275}
+    />
+  </div>
+</div>
+```
+
+## Small donut chart with bottom-aligned legend and right-aligned subtitle
+```js
+import React from 'react';
+import { ChartDonut } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-chart-legend-bottom-subtitle-right-sm">
+    <ChartDonut
+      data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+      donutHeight={150}
+      height={200}
+      labels={datum => `${datum.x}: ${datum.y}%`}
+      legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+      legendPosition="bottom"
+      subTitle="Pets"
+      subTitlePosition="right"
+      title="100"
+      width={300}
+    />
+  </div>
 </div>
 ```

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/chart-donut.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/chart-donut.scss
@@ -1,12 +1,38 @@
 .ws-preview {
   & > * {
-    .donut-chart-container {
+    .donut-chart {
       height: 230px;
       width: 230px;
     }
 
-    .donut-chart-inline {
-      display: inline-flex;
+    .donut-chart-sm {
+      height: 150px;
+      width: 150px;
+    }
+
+    .donut-chart-legend-bottom {
+      height: 275px;
+      width: 300px;
+    }
+
+    .donut-chart-legend-right {
+      height: 230px;
+      width: 350px;
+    }
+
+    .donut-chart-legend-right-sm {
+      height: 150px;
+      width: 275px;
+    }
+
+    .donut-chart-legend-right-subtitle-bottom-sm {
+      height: 175px;
+      width: 275px;
+    }
+
+    .donut-chart-legend-bottom-subtitle-right-sm {
+      height: 200px;
+      width: 300px;
     }
   }
 }

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -474,17 +474,6 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
     return Math.round((donutHeight - dynamicHeight) / 2);
   }
 
-  // Returns the vertical shift for the donut utilization legend and subtitle
-  const getDy = (dynamicTheme: ChartThemeDefinition, position: string) => {
-    const dynamicWidth = donutWidth - (theme.pie.width - dynamicTheme.pie.width);
-    switch (position) {
-      case 'bottom':
-        return getDonutDy(dynamicTheme) + Math.round((donutWidth - dynamicWidth) / 2);
-      default:
-        return getDonutDy(dynamicTheme);
-    }
-  }
-
   // Returns the horizontal shift for the donut utilization legend
   const getLegendDx = (dynamicTheme: ChartThemeDefinition, position: string) => {
     const dynamicWidth = donutWidth - (theme.pie.width - dynamicTheme.pie.width);
@@ -495,6 +484,17 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
         return 0;
     }
   };
+
+  // Returns the vertical shift for the donut utilization legend and subtitle
+  const getLegendAndSubTitleDy = (dynamicTheme: ChartThemeDefinition, position: string) => {
+    const dynamicWidth = donutWidth - (theme.pie.width - dynamicTheme.pie.width);
+    switch (position) {
+      case 'bottom':
+        return getDonutDy(dynamicTheme) + Math.round((donutWidth - dynamicWidth) / 2);
+      default:
+        return getDonutDy(dynamicTheme);
+    }
+  }
 
   // Returns the horizontal shift for the donut utilization subtitle
   const getSubTitleDx = (dynamicTheme: ChartThemeDefinition, position: string) => {
@@ -528,19 +528,18 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
           endAngle: 360 * (datum[0]._y ? datum[0]._y / 100 : 0),
           height,
           legendDx: getLegendDx(dynamicTheme, legendPos),
-          legendDy: getDy(dynamicTheme, legendPos),
+          legendDy: getLegendAndSubTitleDy(dynamicTheme, legendPos),
           legendPosition: legendPos,
           showStatic: false,
           standalone: false,
           subTitleDx: getSubTitleDx(dynamicTheme, subTitlePos),
-          subTitleDy: getDy(dynamicTheme, subTitlePos),
+          subTitleDy: getLegendAndSubTitleDy(dynamicTheme, subTitlePos),
           subTitlePosition: subTitlePos,
           theme: dynamicTheme,
           width,
           ...childProps,
         });
       }
-      return child;
     });
 
   // Static threshold dount chart

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -511,10 +511,9 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   const renderChildren = () =>
     React.Children.toArray(children).map(child => {
       if (child.props) {
-        const {data: childData, ...childProps} = child.props;
+        const { data: childData, ...childProps } = child.props;
         const datum = Data.formatData([childData], childProps, ['x', 'y']); // Format child data independently of this component's props
-        const dynamicTheme =
-          childProps.theme ||
+        const dynamicTheme = childProps.theme ||
           getDonutThresholdDynamicTheme(childProps.themeColor || themeColor,
             childProps.themeVariant || themeVariant);
         const legendPos = childProps.legendPosition || legendPosition;

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -2,17 +2,21 @@ import * as React from 'react';
 import {
   AnimatePropTypeInterface,
   CategoryPropType,
-  ColorScalePropType, DataGetterPropType,
-  EventPropTypeInterface, PaddingProps,
-  StringOrNumberOrCallback, VictoryStyleInterface
+  ColorScalePropType,
+  DataGetterPropType,
+  EventPropTypeInterface,
+  PaddingProps,
+  StringOrNumberOrCallback,
+  VictoryStyleInterface
 } from "victory";
 import { Data } from 'victory-core';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { ChartContainer } from '../ChartContainer/ChartContainer';
-import { ChartPie, ChartPieProps } from '../ChartPie/ChartPie';
+import { ChartDonut, ChartDonutProps } from '../ChartDonut/ChartDonut';
 import { ChartThemeDefinition } from "../ChartTheme/ChartTheme";
 import { getChartOrigin } from '../ChartUtils/chart-origin';
 import { getDonutThresholdDynamicTheme, getDonutThresholdStaticTheme } from '../ChartUtils/chart-theme';
+import { DonutStyles } from "../ChartTheme/themes/donut-theme";
 
 export enum ChartDonutThresholdDonutOrientation {
   left = 'left',
@@ -31,15 +35,26 @@ export enum ChartDonutThresholdLabelPosition {
   startAngle = 'startAngle'
 };
 
+export enum ChartDonutThresholdLegendPosition {
+  bottom = 'bottom',
+  right = 'right'
+};
+
 export enum ChartDonutThresholdSortOrder {
   ascending = 'ascending',
   descending = 'descending'
 };
 
+export enum ChartDonutThresholdSubTitlePosition {
+  bottom = 'bottom',
+  center = 'center',
+  right = 'right'
+}
+
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
  */
-export interface ChartDonutThresholdProps extends ChartPieProps {
+export interface ChartDonutThresholdProps extends ChartDonutProps {
   /**
    * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-pie/
    */
@@ -132,10 +147,6 @@ export interface ChartDonutThresholdProps extends ChartPieProps {
    * The innerRadius may also need to be set when changing the donut size.
    */
   donutHeight?: number;
-  /**
-   * The orientation of the donut chart in relation to the legend. Valid values are 'left', 'top', and 'right'
-   */
-  donutOrientation?: 'left' | 'right' | 'top';
   /**
    * Specifies the width of the donut chart. This value should be given as a
    * number of pixels.
@@ -249,6 +260,10 @@ export interface ChartDonutThresholdProps extends ChartPieProps {
    */
   labels?: string[] | ((data: any) => string);
   /**
+   * The legend position relation to the donut chart. Valid values are 'bottom' and 'right'
+   */
+  legendPosition?: 'bottom' | 'right';
+  /**
    * The name prop is used to reference a component instance when defining shared events.
    */
   name?: string;
@@ -315,6 +330,10 @@ export interface ChartDonutThresholdProps extends ChartPieProps {
    * The subtitle for the donut chart
    */
   subTitle?: string;
+  /**
+   * The orientation of the donut chart in relation to the legend. Valid values are 'bottom', 'center', and 'right'
+   */
+  subTitlePosition?: 'bottom' | 'center' | 'right';
   /**
    * The theme prop takes a style object with nested data, labels, and parent objects.
    * You can create this object yourself, or you can use a theme provided by
@@ -391,9 +410,12 @@ export interface ChartDonutThresholdProps extends ChartPieProps {
 export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdProps> = ({
   children,
   data = [],
-  donutOrientation = 'left',
   labels = [], // Don't show any tooltip labels by default, let consumer override if needed
+  legendComponent,
+  legendData,
+  legendPosition = DonutStyles.legend.position as ChartDonutThresholdLegendPosition,
   standalone = true,
+  subTitlePosition = DonutStyles.label.subTitlePosition as ChartDonutThresholdSubTitlePosition,
   themeColor,
   themeVariant,
   x,
@@ -404,8 +426,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   height = theme.pie.height,
   width = theme.pie.width,
   donutHeight = Math.min(height, width),
-  donutWidth = Math.min(height, width),
-  innerRadius = (Math.min(donutHeight, donutWidth) - 34) / 2,
+  donutWidth = Math.min(height, width, donutHeight),
   ...rest
 }: ChartDonutThresholdProps) => {
 
@@ -436,24 +457,55 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
     ];
   };
 
-  // Returns the horizontal shift for the dynamic utilization donut cart
-  const getDynamicDonutDx = (dynamicTheme: ChartThemeDefinition, orientation: string) => {
+  // Returns the horizontal shift for the donut utilization chart
+  const getDonutDx = (dynamicTheme: ChartThemeDefinition, legendPosition: string) => {
     const dynamicWidth = donutWidth - (theme.pie.width - dynamicTheme.pie.width);
-    switch (orientation) {
-      case 'left':
-        return Math.round((donutWidth - dynamicWidth) / 2);
+    switch (legendPosition) {
       case 'right':
-        return -Math.round((donutWidth - dynamicWidth) / 2);
+        return Math.round((donutWidth - dynamicWidth) / 2);
       default:
         return 0;
     }
   };
 
-  // Returns the vertical shift for the dynamic utilization donut cart
-  const getDynamicDonutDy = (dynamicTheme: ChartThemeDefinition) => {
+  // Returns the vertical shift for the donut utilization chart
+  const getDonutDy = (dynamicTheme: ChartThemeDefinition) => {
     const dynamicHeight = donutHeight - (theme.pie.height - dynamicTheme.pie.height);
     return Math.round((donutHeight - dynamicHeight) / 2);
   }
+
+  // Returns the vertical shift for the donut utilization legend and subtitle
+  const getDy = (dynamicTheme: ChartThemeDefinition, position: string) => {
+    const dynamicWidth = donutWidth - (theme.pie.width - dynamicTheme.pie.width);
+    switch (position) {
+      case 'bottom':
+        return getDonutDy(dynamicTheme) + Math.round((donutWidth - dynamicWidth) / 2);
+      default:
+        return getDonutDy(dynamicTheme);
+    }
+  }
+
+  // Returns the horizontal shift for the donut utilization legend
+  const getLegendDx = (dynamicTheme: ChartThemeDefinition, position: string) => {
+    const dynamicWidth = donutWidth - (theme.pie.width - dynamicTheme.pie.width);
+    switch (position) {
+      case 'right':
+        return getDonutDx(dynamicTheme, legendPosition) + Math.round((donutWidth - dynamicWidth) / 2);
+      default:
+        return 0;
+    }
+  };
+
+  // Returns the horizontal shift for the donut utilization subtitle
+  const getSubTitleDx = (dynamicTheme: ChartThemeDefinition, position: string) => {
+    const dynamicWidth = donutWidth - (theme.pie.width - dynamicTheme.pie.width);
+    switch (position) {
+      case 'right':
+        return getDonutDx(dynamicTheme, legendPosition) + Math.round((donutWidth - dynamicWidth) / 2);
+      default:
+        return Math.round((donutWidth - dynamicWidth) / 2);
+    }
+  };
 
   // Render dynamic utilization donut cart
   const renderChildren = () =>
@@ -461,24 +513,30 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
       if (child.props) {
         const {data: childData, ...childProps} = child.props;
         const datum = Data.formatData([childData], childProps, ['x', 'y']); // Format child data independently of this component's props
-        const orientation = childProps.donutOrientation || donutOrientation;
         const dynamicTheme =
           childProps.theme ||
           getDonutThresholdDynamicTheme(childProps.themeColor || themeColor,
             childProps.themeVariant || themeVariant);
+        const legendPos = childProps.legendPosition || legendPosition;
+        const subTitlePos = childProps.subTitlePosition || subTitlePosition;
         return React.cloneElement(child, {
           data: childData,
-          donutDx: getDynamicDonutDx(dynamicTheme, orientation),
-          donutDy: getDynamicDonutDy(dynamicTheme),
+          donutDx: getDonutDx(dynamicTheme, legendPos),
+          donutDy: getDonutDy(dynamicTheme),
           donutHeight: donutHeight - (theme.pie.height - dynamicTheme.pie.height),
-          donutOrientation: orientation,
           donutWidth: donutWidth - (theme.pie.width - dynamicTheme.pie.width),
-          endAngle: 360 * (datum[0]._y ? datum[0]._y / 100 : 100),
+          endAngle: 360 * (datum[0]._y ? datum[0]._y / 100 : 0),
           height,
+          legendDx: getLegendDx(dynamicTheme, legendPos),
+          legendDy: getDy(dynamicTheme, legendPos),
+          legendPosition: legendPos,
           showStatic: false,
           standalone: false,
+          subTitleDx: getSubTitleDx(dynamicTheme, subTitlePos),
+          subTitleDy: getDy(dynamicTheme, subTitlePos),
+          subTitlePosition: subTitlePos,
           theme: dynamicTheme,
-          width: width,
+          width,
           ...childProps,
         });
       }
@@ -488,17 +546,15 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   // Static threshold dount chart
   const chart = (
     <React.Fragment>
-      <ChartPie
+      <ChartDonut
         data={getComputedData()}
         height={donutHeight}
-        innerRadius={innerRadius > 0 ? innerRadius : 0}
         labels={labels}
         origin={getChartOrigin({
           chartHeight: donutHeight,
           chartWidth: donutWidth,
-          chartOrientation: donutOrientation,
-          height,
-          width
+          legendPosition,
+          svgWidth: width
         })}
         standalone={false}
         theme={theme}
@@ -518,5 +574,5 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   );
 };
 
-// Note: ChartPie.role must be hoisted
-hoistNonReactStatics(ChartDonutThreshold, ChartPie);
+// Note: ChartDonut.role must be hoisted
+hoistNonReactStatics(ChartDonutThreshold, ChartDonut);

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -269,7 +269,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
   name?: string;
   /**
    * Victory components will pass an origin prop is to define the center point in svg coordinates for polar charts.
-   * **This prop should not be set manually.**
+   * It should not be set manually.**
    */
   origin?: { x: number, y: number };
   /**

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -126,11 +126,11 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   dataComponent?: React.ReactElement<any>;
   /**
-   * Defines a horizontal shift from the x coordinate. This should not be set manually.
+   * Defines a horizontal shift from the x coordinate. It should not be set manually.
    */
   donutDx?: number;
   /**
-   * Defines a vertical shift from the y coordinate. This should not be set manually.
+   * Defines a vertical shift from the y coordinate. It should not be set manually.
    */
   donutDy?: number;
   /**
@@ -169,11 +169,11 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   donutWidth?: number;
   /**
-   * Defines a horizontal shift from the x coordinate for legend and subtitle. This should not be set manually.
+   * Defines a horizontal shift from the x coordinate for legend and subtitle. It should not be set manually.
    */
   dx?: number;
   /**
-   * Defines a vertical shift from the y coordinate for legend and subtitle. This should not be set manually.
+   * Defines a vertical shift from the y coordinate for legend and subtitle. It should not be set manually.
    */
   dy?: number;
   /**
@@ -293,11 +293,11 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   legendData?: any[];
   /**
-   * Defines a horizontal shift from the x coordinate. This should not be set manually.
+   * Defines a horizontal shift from the x coordinate. It should not be set manually.
    */
   legendDx?: number;
   /**
-   * Defines a vertical shift from the y coordinate. This should not be set manually.
+   * Defines a vertical shift from the y coordinate. It should not be set manually.
    */
   legendDy?: number;
   /**
@@ -359,7 +359,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   sharedEvents?: any;
   /**
-   * This will show the static, unused portion of the donut chart
+   * This will show the static, unused portion of the donut chart. It should not be set manually.
    */
   showStatic?: boolean;
   /**
@@ -401,11 +401,11 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   subTitleComponent?: React.ReactElement<any>;
   /**
-   * Defines a horizontal shift from the x coordinate. This should not be set manually.
+   * Defines a horizontal shift from the x coordinate. It should not be set manually.
    */
   subTitleDx?: number;
   /**
-   * Defines a vertical shift from the y coordinate. This should not be set manually.
+   * Defines a vertical shift from the y coordinate. It should not be set manually.
    */
   subTitleDy?: number;
   /**

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -8,30 +8,14 @@ import {
   EventPropTypeInterface,
   PaddingProps,
   StringOrNumberOrCallback,
-  VictoryLegend,
   VictoryStyleInterface
 } from 'victory';
 import { Data } from 'victory-core';
-import { getDonutUtilizationTheme } from '../ChartUtils/chart-theme';
 import { ChartContainer } from '../ChartContainer/ChartContainer';
-import { ChartLabel } from '../ChartLabel/ChartLabel';
-import { ChartLegend } from '../ChartLegend/ChartLegend';
-import { ChartPie, ChartPieProps } from "../ChartPie/ChartPie";
-import { DonutUtilizationStyles } from '../ChartTheme/themes/donut-utilization-theme';
+import { ChartDonut, ChartDonutProps } from "../ChartDonut/ChartDonut";
 import { ChartThemeDefinition, ChartDonutUtilizationStaticTheme } from '../ChartTheme/ChartTheme';
-import { getChartOrigin, getChartOriginX, getChartOriginY } from '../ChartUtils/chart-origin';
-import { getLegendX, getLegendY } from '../ChartUtils/chart-legend';
-
-export enum ChartDonutUtilizationDonutOrientation {
-  left = 'left',
-  right = 'right',
-  top = 'top'
-};
-
-export enum ChartDonutUtilizationLabelOrientation {
-  horizontal = 'horizontal',
-  vertical = 'vertical'
-};
+import { getDonutUtilizationTheme } from '../ChartUtils/chart-theme';
+import { DonutUtilizationStyles } from '../ChartTheme/themes/donut-utilization-theme';
 
 export enum ChartDonutUtilizationLabelPosition {
   centroid = 'centroid',
@@ -39,15 +23,31 @@ export enum ChartDonutUtilizationLabelPosition {
   startAngle = 'startAngle'
 };
 
+export enum ChartDonutUtilizationLegendOrientation {
+  horizontal = 'horizontal',
+  vertical = 'vertical'
+};
+
+export enum ChartDonutUtilizationLegendPosition {
+  bottom = 'bottom',
+  right = 'right'
+};
+
 export enum ChartDonutUtilizationSortOrder {
   ascending = 'ascending',
   descending = 'descending'
 };
 
+export enum ChartDonutUtilizationSubTitlePosition {
+  bottom = 'bottom',
+  center = 'center',
+  right = 'right'
+}
+
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
  */
-export interface ChartDonutUtilizationProps extends ChartPieProps {
+export interface ChartDonutUtilizationProps extends ChartDonutProps {
   /**
    * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-pie/
    */
@@ -152,10 +152,6 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
    */
   donutHeight?: number;
   /**
-   * The orientation of the donut chart in relation to the legend. Valid values are 'left', 'top', and 'right'
-   */
-  donutOrientation?: 'left' | 'right' | 'top';
-  /**
    * Specifies the width of the donut chart. This value should be given as a
    * number of pixels.
    *
@@ -172,6 +168,14 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
    * The innerRadius may also need to be set when changing the donut size.
    */
   donutWidth?: number;
+  /**
+   * Defines a horizontal shift from the x coordinate for legend and subtitle. This should not be set manually.
+   */
+  dx?: number;
+  /**
+   * Defines a vertical shift from the y coordinate for legend and subtitle. This should not be set manually.
+   */
+  dy?: number;
   /**
    * The overall end angle of the pie in degrees. This prop is used in conjunction with
    * startAngle to create a pie that spans only a segment of a circle.
@@ -273,7 +277,8 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
   /**
    * The legend component to render with chart.
    *
-   * Note: Default legend properties may be applied
+   * Note: Use legendData so the legend width can be calculated and positioned properly.
+   * Default legend properties may be applied
    */
   legendComponent?: React.ReactElement<any>;
   /**
@@ -288,6 +293,14 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
    */
   legendData?: any[];
   /**
+   * Defines a horizontal shift from the x coordinate. This should not be set manually.
+   */
+  legendDx?: number;
+  /**
+   * Defines a vertical shift from the y coordinate. This should not be set manually.
+   */
+  legendDy?: number;
+  /**
    * The orientation prop takes a string that defines whether legend data
    * are displayed in a row or column. When orientation is "horizontal",
    * legend items will be displayed in a single row. When orientation is
@@ -297,6 +310,10 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
    * displaying many series of data.
    */
   legendOrientation?: 'horizontal' | 'vertical';
+  /**
+   * The legend position relation to the donut chart. Valid values are 'bottom' and 'right'
+   */
+  legendPosition?: 'bottom' | 'right';
   /**
    * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
    * If this prop is not set, the label radius will default to the radius of the pie + label padding.
@@ -374,9 +391,27 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
    */
   style?: VictoryStyleInterface;
   /**
-   * The subtitle for the donut chart
+   * The subtitle for the donut chart label
    */
   subTitle?: string;
+  /**
+   * The label component to render the chart subTitle.
+   *
+   * Note: Default label properties may be applied
+   */
+  subTitleComponent?: React.ReactElement<any>;
+  /**
+   * Defines a horizontal shift from the x coordinate. This should not be set manually.
+   */
+  subTitleDx?: number;
+  /**
+   * Defines a vertical shift from the y coordinate. This should not be set manually.
+   */
+  subTitleDy?: number;
+  /**
+   * The orientation of the donut chart in relation to the legend. Valid values are 'bottom', 'center', and 'right'
+   */
+  subTitlePosition?: 'bottom' | 'center' | 'right';
   /**
    * The theme prop takes a style object with nested data, labels, and parent objects.
    * You can create this object yourself, or you can use a theme provided by
@@ -402,7 +437,7 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
    */
   themeVariant?: string;
   /**
-   * The title for the donut chart
+   * The title for the donut chart label
    */
   title?: string;
   /**
@@ -452,30 +487,20 @@ export interface ChartDonutUtilizationProps extends ChartPieProps {
 
 export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizationProps> = ({
   data,
-  donutDx = 0,
-  donutDy = 0,
-  donutOrientation = 'left',
-  legendComponent,
-  legendData,
-  legendOrientation = DonutUtilizationStyles.legend.orientation as ChartDonutUtilizationLabelOrientation,
   showStatic = true,
   standalone = true,
-  subTitle,
   themeColor,
   themeVariant,
   thresholds,
-  title,
   x,
   y,
 
   // destructure last
   theme = getDonutUtilizationTheme(themeColor, themeVariant),
-  capHeight = title && subTitle ? 1.1 : undefined,
   height = theme.pie.height,
   width = theme.pie.width,
   donutHeight = Math.min(height, width),
-  donutWidth = Math.min(height, width),
-  innerRadius = (Math.min(donutHeight, donutWidth) - 34) / 2,
+  donutWidth = Math.min(height, width, donutHeight),
   ...rest
 }: ChartDonutUtilizationProps) => {
   // Returns computed data representing pie chart slices
@@ -509,82 +534,6 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
     return result;
   };
 
-  // Returns legend
-  const getLegend = () => {
-    if (legendComponent) {
-      const props = legendComponent.props;
-      return React.cloneElement(legendComponent, {
-        data: props.data ? props.data : legendData,
-        orientation: props.legendOrientation ? props.legendOrientation : legendOrientation,
-        standalone: false,
-        theme: props.theme ? props.theme : theme,
-        x: props.x ? props.x : getLegendX({
-          chartOrientation: donutOrientation,
-          legendOrientation: props.legendOrientation ? props.legendOrientation : legendOrientation,
-          legendWidth: getLegendDimensions().width,
-          theme,
-          width
-        }),
-        y: props.y ? props.y : getLegendY({
-          chartDy: donutDy,
-          chartHeight: donutHeight,
-          chartOrientation: donutOrientation,
-          chartType: 'pie',
-          height,
-          legendData: props.data ? props.data : legendData,
-          legendHeight: getLegendDimensions().height,
-          theme
-        })
-      });
-    } else if (legendData) {
-      return (
-        <ChartLegend
-          data={legendData}
-          orientation={legendOrientation}
-          standalone={false}
-          theme={theme}
-          x={getLegendX({
-            chartOrientation: donutOrientation,
-            legendOrientation,
-            legendWidth: getLegendDimensions().width,
-            theme,
-            width
-          })}
-          y={getLegendY({
-            chartDy: donutDy,
-            chartHeight: donutHeight,
-            chartOrientation: donutOrientation,
-            chartType: 'pie',
-            height,
-            legendData,
-            legendHeight: getLegendDimensions().height,
-            theme
-          })}
-        />
-      );
-    }
-    return null;
-  };
-
-  // Legend dimensions
-  const getLegendDimensions = () => {
-    if (legendComponent) {
-      const props = legendComponent.props;
-      return (VictoryLegend as any).getDimensions({
-        data: props.data ? props.data : legendData,
-        orientation: props.legendOrientation ? props.legendOrientation : legendOrientation,
-        theme: props.theme ? props.theme : theme,
-      });
-    } else if (legendData) {
-      return (VictoryLegend as any).getDimensions({
-        data: legendData,
-        orientation: legendOrientation,
-        theme
-      });
-    }
-    return {};
-  }
-
   // Returns theme based on threshold and current value
   const getThresholdTheme = () => {
     const newTheme = { ...theme };
@@ -608,41 +557,14 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
 
   const chart = (
     <React.Fragment>
-      <ChartLabel
-        capHeight={capHeight}
-        style={[DonutUtilizationStyles.label.title, DonutUtilizationStyles.label.subTitle] as any} // Todo: Array supported, but @types/victory is wrong
-        text={title && subTitle ? [title, subTitle] : title}
-        textAnchor="middle"
-        verticalAnchor="middle"
-        x={getChartOriginX({
-          chartDx: donutDx,
-          chartWidth: donutWidth,
-          chartOrientation: donutOrientation,
-          width
-        })}
-        y={getChartOriginY({
-          chartDy: donutDy,
-          chartHeight: donutHeight,
-          chartOrientation: donutOrientation,
-          height
-        })}
-      />
-      <ChartPie
+      <ChartDonut
         data={getComputedData()}
-        height={donutHeight}
-        innerRadius={innerRadius > 0 ? innerRadius : 0}
-        origin={getChartOrigin({
-          chartDx: donutDx,
-          chartDy: donutDy,
-          chartHeight: donutHeight,
-          chartWidth: donutWidth,
-          chartOrientation: donutOrientation,
-          height,
-          width
-        })}
+        donutHeight={donutHeight}
+        donutWidth={donutWidth}
+        height={height}
         standalone={false}
         theme={getThresholdTheme()}
-        width={donutWidth}
+        width={width}
         {...rest}
       />
     </React.Fragment>
@@ -651,15 +573,13 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
   return standalone ? (
     <ChartContainer height={height} width={width}>
       {chart}
-      {getLegend()}
     </ChartContainer>
   ) : (
     <React.Fragment>
       {chart}
-      {getLegend()}
     </React.Fragment>
   );
 };
 
-// Note: ChartPie.role must be hoisted
-hoistNonReactStatics(ChartDonutUtilization, ChartPie);
+// Note: ChartDonut.role must be hoisted
+hoistNonReactStatics(ChartDonutUtilization, ChartDonut);

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`Chart 1`] = `
       ]
     }
     height={230}
-    innerRadius={98}
     labels={Array []}
     origin={
       Object {
@@ -494,7 +493,6 @@ exports[`Chart 2`] = `
       ]
     }
     height={230}
-    innerRadius={98}
     labels={Array []}
     origin={
       Object {
@@ -986,7 +984,6 @@ exports[`renders component data 1`] = `
       ]
     }
     height={200}
-    innerRadius={83}
     labels={Array []}
     origin={
       Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
@@ -6,23 +6,6 @@ exports[`Chart 1`] = `
   width={230}
 >
   <Component
-    style={
-      Array [
-        Object {
-          "fontSize": 24,
-        },
-        Object {
-          "fill": "#bbb",
-          "fontSize": 14,
-        },
-      ]
-    }
-    textAnchor="middle"
-    verticalAnchor="middle"
-    x={115}
-    y={115}
-  />
-  <Component
     data={
       Array [
         Object {
@@ -34,14 +17,9 @@ exports[`Chart 1`] = `
         },
       ]
     }
+    donutHeight={230}
+    donutWidth={230}
     height={230}
-    innerRadius={98}
-    origin={
-      Object {
-        "x": 115,
-        "y": 115,
-      }
-    }
     standalone={false}
     theme={
       Object {
@@ -504,23 +482,6 @@ exports[`Chart 2`] = `
   width={230}
 >
   <Component
-    style={
-      Array [
-        Object {
-          "fontSize": 24,
-        },
-        Object {
-          "fill": "#bbb",
-          "fontSize": 14,
-        },
-      ]
-    }
-    textAnchor="middle"
-    verticalAnchor="middle"
-    x={115}
-    y={115}
-  />
-  <Component
     data={
       Array [
         Object {
@@ -532,14 +493,9 @@ exports[`Chart 2`] = `
         },
       ]
     }
+    donutHeight={230}
+    donutWidth={230}
     height={230}
-    innerRadius={98}
-    origin={
-      Object {
-        "x": 115,
-        "y": 115,
-      }
-    }
     standalone={false}
     theme={
       Object {
@@ -1002,23 +958,6 @@ exports[`renders component data 1`] = `
   width={200}
 >
   <Component
-    style={
-      Array [
-        Object {
-          "fontSize": 24,
-        },
-        Object {
-          "fill": "#bbb",
-          "fontSize": 14,
-        },
-      ]
-    }
-    textAnchor="middle"
-    verticalAnchor="middle"
-    x={100}
-    y={100}
-  />
-  <Component
     data={
       Array [
         Object {
@@ -1030,14 +969,9 @@ exports[`renders component data 1`] = `
         },
       ]
     }
+    donutHeight={200}
+    donutWidth={200}
     height={200}
-    innerRadius={83}
-    origin={
-      Object {
-        "x": 100,
-        "y": 100,
-      }
-    }
     standalone={false}
     theme={
       Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -17,7 +17,7 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
   <div className="donut-utilization-chart">
     <ChartDonutUtilization
       data={{ x: 'GBps capacity', y: 75 }}
-      labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
+      labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
       subTitle="of 100 GBps"
       title="75%"
     />
@@ -61,8 +61,9 @@ class UtilizationChart extends React.Component {
         <div className="donut-utilization-chart-legend-right">
           <ChartDonutUtilization
             data={{ x: 'GBps capacity', y: used }}
-            labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
-            legendData={[{ name: `GBps capacity - ${spacer}${used}%` }, { name: 'Unused' }]}
+            labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
+            legendOrientation="vertical"
             subTitle="of 100 GBps"
             title={`${used}%`}
             thresholds={[{ value: 60 }, { value: 90 }]}
@@ -108,17 +109,21 @@ class UtilizationChart extends React.Component {
     const { spacer, used } = this.state;
     return (
       <div>
-        <div className="donut-utilization-chart-legend-right">
+        <div className="donut-utilization-chart-legend-bottom-vert">
           <ChartDonutUtilization
-            data={{ x: 'GBps capacity', y: used }}
-            labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
-            legendData={[{ name: `GBps capacity - ${spacer}${used}%` }, { name: 'Unused' }]}
+            data={{ x: 'Storage capacity', y: used }}
+            donutHeight={230}
+            height={300}
+            labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
+            legendOrientation="vertical"
+            legendPosition="bottom"
             subTitle="of 100 GBps"
             title={`${used}%`}
             themeColor={ChartThemeColor.green}
             themeVariant={ChartThemeVariant.light}
             thresholds={[{ value: 60 }, { value: 90 }]}
-            width={435}
+            width={230}
           />
         </div>
       </div>
@@ -133,41 +138,18 @@ import React from 'react';
 import { ChartDonutUtilization } from '@patternfly/react-charts';
 
 <div>
-  <div className="donut-utilization-chart-legend-bottom">
+  <div className="donut-utilization-chart-legend-bottom-horz">
     <ChartDonutUtilization
-      data={{ x: 'GBps capacity', y: 45 }}
+      data={{ x: 'Storage capacity', y: 45 }}
       donutHeight={230}
-      donutOrientation="top"
       height={275}
-      labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
-      legendData={[{ name: `GBps capacity - 45%` }, { name: 'Unused' }]}
-      legendOrientation="horizontal"
-      legendWidth={282}
+      labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+      legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
+      legendPosition="bottom"
       subTitle="of 100 GBps"
       title="45%"
       thresholds={[{ value: 60 }, { value: 90 }]}
       width={300}
-    />
-  </div>
-</div>
-```
-
-## Simple donut utilization chart with left-aligned legend
-```js
-import React from 'react';
-import { ChartDonutUtilization } from '@patternfly/react-charts';
-
-<div>
-  <div className="donut-utilization-chart-legend-left">
-    <ChartDonutUtilization
-      data={{ x: 'GBps capacity', y: 45 }}
-      donutOrientation="right"
-      labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
-      legendData={[{ name: `GBps capacity - 45%` }, { name: 'Unused' }]}
-      subTitle="of 100 GBps"
-      title="45%"
-      thresholds={[{ value: 60 }, { value: 90 }]}
-      width={425}
     />
   </div>
 </div>
@@ -185,8 +167,8 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
       labels={datum => datum.x ? datum.x : null}
     >
       <ChartDonutUtilization
-        data={{ x: 'GBps capacity', y: 45 }}
-        labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
+        data={{ x: 'Storage capacity', y: 45 }}
+        labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
         subTitle="of 100 GBps"
         title="45%"
       />
@@ -227,12 +209,13 @@ class ThresholdChart extends React.Component {
           <ChartDonutThreshold
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
             labels={datum => datum.x ? datum.x : null}
-            width={492}
+            width={500}
           >
             <ChartDonutUtilization
-              data={{ x: 'GBps capacity', y: used }}
-              labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
-              legendData={[{ name: `GBps capacity - ${used}%` }, { name: 'Warning threshold at - 60%' }, { name: 'Danger threshold at - 90%' }]}
+              data={{ x: 'Storage capacity', y: used }}
+              labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
+              legendOrientation="vertical"
               subTitle="of 100 GBps"
               title={`${used}%`}
               thresholds={[{ value: 60 }, { value: 90 }]}
@@ -273,20 +256,19 @@ class ThresholdChart extends React.Component {
     const { used } = this.state;
     return (
       <div>
-        <div className="donut-threshold-chart-legend-right">
+        <div className="donut-threshold-chart-legend-bottom-vert">
           <ChartDonutThreshold
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
+            height={350}
             labels={datum => datum.x ? datum.x : null}
-            width={492}
+            legendPosition="bottom"
+            width={230}
           >
             <ChartDonutUtilization
-              data={{ x: 'GBps capacity', y: used }}
-              labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
-              legendComponent={
-                <ChartLegend
-                  data={[{ name: `GBps capacity - ${used}%` }, { name: 'Warning threshold at - 60%' }, { name: 'Danger threshold at - 90%' }]}
-                />
-              }
+              data={{ x: 'Storage capacity', y: used }}
+              labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
+              legendOrientation="vertical"
               subTitle="of 100 GBps"
               title={`${used}%`}
               themeColor={ChartThemeColor.green}
@@ -307,43 +289,19 @@ import React from 'react';
 import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
 
 <div>
-  <div className="donut-threshold-chart-legend-bottom">
+  <div className="donut-threshold-chart-legend-bottom-horz">
     <ChartDonutThreshold
       data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-      donutOrientation="top"
-      height={325}
+      donutHeight={230}
+      height={275}
       labels={datum => datum.x ? datum.x : null}
-      width={230}
+      legendPosition="bottom"
+      width={675}
     >
       <ChartDonutUtilization
-        data={{ x: 'GBps capacity', y: 45 }}
-        labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
-        legendData={[{ name: `GBps capacity - 45%` }, { name: 'Warning threshold at - 60%' }, { name: 'Danger threshold at - 90%' }]}
-        subTitle="of 100 GBps"
-        title="45%"
-      />
-    </ChartDonutThreshold>
-  </div>
-</div>
-```
-
-## Donut utilization chart with static thresholds and left-aligned legend
-```js
-import React from 'react';
-import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
-
-<div>
-  <div className="donut-threshold-chart-legend-left">
-    <ChartDonutThreshold
-      data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-      donutOrientation="right"
-      labels={datum => datum.x ? datum.x : null}
-      width={475}
-    >
-      <ChartDonutUtilization
-        data={{ x: 'GBps capacity', y: 45 }}
-        labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
-        legendData={[{ name: `GBps capacity - 45%` }, { name: 'Warning threshold at - 60%' }, { name: 'Danger threshold at - 90%' }]}
+        data={{ x: 'Storage capacity', y: 45 }}
+        labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+        legendData={[{ name: `Storage capacity: 45%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
         subTitle="of 100 GBps"
         title="45%"
       />
@@ -360,9 +318,9 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
 <div>
   <div className="donut-utilization-chart-sm">
     <ChartDonutUtilization
-      data={{ x: 'GBps capacity', y: 75 }}
+      data={{ x: 'Storage capacity', y: 75 }}
       height={150}
-      labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
+      labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
       subTitle="of 100 GBps"
       title="75%"
       width={150}
@@ -406,10 +364,11 @@ class UtilizationChart extends React.Component {
       <div>
         <div className="donut-utilization-chart-legend-right-sm">
           <ChartDonutUtilization
-            data={{ x: 'GBps capacity', y: used }}
+            data={{ x: 'Storage capacity', y: used }}
             height={150}
-            labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
-            legendData={[{ name: `GBps capacity - ${spacer}${used}%` }, { name: 'Unused' }]}
+            labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
+            legendOrientation="vertical"
             subTitle="of 100 GBps"
             title={`${used}%`}
             thresholds={[{ value: 60 }, { value: 90 }]}
@@ -420,6 +379,54 @@ class UtilizationChart extends React.Component {
     );
   }
 }
+```
+
+## Small donut utilization chart with right-aligned legend and bottom-aligned subtitle
+```js
+import React from 'react';
+import { ChartDonutUtilization } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-utilization-chart-legend-right-subtitle-bottom-sm">
+    <ChartDonutUtilization
+      data={{ x: 'Storage capacity', y: 45 }}
+      donutHeight={150}
+      height={175}
+      labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+      legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
+      legendOrientation="vertical"
+      subTitle="of 100 GBps"
+      subTitlePosition="bottom"
+      title="45%"
+      thresholds={[{ value: 60 }, { value: 90 }]}
+      width={350}
+    />
+  </div>
+</div>
+```
+
+## Small donut utilization chart with bottom-aligned legend and right-aligned subtitle
+```js
+import React from 'react';
+import { ChartDonutUtilization } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-utilization-chart-legend-bottom-subtitle-right-sm">
+    <ChartDonutUtilization
+      data={{ x: 'Storage capacity', y: 45 }}
+      donutHeight={150}
+      height={200}
+      labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+      legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
+      legendPosition="bottom"
+      subTitle="of 100 GBps"
+      subTitlePosition="right"
+      title="45%"
+      thresholds={[{ value: 60 }, { value: 90 }]}
+      width={350}
+    />
+  </div>
+</div>
 ```
 
 ## Small donut utilization chart with static thresholds
@@ -436,8 +443,8 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
       width={175}
     >
       <ChartDonutUtilization
-        data={{ x: 'GBps capacity', y: 45 }}
-        labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
+        data={{ x: 'Storage capacity', y: 45 }}
+        labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
         subTitle="of 100 GBps"
         title="45%"
       />
@@ -482,9 +489,10 @@ class ThresholdChart extends React.Component {
             width={425}
           >
             <ChartDonutUtilization
-              data={{ x: 'GBps capacity', y: used }}
-              labels={datum => datum.x ? `${datum.x} - ${datum.y}%` : null}
-              legendData={[{ name: `GBps capacity - ${used}%` }, { name: 'Warning threshold at - 60%' }, { name: 'Danger threshold at - 90%' }]}
+              data={{ x: 'Storage capacity', y: used }}
+              labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
+              legendOrientation="vertical"
               subTitle="of 100 GBps"
               title={`${used}%`}
               thresholds={[{ value: 60 }, { value: 90 }]}
@@ -495,4 +503,62 @@ class ThresholdChart extends React.Component {
     );
   }
 }
+```
+
+## Small donut utilization chart with static thresholds with right-aligned legend and bottom-aligned subtitle
+```js
+import React from 'react';
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-threshold-chart-legend-right-subtitle-bottom-sm">
+    <ChartDonutThreshold
+      data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
+      donutHeight={175}
+      height={200}
+      labels={datum => datum.x ? datum.x : null}
+      subTitlePosition="bottom"
+      width={425}
+    >
+      <ChartDonutUtilization
+        data={{ x: 'Storage capacity', y: 45 }}
+        labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+        legendData={[{ name: `Storage capacity: 45%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at  90%' }]}
+        legendOrientation="vertical"
+        subTitle="of 100 GBps"
+        title="45%"
+        thresholds={[{ value: 60 }, { value: 90 }]}
+      />
+    </ChartDonutThreshold>
+  </div>
+</div>
+```
+
+## Small donut utilization chart with static thresholds with bottom-aligned legend and right-aligned subtitle
+```js
+import React from 'react';
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-threshold-chart-legend-bottom-subtitle-right-sm">
+    <ChartDonutThreshold
+      data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
+      donutHeight={175}
+      height={225}
+      labels={datum => datum.x ? datum.x : null}
+      legendPosition="bottom"
+      subTitlePosition="right"
+      width={675}
+    >
+      <ChartDonutUtilization
+        data={{ x: 'Storage capacity', y: 45 }}
+        labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+        legendData={[{ name: `Storage capacity: 45%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
+        subTitle="of 100 GBps"
+        title="45%"
+        thresholds={[{ value: 60 }, { value: 90 }]}
+      />
+    </ChartDonutThreshold>
+  </div>
+</div>
 ```

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/chart-donut-utilization.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/chart-donut-utilization.scss
@@ -10,24 +10,34 @@
       width: 175px;
     }
 
-    .donut-threshold-chart-legend-bottom {
-      height: 325px;
-      width: 230px;
+    .donut-threshold-chart-legend-bottom-horz {
+      height: 275px;
+      width: 675px;
     }
 
-    .donut-threshold-chart-legend-left {
-      height: 230px;
-      width: 475px;
+    .donut-threshold-chart-legend-bottom-vert {
+      height: 350px;
+      width: 230px;
     }
 
     .donut-threshold-chart-legend-right {
       height: 230px;
-      width: 492px;
+      width: 500px;
     }
 
     .donut-threshold-chart-legend-right-sm {
       height: 175px;
       width: 425px;
+    }
+
+    .donut-threshold-chart-legend-right-subtitle-bottom-sm {
+      height: 200px;
+      width: 425px;
+    }
+
+    .donut-threshold-chart-legend-bottom-subtitle-right-sm {
+      height: 225px;
+      width: 675px;
     }
 
     .donut-utilization-chart {
@@ -40,14 +50,14 @@
       width: 150px;
     }
 
-    .donut-utilization-chart-legend-bottom {
+    .donut-utilization-chart-legend-bottom-horz {
       height: 275px;
       width: 300px;
     }
 
-    .donut-utilization-chart-legend-left {
-      height: 230px;
-      width: 425px;
+    .donut-utilization-chart-legend-bottom-vert {
+      height: 300px;
+      width: 230px;
     }
 
     .donut-utilization-chart-legend-right {
@@ -57,6 +67,16 @@
 
     .donut-utilization-chart-legend-right-sm {
       height: 150px;
+      width: 350px;
+    }
+
+    .donut-utilization-chart-legend-bottom-subtitle-right-sm {
+      height: 200px;
+      width: 350px;
+    }
+
+    .donut-utilization-chart-legend-right-subtitle-bottom-sm {
+      height: 175px;
       width: 350px;
     }
   }

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -50,13 +50,13 @@ import { ChartLegend, ChartPie, ChartThemeColor } from '@patternfly/react-charts
     </div>
   </div>
   <ChartLegend
-        data={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
-        height={35}
-        orientation={'horizontal'}
-        responsive={false}
-        themeColor={ChartThemeColor.multi}
-        themeVariant={ChartThemeVariant.light}
-        x={8}
-      />
+    data={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+    height={35}
+    orientation={'horizontal'}
+    responsive={false}
+    themeColor={ChartThemeColor.multi}
+    themeVariant={ChartThemeVariant.light}
+    x={8}
+  />
 </div>
 ```

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -16,14 +16,14 @@ import { ChartLegend, ChartPie } from '@patternfly/react-charts';
 
 <div>
   <div className="pie-chart-inline">
-    <div className="pie-chart-container">
+    <div className="pie-chart-legend-right">
       <ChartPie
         data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
         labels={datum => `${datum.x}: ${datum.y}`}
       />
     </div>
     <ChartLegend
-      data={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
+      data={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
       height={230}
       orientation={'vertical'}
       responsive={false}
@@ -40,21 +40,23 @@ import { ChartLegend, ChartPie, ChartThemeColor } from '@patternfly/react-charts
 
 <div>
   <div className="pie-chart-container">
-    <ChartPie
-      data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-      labels={datum => `${datum.x}: ${datum.y}`}
-      themeColor={ChartThemeColor.multi}
-      themeVariant={ChartThemeVariant.light}
-    />
+    <div className="pie-chart-legend-bottom">
+      <ChartPie
+        data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+        labels={datum => `${datum.x}: ${datum.y}`}
+        themeColor={ChartThemeColor.multi}
+        themeVariant={ChartThemeVariant.light}
+      />
+    </div>
   </div>
   <ChartLegend
-    data={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
-    height={35}
-    orientation={'horizontal'}
-    responsive={false}
-    themeColor={ChartThemeColor.multi}
-    themeVariant={ChartThemeVariant.light}
-    x={8}
-  />
+        data={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+        height={35}
+        orientation={'horizontal'}
+        responsive={false}
+        themeColor={ChartThemeColor.multi}
+        themeVariant={ChartThemeVariant.light}
+        x={8}
+      />
 </div>
 ```

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/examples/chart-pie.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/examples/chart-pie.scss
@@ -1,12 +1,23 @@
 .ws-preview {
   & > * {
     .pie-chart-container {
-      height: 230px;
-      width: 230px;
+      display: flex;
+      justify-content: center;
+      width: 300px;
     }
 
     .pie-chart-inline {
       display: inline-flex;
+    }
+
+    .pie-chart-legend-bottom {
+      height: 230px;
+      width: 230px;
+    }
+
+    .pie-chart-legend-right {
+      height: 230px;
+      width: 230px;
     }
   }
 }

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/common-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/common-theme.ts
@@ -1,0 +1,11 @@
+// TODO Replace label props with PF css when available
+
+// Common properties not included with Victory theme
+export const CommonStyles = {
+  label: {
+    margin: 8
+  },
+  legend: {
+    margin: 16
+  },
+};

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-theme.ts
@@ -4,12 +4,18 @@
 export const DonutStyles = {
   label: {
     subTitle: {
+      // Victory props only
       fill: '#bbb',
       fontSize: 14
     },
+    subTitlePosition: 'center',
     title: {
+      // Victory props only
       fontSize: 24
     }
+  },
+  legend: {
+    position: 'right'
   }
 };
 

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-utilization-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-utilization-theme.ts
@@ -2,18 +2,6 @@
 
 // Donut utilization styles
 export const DonutUtilizationStyles = {
-  label: {
-    subTitle: {
-      fill: '#bbb',
-      fontSize: 14
-    },
-    title: {
-      fontSize: 24
-    }
-  },
-  legend: {
-    orientation: 'vertical'
-  },
   thresholds: {
     colorScale: ['#F0AB00', '#C9190B']
   }

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-label.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-label.ts
@@ -1,0 +1,78 @@
+import { getLegendDimensions } from './chart-legend';
+import { CommonStyles } from '../ChartTheme/themes/common-theme';
+import { ChartThemeDefinition } from '../ChartTheme/ChartTheme';
+
+interface ChartLabelDimensionsInterface {
+  label: string; // The label text
+  theme: ChartThemeDefinition; // The theme that will be applied to the chart
+}
+
+interface ChartLabelPaddingXInterface {
+  dx?: number; // Horizontal shift from the x coordinate
+  chartWidth: number; // Width of chart (e.g., donut) within SVG
+  labelPosition: string; // Position of label (e.g., bottom, right)
+  legendPosition: string; // Position of legend (e.g., bottom, right)
+  svgWidth: number; // Overall width of SVG
+}
+
+interface ChartLabelPaddingYInterface {
+  dy?: number; // Vertical shift from the x coordinate
+  chartHeight: number; // Width of chart (e.g., donut) within SVG
+  labelPosition: string; // Position of label (e.g., bottom, right)
+}
+
+// Returns x coordinate for label
+export const getLabelX = ({
+  chartWidth,
+  dx = 0,
+  labelPosition,
+  legendPosition,
+  svgWidth
+}: ChartLabelPaddingXInterface) => {
+  if (!chartWidth) {
+    return 0;
+  }
+  switch (labelPosition) {
+    case 'center':
+      switch (legendPosition) {
+        case 'bottom':
+          return Math.round(svgWidth / 2) + dx;
+        default:
+          return Math.round(chartWidth / 2) + dx;
+      }
+    case 'bottom':
+      return Math.round(chartWidth / 2) + dx;
+    case 'right':
+      switch (legendPosition) {
+        case 'bottom':
+          return Math.round(svgWidth / 2) + Math.round(chartWidth / 2) + CommonStyles.label.margin + dx;
+        case 'right':
+          return chartWidth + CommonStyles.label.margin + dx;
+        default:
+          return dx;
+      }
+    default:
+      return dx;
+  }
+};
+
+// Returns y coordinate for label
+export const getLabelY = ({
+  chartHeight,
+  dy = 0,
+  labelPosition,
+}: ChartLabelPaddingYInterface) => {
+  if (!chartHeight) {
+    return 0;
+  }
+  switch (labelPosition) {
+    case 'center':
+      return Math.round(chartHeight / 2) + dy;
+    case 'bottom':
+      return chartHeight + CommonStyles.label.margin + dy;
+    case 'right':
+      return Math.round(chartHeight / 2) + dy;
+    default:
+      return dy;
+  }
+};

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-label.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-label.ts
@@ -1,4 +1,3 @@
-import { getLegendDimensions } from './chart-legend';
 import { CommonStyles } from '../ChartTheme/themes/common-theme';
 import { ChartThemeDefinition } from '../ChartTheme/ChartTheme';
 

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -1,22 +1,34 @@
+import { VictoryLegend } from 'victory';
+import { ChartLegendProps } from '../ChartLegend/ChartLegend';
 import { ChartThemeDefinition } from '../ChartTheme/ChartTheme';
+import { CommonStyles } from '../ChartTheme/themes/common-theme';
 
 interface ChartLegendPaddingXInterface {
-  chartOrientation: string;
-  legendOrientation: string;
-  legendWidth: number;
-  theme: ChartThemeDefinition;
-  width: number;
+  chartWidth: number; // Width of chart (e.g., donut) within SVG
+  dx?: number; // Horizontal shift from the x coordinate
+  legendData: any[]; // The legend data used to determine width
+  legendOrientation: string; // Orientation of legend (e.g., vertical, horizontal)
+  legendPosition: string; // Position of legend (e.g., bottom, right)
+  legendWidth: number; // Width of legend within SVG
+  svgWidth: number; // Overall width of SVG
+  theme: ChartThemeDefinition; // The theme that will be applied to the chart
 }
 
 interface ChartLegendPaddingYInterface {
-  chartDy?: number;
-  chartHeight: number;
-  chartOrientation: string;
-  chartType: string;
-  height: number;
-  legendData: any[]
-  legendHeight: number;
-  theme: ChartThemeDefinition;
+  chartHeight: number; // Height of chart (e.g., donut) within SVG
+  chartType: string; // The type of chart (e.g., pie) to lookup for props like padding
+  dy?: number; // Vertical shift from the x coordinate
+  legendData: any[]; // The legend data used to determine width
+  legendHeight: number; // Height of legend within SVG
+  legendPosition: string; // Position of legend (e.g., bottom, right)
+  theme: ChartThemeDefinition; // The theme that will be applied to the chart
+}
+
+interface ChartLegendDimensionsInterface {
+  legendData: any[]; // The legend data used to determine width
+  legendOrientation: string; // Orientation of legend (e.g., vertical, horizontal)
+  legendProps: ChartLegendProps; // Legend properties
+  theme: ChartThemeDefinition; // The theme that will be applied to the chart
 }
 
 // Returns chart padding
@@ -27,56 +39,92 @@ export const getChartPadding = (chartType: string = 'chart', theme: ChartThemeDe
   return padding + offset;
 };
 
-// Returns legend padding
-export const getLegendPadding = (legendData: any[]) => (legendData && legendData.length > 0 ? 15 : 0);
+
+// Returns legend dimensions
+export const getLegendDimensions = ({
+  legendData,
+  legendOrientation,
+  legendProps,
+  theme
+}: ChartLegendDimensionsInterface) => {
+  if (legendData || legendProps.data) {
+    return (VictoryLegend as any).getDimensions({
+      data: legendData,
+      orientation: legendOrientation,
+      theme,
+      ...legendProps // override above
+    });
+  }
+  return {};
+}
 
 // Returns x coordinate for legend
 export const getLegendX = ({
-  chartOrientation,
+  chartWidth,
+  dx = 0,
+  legendData,
+  legendPosition,
   legendOrientation,
   legendWidth,
-  theme,
-  width
+  svgWidth
 }: ChartLegendPaddingXInterface) => {
   if (!legendWidth) {
     return 0;
   }
-  const offset = legendOrientation === 'vertical' ? 22 : 4;
-  const gutter = legendOrientation === 'vertical' ? theme.legend.gutter : 0;
-  const padding = gutter + offset;
-  switch (chartOrientation) {
-    case 'left':
-      return width > legendWidth ? width - legendWidth : 0;
-    case 'top':
-      return width > legendWidth - padding ? Math.round((width - (legendWidth - padding)) / 2) : 0;
+  const borderPadding = getBorderPaddingWorkAround(legendData, legendOrientation);
+
+  const test = Math.round((svgWidth - (legendWidth - borderPadding)) / 2) + dx;
+
+  switch (legendPosition) {
+    case 'bottom':
+      return svgWidth > legendWidth - borderPadding
+        ? Math.round((svgWidth - (legendWidth - borderPadding)) / 2) + dx : dx;
+    case 'right':
+      return chartWidth + CommonStyles.legend.margin + dx;
     default:
-      return 0;
+      return dx;
   }
 };
 
 // Returns y coordinate for legend
 export const getLegendY = ({
-  chartDy = 0,
   chartHeight,
-  chartOrientation,
+  dy = 0,
+  legendPosition,
   chartType,
-  height,
   legendData,
   legendHeight,
   theme
 }: ChartLegendPaddingYInterface) => {
-  // Todo: Get padding for other types of charts
+  const getLegendPadding = (legendData: any[]) => (legendData && legendData.length > 0 ? 15 : 0);
   const dHeight = chartHeight ? chartHeight + getChartPadding(chartType, theme) : 0;
   const lHeight = legendHeight ? legendHeight + getLegendPadding(legendData) : 0;
 
-  switch (chartOrientation) {
+  switch (legendPosition) {
+    case 'bottom':
+      return chartHeight + CommonStyles.legend.margin + dy;
     case 'left':
-      return dHeight > lHeight ? Math.round((dHeight - lHeight) / 2) + chartDy : 0;
+      return dHeight > lHeight ? Math.round((dHeight - lHeight) / 2) + dy : dy;
     case 'right':
-      return dHeight > lHeight ? Math.round((dHeight - lHeight) / 2) + chartDy : 0;
-    case 'top':
-      return height > lHeight ? height - lHeight + chartDy : 0;
+      return dHeight > lHeight ? Math.round((dHeight - lHeight) / 2) + dy : dy;
     default:
-      return chartDy;
+      return dy;
   }
+};
+
+const getBorderPaddingWorkAround = (legendData: any[], legendOrientation: string) => {
+  const offset = .4;
+  let result = 0;
+  if (legendData && legendOrientation === 'vertical') {
+    // For vertical legends, the greatest number of chars affects right-side border padding
+    legendData.forEach(data => {
+      if (data.name && data.name.length > result) {
+        result = data.name.length;
+      }
+    });
+  } else if (legendData && legendData[legendData.length - 1].name) {
+    // For horizontal legends, the number of chars for the last legend item affects right-side border padding
+    result = legendData[legendData.length - 1].name.length;
+  }
+  return result + result * offset;
 };

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-origin.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-origin.ts
@@ -1,61 +1,63 @@
 interface ChartOriginInterface {
-  chartDx?: number;
-  chartDy?: number;
-  chartHeight: number;
-  chartOrientation: string;
-  chartWidth: number;
-  height: number;
-  width: number;
+  chartHeight: number; // Height of chart (e.g., donut) within SVG
+  chartWidth: number; // Width of chart (e.g., donut) within SVG
+  dx?: number; // Horizontal shift from the x coordinate
+  dy?: number; // vertical shift from the x coordinate
+  legendPosition?: string; // Position of legend (e.g., bottom, right)
+  svgWidth: number; // Overall width of SVG
 }
 
 interface ChartOriginXInterface {
-  chartDx?: number;
-  chartOrientation: string;
-  chartWidth: number;
-  width: number;
+  chartWidth: number; // Width of chart (e.g., donut) within SVG
+  dx?: number; // Horizontal shift from the x coordinate
+  legendPosition?: string; // Position of legend (e.g., bottom, right)
+  svgWidth: number; // Overall width of SVG
 }
 
 interface ChartOriginYInterface {
-  chartDy?: number;
-  chartHeight: number;
-  chartOrientation: string;
-  height: number;
+  chartHeight: number; // Height of chart (e.g., donut) within SVG
+  dy?: number; // vertical shift from the x coordinate
+  legendPosition?: string; // Position of legend (e.g., bottom, right)
 }
 
 // Returns origin x and y coordinates
 export const getChartOrigin = ({
-  chartDx = 0,
-  chartDy = 0,
   chartHeight,
-  chartOrientation,
   chartWidth,
-  height,
-  width
+  dx = 0,
+  dy = 0,
+  legendPosition,
+  svgWidth
 }: ChartOriginInterface) => ({
-  x: getChartOriginX({ chartDx, chartOrientation, chartWidth, width }),
-  y: getChartOriginY({ chartDy, chartHeight, chartOrientation, height })
+  x: getChartOriginX({ chartWidth, dx, legendPosition, svgWidth }),
+  y: getChartOriginY({ chartHeight, dy, legendPosition })
 });
 
 // Returns origin x coordinate
-export const getChartOriginX = ({ chartDx = 0, chartOrientation, chartWidth, width }: ChartOriginXInterface) => {
-  switch (chartOrientation) {
-    case 'left':
-      return (chartWidth ? Math.round(chartWidth / 2) : 0) + chartDx;
-    case 'right':
-      return (width > chartWidth ? Math.round(width - chartWidth / 2) : 0) + chartDx;
-    case 'top':
-      return (width ? Math.round(width / 2) : 0) + chartDx;
+export const getChartOriginX = ({
+  chartWidth,
+  dx = 0,
+  legendPosition,
+  svgWidth
+}: ChartOriginXInterface) => {
+  switch (legendPosition) {
+    case 'bottom':
+      return Math.round(svgWidth / 2) + dx;
     default:
-      return 0;
+      return Math.round(chartWidth / 2) + dx;
   }
 };
 
 // Returns origin y coordinate
-export const getChartOriginY = ({ chartDy = 0, chartHeight, chartOrientation, height }: ChartOriginYInterface) => {
-  switch (chartOrientation) {
-    case 'bottom':
-      return chartDy; // TBD...
+export const getChartOriginY = ({
+  chartHeight,
+  dy = 0,
+  legendPosition
+}: ChartOriginYInterface) => {
+  switch (legendPosition) {
+    case 'top':
+      return dy; // TBD...
     default:
-      return (chartHeight ? Math.round(chartHeight / 2) : 0) + chartDy;
+      return Math.round(chartHeight / 2) + dy;
   }
 };

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-theme.ts
@@ -34,6 +34,9 @@ export const getDonutThresholdDynamicTheme = (themeColor: string, themeVariant: 
 
   // Merge just the first color of dynamic (blue, green, etc.) with static (grey) for expected colorScale
   theme.legend.colorScale = [theme.pie.colorScale[0], ...ChartDonutThresholdDynamicTheme.legend.colorScale];
+
+  // Merge the threshold colors in case users want to show the unused data
+  theme.pie.colorScale = [theme.pie.colorScale[0], ...ChartDonutThresholdStaticTheme.pie.colorScale];
   return theme;
 };
 

--- a/packages/patternfly-4/react-charts/src/declarations.d.ts
+++ b/packages/patternfly-4/react-charts/src/declarations.d.ts
@@ -2,4 +2,5 @@ declare module 'victory-core' {
   export const Data: any;
   export const Helpers: any;
   export const Path: any;
+  export const TextSize: any;
 }

--- a/packages/patternfly-4/react-core/src/declarations.d.ts
+++ b/packages/patternfly-4/react-core/src/declarations.d.ts
@@ -3,4 +3,5 @@ declare module 'victory-core' {
   export const Data: any;
   export const Helpers: any;
   export const Path: any;
+  export const TextSize: any;
 }


### PR DESCRIPTION
Refactored the donut, donut utilization, and donut threshold charts in order to position the subtitle to the right or below the chart, similar to the PF3 functionality for small charts (e.g., 150x150px). 

With this change, the label and legend creation has been moved from donut utilization to donut. The donut did not support legends, previously.

In addition, I've refactored the legends so that they are positioned with 16px padding (8px for labels) per the mock below.

<img width="537" alt="Screen Shot 2019-06-13 at 7 24 36 PM" src="https://user-images.githubusercontent.com/17481322/59474178-e2141300-8e13-11e9-99d1-71d84b506512.png">

Fixes https://github.com/patternfly/patternfly-react/issues/2213
Fixes https://github.com/patternfly/patternfly-react/issues/2183