### PR TITLE
fix(eslint-plugin-react): Pin down eslint-plugin-react to avoid 7.14.0

### DIFF
--- a/packages/eslint-plugin-patternfly-react/package.json
+++ b/packages/eslint-plugin-patternfly-react/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-promise": "^3.7.0",
-    "eslint-plugin-react": "^7.7.0",
+    "eslint-plugin-react": "~7.13.0",
     "eslint-plugin-rulesdir": "^0.1.0",
     "eslint-plugin-standard": "^3.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8178,7 +8178,7 @@ eslint-plugin-node@^6.0.1:
     eslint-plugin-node "^6.0.1"
     eslint-plugin-prettier "^2.6.0"
     eslint-plugin-promise "^3.7.0"
-    eslint-plugin-react "^7.7.0"
+    eslint-plugin-react "~7.13.0"
     eslint-plugin-rulesdir "^0.1.0"
     eslint-plugin-standard "^3.0.1"
 
@@ -8203,9 +8203,10 @@ eslint-plugin-react@7.11.1:
     jsx-ast-utils "^2.0.1"
     prop-types "^15.6.2"
 
-eslint-plugin-react@^7.7.0, eslint-plugin-react@^7.8.2:
+eslint-plugin-react@^7.8.2, eslint-plugin-react@~7.13.0:
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz#bc13fd7101de67996ea51b33873cd9dc2b7e5758"
+  integrity sha512-uA5LrHylu8lW/eAH3bEQe9YdzpPaFd9yAJTwTi/i/BKTD7j6aQMKVAdGM/ML72zD6womuSK7EiGtMKuK06lWjQ==
   dependencies:
     array-includes "^3.0.3"
     doctrine "^2.1.0"


### PR DESCRIPTION
**What**:

Pin down `eslint-plugin-react` to avoid version 7.14.0

`eslint-plugin-react` just released version [7.14.0](https://github.com/yannickcr/eslint-plugin-react/releases/tag/v7.14.0) with the following issue:
https://github.com/yannickcr/eslint-plugin-react/issues/2319

When using the latest version of `patternfly-react-eslint` I am receiving this error:
```sh
VariableDeclarator ASTNodes are not handled by markPropTypesAsUsed
Error: VariableDeclarator ASTNodes are not handled by markPropTypesAsUsed
    at markPropTypesAsUsed (/home/vagrant/foreman/node_modules/eslint-plugin-react/lib/util/usedPropTypes.js:338:15)
    at Object.VariableDeclarator (/home/vagrant/foreman/node_modules/eslint-plugin-react/lib/util/usedPropTypes.js:492:9)
    at updatedRuleInstructions.(anonymous function) (/home/vagrant/foreman/node_modules/eslint-plugin-react/lib/util/Components.js:780:47)
    at listeners.(anonymous function).forEach.listener (/home/vagrant/foreman/node_modules/eslint/lib/util/safe-emitter.js:47:58)
    at Array.forEach (<anonymous>)
    at Object.emit (/home/vagrant/foreman/node_modules/eslint/lib/util/safe-emitter.js:47:38)
    at NodeEventGenerator.applySelector (/home/vagrant/foreman/node_modules/eslint/lib/util/node-event-generator.js:251:26)
    at NodeEventGenerator.applySelectors (/home/vagrant/foreman/node_modules/eslint/lib/util/node-event-generator.js:280:22)
    at NodeEventGenerator.enterNode (/home/vagrant/foreman/node_modules/eslint/lib/util/node-event-generator.js:294:14)
    at CodePathAnalyzer.enterNode (/home/vagrant/foreman/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:608:23)
```