### PR TITLE
chore(core): undo 4.0.0 release again

### DIFF
--- a/packages/patternfly-4/react-core/CHANGELOG.md
+++ b/packages/patternfly-4/react-core/CHANGELOG.md
@@ -17,8 +17,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **Select:** convert to Typescript ([#2201](https://github.com/patternfly/patternfly-react/issues/2201)) ([fd9fca1](https://github.com/patternfly/patternfly-react/commit/fd9fca1))
 
 
-### BREAKING CHANGES
-
 * **Select:** Checkbox select variant collapsed into Select. CheckboxSelectGroup now is a generic
 Select Group to be used in any variant.
 
@@ -48,7 +46,7 @@ update tests, minor fixes
 
 
 
-## [4.1.2](https://github.com/patternfly/patternfly-react/compare/@patternfly/react-core@4.1.1...@patternfly/react-core@4.1.2) (2019-07-01)
+# (2019-07-01)
 
 
 ### Bug Fixes
@@ -59,7 +57,7 @@ update tests, minor fixes
 
 
 
-## [4.1.1](https://github.com/patternfly/patternfly-react/compare/@patternfly/react-core@4.1.0...@patternfly/react-core@4.1.1) (2019-07-01)
+# (2019-07-01)
 
 **Note:** Version bump only for package @patternfly/react-core
 
@@ -67,7 +65,7 @@ update tests, minor fixes
 
 
 
-# [4.1.0](https://github.com/patternfly/patternfly-react/compare/@patternfly/react-core@4.0.0...@patternfly/react-core@4.1.0) (2019-07-01)
+# (2019-07-01)
 
 
 ### Features
@@ -78,7 +76,7 @@ update tests, minor fixes
 
 
 
-# [4.0.0](https://github.com/patternfly/patternfly-react/compare/@patternfly/react-core@3.58.0...@patternfly/react-core@4.0.0) (2019-07-01)
+# (2019-07-01)
 
 
 ### Features

--- a/packages/patternfly-4/react-core/package.json
+++ b/packages/patternfly-4/react-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternfly/react-core",
-  "version": "4.0.0",
+  "version": "3.58.0",
   "description": "This library provides a set of common React components for use with the PatternFly reference implementation.",
   "main": "dist/js/index.js",
   "module": "dist/esm/index.js",

--- a/packages/patternfly-4/react-docs/package.json
+++ b/packages/patternfly-4/react-docs/package.json
@@ -17,7 +17,7 @@
     "@mdx-js/mdx": "1.0.2",
     "@mdx-js/react": "1.0.2",
     "@patternfly/patternfly": "2.17.0",
-    "@patternfly/react-core": "^4.0.0",
+    "@patternfly/react-core": "^3.58.0",
     "@patternfly/react-icons": "^3.10.6",
     "@patternfly/react-virtualized-extension": "^1.1.44",
     "gatsby": "2.3.14",

--- a/packages/patternfly-4/react-inline-edit-extension/package.json
+++ b/packages/patternfly-4/react-inline-edit-extension/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/patternfly-4/",
   "dependencies": {
     "@patternfly/patternfly": "2.17.0",
-    "@patternfly/react-core": "^4.0.0",
+    "@patternfly/react-core": "^3.58.0",
     "@patternfly/react-icons": "^3.10.6",
     "@patternfly/react-styles": "^3.4.6",
     "@patternfly/react-table": "^2.13.42",

--- a/packages/patternfly-4/react-integration/demo-app-ts/package.json
+++ b/packages/patternfly-4/react-integration/demo-app-ts/package.json
@@ -7,7 +7,7 @@
     "start:demo-app": "react-scripts start"
   },
   "dependencies": {
-    "@patternfly/react-core": "^4.0.0",
+    "@patternfly/react-core": "^3.58.0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-router": "^4.3.1",

--- a/packages/patternfly-4/react-table/package.json
+++ b/packages/patternfly-4/react-table/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/patternfly-4/react-table#readme",
   "dependencies": {
     "@patternfly/patternfly": "2.17.0",
-    "@patternfly/react-core": "^4.0.0",
+    "@patternfly/react-core": "^3.58.0",
     "@patternfly/react-icons": "^3.10.6",
     "@patternfly/react-styles": "^3.4.6",
     "@patternfly/react-tokens": "^2.6.5",

--- a/packages/patternfly-4/react-topology/package.json
+++ b/packages/patternfly-4/react-topology/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/patternfly-4/react-topology#readme",
   "dependencies": {
-    "@patternfly/react-core": "^4.0.0",
+    "@patternfly/react-core": "^3.58.0",
     "@patternfly/react-icons": "^3.10.6",
     "@patternfly/react-styles": "^3.4.6"
   },

--- a/packages/patternfly-4/react-virtualized-extension/package.json
+++ b/packages/patternfly-4/react-virtualized-extension/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/patternfly/patternfly-react/tree/master/packages/patternfly-4/",
   "dependencies": {
     "@patternfly/patternfly": "2.17.0",
-    "@patternfly/react-core": "^4.0.0",
+    "@patternfly/react-core": "^3.58.0",
     "@patternfly/react-icons": "^3.10.6",
     "@patternfly/react-styles": "^3.4.6",
     "clsx": "^1.0.1",


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: This time I moved the git `@patternfly/react-core@3.58.0` tag, so lerna should try to release 3.58.1 now!

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
