### PR TITLE
docs(label): add typescript flag to the label docs

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Label/Label.md
+++ b/packages/patternfly-4/react-core/src/components/Label/Label.md
@@ -1,6 +1,7 @@
 ---
 title: 'Label'
 cssPrefix: 'pf-c-label'
+typescript: true
 propComponents: ['Label']
 ---
 


### PR DESCRIPTION
**What**:

Add the `TS` label to the `Label` navigation link in the documents to indicate that it's written in TypeScript.