### PR TITLE
fix(virtual-scroll): add columnCount prop to VirtualTableBody

### DIFF
--- a/packages/patternfly-4/react-virtualized-extension/src/components/Virtualized/VirtualGrid.ts
+++ b/packages/patternfly-4/react-virtualized-extension/src/components/Virtualized/VirtualGrid.ts
@@ -29,7 +29,6 @@ import {
   CellCache,
   StyleCache
 } from './types';
-import { overflow } from 'styled-system';
 /**
  * Specifies the number of milliseconds during which to disable pointer events while a scroll is in progress.
  * This improves performance and makes scrolling smoother.

--- a/packages/patternfly-4/react-virtualized-extension/src/components/Virtualized/VirtualTableBody.ts
+++ b/packages/patternfly-4/react-virtualized-extension/src/components/Virtualized/VirtualTableBody.ts
@@ -96,7 +96,9 @@ type Props = {
   /** Width of list */
   width: number,
 
-  columns: any[],
+  columns?: any[],
+
+  columnCount?: number,
 
   rows: any[]
 };
@@ -192,7 +194,7 @@ export default class VirtualTableBody extends React.PureComponent<Props> {
   }
 
   render() {
-    const { className, noRowsRenderer, scrollToIndex, width, columns, rows, tabIndex, style } = this.props;
+    const { className, noRowsRenderer, scrollToIndex, width, columns, columnCount, rows, tabIndex, style } = this.props;
 
     const classNames = clsx('ReactVirtualized__List', className);
 
@@ -219,7 +221,7 @@ export default class VirtualTableBody extends React.PureComponent<Props> {
         cellRenderer={this._cellRenderer}
         className={classNames}
         columnWidth={width}
-        columnCount={columns.length}
+        columnCount={columns ? columns.length : columnCount}
         noContentRenderer={noRowsRenderer}
         onScroll={this._onScroll}
         onSectionRendered={this._onSectionRendered}

--- a/packages/patternfly-4/react-virtualized-extension/src/components/Virtualized/Virtualized.md
+++ b/packages/patternfly-4/react-virtualized-extension/src/components/Virtualized/Virtualized.md
@@ -73,14 +73,10 @@ class VirtualizedExample extends React.Component {
       const {rows, columns} = this.state;
       const text = rows[index].cells[0];
 
-      const className = clsx('pf-l-grid', {
+      const className = clsx({
         isVisible: isVisible
       });
 
-      // do not render non visible elements (this excludes overscan)
-      if(!isVisible){
-        return null;
-      }
       return <CellMeasurer
         cache={measurementCache}
         columnIndex={0}
@@ -120,7 +116,7 @@ class VirtualizedExample extends React.Component {
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
-              columns={columns}
+              columnCount={1}
               rows={rows}
               rowCount={rows.length}
               rowRenderer={rowRenderer}
@@ -216,14 +212,9 @@ class SortableExample extends React.Component {
       const {rows, columns} = this.state;
       const text = rows[index].cells[0];
 
-      const className = clsx('pf-l-grid', {
+      const className = clsx({
         isVisible: isVisible
       });
-
-      // do not render non visible elements (this excludes overscan)
-      if(!isVisible){
-        return null;
-      }
       return <CellMeasurer
         cache={measurementCache}
         columnIndex={0}
@@ -266,7 +257,7 @@ class SortableExample extends React.Component {
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
-              columns={columns}
+              columnCount={1}
               rows={rows}
               rowCount={rows.length}
               rowRenderer={rowRenderer}
@@ -365,14 +356,10 @@ class SelectableExample extends React.Component {
       const {rows, columns} = this.state;
       const text = rows[index].cells[0];
 
-      const className = clsx('pf-l-grid', {
+      const className = clsx({
         isVisible: isVisible
       });
 
-      // do not render non visible elements (this excludes overscan)
-      if(!isVisible){
-        return null;
-      }
       return <CellMeasurer
         cache={measurementCache}
         columnIndex={0}
@@ -420,7 +407,7 @@ class SelectableExample extends React.Component {
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
-              columns={columns}
+              columnCount={1}
               rows={rows}
               rowCount={rows.length}
               rowRenderer={rowRenderer}
@@ -518,14 +505,10 @@ class ActionsExample extends React.Component {
       const {rows, columns, actions} = this.state;
       const text = rows[index].cells[0];
 
-      const className = clsx('pf-l-grid', {
+      const className = clsx({
         isVisible: isVisible
       });
 
-      // do not render non visible elements (this excludes overscan)
-      if(!isVisible){
-        return null;
-      }
       return <CellMeasurer
         cache={measurementCache}
         columnIndex={0}
@@ -573,7 +556,7 @@ class ActionsExample extends React.Component {
               rowHeight={measurementCache.rowHeight}
               height={400}
               overscanRowCount={2}
-              columns={columns}
+              columnCount={1}
               rows={rows}
               rowCount={rows.length}
               rowRenderer={rowRenderer}


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

* adds the `columnCount` prop to `VirtualTableBody`. This will allow fewer renderings when the consumer is virtualizing by row (and using a `rowRenderer` instead of a `cellRenderer`). This is just an 
optional way to implement the `Grid` for the consumer by passing `rows` instead of `columns`.

* fix virtual scroll w/ `WindowScroller` example. This will now use `isScrollingOptOut` for more accurate scrolling. See React-Virtualized issue [638](https://github.com/bvaughn/react-virtualized/issues/638). 

* remove the `pf-l-grid` class. This was actually not needed before (i misinterpreted our CSS and thought that the  `pf-m-[x]-col-on-[breakpoint]` classes were scoped to `pf-l-grid`, however they are completely separate).

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
