### PR TITLE
chore(build): use cache instead of npx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,8 +218,11 @@ jobs:
     - image: circleci/node:8.15
     steps:
     - *attach_workspace
+    - restore_cache:
+        keys:
+        - *js_deps_cache_key
     - run:
-        name: Avoid hosts unknown for github
+        name: Avoid Unknown Host for github.com
         command: mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
     - run:
         name: Deploy to NPM and Github

--- a/.circleci/release.sh
+++ b/.circleci/release.sh
@@ -13,4 +13,4 @@ echo "Doing a release..."
 # Lerna is complicated. Commands: https://github.com/lerna/lerna/tree/master/commands
 # Identify packages that have been updated since the previous tagged release
 # Update their versions and changelogs
-npx lerna publish --conventional-commits --create-release=github --yes
+yarn run lerna publish --conventional-commits --create-release=github --yes


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Restore node_modules cache to use `yarn run lerna` instead of using `npx lerna`. NPX reinstalls `lerna` each time and is slower.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
