### PR TITLE
chore(styles): remove TS from css/*

### DIFF
--- a/packages/patternfly-4/react-styles/package.json
+++ b/packages/patternfly-4/react-styles/package.json
@@ -15,13 +15,12 @@
     "tag": "prerelease"
   },
   "scripts": {
-    "build": "yarn build:babel && node ./scripts/copyTS.js && yarn build:css && yarn build:types && node ./scripts/copyStyles.js",
+    "build": "yarn build:babel && node ./scripts/copyTS.js && yarn build:css && node ./scripts/copyStyles.js",
     "build:babel": "concurrently 'yarn build:babel:esm && yarn build:babel:umd' 'yarn build:babel:cjs'",
     "build:babel:cjs": "babel --source-maps --extensions '.js,.ts,.tsx' src --out-dir dist/js --presets=@babel/preset-env",
     "build:babel:esm": "babel --source-maps --extensions '.js,.ts,.tsx' src --out-dir dist/esm",
     "build:babel:umd": "babel --source-maps --extensions '.js' dist/esm --out-dir dist/umd --plugins=transform-es2015-modules-umd",
-    "build:css": "node src/generateClasses.js",
-    "build:types": "tsc",
+    "build:css": "node src/generateClasses.js && tsc && node src/removeTS.js",
     "clean": "rimraf dist css",
     "develop": "yarn build:babel:esm --skip-initial-build --watch --verbose"
   },

--- a/packages/patternfly-4/react-styles/src/removeTS.js
+++ b/packages/patternfly-4/react-styles/src/removeTS.js
@@ -1,0 +1,8 @@
+/* eslint-disable global-require,import/no-dynamic-require */
+const glob = require('glob');
+const fs = require('fs');
+
+const tsFiles = glob.sync('css/**/*.ts', { ignore: ['**/*.d.ts'] });
+
+tsFiles.forEach(file => fs.unlinkSync(file));
+

--- a/packages/patternfly-4/react-styles/src/removeTS.js
+++ b/packages/patternfly-4/react-styles/src/removeTS.js
@@ -2,7 +2,4 @@
 const glob = require('glob');
 const fs = require('fs');
 
-const tsFiles = glob.sync('css/**/*.ts', { ignore: ['**/*.d.ts'] });
-
-tsFiles.forEach(file => fs.unlinkSync(file));
-
+glob.sync('css/**/*.ts', { ignore: ['**/*.d.ts'] }).forEach(file => fs.unlinkSync(file));


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Remove the `.ts` file output from `@patternfly/react-styles/css/*` since we already have it compiled to `.js` and `.d.ts`. Consumers (or other packages) shouldn't be transpiling the `.ts` files themselves.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
