### PR TITLE
fix(popover): reset pointer-events to capture default target bounds

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.md
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.md
@@ -116,7 +116,7 @@ class AdvancedPopover extends React.Component {
 ## Popover (headless)
 ```js
 import React from 'react';
-import { Popover, PopoverPosition, Checkbox, Button } from '@patternfly/react-core';
+import { Popover, PopoverPosition, Button } from '@patternfly/react-core';
 
 HeadlessPopover = () => (
   <Popover
@@ -126,6 +126,26 @@ HeadlessPopover = () => (
     }
     aria-label="Headless Popover"
     closeBtnAriaLabel="Close Headless Popover"
+    footerContent="Popover Footer"
+  >
+    <Button>Toggle Popover</Button>
+  </Popover>
+);
+```
+
+## Popover with Link
+```js
+import React from 'react';
+import { Popover, PopoverPosition, Button } from '@patternfly/react-core';
+
+HeadlessPopover = () => (
+  <Popover
+    position={PopoverPosition.right}
+    bodyContent={
+      <div><a href="https://www.patternfly.org/" target="_blank">PatternFly</a> is a community project that promotes design commonality and improved user experience. Its offerings include open source code, patterns, style guides, and an active community that helps support it all.</div>
+    }
+    aria-label="Popover with Link"
+    closeBtnAriaLabel="Close Popover with Link"
     footerContent="Popover Footer"
   >
     <Button>Toggle Popover</Button>

--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Tippy from '@tippy.js/react';
-import { Instance as TippyInstance, BasicPlacement } from 'tippy.js';
+import { Instance as TippyInstance } from 'tippy.js';
 import { KEY_CODES } from '../../helpers/constants';
 import styles from '@patternfly/react-styles/css/components/Popover/popover';
 import { css, getModifier } from '@patternfly/react-styles';

--- a/packages/patternfly-4/react-core/src/components/Popover/PopoverCloseButton.tsx
+++ b/packages/patternfly-4/react-core/src/components/Popover/PopoverCloseButton.tsx
@@ -2,18 +2,18 @@ import * as React from 'react';
 import { Button } from '../Button';
 import { TimesIcon } from '@patternfly/react-icons';
 
-export const PopoverCloseButton: React.FunctionComponent<PopoverCloseButtonProps> = ({ 
-  onClose = () => undefined, 
-  ...props 
+export const PopoverCloseButton: React.FunctionComponent<PopoverCloseButtonProps> = ({
+  onClose = () => undefined as void,
+  ...props
   }) => (
-  <Button onClick={onClose} variant="plain" aria-label {...props}>
+  <Button onClick={onClose} variant="plain" aria-label {...props} style={{pointerEvents: 'auto'}}>
     <TimesIcon />
   </Button>
 );
 
 export interface PopoverCloseButtonProps {
   /** PopoverCloseButton onClose function */
-  onClose?(): void;
+  onClose?: () => void;
   /** Aria label for the Close button */
   'aria-label': string;
 }

--- a/packages/patternfly-4/react-core/src/components/Tooltip/styles.tsx
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/styles.tsx
@@ -10,7 +10,7 @@ export const tippyStyles = () => {
   // export const overrides = StyleSheet.parse(
   injectGlobal(`
   .pf-tippy-theme {
-    &.tippy-tooltip { 
+    &.tippy-tooltip {
       background-color: unset;
       font-size: unset;
       color: unset;
@@ -19,9 +19,6 @@ export const tippyStyles = () => {
       text-align: unset;
       padding: unset;
       cursor: text;
-      .tippy-content {
-        pointer-events: none;
-      }
     }
     .pf-c-tooltip, .pf-c-popover {
       max-width: unset;
@@ -33,42 +30,42 @@ export const tippyStyles = () => {
   .tippy-popper[x-placement^=top] .pf-c-tooltip__arrow {
     bottom: 0;
     left: 50%;
-    transform: var(--pf-c-tooltip__arrow--m-top--Transform); 
+    transform: var(--pf-c-tooltip__arrow--m-top--Transform);
   }
   .tippy-popper[x-placement^=bottom] .pf-c-tooltip__arrow {
     top: 0;
     left: 50%;
-    transform: var(--pf-c-tooltip__arrow--m-bottom--Transform); 
+    transform: var(--pf-c-tooltip__arrow--m-bottom--Transform);
   }
   .tippy-popper[x-placement^=left] .pf-c-tooltip__arrow {
     top: 50%;
     right: 0;
-    transform: var(--pf-c-tooltip__arrow--m-left--Transform); 
+    transform: var(--pf-c-tooltip__arrow--m-left--Transform);
   }
   .tippy-popper[x-placement^=right] .pf-c-tooltip__arrow {
     top: 50%;
     left: 0;
-    transform: var(--pf-c-tooltip__arrow--m-right--Transform); 
+    transform: var(--pf-c-tooltip__arrow--m-right--Transform);
   }
   .tippy-popper[x-placement^=top] .pf-c-popover__arrow {
     bottom: 0;
     left: 50%;
-    transform: var(--pf-c-popover__arrow--m-top--Transform); 
+    transform: var(--pf-c-popover__arrow--m-top--Transform);
   }
   .tippy-popper[x-placement^=bottom] .pf-c-popover__arrow {
     top: 0;
     left: 50%;
-    transform: var(--pf-c-popover__arrow--m-bottom--Transform); 
+    transform: var(--pf-c-popover__arrow--m-bottom--Transform);
   }
   .tippy-popper[x-placement^=left] .pf-c-popover__arrow {
     top: 50%;
     right: 0;
-    transform: var(--pf-c-popover__arrow--m-left--Transform); 
+    transform: var(--pf-c-popover__arrow--m-left--Transform);
   }
   .tippy-popper[x-placement^=right] .pf-c-popover__arrow {
     top: 50%;
     left: 0;
-    transform: var(--pf-c-popover__arrow--m-right--Transform); 
-  }  
+    transform: var(--pf-c-popover__arrow--m-right--Transform);
+  }
 `);
 };


### PR DESCRIPTION
**What**: This PR applies an inline style rule to ensure we capture pointer events for the popover close button. Without this, the target area for the close button is too small and causes usability/accessibility issues.

Looks like the tippy lib was adding this conflicting style rule.

<img width="614" alt="Screen Shot 2019-06-17 at 12 01 51 PM" src="https://user-images.githubusercontent.com/5942899/59619658-0bc18880-90f9-11e9-87fa-f38454258c13.png">

**Additional issues**: https://github.com/patternfly/patternfly-react/issues/2275

![2019-06-17 12 06 40](https://user-images.githubusercontent.com/5942899/59619690-1bd96800-90f9-11e9-8ae8-76bd59c0b6f6.gif)

An outstanding question is; Should this style rule be included as part of core instead?