### PR TITLE
fix(Radio): fix warning from undefined starting params

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.tsx
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.tsx
@@ -3,7 +3,8 @@ import styles from '@patternfly/react-styles/css/components/Radio/radio';
 import { css, getModifier } from '@patternfly/react-styles';
 import { Omit } from '../../helpers/typeUtils';
 
-export interface RadioProps extends Omit<React.HTMLProps<HTMLInputElement>, 'disabled' | 'label' | 'onChange' | 'type'> {
+export interface RadioProps
+  extends Omit<React.HTMLProps<HTMLInputElement>, 'disabled' | 'label' | 'onChange' | 'type'> {
   /** Additional classes added to the radio. */
   className?: string;
   /** Id of the radio. */
@@ -30,7 +31,7 @@ export class Radio extends React.Component<RadioProps> {
     isDisabled: false,
     isValid: true,
     onChange: Function.prototype
-  }
+  };
 
   constructor(props: RadioProps) {
     super(props);
@@ -42,7 +43,7 @@ export class Radio extends React.Component<RadioProps> {
 
   handleChange = (event: React.FormEvent<HTMLInputElement>) => {
     this.props.onChange(event.currentTarget.checked, event);
-  }
+  };
 
   render() {
     const {
@@ -67,11 +68,14 @@ export class Radio extends React.Component<RadioProps> {
           aria-invalid={!isValid}
           disabled={isDisabled}
           checked={checked || isChecked}
-          {...!isChecked && {defaultChecked: defaultChecked}}
-          {...!label && {"aria-label": ariaLabel}}
+          {...!isChecked && { defaultChecked }}
+          {...!label && { 'aria-label': ariaLabel }}
         />
         {label && (
-          <label className={css(styles.radioLabel, getModifier(styles, isDisabled && 'disabled' as any))} htmlFor={props.id}>
+          <label
+            className={css(styles.radioLabel, getModifier(styles, isDisabled && ('disabled' as any)))}
+            htmlFor={props.id}
+          >
             {label}
           </label>
         )}

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.tsx
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.tsx
@@ -28,7 +28,8 @@ export class Radio extends React.Component<RadioProps> {
   static defaultProps = {
     className: '',
     isDisabled: false,
-    isValid: true
+    isValid: true,
+    onChange: Function.prototype
   }
 
   constructor(props: RadioProps) {
@@ -60,14 +61,14 @@ export class Radio extends React.Component<RadioProps> {
       <div className={css(styles.radio, className)}>
         <input
           {...props}
-          aria-label={label ? undefined : ariaLabel}
           className={css(styles.radioInput)}
           type="radio"
           onChange={this.handleChange}
           aria-invalid={!isValid}
           disabled={isDisabled}
           checked={checked || isChecked}
-          defaultChecked={isChecked ? undefined : defaultChecked}
+          {...!isChecked && {defaultChecked: defaultChecked}}
+          {...!label && {"aria-label": ariaLabel}}
         />
         {label && (
           <label className={css(styles.radioLabel, getModifier(styles, isDisabled && 'disabled' as any))} htmlFor={props.id}>


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Fixes warning re: controlled/uncontrolled switch. Also fixes warning for missing prop on uncontrolled radio.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Refer to issue**: #2028

<!-- feel free to add additional comments -->
