### PR TITLE
CircleCI build: Increment key version to clear cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v{{ .Environment.CACHE_VERSION }}-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - v2{{ .Environment.CACHE_VERSION }}-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Conditional install
           command: if [ ! -d node_modules ]; then yarn install --frozen-lockfile; fi
@@ -26,7 +26,7 @@ jobs:
             - packages/patternfly-4/react-styles/node_modules
             - packages/patternfly-3/patternfly-react/node_modules
             - .cache # Incremental builds
-          key: v{{ .Environment.CACHE_VERSION }}-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: v2{{ .Environment.CACHE_VERSION }}-deps-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Build Dist
           command: yarn build


### PR DESCRIPTION
Added `v2` prefix to the key name. This will clear the cache and get PR builds working, again.

See https://circleci.com/docs/2.0/caching/#clearing-cache

Fixes https://github.com/patternfly/patternfly-react/issues/2277