### PR TITLE
feat(Pagination): Let users enter numbers into the input field

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Pagination/Navigation.tsx
+++ b/packages/patternfly-4/react-core/src/components/Pagination/Navigation.tsx
@@ -77,12 +77,12 @@ export class Navigation extends React.Component<NavigationProps, NavigationState
     return inputPage;
   }
 
-  onChange(event: React.ChangeEvent<HTMLInputElement>, lastPage: number): void {
+  private onChange(event: React.ChangeEvent<HTMLInputElement>, lastPage: number): void {
     const inputPage = this.parseInteger(event.target.value, lastPage);
     this.setState({ userInputPage: Number.isNaN(inputPage as number) ? event.target.value : inputPage });
   }
 
-  onKeyDown(event: React.KeyboardEvent<HTMLInputElement>, page: number | string, lastPage: number, onPageInput: (event: React.SyntheticEvent<HTMLButtonElement>, page: number) => void, onSetPage: (event: React.SyntheticEvent<HTMLButtonElement>, page: number) => void): void {
+  private onKeyDown(event: React.KeyboardEvent<HTMLInputElement>, page: number | string, lastPage: number, onPageInput: (event: React.SyntheticEvent<HTMLButtonElement>, page: number) => void, onSetPage: (event: React.SyntheticEvent<HTMLButtonElement>, page: number) => void): void {
     if (event.keyCode === KEY_CODES.ENTER) {
       const inputPage = this.parseInteger(this.state.userInputPage, lastPage) as number;
       onPageInput(event, Number.isNaN(inputPage) ? page as number : inputPage);

--- a/packages/patternfly-4/react-core/src/components/Pagination/Navigation.tsx
+++ b/packages/patternfly-4/react-core/src/components/Pagination/Navigation.tsx
@@ -26,7 +26,7 @@ export interface NavigationProps extends React.HTMLProps<HTMLElement> {
   /** Accessible label for the pagination component */
   paginationTitle?: string;
   /** The number of the current page */
-  page: number | React.ReactText;
+  page: React.ReactText;
   /** Function called when user sets page */
   onSetPage: (event: React.SyntheticEvent<HTMLButtonElement>, page: number) => void;
   /** Function called when user clicks to navigate to next page */
@@ -42,7 +42,7 @@ export interface NavigationProps extends React.HTMLProps<HTMLElement> {
 }
 
 export interface NavigationState {
-  userInputPage?: React.ReactText | number;
+  userInputPage?: React.ReactText;
 }
 
 export class Navigation extends React.Component<NavigationProps, NavigationState> {
@@ -68,7 +68,7 @@ export class Navigation extends React.Component<NavigationProps, NavigationState
     onPageInput: () => undefined as any,
   };
 
-  private parseInteger(input: React.ReactText, lastPage: number): number | string {
+  private static parseInteger(input: React.ReactText, lastPage: number): number {
     let inputPage = Number.parseInt(input as string, 10);
     if (!Number.isNaN(inputPage)) {
       inputPage = inputPage > lastPage ? lastPage : inputPage;
@@ -78,13 +78,13 @@ export class Navigation extends React.Component<NavigationProps, NavigationState
   }
 
   private onChange(event: React.ChangeEvent<HTMLInputElement>, lastPage: number): void {
-    const inputPage = this.parseInteger(event.target.value, lastPage);
+    const inputPage = Navigation.parseInteger(event.target.value, lastPage);
     this.setState({ userInputPage: Number.isNaN(inputPage as number) ? event.target.value : inputPage });
   }
 
   private onKeyDown(event: React.KeyboardEvent<HTMLInputElement>, page: number | string, lastPage: number, onPageInput: (event: React.SyntheticEvent<HTMLButtonElement>, page: number) => void, onSetPage: (event: React.SyntheticEvent<HTMLButtonElement>, page: number) => void): void {
     if (event.keyCode === KEY_CODES.ENTER) {
-      const inputPage = this.parseInteger(this.state.userInputPage, lastPage) as number;
+      const inputPage = Navigation.parseInteger(this.state.userInputPage, lastPage) as number;
       onPageInput(event, Number.isNaN(inputPage) ? page as number : inputPage);
       onSetPage(event, Number.isNaN(inputPage) ? page as number : inputPage);
     }

--- a/packages/patternfly-4/react-core/src/components/Pagination/Navigation.tsx
+++ b/packages/patternfly-4/react-core/src/components/Pagination/Navigation.tsx
@@ -4,6 +4,7 @@ import { css } from '@patternfly/react-styles';
 import { AngleLeftIcon, AngleDoubleLeftIcon, AngleRightIcon, AngleDoubleRightIcon } from '@patternfly/react-icons';
 import { Button, ButtonVariant } from '../Button';
 import { pluralize } from '../../helpers';
+import { KEY_CODES } from '../../helpers/constants';
 
 export interface NavigationProps extends React.HTMLProps<HTMLElement> {
   /** Additional classes for the container */
@@ -25,7 +26,7 @@ export interface NavigationProps extends React.HTMLProps<HTMLElement> {
   /** Accessible label for the pagination component */
   paginationTitle?: string;
   /** The number of the current page */
-  page: number;
+  page: number | React.ReactText;
   /** Function called when user sets page */
   onSetPage: (event: React.SyntheticEvent<HTMLButtonElement>, page: number) => void;
   /** Function called when user clicks to navigate to next page */
@@ -40,97 +41,148 @@ export interface NavigationProps extends React.HTMLProps<HTMLElement> {
   onPageInput?: (event: React.SyntheticEvent<HTMLButtonElement>, page: number) => void;
 }
 
-export const Navigation: React.FunctionComponent<NavigationProps> = ({
-  page,
-  onSetPage,
-  className = '',
-  lastPage = 0,
-  pagesTitle = '',
-  toLastPage = 'Go to last page',
-  toNextPage = 'Go to next page',
-  toFirstPage = 'Go to first page',
-  toPreviousPage = 'Go to previous page',
-  currPage = 'Current page',
-  paginationTitle = 'Pagination',
-  onNextClick = () => undefined,
-  onPreviousClick = () => undefined,
-  onFirstClick = () => undefined,
-  onLastClick = () => undefined,
-  onPageInput = () => undefined,
-  ...props
-}: NavigationProps) => (
-  <nav className={css(styles.paginationNav, className)} aria-label={paginationTitle} {...props}>
-    <Button
-      variant={ButtonVariant.plain}
-      isDisabled={page === 1}
-      aria-label={toFirstPage}
-      data-action="first"
-      onClick={event => {
-        onFirstClick(event, 1);
-        onSetPage(event, 1);
-      }}
-    >
-      <AngleDoubleLeftIcon />
-    </Button>
-    <Button
-      variant={ButtonVariant.plain}
-      isDisabled={page === 1}
-      data-action="previous"
-      onClick={event => {
-        const newPage = page - 1 >= 1 ? page - 1 : 1;
-        onPreviousClick(event, newPage);
-        onSetPage(event, newPage);
-      }}
-      aria-label={toPreviousPage}
-    >
-      <AngleLeftIcon />
-    </Button>
-    <div className={css(styles.paginationNavPageSelect)}>
-      <input
-        className={css(styles.formControl)}
-        aria-label={currPage}
-        type="number"
-        min="1"
-        max={lastPage}
-        value={page}
-        onChange={event => {
-          let inputPage = Number.parseInt(event.target.value, 10);
-          inputPage = Number.isNaN(inputPage) ? page : inputPage;
-          inputPage = inputPage > lastPage ? lastPage : inputPage;
-          inputPage = inputPage < 1 ? 1 : inputPage;
-          onSetPage(event, Number.isNaN(inputPage) ? page : inputPage);
-          onPageInput(event, Number.isNaN(inputPage) ? page : inputPage);
-        }}
-      />
-      <span aria-hidden="true">
-        of {pluralize(lastPage, pagesTitle)}
-      </span>
-    </div>
-    <Button
-      variant={ButtonVariant.plain}
-      isDisabled={page === lastPage}
-      aria-label={toNextPage}
-      data-action="next"
-      onClick={event => {
-        const newPage = page + 1 <= lastPage ? page + 1 : lastPage;
-        onNextClick(event, newPage);
-        onSetPage(event, newPage);
-      }}
-    >
-      <AngleRightIcon />
-    </Button>
-    <Button
-      variant={ButtonVariant.plain}
-      isDisabled={page === lastPage}
-      aria-label={toLastPage}
-      data-action="last"
-      onClick={event => {
-        onLastClick(event, lastPage);
-        onSetPage(event, lastPage);
-      }}
-    >
-      <AngleDoubleRightIcon />
-    </Button>
-  </nav>
-);
+export interface NavigationState {
+  userInputPage?: React.ReactText | number;
+}
 
+export class Navigation extends React.Component<NavigationProps, NavigationState> {
+  constructor(props: NavigationProps) {
+    super(props);
+    this.state = { userInputPage: this.props.page };
+  }
+
+  static defaultProps = {
+    className: '',
+    lastPage: 0,
+    pagesTitle: '',
+    toLastPage: 'Go to last page',
+    toNextPage: 'Go to next page',
+    toFirstPage: 'Go to first page',
+    toPreviousPage: 'Go to previous page',
+    currPage: 'Current page',
+    paginationTitle: 'Pagination',
+    onNextClick: () => undefined as any,
+    onPreviousClick: () => undefined as any,
+    onFirstClick: () => undefined as any,
+    onLastClick: () => undefined as any,
+    onPageInput: () => undefined as any,
+  };
+
+  private parseInteger(input: React.ReactText, lastPage: number): number | string {
+    let inputPage = Number.parseInt(input as string, 10);
+    if (!Number.isNaN(inputPage)) {
+      inputPage = inputPage > lastPage ? lastPage : inputPage;
+      inputPage = inputPage < 1 ? 1 : inputPage;
+    }
+    return inputPage;
+  }
+
+  onChange(event: React.ChangeEvent<HTMLInputElement>, lastPage: number): void {
+    const inputPage = this.parseInteger(event.target.value, lastPage);
+    this.setState({ userInputPage: Number.isNaN(inputPage as number) ? event.target.value : inputPage });
+  }
+
+  onKeyDown(event: React.KeyboardEvent<HTMLInputElement>, page: number | string, lastPage: number, onPageInput: (event: React.SyntheticEvent<HTMLButtonElement>, page: number) => void, onSetPage: (event: React.SyntheticEvent<HTMLButtonElement>, page: number) => void): void {
+    if (event.keyCode === KEY_CODES.ENTER) {
+      const inputPage = this.parseInteger(this.state.userInputPage, lastPage) as number;
+      onPageInput(event, Number.isNaN(inputPage) ? page as number : inputPage);
+      onSetPage(event, Number.isNaN(inputPage) ? page as number : inputPage);
+    }
+  }
+
+  render () {
+    const {
+      page,
+      lastPage,
+      pagesTitle,
+      toLastPage,
+      toNextPage,
+      toFirstPage,
+      toPreviousPage,
+      currPage,
+      paginationTitle,
+      onSetPage,
+      onNextClick,
+      onPreviousClick,
+      onFirstClick,
+      onLastClick,
+      onPageInput,
+      className,
+      ...props
+    } = this.props;
+    const { userInputPage } = this.state;
+    return (
+      <nav className={css(styles.paginationNav, className)} aria-label={paginationTitle} {...props}>
+        <Button
+          variant={ButtonVariant.plain}
+          isDisabled={page === 1}
+          aria-label={toFirstPage}
+          data-action="first"
+          onClick={event => {
+            onFirstClick(event, 1);
+            onSetPage(event, 1);
+            this.setState({ userInputPage: 1 });
+          }}
+        >
+          <AngleDoubleLeftIcon />
+        </Button>
+        <Button
+          variant={ButtonVariant.plain}
+          isDisabled={page === 1}
+          data-action="previous"
+          onClick={event => {
+            const newPage = page as number - 1 >= 1 ? page as number - 1 : 1;
+            onPreviousClick(event, newPage);
+            onSetPage(event, newPage);
+            this.setState({ userInputPage: newPage });
+          }}
+          aria-label={toPreviousPage}
+        >
+          <AngleLeftIcon />
+        </Button>
+        <div className={css(styles.paginationNavPageSelect)}>
+          <input
+            className={css(styles.formControl)}
+            aria-label={currPage}
+            type="number"
+            min="1"
+            max={lastPage}
+            value={userInputPage}
+            onKeyDown={event => this.onKeyDown(event, page, lastPage, onPageInput, onSetPage)}
+            onChange={event => this.onChange(event, lastPage)}
+          />
+          <span aria-hidden="true">
+            of {pluralize(lastPage, pagesTitle)}
+          </span>
+        </div>
+        <Button
+          variant={ButtonVariant.plain}
+          isDisabled={page === lastPage}
+          aria-label={toNextPage}
+          data-action="next"
+          onClick={event => {
+            const newPage = page as number + 1 <= lastPage ? page as number + 1 : lastPage;
+            onNextClick(event, newPage);
+            onSetPage(event, newPage);
+            this.setState({ userInputPage: newPage });
+          }}
+        >
+          <AngleRightIcon />
+        </Button>
+        <Button
+          variant={ButtonVariant.plain}
+          isDisabled={page === lastPage}
+          aria-label={toLastPage}
+          data-action="last"
+          onClick={event => {
+            onLastClick(event, lastPage);
+            onSetPage(event, lastPage);
+            this.setState({ userInputPage: lastPage });
+          }}
+        >
+          <AngleDoubleRightIcon />
+        </Button>
+      </nav>
+    );
+  }
+}

--- a/packages/patternfly-4/react-core/src/components/Pagination/Pagination.test.js
+++ b/packages/patternfly-4/react-core/src/components/Pagination/Pagination.test.js
@@ -111,7 +111,8 @@ describe('API', () => {
       wrapper
         .find('input')
         .first()
-        .simulate('change', { target: { value: '1' } });
+        .simulate('change', { target: { value: '1' } })
+        .simulate('keydown', { keyCode: 13 });
       expect(onSetPage.mock.calls).toHaveLength(1);
       expect(onSetPage.mock.calls[0][1]).toBe(1);
     });
@@ -121,7 +122,8 @@ describe('API', () => {
       wrapper
         .find('input')
         .first()
-        .simulate('change', { target: { value: 'a' } });
+        .simulate('change', { target: { value: 'a' } })
+        .simulate('keydown', { keyCode: 13 });
       expect(onSetPage.mock.calls).toHaveLength(1);
       expect(onSetPage.mock.calls[0][1]).toBe(1);
     });
@@ -131,7 +133,8 @@ describe('API', () => {
       wrapper
         .find('input')
         .first()
-        .simulate('change', { target: { value: '10' } });
+        .simulate('change', { target: { value: '10' } })
+        .simulate('keydown', { keyCode: 13 });
       expect(onSetPage.mock.calls).toHaveLength(1);
       expect(onSetPage.mock.calls[0][1]).toBe(4);
     });
@@ -141,7 +144,8 @@ describe('API', () => {
       wrapper
         .find('input')
         .first()
-        .simulate('change', { target: { value: '-10' } });
+        .simulate('change', { target: { value: '-10' } })
+        .simulate('keydown', { keyCode: 13 });
       expect(onSetPage.mock.calls).toHaveLength(1);
       expect(onSetPage.mock.calls[0][1]).toBe(1);
     });

--- a/packages/patternfly-4/react-core/src/components/Pagination/__snapshots__/Pagination.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Pagination/__snapshots__/Pagination.test.js.snap
@@ -391,7 +391,8 @@ exports[`component render custom pagination toggle 1`] = `
         </Dropdown>
       </div>
     </PaginationOptionsMenu>
-    <Component
+    <Navigation
+      className=""
       currPage="Current page"
       lastPage={4}
       onFirstClick={[Function]}
@@ -511,6 +512,7 @@ exports[`component render custom pagination toggle 1`] = `
             max={4}
             min="1"
             onChange={[Function]}
+            onKeyDown={[Function]}
             type="number"
             value={1}
           />
@@ -612,7 +614,7 @@ exports[`component render custom pagination toggle 1`] = `
           </button>
         </Component>
       </nav>
-    </Component>
+    </Navigation>
   </div>
 </Component>
 `;
@@ -893,7 +895,8 @@ exports[`component render custom perPageOptions 1`] = `
         </Dropdown>
       </div>
     </PaginationOptionsMenu>
-    <Component
+    <Navigation
+      className=""
       currPage="Current page"
       lastPage={4}
       onFirstClick={[Function]}
@@ -1013,6 +1016,7 @@ exports[`component render custom perPageOptions 1`] = `
             max={4}
             min="1"
             onChange={[Function]}
+            onKeyDown={[Function]}
             type="number"
             value={1}
           />
@@ -1114,7 +1118,7 @@ exports[`component render custom perPageOptions 1`] = `
           </button>
         </Component>
       </nav>
-    </Component>
+    </Navigation>
   </div>
 </Component>
 `;
@@ -1529,7 +1533,8 @@ exports[`component render custom start end 1`] = `
         </Dropdown>
       </div>
     </PaginationOptionsMenu>
-    <Component
+    <Navigation
+      className=""
       currPage="Current page"
       lastPage={4}
       onFirstClick={[Function]}
@@ -1649,6 +1654,7 @@ exports[`component render custom start end 1`] = `
             max={4}
             min="1"
             onChange={[Function]}
+            onKeyDown={[Function]}
             type="number"
             value={1}
           />
@@ -1750,7 +1756,7 @@ exports[`component render custom start end 1`] = `
           </button>
         </Component>
       </nav>
-    </Component>
+    </Navigation>
   </div>
 </Component>
 `;
@@ -1876,7 +1882,8 @@ exports[`component render empty per page options 1`] = `
         </Dropdown>
       </div>
     </PaginationOptionsMenu>
-    <Component
+    <Navigation
+      className=""
       currPage="Current page"
       lastPage={4}
       onFirstClick={[Function]}
@@ -1996,6 +2003,7 @@ exports[`component render empty per page options 1`] = `
             max={4}
             min="1"
             onChange={[Function]}
+            onKeyDown={[Function]}
             type="number"
             value={1}
           />
@@ -2097,7 +2105,7 @@ exports[`component render empty per page options 1`] = `
           </button>
         </Component>
       </nav>
-    </Component>
+    </Navigation>
   </div>
 </Component>
 `;
@@ -2512,7 +2520,8 @@ exports[`component render last page 1`] = `
         </Dropdown>
       </div>
     </PaginationOptionsMenu>
-    <Component
+    <Navigation
+      className=""
       currPage="Current page"
       lastPage={2}
       onFirstClick={[Function]}
@@ -2632,6 +2641,7 @@ exports[`component render last page 1`] = `
             max={2}
             min="1"
             onChange={[Function]}
+            onKeyDown={[Function]}
             type="number"
             value={2}
           />
@@ -2733,7 +2743,7 @@ exports[`component render last page 1`] = `
           </button>
         </Component>
       </nav>
-    </Component>
+    </Navigation>
   </div>
 </Component>
 `;
@@ -3147,7 +3157,8 @@ exports[`component render limited number of pages 1`] = `
         </Dropdown>
       </div>
     </PaginationOptionsMenu>
-    <Component
+    <Navigation
+      className=""
       currPage="Current page"
       lastPage={1}
       onFirstClick={[Function]}
@@ -3267,6 +3278,7 @@ exports[`component render limited number of pages 1`] = `
             max={1}
             min="1"
             onChange={[Function]}
+            onKeyDown={[Function]}
             type="number"
             value={1}
           />
@@ -3368,7 +3380,7 @@ exports[`component render limited number of pages 1`] = `
           </button>
         </Component>
       </nav>
-    </Component>
+    </Navigation>
   </div>
 </Component>
 `;
@@ -3781,7 +3793,8 @@ exports[`component render no items 1`] = `
         </Dropdown>
       </div>
     </PaginationOptionsMenu>
-    <Component
+    <Navigation
+      className=""
       currPage="Current page"
       lastPage={0}
       onFirstClick={[Function]}
@@ -3901,6 +3914,7 @@ exports[`component render no items 1`] = `
             max={0}
             min="1"
             onChange={[Function]}
+            onKeyDown={[Function]}
             type="number"
             value={1}
           />
@@ -4002,7 +4016,7 @@ exports[`component render no items 1`] = `
           </button>
         </Component>
       </nav>
-    </Component>
+    </Navigation>
   </div>
 </Component>
 `;
@@ -4411,7 +4425,8 @@ exports[`component render should render correctly bottom 1`] = `
         </Dropdown>
       </div>
     </PaginationOptionsMenu>
-    <Component
+    <Navigation
+      className=""
       currPage="Current page"
       lastPage={2}
       onFirstClick={[Function]}
@@ -4531,6 +4546,7 @@ exports[`component render should render correctly bottom 1`] = `
             max={2}
             min="1"
             onChange={[Function]}
+            onKeyDown={[Function]}
             type="number"
             value={1}
           />
@@ -4632,7 +4648,7 @@ exports[`component render should render correctly bottom 1`] = `
           </button>
         </Component>
       </nav>
-    </Component>
+    </Navigation>
   </div>
 </Component>
 `;
@@ -5045,7 +5061,8 @@ exports[`component render should render correctly top 1`] = `
         </Dropdown>
       </div>
     </PaginationOptionsMenu>
-    <Component
+    <Navigation
+      className=""
       currPage="Current page"
       lastPage={2}
       onFirstClick={[Function]}
@@ -5165,6 +5182,7 @@ exports[`component render should render correctly top 1`] = `
             max={2}
             min="1"
             onChange={[Function]}
+            onKeyDown={[Function]}
             type="number"
             value={1}
           />
@@ -5266,7 +5284,7 @@ exports[`component render should render correctly top 1`] = `
           </button>
         </Component>
       </nav>
-    </Component>
+    </Navigation>
   </div>
 </Component>
 `;
@@ -5685,7 +5703,9 @@ exports[`component render titles 1`] = `
         </Dropdown>
       </div>
     </PaginationOptionsMenu>
-    <Component
+    <Navigation
+      className=""
+      currPage="Current page"
       lastPage={4}
       onFirstClick={[Function]}
       onLastClick={[Function]}
@@ -5694,6 +5714,12 @@ exports[`component render titles 1`] = `
       onPreviousClick={[Function]}
       onSetPage={[Function]}
       page={1}
+      pagesTitle=""
+      paginationTitle="Pagination"
+      toFirstPage="Go to first page"
+      toLastPage="Go to last page"
+      toNextPage="Go to next page"
+      toPreviousPage="Go to previous page"
     >
       <nav
         aria-label="Pagination"
@@ -5798,6 +5824,7 @@ exports[`component render titles 1`] = `
             max={4}
             min="1"
             onChange={[Function]}
+            onKeyDown={[Function]}
             type="number"
             value={1}
           />
@@ -5899,7 +5926,7 @@ exports[`component render titles 1`] = `
           </button>
         </Component>
       </nav>
-    </Component>
+    </Navigation>
   </div>
 </Component>
 `;
@@ -6313,7 +6340,8 @@ exports[`component render up drop direction 1`] = `
         </Dropdown>
       </div>
     </PaginationOptionsMenu>
-    <Component
+    <Navigation
+      className=""
       currPage="Current page"
       lastPage={4}
       onFirstClick={[Function]}
@@ -6433,6 +6461,7 @@ exports[`component render up drop direction 1`] = `
             max={4}
             min="1"
             onChange={[Function]}
+            onKeyDown={[Function]}
             type="number"
             value={1}
           />
@@ -6534,7 +6563,7 @@ exports[`component render up drop direction 1`] = `
           </button>
         </Component>
       </nav>
-    </Component>
+    </Navigation>
   </div>
 </Component>
 `;

--- a/packages/patternfly-4/react-integration/cypress/integration/pagination.spec.ts
+++ b/packages/patternfly-4/react-integration/cypress/integration/pagination.spec.ts
@@ -58,7 +58,11 @@ describe('Login Page Demo Test', () => {
           .then(toggleText => expect(toggleText).to.have.text('11 - 20 of 523 items'));
         cy.get('#pagination-options-menu-top').find('.pf-c-pagination__nav-page-select input')
           .then(input => expect(input).to.have.value('2'));
+      });
 
+    cy.get('#pagination-options-menu-bottom').find('button[data-action="next"]')
+      .then((button: JQuery<HTMLButtonElement>) => {
+        cy.wrap(button).click();
         cy.get('#pagination-options-menu-bottom').find('button[data-action="first"]')
           .then(firstButton => expect(firstButton).not.to.be.disabled);
         cy.get('#pagination-options-menu-bottom').find('button[data-action="previous"]')
@@ -67,6 +71,7 @@ describe('Login Page Demo Test', () => {
           .then(toggleText => expect(toggleText).to.have.text('11 - 20 of 523 items'));
         cy.get('#pagination-options-menu-bottom').find('.pf-c-pagination__nav-page-select input')
           .then(input => expect(input).to.have.value('2'));
-    });
+      });
+
   });
 });

--- a/packages/patternfly-4/react-integration/cypress/integration/pagination.spec.ts
+++ b/packages/patternfly-4/react-integration/cypress/integration/pagination.spec.ts
@@ -1,4 +1,4 @@
-describe('Login Page Demo Test', () => {
+describe('Pagination Demo Test', () => {
   it('Navigate to Pagination section', () => {
     cy.visit('http://localhost:3000/');
     cy.get('#pagination-demo-nav-item-link').click();

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/PaginationDemo/PaginationDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/PaginationDemo/PaginationDemo.tsx
@@ -5,19 +5,27 @@ import {
 } from '@patternfly/react-core';
 
 type OptionsMenuDemoState = {
-  page: number,
+  topPage: number,
+  bottomPage: number,
   perPage: number,
 }
 
 export class PaginationDemo extends React.Component<React.HTMLProps<HTMLDivElement>, OptionsMenuDemoState> {
   state = {
-    page: 1,
+    topPage: 1,
+    bottomPage: 1,
     perPage: 20,
   };
 
-  onSetPage = (_event, pageNumber) => {
+  onSetTopPage = (_event, pageNumber) => {
     this.setState({
-      page: pageNumber
+      topPage: pageNumber
+    });
+  };
+
+  onSetBottomPage = (_event, pageNumber) => {
+    this.setState({
+      bottomPage: pageNumber
     });
   };
 
@@ -34,8 +42,8 @@ export class PaginationDemo extends React.Component<React.HTMLProps<HTMLDivEleme
         <Pagination
           itemCount={523}
           perPage={this.state.perPage}
-          page={this.state.page}
-          onSetPage={this.onSetPage}
+          page={this.state.topPage}
+          onSetPage={this.onSetTopPage}
           widgetId="pagination-options-menu-top"
           onPerPageSelect={this.onPerPageSelect}
         />
@@ -43,9 +51,9 @@ export class PaginationDemo extends React.Component<React.HTMLProps<HTMLDivEleme
           itemCount={523}
           widgetId="pagination-options-menu-bottom"
           perPage={this.state.perPage}
-          page={this.state.page}
+          page={this.state.bottomPage}
           variant={PaginationVariant.bottom}
-          onSetPage={this.onSetPage}
+          onSetPage={this.onSetBottomPage}
           onPerPageSelect={this.onPerPageSelect}
         />
       </React.Fragment>


### PR DESCRIPTION
Users can now enter numbers into the input field without highlighting the page number in the input field. You have to hit enter in order for the change to go through and affect the dropdown/buttons. Non-integer inputs will default to the previous page number on enter.

Fixes #2344.