### PR TITLE
fix(topology): Remove utility PF from control bar buttons

### DIFF
--- a/packages/patternfly-4/react-topology/src/components/TopologyControlBar/TopologyControlBar.tsx
+++ b/packages/patternfly-4/react-topology/src/components/TopologyControlBar/TopologyControlBar.tsx
@@ -259,7 +259,7 @@ export const TopologyControlBar: React.FunctionComponent<TopologyControlBarProps
     const renderedButton = (
       <Button
         id={button.id}
-        className={`pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs${button.disabled ? ' pf-m-disabled' : ''}`}
+        className={`pf-topology-control-bar__button${button.disabled ? ' pf-m-disabled' : ''}`}
         onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => handleButtonClick(event, button)}
         disabled={button.disabled}
         aria-disabled={button.disabled}

--- a/packages/patternfly-4/react-topology/src/components/TopologyControlBar/__snapshots__/TopologyControlBar.test.tsx.snap
+++ b/packages/patternfly-4/react-topology/src/components/TopologyControlBar/__snapshots__/TopologyControlBar.test.tsx.snap
@@ -1,7 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TopologyControlBar should accept button options correctly 1`] = `
-.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button.pf-u-px-sm.pf-u-mr-xs {
+.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
+  display: block;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  margin-right: 0.25rem;
+  margin-top: 0.25rem;
+  background-color: #ffffff;
+  border-radius: 3px;
+  box-shadow: 0 0.0625rem 0.125rem 0 rgba(3, 3, 3, 0.2);
+}
+.pf-topology-control-bar__button {
   display: block;
 }
 .pf-c-tooltip__arrow {
@@ -13,7 +23,17 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
 .pf-l-toolbar__item {
   display: block;
 }
-.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button.pf-u-px-sm.pf-u-mr-xs {
+.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
+  display: block;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  margin-right: 0.25rem;
+  margin-top: 0.25rem;
+  background-color: #ffffff;
+  border-radius: 3px;
+  box-shadow: 0 0.0625rem 0.125rem 0 rgba(3, 3, 3, 0.2);
+}
+.pf-topology-control-bar__button {
   display: block;
 }
 .pf-c-tooltip__arrow {
@@ -25,7 +45,17 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
 .pf-l-toolbar__item {
   display: block;
 }
-.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button.pf-u-px-sm.pf-u-mr-xs.pf-m-disabled {
+.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button.pf-m-disabled {
+  display: block;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  margin-right: 0.25rem;
+  margin-top: 0.25rem;
+  background-color: #ffffff;
+  border-radius: 3px;
+  box-shadow: 0 0.0625rem 0.125rem 0 rgba(3, 3, 3, 0.2);
+}
+.pf-topology-control-bar__button.pf-m-disabled {
   display: block;
 }
 .pf-c-tooltip__arrow {
@@ -193,7 +223,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                 >
                   <Button
                     aria-disabled={false}
-                    className="pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                    className="pf-topology-control-bar__button"
                     disabled={false}
                     id="zoom-in"
                     onClick={[Function]}
@@ -202,7 +232,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                     <button
                       aria-disabled={null}
                       aria-label={null}
-                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
                       disabled={false}
                       id="zoom-in"
                       onClick={[Function]}
@@ -334,7 +364,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                 >
                   <Button
                     aria-disabled={false}
-                    className="pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                    className="pf-topology-control-bar__button"
                     disabled={false}
                     id="zoom-out"
                     onClick={[Function]}
@@ -343,7 +373,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                     <button
                       aria-disabled={null}
                       aria-label={null}
-                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
                       disabled={false}
                       id="zoom-out"
                       onClick={[Function]}
@@ -498,7 +528,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                 >
                   <Button
                     aria-disabled={true}
-                    className="pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs pf-m-disabled"
+                    className="pf-topology-control-bar__button pf-m-disabled"
                     disabled={true}
                     id="reset-view"
                     onClick={[Function]}
@@ -507,7 +537,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                     <button
                       aria-disabled={null}
                       aria-label={null}
-                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs pf-m-disabled"
+                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button pf-m-disabled"
                       disabled={false}
                       id="reset-view"
                       onClick={[Function]}
@@ -600,7 +630,17 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
 `;
 
 exports[`TopologyControlBar should display the default controls correctly 1`] = `
-.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button.pf-u-px-sm.pf-u-mr-xs {
+.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
+  display: block;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  margin-right: 0.25rem;
+  margin-top: 0.25rem;
+  background-color: #ffffff;
+  border-radius: 3px;
+  box-shadow: 0 0.0625rem 0.125rem 0 rgba(3, 3, 3, 0.2);
+}
+.pf-topology-control-bar__button {
   display: block;
 }
 .pf-c-tooltip__arrow {
@@ -612,7 +652,17 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
 .pf-l-toolbar__item {
   display: block;
 }
-.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button.pf-u-px-sm.pf-u-mr-xs {
+.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
+  display: block;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  margin-right: 0.25rem;
+  margin-top: 0.25rem;
+  background-color: #ffffff;
+  border-radius: 3px;
+  box-shadow: 0 0.0625rem 0.125rem 0 rgba(3, 3, 3, 0.2);
+}
+.pf-topology-control-bar__button {
   display: block;
 }
 .pf-c-tooltip__arrow {
@@ -624,7 +674,17 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
 .pf-l-toolbar__item {
   display: block;
 }
-.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button.pf-u-px-sm.pf-u-mr-xs {
+.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
+  display: block;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  margin-right: 0.25rem;
+  margin-top: 0.25rem;
+  background-color: #ffffff;
+  border-radius: 3px;
+  box-shadow: 0 0.0625rem 0.125rem 0 rgba(3, 3, 3, 0.2);
+}
+.pf-topology-control-bar__button {
   display: block;
 }
 .pf-c-tooltip__arrow {
@@ -636,7 +696,17 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
 .pf-l-toolbar__item {
   display: block;
 }
-.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button.pf-u-px-sm.pf-u-mr-xs {
+.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
+  display: block;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  margin-right: 0.25rem;
+  margin-top: 0.25rem;
+  background-color: #ffffff;
+  border-radius: 3px;
+  box-shadow: 0 0.0625rem 0.125rem 0 rgba(3, 3, 3, 0.2);
+}
+.pf-topology-control-bar__button {
   display: block;
 }
 .pf-c-tooltip__arrow {
@@ -648,7 +718,17 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
 .pf-l-toolbar__item {
   display: block;
 }
-.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button.pf-u-px-sm.pf-u-mr-xs {
+.pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
+  display: block;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  margin-right: 0.25rem;
+  margin-top: 0.25rem;
+  background-color: #ffffff;
+  border-radius: 3px;
+  box-shadow: 0 0.0625rem 0.125rem 0 rgba(3, 3, 3, 0.2);
+}
+.pf-topology-control-bar__button {
   display: block;
 }
 .pf-l-toolbar__item {
@@ -823,7 +903,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                 >
                   <Button
                     aria-disabled={false}
-                    className="pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                    className="pf-topology-control-bar__button"
                     disabled={false}
                     id="zoom-in"
                     onClick={[Function]}
@@ -832,7 +912,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                     <button
                       aria-disabled={null}
                       aria-label={null}
-                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
                       disabled={false}
                       id="zoom-in"
                       onClick={[Function]}
@@ -987,7 +1067,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                 >
                   <Button
                     aria-disabled={false}
-                    className="pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                    className="pf-topology-control-bar__button"
                     disabled={false}
                     id="zoom-out"
                     onClick={[Function]}
@@ -996,7 +1076,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                     <button
                       aria-disabled={null}
                       aria-label={null}
-                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
                       disabled={false}
                       id="zoom-out"
                       onClick={[Function]}
@@ -1151,7 +1231,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                 >
                   <Button
                     aria-disabled={false}
-                    className="pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                    className="pf-topology-control-bar__button"
                     disabled={false}
                     id="fit-to-screen"
                     onClick={[Function]}
@@ -1160,7 +1240,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                     <button
                       aria-disabled={null}
                       aria-label={null}
-                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
                       disabled={false}
                       id="fit-to-screen"
                       onClick={[Function]}
@@ -1315,7 +1395,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                 >
                   <Button
                     aria-disabled={false}
-                    className="pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                    className="pf-topology-control-bar__button"
                     disabled={false}
                     id="reset-view"
                     onClick={[Function]}
@@ -1324,7 +1404,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                     <button
                       aria-disabled={null}
                       aria-label={null}
-                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                      className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
                       disabled={false}
                       id="reset-view"
                       onClick={[Function]}
@@ -1418,7 +1498,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
             >
               <Button
                 aria-disabled={false}
-                className="pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                className="pf-topology-control-bar__button"
                 disabled={false}
                 id="legend"
                 onClick={[Function]}
@@ -1427,7 +1507,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                 <button
                   aria-disabled={null}
                   aria-label={null}
-                  className="pf-c-button pf-m-tertiary pf-topology-control-bar__button pf-u-px-sm pf-u-mr-xs"
+                  className="pf-c-button pf-m-tertiary pf-topology-control-bar__button"
                   disabled={false}
                   id="legend"
                   onClick={[Function]}

--- a/packages/patternfly-4/react-topology/src/components/TopologyControlBar/css/topology-controlbar-css.ts
+++ b/packages/patternfly-4/react-topology/src/components/TopologyControlBar/css/topology-controlbar-css.ts
@@ -6,19 +6,23 @@ export const topologyControlbarCss = StyleSheet.parse(`
     bottom: var(--pf-global--spacer--md);
     left: var(--pf-global--spacer--xl);
     
-    .pf-c-button.pf-m-tertiary {
+    &__button.pf-c-button.pf-m-tertiary {
+      padding-left: var(--pf-global--spacer--sm);
+      padding-right: var(--pf-global--spacer--sm);
+      margin-right: var(--pf-global--spacer--xs);
+      margin-top: var(--pf-global--spacer--xs);
       background-color: var(--pf-global--BackgroundColor--100);
       border: none;
       border-radius: var(--pf-global--BorderRadius--sm);
       box-shadow: var(--pf-global--BoxShadow--sm);
-      margin-top: var(--pf-global--spacer--xs);
-    }
-    .pf-c-button.pf-m-tertiary:after {
-      display: none;
-    }
-    .pf-c-button.pf-m-tertiary:hover {
-      border: none;
-      box-shadow: var(--pf-global--BoxShadow--md);
+
+      &:after {
+        display: none;
+      }
+      &:hover {
+        border: none;
+        box-shadow: var(--pf-global--BoxShadow--md);
+      }
     }
   }
 `);

--- a/packages/patternfly-4/react-topology/src/components/TopologyView/__snapshots__/TopologyView.test.tsx.snap
+++ b/packages/patternfly-4/react-topology/src/components/TopologyView/__snapshots__/TopologyView.test.tsx.snap
@@ -43,12 +43,6 @@ exports[`TopologyView should display an empty topology correctly 1`] = `
 `;
 
 exports[`TopologyView should display topology correctly 1`] = `
-.pf-topology-control-bar {
-  display: block;
-  position: absolute;
-  bottom: 1rem;
-  left: 2rem;
-}
 .pf-topology-content {
   display: flex;
   background-color: #ededed;
@@ -141,12 +135,6 @@ exports[`TopologyView should display topology correctly 1`] = `
 `;
 
 exports[`TopologyView should display topology sidebar correctly 1`] = `
-.pf-topology-control-bar {
-  display: block;
-  position: absolute;
-  bottom: 1rem;
-  left: 2rem;
-}
 .pf-topology-content {
   display: flex;
   background-color: #ededed;
@@ -248,12 +236,6 @@ exports[`TopologyView should display topology sidebar correctly 1`] = `
 `;
 
 exports[`TopologyView should display topology w/ open sidebar correctly 1`] = `
-.pf-topology-control-bar {
-  display: block;
-  position: absolute;
-  bottom: 1rem;
-  left: 2rem;
-}
 .pf-topology-content {
   display: flex;
   background-color: #ededed;

--- a/packages/patternfly-4/react-topology/src/components/TopologyView/css/topology-view-css.ts
+++ b/packages/patternfly-4/react-topology/src/components/TopologyView/css/topology-view-css.ts
@@ -10,24 +10,4 @@ export const topologyViewCss = StyleSheet.parse(`
     width: 100%;
     height: 100%;
   }
-
-  .pf-topology-control-bar {
-    position: absolute;
-    bottom: var(--pf-global--spacer--md);
-    left: var(--pf-global--spacer--xl);
-    
-    .pf-c-button.pf-m-tertiary {
-      background-color: var(--pf-global--BackgroundColor--100);
-      border: none;
-      border-radius: var(--pf-global--BorderRadius--sm);
-      box-shadow: var(--pf-global--BoxShadow--sm);
-    }
-    .pf-c-button.pf-m-tertiary:after {
-      display: none;
-    }
-    .pf-c-button.pf-m-tertiary:hover {
-      border: none;
-      box-shadow: var(--pf-global--BoxShadow--md);
-    }
-  }
 `);


### PR DESCRIPTION
Set specifically on control buttons

**What**:
Remove pf-u-* classes from the control bar buttons (not every project will pull these in) and set the styles specifically on the component.
