### PR TITLE
fix(charts): adds sparkline example and interpolation to area examples

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
@@ -354,10 +354,10 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   ...rest
 }: ChartProps) => {
   const defaultPadding = {
-    bottom: theme.chart.padding,
-    left: theme.chart.padding,
-    top: theme.chart.padding,
-    right: theme.chart.padding,
+    bottom: theme.chart.padding || 0,
+    left: theme.chart.padding || 0,
+    top: theme.chart.padding || 0,
+    right: theme.chart.padding || 0,
     ...(padding as any)
   };
 

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -5,40 +5,8 @@ typescript: true
 propComponents: ['Chart', 'ChartArea', 'ChartGroup', 'ChartVoronoiContainer']
 ---
 
-import { Chart, ChartArea, ChartAxis, ChartGroup, ChartLegend, ChartLegendWrapper, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartLabel, ChartLegendWrapper, ChartVoronoiContainer } from '@patternfly/react-charts';
 import './chart-area.scss';
-
-## Simple area chart with right-aligned legend
-```js
-import React from 'react';
-import { Chart, ChartArea, ChartGroup } from '@patternfly/react-charts';
-
-<div>
-  <div className="area-chart-legend-right">
-    <Chart
-      legendData={[{ name: 'Cats' }]}
-      legendOrientation="vertical"
-      legendPosition="right"
-      height={200}
-      padding={{
-        right: 200
-      }}
-      width={800}
-    >
-      <ChartGroup>
-        <ChartArea
-          data={[
-            { name: 'Cats', x: 1, y: 3 },
-            { name: 'Cats', x: 2, y: 4 },
-            { name: 'Cats', x: 3, y: 8 },
-            { name: 'Cats', x: 4, y: 6 }
-          ]}
-        />
-      </ChartGroup>
-    </Chart>
-  </div>
-</div>
-```
 
 ## Cyan area chart with tooltip and right-aligned legend
 ```js
@@ -56,6 +24,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiC
       padding={{
         right: 200
       }}
+      maxDomain={{y: 9}}
       themeColor={ChartThemeColor.cyan}
       width={800}
     >
@@ -69,6 +38,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiC
             { name: 'Cats', x: 3, y: 8 },
             { name: 'Cats', x: 4, y: 6 }
           ]}
+          interpolation="basis"
         />
         <ChartArea
           data={[
@@ -78,6 +48,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiC
             { name: 'Birds', x: 4, y: 5 },
             { name: 'Birds', x: 5, y: 6 }
           ]}
+          interpolation="basis"
         />
         <ChartArea
           data={[
@@ -87,6 +58,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiC
             { name: 'Dogs', x: 4, y: 2 },
             { name: 'Dogs', x: 5, y: 4 }
           ]}
+          interpolation="basis"
         />
       </ChartGroup>
     </Chart>
@@ -109,6 +81,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patte
       padding={{
         bottom: 75
       }}
+      maxDomain={{y: 9}}
       themeColor={ChartThemeColor.multi}
       width={650}
     >
@@ -122,6 +95,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patte
             { name: 'Cats', x: 3, y: 8 },
             { name: 'Cats', x: 4, y: 6 }
           ]}
+          interpolation="basis"
         />
         <ChartArea
           data={[
@@ -131,6 +105,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patte
             { name: 'Birds', x: 4, y: 5 },
             { name: 'Birds', x: 5, y: 6 }
           ]}
+          interpolation="basis"
         />
         <ChartArea
           data={[
@@ -140,9 +115,38 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patte
             { name: 'Dogs', x: 4, y: 2 },
             { name: 'Dogs', x: 5, y: 4 }
           ]}
+          interpolation="basis"
         />
       </ChartGroup>
     </Chart>
+  </div>
+</div>
+```
+
+## Sparkline chart
+```js
+import React from 'react';
+import { ChartArea, ChartGroup, ChartLabel } from '@patternfly/react-charts';
+
+<div>
+  <div className="sparkline-container">
+    <div className="sparkline-chart">
+      <ChartGroup
+        height={100}
+        padding={0}
+        width={400}
+      >
+        <ChartArea
+          data={[
+            { name: 'Cats', x: 1, y: 3 },
+            { name: 'Cats', x: 2, y: 4 },
+            { name: 'Cats', x: 3, y: 8 },
+            { name: 'Cats', x: 4, y: 6 }
+          ]}
+        />
+      </ChartGroup>
+    </div>
+    <ChartLabel text="CPU utilization"/>
   </div>
 </div>
 ```

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/chart-area.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/chart-area.scss
@@ -9,5 +9,16 @@
       height: 200px;
       width: 800px;
     }
+
+    .sparkline-chart {
+      height: 100px;
+      width: 400px;
+    }
+
+    .sparkline-container {
+      margin-left: 50px;
+      margin-top: 50px;
+      height: 135px;
+    }
   }
 }


### PR DESCRIPTION
This adds a sparkline example and interpolation (curved lines) to other area examples.

See https://www.patternfly.org/pattern-library/data-visualization/sparkline/

fixes https://github.com/patternfly/patternfly-react/issues/2367

<img width="603" alt="Screen Shot 2019-06-26 at 10 20 43 PM" src="https://user-images.githubusercontent.com/17481322/60228436-a9872700-9860-11e9-903c-02473b83822e.png">

