### PR TITLE
fix(dropdown): Automatically focus first dropdown item when DropdownMenu mounts

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
@@ -41,16 +41,14 @@ class DropdownMenu extends React.Component {
   refsCollection = [];
 
   componentDidMount() {
-    if (this.props.openedOnEnter) {
-      const focusTarget =
-        this.refsCollection.filter(
-          ref => ref && ((ref.current && !ref.current.hasAttribute('disabled')) || !ref.hasAttribute('disabled'))
-        )[0] || null;
-      if (this.props.component === 'ul') focusTarget && focusTarget.focus();
-      else {
-        (focusTarget.current.focus && focusTarget.current.focus()) ||
-          (focusTarget && ReactDOM.findDOMNode(focusTarget.current).focus()); // eslint-disable-line react/no-find-dom-node
-      }
+    const focusTarget =
+      this.refsCollection.filter(
+        ref => ref && ((ref.current && !ref.current.hasAttribute('disabled')) || !ref.hasAttribute('disabled'))
+      )[0] || null;
+    if (this.props.component === 'ul') focusTarget && focusTarget.focus();
+    else {
+      (focusTarget.current.focus && focusTarget.current.focus()) ||
+        (focusTarget && ReactDOM.findDOMNode(focusTarget.current).focus()); // eslint-disable-line react/no-find-dom-node
     }
   }
 


### PR DESCRIPTION
fix #2083

**What**:
Update DropdownMenu to focus first dropdown item on mount so that keyboard navigation will always work.
