### PR TITLE
donut-charts: add invert prop for reversing thresholds

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -246,6 +246,10 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    */
   innerRadius?: number;
   /**
+   * Invert the threshold color scale used to represent warnings, errors, etc.
+   */
+  invert?: boolean;
+  /**
    * The labelRadius prop defines the radius of the arc that will be used for positioning each slice label.
    * If this prop is not set, the label radius will default to the radius of the pie + label padding.
    */
@@ -363,13 +367,6 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    */
   title?: string;
   /**
-   * The dynamic portion of the chart will change colors when data reaches the given threshold. Colors may be
-   * overridden, but defaults shall be provided.
-   *
-   * @example thresholds={[{ value: 60, color: '#F0AB00' }, { value: 90, color: '#C9190B' }]}
-   */
-  thresholds?: any[];
-  /**
    * Specifies the width of the svg viewBox of the chart container. This value should be given as a
    * number of pixels.
    *
@@ -410,6 +407,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
 export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdProps> = ({
   children,
   data = [],
+  invert = false,
   labels = [], // Don't show any tooltip labels by default, let consumer override if needed
   legendComponent,
   legendData,
@@ -422,7 +420,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   y,
 
   // destructure last
-  theme = getDonutThresholdStaticTheme(themeColor, themeVariant),
+  theme = getDonutThresholdStaticTheme(themeColor, themeVariant, invert),
   height = theme.pie.height,
   width = theme.pie.width,
   donutHeight = Math.min(height, width),
@@ -526,6 +524,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
           donutWidth: donutWidth - (theme.pie.width - dynamicTheme.pie.width),
           endAngle: 360 * (datum[0]._y ? datum[0]._y / 100 : 0),
           height,
+          invert,
           legendDx: getLegendDx(dynamicTheme, legendPos),
           legendDy: getLegendAndSubTitleDy(dynamicTheme, legendPos),
           legendPosition: legendPos,

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -76,6 +76,58 @@ class UtilizationChart extends React.Component {
 }
 ```
 
+## Simple, inverted donut utilization chart with right-aligned legend
+```js
+import React from 'react';
+import { ChartDonutUtilization } from '@patternfly/react-charts';
+
+class UtilizationChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      spacer: '',
+      used: 100
+    };
+  }
+
+  componentDidMount() {
+    this.interval = setInterval(() => {
+      const { used } = this.state;
+      const val = (((used - 10) % 100) + 100) % 100;
+      this.setState({
+        spacer: val < 10 ? ' ' : '',
+        used: val
+      });
+    }, 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
+
+  render() {
+    const { spacer, used } = this.state;
+    return (
+      <div>
+        <div className="donut-utilization-chart-legend-right">
+          <ChartDonutUtilization
+            data={{ x: 'GBps capacity', y: used }}
+            invert
+            labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
+            legendOrientation="vertical"
+            subTitle="of 100 GBps"
+            title={`${used}%`}
+            thresholds={[{ value: 60 }, { value: 20 }]}
+            width={435}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+```
+
 ## Simple, green donut utilization chart with right-aligned legend
 ```js
 import React from 'react';
@@ -219,6 +271,63 @@ class ThresholdChart extends React.Component {
               subTitle="of 100 GBps"
               title={`${used}%`}
               thresholds={[{ value: 60 }, { value: 90 }]}
+            />
+          </ChartDonutThreshold>
+        </div>
+      </div>
+    );
+  }
+}
+```
+
+## Donut utilization chart with inverted static thresholds and right-aligned legend
+```js
+import React from 'react';
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
+
+class ThresholdChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      spacer: '',
+      used: 100
+    };
+  }
+  
+  componentDidMount() {
+    this.interval = setInterval(() => {
+      const { used } = this.state;
+      const val = (((used - 10) % 100) + 100) % 100;
+      this.setState({
+        spacer: val < 10 ? ' ' : '',
+        used: val
+      });
+    }, 1000);
+  }
+    
+  componentWillUnmount() {
+    clearInterval(this.interval);
+  }
+
+  render() {
+    const { used } = this.state;
+    return (
+      <div>
+        <div className="donut-threshold-chart-legend-right">
+          <ChartDonutThreshold
+            data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 20%', y: 20 }]}
+            invert
+            labels={datum => datum.x ? datum.x : null}
+            width={500}
+          >
+            <ChartDonutUtilization
+              data={{ x: 'Storage capacity', y: used }}
+              labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 20%' }]}
+              legendOrientation="vertical"
+              subTitle="of 100 GBps"
+              title={`${used}%`}
+              thresholds={[{ value: 60 }, { value: 20 }]}
             />
           </ChartDonutThreshold>
         </div>

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-theme.ts
@@ -26,10 +26,11 @@ import {
   ChartThemeColor,
   ChartThemeVariant
 } from '../ChartTheme/ChartTheme';
+import { cloneDeep } from 'lodash';
 
 // Apply custom properties to color and base themes
-export const getCustomTheme = (themeColor: string, themeVariant: string,
-                               customTheme: ChartThemeDefinition): ChartThemeDefinition =>
+export const getCustomTheme = (themeColor: string, themeVariant: string, customTheme: ChartThemeDefinition
+): ChartThemeDefinition =>
   merge(getTheme(themeColor, themeVariant), customTheme);
 
 // Apply donut properties onto pie chart theme
@@ -49,8 +50,14 @@ export const getDonutThresholdDynamicTheme = (themeColor: string, themeVariant: 
 };
 
 // Apply static donut threshold properties onto pie chart theme
-export const getDonutThresholdStaticTheme = (themeColor: string, themeVariant: string): ChartThemeDefinition =>
-  getCustomTheme(themeColor, themeVariant, ChartDonutThresholdStaticTheme);
+export const getDonutThresholdStaticTheme = (themeColor: string, themeVariant: string, invert?: boolean
+): ChartThemeDefinition => {
+  const staticTheme = cloneDeep(ChartDonutThresholdStaticTheme);
+  if (invert) {
+    staticTheme.pie.colorScale = staticTheme.pie.colorScale.reverse();
+  }
+  return getCustomTheme(themeColor, themeVariant, staticTheme);
+};
 
 // Apply donut utilization properties onto pie chart theme
 export const getDonutUtilizationTheme = (themeColor: string, themeVariant: string): ChartThemeDefinition => {


### PR DESCRIPTION
This adds an invert property to the donut utilization and threshold charts, which inverts the threshold color scale used to represent warnings, errors, etc.

Instead of showing a warning at 60% and an error at 90%; for example, this would allow users to show a warning below 60% and an error below 20%.

fixes https://github.com/patternfly/patternfly-react/issues/2254

![chrome-capture2](https://user-images.githubusercontent.com/17481322/59715662-5d920d80-91e2-11e9-88bd-f322b43077a5.gif)

![chrome-capture](https://user-images.githubusercontent.com/17481322/59715650-58cd5980-91e2-11e9-979d-da6b3c1714ae.gif)
