### PR TITLE
fix(expandable): Add button type to the Expandable Component

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Expandable/Expandable.tsx
+++ b/packages/patternfly-4/react-core/src/components/Expandable/Expandable.tsx
@@ -41,6 +41,7 @@ export const Expandable: React.SFC<ExpandableProps> = ({
         isHovered && styles.modifiers.hover,
         isActive && styles.modifiers.active
       )}
+      type="button"
       aria-expanded={isExpanded}
       onClick={onToggle}
     >

--- a/packages/patternfly-4/react-core/src/components/Expandable/__snapshots__/Expandable.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Expandable/__snapshots__/Expandable.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Expandable 1`] = `
     aria-expanded={false}
     className="pf-c-expandable__toggle"
     onClick={[Function]}
+    type="button"
   >
     <AngleRightIcon
       aria-hidden={true}
@@ -36,6 +37,7 @@ exports[`Renders Expandable expanded 1`] = `
     aria-expanded={true}
     className="pf-c-expandable__toggle"
     onClick={[Function]}
+    type="button"
   >
     <AngleRightIcon
       aria-hidden={true}


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Added button type to the component, without which it acts like a submit button on a form.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: None

<!-- feel free to add additional comments -->
Fixes: https://github.com/patternfly/patternfly-react/issues/2339
