### PR TITLE
fix(Chart): Fix runtime errors related to theme padding

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
+import { isFinite } from 'lodash';
+
 import {
   AnimatePropTypeInterface,
+  BlockProps,
   D3Scale,
   DomainPropType,
   DomainPaddingPropType,
@@ -12,7 +15,7 @@ import {
   VictoryChart,
   VictoryChartProps,
   VictoryStyleInterface,
-  VictoryZoomContainer
+  VictoryZoomContainer,
 } from 'victory';
 import {
   ChartLegend,
@@ -22,6 +25,7 @@ import {
 } from "../ChartLegend";
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
+import { getPaddingForSide } from '../ChartUtils/chart-padding';
 
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
@@ -353,12 +357,12 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   width = theme.chart.width,
   ...rest
 }: ChartProps) => {
+
   const defaultPadding = {
-    bottom: theme.chart.padding || 0,
-    left: theme.chart.padding || 0,
-    top: theme.chart.padding || 0,
-    right: theme.chart.padding || 0,
-    ...(padding as any)
+    bottom: getPaddingForSide('bottom',  padding, theme.chart.padding),
+    left: getPaddingForSide('left', padding, theme.chart.padding),
+    right: getPaddingForSide('right', padding, theme.chart.padding),
+    top: getPaddingForSide('top', padding, theme.chart.padding),
   };
 
   const chartSize = {

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-padding.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-padding.ts
@@ -1,0 +1,14 @@
+import { get, isEmpty, isFinite } from 'lodash';
+import { PaddingProps } from 'victory';
+
+export const getPaddingForSide = (side: 'bottom' | 'left' | 'right' | 'top', padding: PaddingProps, fallback: PaddingProps): number => {
+  if (!isEmpty(padding)) {
+    return get(padding, side, 0);
+  }
+
+  if (isFinite(padding)) {
+    return padding as number;
+  }
+
+  return getPaddingForSide(side, fallback, 0);
+}


### PR DESCRIPTION
Add more robust logic for setting padding values in Chart component

fix #2429

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
- Add new util function for getting padding values from props and falling back to the theme
- Use new util function in Chart component to get default padding values

