### PR TITLE
fix(Modal): get modal container from state to set/unset aria-hidden

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Modal/Modal.tsx
+++ b/packages/patternfly-4/react-core/src/components/Modal/Modal.tsx
@@ -73,7 +73,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
   toggleSiblingsFromScreenReaders = (hide: boolean) => {
     const bodyChildren = document.body.children;
     for (const child of Array.from(bodyChildren)) {
-      if (child !== this.container) {
+      if (child !== this.state.container) {
         hide ? child.setAttribute('aria-hidden', '' + hide) : child.removeAttribute('aria-hidden');
       }
     }


### PR DESCRIPTION
**What**:
fixes #2405 

When displaying a modal both the children of the body and the modal container had `aria-hidden=true`. The problem was that the container that was compared with the children is not stored in `this.container` but in the state.

This PR fixes this problem.

//cc @jgiardino 