### PR TITLE
fix(charts): add default padding to chart examples

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
@@ -344,7 +344,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   containerComponent = allowZoom ? <VictoryZoomContainer /> : undefined,
   legendData,
   legendPosition = ChartCommonStyles.legend.position as ChartLegendPosition,
-  padding = {},
+  padding,
   standalone = true,
   themeColor,
   themeVariant,

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -22,7 +22,10 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiC
       legendPosition="right"
       height={200}
       padding={{
-        right: 200
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accomodate legend
+        top: 50
       }}
       maxDomain={{y: 9}}
       themeColor={ChartThemeColor.cyan}
@@ -79,7 +82,10 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patte
       legendPosition="bottom"
       height={225}
       padding={{
-        bottom: 75
+        bottom: 75, // Adjusted to accomodate legend
+        left: 50,
+        right: 50,
+        top: 50,
       }}
       maxDomain={{y: 9}}
       themeColor={ChartThemeColor.multi}

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -23,7 +23,10 @@ import { Chart, ChartBar } from '@patternfly/react-charts';
       legendPosition="right"
       height={250}
       padding={{
-        right: 200
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accomodate legend
+        top: 50
       }}
       width={600}
     >
@@ -48,7 +51,10 @@ import { Chart, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-
       legendPosition="right"
       height={250}
       padding={{
-        right: 200
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accomodate legend
+        top: 50
       }}
       themeColor={ChartThemeColor.purple}
       width={600}
@@ -80,7 +86,10 @@ import { Chart, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-
       legendPosition="bottom"
       height={400}
       padding={{
-        bottom: 75
+        bottom: 75, // Adjusted to accomodate legend
+        left: 50,
+        right: 50,
+        top: 50
       }}
       themeColor={ChartThemeColor.multi}
       width={450}

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -22,7 +22,10 @@ import { Chart, ChartAxis, ChartGroup, ChartLine } from '@patternfly/react-chart
       legendPosition="right"
       height={250}
       padding={{
-        right: 200
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accomodate legend
+        top: 50
       }}
       width={600}
     >
@@ -58,7 +61,10 @@ import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor } from '@patte
       legendTitle="Average number of pets"
       height={250}
       padding={{
-        right: 200
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accomodate legend
+        top: 50
       }}
       themeColor={ChartThemeColor.green}
       width={600}
@@ -124,7 +130,10 @@ import { VictoryZoomContainer } from 'victory';
       legendTitle="Average number of pets"
       height={275}
       padding={{
-        bottom: 75
+        bottom: 75, // Adjusted to accomodate legend
+        left: 50,
+        right: 50,
+        top: 50
       }}
       themeColor={ChartThemeColor.multi}
       width={450}

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -21,7 +21,10 @@ import { Chart, ChartStack } from '@patternfly/react-charts';
       legendPosition="right"
       height={250}
       padding={{
-        right: 200
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accomodate legend
+        top: 50
       }}
       width={600}
     >
@@ -49,7 +52,10 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
       legendPosition="bottom"
       height={275}
       padding={{
-        bottom: 75
+        bottom: 75, // Adjusted to accomodate legend
+        left: 50,
+        right: 50, 
+        top: 50
       }}
       themeColor={ChartThemeColor.gold}
       width={450}
@@ -81,7 +87,10 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
       legendPosition="bottom"
       height={275}
       padding={{
-        bottom: 75
+        bottom: 75, // Adjusted to accomodate legend
+        left: 50,
+        right: 50, 
+        top: 50
       }}
       themeColor={ChartThemeColor.multi}
       width={450}


### PR DESCRIPTION
Adds default padding to chart examples.

fixes https://github.com/patternfly/patternfly-react/issues/2437
