### PR TITLE
Update chart theme to use pf-core variables

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
@@ -344,7 +344,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   containerComponent = allowZoom ? <VictoryZoomContainer /> : undefined,
   legendData,
   legendPosition = ChartCommonStyles.legend.position as ChartLegendPosition,
-  padding = {},
+  padding,
   standalone = true,
   themeColor,
   themeVariant,

--- a/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.tsx.snap
@@ -2176,7 +2176,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2206,7 +2206,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -2214,13 +2214,15 @@ exports[`Chart 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2228,8 +2230,11 @@ exports[`Chart 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -2248,11 +2253,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2280,7 +2287,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2293,7 +2300,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2306,7 +2313,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2318,7 +2325,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2330,7 +2337,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2360,7 +2367,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2401,12 +2408,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2444,7 +2452,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2452,7 +2460,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -2474,12 +2482,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2498,15 +2507,17 @@ exports[`Chart 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -2528,12 +2539,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2574,7 +2586,7 @@ exports[`Chart 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -2607,7 +2619,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -4800,7 +4812,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4830,7 +4842,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -4838,13 +4850,15 @@ exports[`Chart 2`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4852,8 +4866,11 @@ exports[`Chart 2`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -4872,11 +4889,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4904,7 +4923,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4917,7 +4936,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4930,7 +4949,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4942,7 +4961,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4954,7 +4973,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -4984,7 +5003,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -5025,12 +5044,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -5068,7 +5088,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -5076,7 +5096,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -5098,12 +5118,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -5122,15 +5143,17 @@ exports[`Chart 2`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -5152,12 +5175,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -5198,7 +5222,7 @@ exports[`Chart 2`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -5231,7 +5255,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -7429,7 +7453,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7459,7 +7483,7 @@ exports[`renders axis and component children 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -7467,13 +7491,15 @@ exports[`renders axis and component children 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7481,8 +7507,11 @@ exports[`renders axis and component children 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -7501,11 +7530,13 @@ exports[`renders axis and component children 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7533,7 +7564,7 @@ exports[`renders axis and component children 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7546,7 +7577,7 @@ exports[`renders axis and component children 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7559,7 +7590,7 @@ exports[`renders axis and component children 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7571,7 +7602,7 @@ exports[`renders axis and component children 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7583,7 +7614,7 @@ exports[`renders axis and component children 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7613,7 +7644,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7654,12 +7685,13 @@ exports[`renders axis and component children 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7697,7 +7729,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7705,7 +7737,7 @@ exports[`renders axis and component children 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -7727,12 +7759,13 @@ exports[`renders axis and component children 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7751,15 +7784,17 @@ exports[`renders axis and component children 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -7781,12 +7816,13 @@ exports[`renders axis and component children 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -7827,7 +7863,7 @@ exports[`renders axis and component children 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -7860,7 +7896,7 @@ exports[`renders axis and component children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -89,7 +89,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -97,13 +97,15 @@ exports[`Chart 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -111,8 +113,11 @@ exports[`Chart 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -131,11 +136,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -163,7 +170,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -176,7 +183,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -189,7 +196,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -201,7 +208,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -213,7 +220,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -243,7 +250,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -284,12 +291,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -327,7 +335,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -335,7 +343,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -357,12 +365,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -381,15 +390,17 @@ exports[`Chart 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -411,12 +422,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -457,7 +469,7 @@ exports[`Chart 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -490,7 +502,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -565,7 +577,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -595,7 +607,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -603,13 +615,15 @@ exports[`Chart 2`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -617,8 +631,11 @@ exports[`Chart 2`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -637,11 +654,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -669,7 +688,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -682,7 +701,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -695,7 +714,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -707,7 +726,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -719,7 +738,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -749,7 +768,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -790,12 +809,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -833,7 +853,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -841,7 +861,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -863,12 +883,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -887,15 +908,17 @@ exports[`Chart 2`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -917,12 +940,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -963,7 +987,7 @@ exports[`Chart 2`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -996,7 +1020,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1095,7 +1119,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1125,7 +1149,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1133,13 +1157,15 @@ exports[`renders component data 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1147,8 +1173,11 @@ exports[`renders component data 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -1167,11 +1196,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1199,7 +1230,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1212,7 +1243,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1225,7 +1256,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1237,7 +1268,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1249,7 +1280,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1279,7 +1310,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1320,12 +1351,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1363,7 +1395,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1371,7 +1403,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1393,12 +1425,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1417,15 +1450,17 @@ exports[`renders component data 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1447,12 +1482,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1493,7 +1529,7 @@ exports[`renders component data 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -1526,7 +1562,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -22,7 +22,10 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiC
       legendPosition="right"
       height={200}
       padding={{
-        right: 200
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accomodate legend
+        top: 50
       }}
       maxDomain={{y: 9}}
       themeColor={ChartThemeColor.cyan}
@@ -79,7 +82,10 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patte
       legendPosition="bottom"
       height={225}
       padding={{
-        bottom: 75
+        bottom: 75, // Adjusted to accomodate legend
+        left: 50,
+        right: 50,
+        top: 50,
       }}
       maxDomain={{y: 9}}
       themeColor={ChartThemeColor.multi}

--- a/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -89,7 +89,7 @@ exports[`ChartAxis 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -97,13 +97,15 @@ exports[`ChartAxis 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -111,8 +113,11 @@ exports[`ChartAxis 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -131,11 +136,13 @@ exports[`ChartAxis 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -163,7 +170,7 @@ exports[`ChartAxis 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -176,7 +183,7 @@ exports[`ChartAxis 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -189,7 +196,7 @@ exports[`ChartAxis 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -201,7 +208,7 @@ exports[`ChartAxis 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -213,7 +220,7 @@ exports[`ChartAxis 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -243,7 +250,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -284,12 +291,13 @@ exports[`ChartAxis 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -327,7 +335,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -335,7 +343,7 @@ exports[`ChartAxis 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -357,12 +365,13 @@ exports[`ChartAxis 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -381,15 +390,17 @@ exports[`ChartAxis 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -411,12 +422,13 @@ exports[`ChartAxis 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -457,7 +469,7 @@ exports[`ChartAxis 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -490,7 +502,7 @@ exports[`ChartAxis 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -580,7 +592,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -610,7 +622,7 @@ exports[`ChartAxis 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -618,13 +630,15 @@ exports[`ChartAxis 2`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -632,8 +646,11 @@ exports[`ChartAxis 2`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -652,11 +669,13 @@ exports[`ChartAxis 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -684,7 +703,7 @@ exports[`ChartAxis 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -697,7 +716,7 @@ exports[`ChartAxis 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -710,7 +729,7 @@ exports[`ChartAxis 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -722,7 +741,7 @@ exports[`ChartAxis 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -734,7 +753,7 @@ exports[`ChartAxis 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -764,7 +783,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -805,12 +824,13 @@ exports[`ChartAxis 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -848,7 +868,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -856,7 +876,7 @@ exports[`ChartAxis 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -878,12 +898,13 @@ exports[`ChartAxis 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -902,15 +923,17 @@ exports[`ChartAxis 2`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -932,12 +955,13 @@ exports[`ChartAxis 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -978,7 +1002,7 @@ exports[`ChartAxis 2`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -1011,7 +1035,7 @@ exports[`ChartAxis 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3226,7 +3250,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3256,7 +3280,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -3264,13 +3288,15 @@ exports[`renders component data 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3278,8 +3304,11 @@ exports[`renders component data 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -3298,11 +3327,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3330,7 +3361,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3343,7 +3374,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3356,7 +3387,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3368,7 +3399,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3380,7 +3411,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3410,7 +3441,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3451,12 +3482,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3494,7 +3526,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3502,7 +3534,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -3524,12 +3556,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3548,15 +3581,17 @@ exports[`renders component data 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3578,12 +3613,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3624,7 +3660,7 @@ exports[`renders component data 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -3657,7 +3693,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -104,7 +104,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -112,13 +112,15 @@ exports[`Chart 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -126,8 +128,11 @@ exports[`Chart 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -146,11 +151,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -178,7 +185,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -191,7 +198,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -204,7 +211,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -216,7 +223,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -228,7 +235,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -258,7 +265,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -299,12 +306,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -342,7 +350,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -350,7 +358,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -372,12 +380,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -396,15 +405,17 @@ exports[`Chart 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -426,12 +437,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -472,7 +484,7 @@ exports[`Chart 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -505,7 +517,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -595,7 +607,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -625,7 +637,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -633,13 +645,15 @@ exports[`Chart 2`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -647,8 +661,11 @@ exports[`Chart 2`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -667,11 +684,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -699,7 +718,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -712,7 +731,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -725,7 +744,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -737,7 +756,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -749,7 +768,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -779,7 +798,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -820,12 +839,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -863,7 +883,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -871,7 +891,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -893,12 +913,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -917,15 +938,17 @@ exports[`Chart 2`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -947,12 +970,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -993,7 +1017,7 @@ exports[`Chart 2`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -1026,7 +1050,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3226,7 +3250,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3256,7 +3280,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -3264,13 +3288,15 @@ exports[`renders component data 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3278,8 +3304,11 @@ exports[`renders component data 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -3298,11 +3327,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3330,7 +3361,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3343,7 +3374,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3356,7 +3387,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3368,7 +3399,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3380,7 +3411,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3410,7 +3441,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3451,12 +3482,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3494,7 +3526,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3502,7 +3534,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -3524,12 +3556,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3548,15 +3581,17 @@ exports[`renders component data 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3578,12 +3613,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3624,7 +3660,7 @@ exports[`renders component data 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -3657,7 +3693,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -23,7 +23,10 @@ import { Chart, ChartBar } from '@patternfly/react-charts';
       legendPosition="right"
       height={250}
       padding={{
-        right: 200
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accomodate legend
+        top: 50
       }}
       width={600}
     >
@@ -48,7 +51,10 @@ import { Chart, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-
       legendPosition="right"
       height={250}
       padding={{
-        right: 200
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accomodate legend
+        top: 50
       }}
       themeColor={ChartThemeColor.purple}
       width={600}
@@ -80,7 +86,10 @@ import { Chart, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-
       legendPosition="bottom"
       height={400}
       padding={{
-        bottom: 75
+        bottom: 75, // Adjusted to accomodate legend
+        left: 50,
+        right: 50,
+        top: 50
       }}
       themeColor={ChartThemeColor.multi}
       width={450}

--- a/packages/patternfly-4/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Chart 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -61,7 +61,7 @@ exports[`Chart 1`] = `
               },
               "axisLabel": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 100,
@@ -69,13 +69,15 @@ exports[`Chart 1`] = `
                 "textAnchor": "middle",
               },
               "grid": Object {
-                "fill": "none",
+                "fill": "transparent",
                 "pointerEvents": "painted",
                 "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
               },
               "tickLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -83,8 +85,11 @@ exports[`Chart 1`] = `
               },
               "ticks": Object {
                 "fill": "transparent",
-                "size": 1,
-                "stroke": "transparent",
+                "size": 5,
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
               },
             },
             "width": 450,
@@ -103,11 +108,13 @@ exports[`Chart 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "#06c",
+                "padding": 8,
                 "stroke": "none",
+                "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -135,7 +142,7 @@ exports[`Chart 1`] = `
               },
               "maxLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -148,7 +155,7 @@ exports[`Chart 1`] = `
               },
               "medianLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -161,7 +168,7 @@ exports[`Chart 1`] = `
               },
               "minLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -173,7 +180,7 @@ exports[`Chart 1`] = `
               },
               "q1Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -185,7 +192,7 @@ exports[`Chart 1`] = `
               },
               "q3Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -215,7 +222,7 @@ exports[`Chart 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -256,12 +263,13 @@ exports[`Chart 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -299,7 +307,7 @@ exports[`Chart 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -307,7 +315,7 @@ exports[`Chart 1`] = `
               },
               "title": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 2,
@@ -329,12 +337,13 @@ exports[`Chart 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -353,15 +362,17 @@ exports[`Chart 1`] = `
               "#004b95",
             ],
             "height": 230,
+            "padAngle": 1,
             "padding": 8,
             "style": Object {
               "data": Object {
                 "padding": 8,
+                "stroke": "transparent",
                 "strokeWidth": 1,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -383,12 +394,13 @@ exports[`Chart 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "#bee1f4",
+                "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -429,7 +441,7 @@ exports[`Chart 1`] = `
             "pointerWidth": 20,
             "style": Object {
               "fill": "#EDEDED",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 16,
@@ -462,7 +474,7 @@ exports[`Chart 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -520,7 +532,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -550,7 +562,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -558,13 +570,15 @@ exports[`Chart 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -572,8 +586,11 @@ exports[`Chart 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -592,11 +609,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -624,7 +643,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -637,7 +656,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -650,7 +669,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -662,7 +681,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -674,7 +693,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -704,7 +723,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -745,12 +764,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -788,7 +808,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -796,7 +816,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -818,12 +838,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -842,15 +863,17 @@ exports[`Chart 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -872,12 +895,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -918,7 +942,7 @@ exports[`Chart 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -951,7 +975,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1007,7 +1031,7 @@ exports[`Chart 2`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1037,7 +1061,7 @@ exports[`Chart 2`] = `
               },
               "axisLabel": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 100,
@@ -1045,13 +1069,15 @@ exports[`Chart 2`] = `
                 "textAnchor": "middle",
               },
               "grid": Object {
-                "fill": "none",
+                "fill": "transparent",
                 "pointerEvents": "painted",
                 "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
               },
               "tickLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1059,8 +1085,11 @@ exports[`Chart 2`] = `
               },
               "ticks": Object {
                 "fill": "transparent",
-                "size": 1,
-                "stroke": "transparent",
+                "size": 5,
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
               },
             },
             "width": 450,
@@ -1079,11 +1108,13 @@ exports[`Chart 2`] = `
             "style": Object {
               "data": Object {
                 "fill": "#06c",
+                "padding": 8,
                 "stroke": "none",
+                "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1111,7 +1142,7 @@ exports[`Chart 2`] = `
               },
               "maxLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1124,7 +1155,7 @@ exports[`Chart 2`] = `
               },
               "medianLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1137,7 +1168,7 @@ exports[`Chart 2`] = `
               },
               "minLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1149,7 +1180,7 @@ exports[`Chart 2`] = `
               },
               "q1Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1161,7 +1192,7 @@ exports[`Chart 2`] = `
               },
               "q3Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1191,7 +1222,7 @@ exports[`Chart 2`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1232,12 +1263,13 @@ exports[`Chart 2`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1275,7 +1307,7 @@ exports[`Chart 2`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1283,7 +1315,7 @@ exports[`Chart 2`] = `
               },
               "title": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 2,
@@ -1305,12 +1337,13 @@ exports[`Chart 2`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1329,15 +1362,17 @@ exports[`Chart 2`] = `
               "#004b95",
             ],
             "height": 230,
+            "padAngle": 1,
             "padding": 8,
             "style": Object {
               "data": Object {
                 "padding": 8,
+                "stroke": "transparent",
                 "strokeWidth": 1,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -1359,12 +1394,13 @@ exports[`Chart 2`] = `
             "style": Object {
               "data": Object {
                 "fill": "#bee1f4",
+                "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1405,7 +1441,7 @@ exports[`Chart 2`] = `
             "pointerWidth": 20,
             "style": Object {
               "fill": "#EDEDED",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 16,
@@ -1438,7 +1474,7 @@ exports[`Chart 2`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -1496,7 +1532,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1526,7 +1562,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1534,13 +1570,15 @@ exports[`Chart 2`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1548,8 +1586,11 @@ exports[`Chart 2`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -1568,11 +1609,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1600,7 +1643,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1613,7 +1656,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1626,7 +1669,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1638,7 +1681,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1650,7 +1693,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1680,7 +1723,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1721,12 +1764,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1764,7 +1808,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1772,7 +1816,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1794,12 +1838,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1818,15 +1863,17 @@ exports[`Chart 2`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1848,12 +1895,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1894,7 +1942,7 @@ exports[`Chart 2`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -1927,7 +1975,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1983,7 +2031,7 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2013,7 +2061,7 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "axisLabel": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 100,
@@ -2021,13 +2069,15 @@ exports[`renders container via ChartLegend 1`] = `
                 "textAnchor": "middle",
               },
               "grid": Object {
-                "fill": "none",
+                "fill": "transparent",
                 "pointerEvents": "painted",
                 "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
               },
               "tickLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2035,8 +2085,11 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "ticks": Object {
                 "fill": "transparent",
-                "size": 1,
-                "stroke": "transparent",
+                "size": 5,
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
               },
             },
             "width": 450,
@@ -2055,11 +2108,13 @@ exports[`renders container via ChartLegend 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "#06c",
+                "padding": 8,
                 "stroke": "none",
+                "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2087,7 +2142,7 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "maxLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2100,7 +2155,7 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "medianLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2113,7 +2168,7 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "minLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2125,7 +2180,7 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "q1Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2137,7 +2192,7 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "q3Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2167,7 +2222,7 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2208,12 +2263,13 @@ exports[`renders container via ChartLegend 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2251,7 +2307,7 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2259,7 +2315,7 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "title": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 2,
@@ -2281,12 +2337,13 @@ exports[`renders container via ChartLegend 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2305,15 +2362,17 @@ exports[`renders container via ChartLegend 1`] = `
               "#004b95",
             ],
             "height": 230,
+            "padAngle": 1,
             "padding": 8,
             "style": Object {
               "data": Object {
                 "padding": 8,
+                "stroke": "transparent",
                 "strokeWidth": 1,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -2335,12 +2394,13 @@ exports[`renders container via ChartLegend 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "#bee1f4",
+                "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2381,7 +2441,7 @@ exports[`renders container via ChartLegend 1`] = `
             "pointerWidth": 20,
             "style": Object {
               "fill": "#EDEDED",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 16,
@@ -2414,7 +2474,7 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -2473,7 +2533,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2503,7 +2563,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -2511,13 +2571,15 @@ exports[`renders container via ChartLegend 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2525,8 +2587,11 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -2545,11 +2610,13 @@ exports[`renders container via ChartLegend 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2577,7 +2644,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2590,7 +2657,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2603,7 +2670,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2615,7 +2682,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2627,7 +2694,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2657,7 +2724,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2698,12 +2765,13 @@ exports[`renders container via ChartLegend 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2741,7 +2809,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2749,7 +2817,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -2771,12 +2839,13 @@ exports[`renders container via ChartLegend 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2795,15 +2864,17 @@ exports[`renders container via ChartLegend 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -2825,12 +2896,13 @@ exports[`renders container via ChartLegend 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2871,7 +2943,7 @@ exports[`renders container via ChartLegend 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -2904,7 +2976,7 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Chart 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -61,7 +61,7 @@ exports[`Chart 1`] = `
                 },
                 "axisLabel": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 100,
@@ -69,13 +69,15 @@ exports[`Chart 1`] = `
                   "textAnchor": "middle",
                 },
                 "grid": Object {
-                  "fill": "none",
+                  "fill": "transparent",
                   "pointerEvents": "painted",
                   "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
                 },
                 "tickLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -83,8 +85,11 @@ exports[`Chart 1`] = `
                 },
                 "ticks": Object {
                   "fill": "transparent",
-                  "size": 1,
-                  "stroke": "transparent",
+                  "size": 5,
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
                 },
               },
               "width": 450,
@@ -103,11 +108,13 @@ exports[`Chart 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "#06c",
+                  "padding": 8,
                   "stroke": "none",
+                  "strokeWidth": 0,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -135,7 +142,7 @@ exports[`Chart 1`] = `
                 },
                 "maxLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -148,7 +155,7 @@ exports[`Chart 1`] = `
                 },
                 "medianLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -161,7 +168,7 @@ exports[`Chart 1`] = `
                 },
                 "minLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -173,7 +180,7 @@ exports[`Chart 1`] = `
                 },
                 "q1Labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -185,7 +192,7 @@ exports[`Chart 1`] = `
                 },
                 "q3Labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -215,7 +222,7 @@ exports[`Chart 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -256,12 +263,13 @@ exports[`Chart 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
+                  "opacity": 1,
                   "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -299,7 +307,7 @@ exports[`Chart 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -307,7 +315,7 @@ exports[`Chart 1`] = `
                 },
                 "title": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 2,
@@ -329,12 +337,13 @@ exports[`Chart 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
+                  "opacity": 1,
                   "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -358,11 +367,12 @@ exports[`Chart 1`] = `
               "style": Object {
                 "data": Object {
                   "padding": 8,
+                  "stroke": "transparent",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
@@ -384,12 +394,13 @@ exports[`Chart 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "#bee1f4",
+                  "opacity": 1,
                   "stroke": "transparent",
                   "strokeWidth": 0,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -430,7 +441,7 @@ exports[`Chart 1`] = `
               "pointerWidth": 20,
               "style": Object {
                 "fill": "#EDEDED",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 16,
@@ -463,7 +474,7 @@ exports[`Chart 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
@@ -505,7 +516,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -535,7 +546,7 @@ exports[`Chart 1`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -543,13 +554,15 @@ exports[`Chart 1`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -557,8 +570,11 @@ exports[`Chart 1`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -577,11 +593,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -609,7 +627,7 @@ exports[`Chart 1`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -622,7 +640,7 @@ exports[`Chart 1`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -635,7 +653,7 @@ exports[`Chart 1`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -647,7 +665,7 @@ exports[`Chart 1`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -659,7 +677,7 @@ exports[`Chart 1`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -689,7 +707,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -730,12 +748,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -773,7 +792,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -781,7 +800,7 @@ exports[`Chart 1`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -803,12 +822,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -832,11 +852,12 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -858,12 +879,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -904,7 +926,7 @@ exports[`Chart 1`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -937,7 +959,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -986,7 +1008,7 @@ exports[`Chart 2`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1016,7 +1038,7 @@ exports[`Chart 2`] = `
                 },
                 "axisLabel": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 100,
@@ -1024,13 +1046,15 @@ exports[`Chart 2`] = `
                   "textAnchor": "middle",
                 },
                 "grid": Object {
-                  "fill": "none",
+                  "fill": "transparent",
                   "pointerEvents": "painted",
                   "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
                 },
                 "tickLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1038,8 +1062,11 @@ exports[`Chart 2`] = `
                 },
                 "ticks": Object {
                   "fill": "transparent",
-                  "size": 1,
-                  "stroke": "transparent",
+                  "size": 5,
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
                 },
               },
               "width": 450,
@@ -1058,11 +1085,13 @@ exports[`Chart 2`] = `
               "style": Object {
                 "data": Object {
                   "fill": "#06c",
+                  "padding": 8,
                   "stroke": "none",
+                  "strokeWidth": 0,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1090,7 +1119,7 @@ exports[`Chart 2`] = `
                 },
                 "maxLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1103,7 +1132,7 @@ exports[`Chart 2`] = `
                 },
                 "medianLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1116,7 +1145,7 @@ exports[`Chart 2`] = `
                 },
                 "minLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1128,7 +1157,7 @@ exports[`Chart 2`] = `
                 },
                 "q1Labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1140,7 +1169,7 @@ exports[`Chart 2`] = `
                 },
                 "q3Labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1170,7 +1199,7 @@ exports[`Chart 2`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1211,12 +1240,13 @@ exports[`Chart 2`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
+                  "opacity": 1,
                   "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1254,7 +1284,7 @@ exports[`Chart 2`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1262,7 +1292,7 @@ exports[`Chart 2`] = `
                 },
                 "title": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 2,
@@ -1284,12 +1314,13 @@ exports[`Chart 2`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
+                  "opacity": 1,
                   "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1313,11 +1344,12 @@ exports[`Chart 2`] = `
               "style": Object {
                 "data": Object {
                   "padding": 8,
+                  "stroke": "transparent",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
@@ -1339,12 +1371,13 @@ exports[`Chart 2`] = `
               "style": Object {
                 "data": Object {
                   "fill": "#bee1f4",
+                  "opacity": 1,
                   "stroke": "transparent",
                   "strokeWidth": 0,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1385,7 +1418,7 @@ exports[`Chart 2`] = `
               "pointerWidth": 20,
               "style": Object {
                 "fill": "#EDEDED",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 16,
@@ -1418,7 +1451,7 @@ exports[`Chart 2`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
@@ -1460,7 +1493,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1490,7 +1523,7 @@ exports[`Chart 2`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -1498,13 +1531,15 @@ exports[`Chart 2`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1512,8 +1547,11 @@ exports[`Chart 2`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -1532,11 +1570,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1564,7 +1604,7 @@ exports[`Chart 2`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1577,7 +1617,7 @@ exports[`Chart 2`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1590,7 +1630,7 @@ exports[`Chart 2`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1602,7 +1642,7 @@ exports[`Chart 2`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1614,7 +1654,7 @@ exports[`Chart 2`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1644,7 +1684,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1685,12 +1725,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1728,7 +1769,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1736,7 +1777,7 @@ exports[`Chart 2`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -1758,12 +1799,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1787,11 +1829,12 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -1813,12 +1856,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1859,7 +1903,7 @@ exports[`Chart 2`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -1892,7 +1936,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -1957,7 +2001,7 @@ exports[`renders component data 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1987,7 +2031,7 @@ exports[`renders component data 1`] = `
                 },
                 "axisLabel": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 100,
@@ -1995,13 +2039,15 @@ exports[`renders component data 1`] = `
                   "textAnchor": "middle",
                 },
                 "grid": Object {
-                  "fill": "none",
+                  "fill": "transparent",
                   "pointerEvents": "painted",
                   "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
                 },
                 "tickLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -2009,8 +2055,11 @@ exports[`renders component data 1`] = `
                 },
                 "ticks": Object {
                   "fill": "transparent",
-                  "size": 1,
-                  "stroke": "transparent",
+                  "size": 5,
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
                 },
               },
               "width": 450,
@@ -2029,11 +2078,13 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "#06c",
+                  "padding": 8,
                   "stroke": "none",
+                  "strokeWidth": 0,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -2061,7 +2112,7 @@ exports[`renders component data 1`] = `
                 },
                 "maxLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -2074,7 +2125,7 @@ exports[`renders component data 1`] = `
                 },
                 "medianLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -2087,7 +2138,7 @@ exports[`renders component data 1`] = `
                 },
                 "minLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -2099,7 +2150,7 @@ exports[`renders component data 1`] = `
                 },
                 "q1Labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -2111,7 +2162,7 @@ exports[`renders component data 1`] = `
                 },
                 "q3Labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -2141,7 +2192,7 @@ exports[`renders component data 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -2182,12 +2233,13 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
+                  "opacity": 1,
                   "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -2225,7 +2277,7 @@ exports[`renders component data 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -2233,7 +2285,7 @@ exports[`renders component data 1`] = `
                 },
                 "title": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 2,
@@ -2255,12 +2307,13 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
+                  "opacity": 1,
                   "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -2284,11 +2337,12 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "data": Object {
                   "padding": 8,
+                  "stroke": "transparent",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
@@ -2310,12 +2364,13 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "#bee1f4",
+                  "opacity": 1,
                   "stroke": "transparent",
                   "strokeWidth": 0,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -2356,7 +2411,7 @@ exports[`renders component data 1`] = `
               "pointerWidth": 20,
               "style": Object {
                 "fill": "#EDEDED",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 16,
@@ -2389,7 +2444,7 @@ exports[`renders component data 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
@@ -2431,7 +2486,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2461,7 +2516,7 @@ exports[`renders component data 1`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -2469,13 +2524,15 @@ exports[`renders component data 1`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2483,8 +2540,11 @@ exports[`renders component data 1`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -2503,11 +2563,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2535,7 +2597,7 @@ exports[`renders component data 1`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2548,7 +2610,7 @@ exports[`renders component data 1`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2561,7 +2623,7 @@ exports[`renders component data 1`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2573,7 +2635,7 @@ exports[`renders component data 1`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2585,7 +2647,7 @@ exports[`renders component data 1`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2615,7 +2677,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2656,12 +2718,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2699,7 +2762,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2707,7 +2770,7 @@ exports[`renders component data 1`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -2729,12 +2792,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2758,11 +2822,12 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -2784,12 +2849,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2830,7 +2896,7 @@ exports[`renders component data 1`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -2863,7 +2929,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -73,7 +73,7 @@ exports[`Chart 1`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -81,13 +81,15 @@ exports[`Chart 1`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -95,8 +97,11 @@ exports[`Chart 1`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -115,11 +120,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -147,7 +154,7 @@ exports[`Chart 1`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -160,7 +167,7 @@ exports[`Chart 1`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -173,7 +180,7 @@ exports[`Chart 1`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -185,7 +192,7 @@ exports[`Chart 1`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -197,7 +204,7 @@ exports[`Chart 1`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -227,7 +234,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -268,12 +275,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -311,7 +319,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -319,7 +327,7 @@ exports[`Chart 1`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -341,12 +349,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -358,9 +367,9 @@ exports[`Chart 1`] = `
         },
         "pie": Object {
           "colorScale": Array [
-            "#EDEDED",
-            "#D2D2D2",
-            "#BBBBBB",
+            "#ededed",
+            "#d2d2d2",
+            "#bbb",
             "#519de9",
             "#004b95",
           ],
@@ -370,11 +379,12 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -396,12 +406,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -442,7 +453,7 @@ exports[`Chart 1`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -475,7 +486,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -536,7 +547,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -566,7 +577,7 @@ exports[`Chart 2`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -574,13 +585,15 @@ exports[`Chart 2`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -588,8 +601,11 @@ exports[`Chart 2`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -608,11 +624,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -640,7 +658,7 @@ exports[`Chart 2`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -653,7 +671,7 @@ exports[`Chart 2`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -666,7 +684,7 @@ exports[`Chart 2`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -678,7 +696,7 @@ exports[`Chart 2`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -690,7 +708,7 @@ exports[`Chart 2`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -720,7 +738,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -761,12 +779,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -804,7 +823,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -812,7 +831,7 @@ exports[`Chart 2`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -834,12 +853,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -851,9 +871,9 @@ exports[`Chart 2`] = `
         },
         "pie": Object {
           "colorScale": Array [
-            "#EDEDED",
-            "#D2D2D2",
-            "#BBBBBB",
+            "#ededed",
+            "#d2d2d2",
+            "#bbb",
             "#519de9",
             "#004b95",
           ],
@@ -863,11 +883,12 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -889,12 +910,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -935,7 +957,7 @@ exports[`Chart 2`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -968,7 +990,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -1041,7 +1063,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1071,7 +1093,7 @@ exports[`renders component data 1`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -1079,13 +1101,15 @@ exports[`renders component data 1`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1093,8 +1117,11 @@ exports[`renders component data 1`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -1113,11 +1140,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1145,7 +1174,7 @@ exports[`renders component data 1`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1158,7 +1187,7 @@ exports[`renders component data 1`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1171,7 +1200,7 @@ exports[`renders component data 1`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1183,7 +1212,7 @@ exports[`renders component data 1`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1195,7 +1224,7 @@ exports[`renders component data 1`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1225,7 +1254,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1266,12 +1295,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1309,7 +1339,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1317,7 +1347,7 @@ exports[`renders component data 1`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -1339,12 +1369,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1356,9 +1387,9 @@ exports[`renders component data 1`] = `
         },
         "pie": Object {
           "colorScale": Array [
-            "#EDEDED",
-            "#D2D2D2",
-            "#BBBBBB",
+            "#ededed",
+            "#d2d2d2",
+            "#bbb",
             "#519de9",
             "#004b95",
           ],
@@ -1368,11 +1399,12 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -1394,12 +1426,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1440,7 +1473,7 @@ exports[`renders component data 1`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -1473,7 +1506,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -72,7 +72,7 @@ exports[`Chart 1`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -80,13 +80,15 @@ exports[`Chart 1`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -94,8 +96,11 @@ exports[`Chart 1`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -114,11 +119,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -146,7 +153,7 @@ exports[`Chart 1`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -159,7 +166,7 @@ exports[`Chart 1`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -172,7 +179,7 @@ exports[`Chart 1`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -184,7 +191,7 @@ exports[`Chart 1`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -196,7 +203,7 @@ exports[`Chart 1`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -226,7 +233,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -267,12 +274,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -297,9 +305,9 @@ exports[`Chart 1`] = `
         "legend": Object {
           "colorScale": Array [
             "#06c",
-            "#EDEDED",
-            "#D2D2D2",
-            "#BBBBBB",
+            "#ededed",
+            "#d2d2d2",
+            "#bbb",
           ],
           "gutter": 20,
           "orientation": "horizontal",
@@ -309,7 +317,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -317,7 +325,7 @@ exports[`Chart 1`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -339,12 +347,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -357,7 +366,7 @@ exports[`Chart 1`] = `
         "pie": Object {
           "colorScale": Array [
             "#06c",
-            "#EDEDED",
+            "#ededed",
           ],
           "height": 230,
           "padAngle": 1,
@@ -365,11 +374,12 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -391,12 +401,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -437,7 +448,7 @@ exports[`Chart 1`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -470,7 +481,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -530,7 +541,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -560,7 +571,7 @@ exports[`Chart 2`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -568,13 +579,15 @@ exports[`Chart 2`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -582,8 +595,11 @@ exports[`Chart 2`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -602,11 +618,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -634,7 +652,7 @@ exports[`Chart 2`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -647,7 +665,7 @@ exports[`Chart 2`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -660,7 +678,7 @@ exports[`Chart 2`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -672,7 +690,7 @@ exports[`Chart 2`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -684,7 +702,7 @@ exports[`Chart 2`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -714,7 +732,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -755,12 +773,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -785,9 +804,9 @@ exports[`Chart 2`] = `
         "legend": Object {
           "colorScale": Array [
             "#06c",
-            "#EDEDED",
-            "#D2D2D2",
-            "#BBBBBB",
+            "#ededed",
+            "#d2d2d2",
+            "#bbb",
           ],
           "gutter": 20,
           "orientation": "horizontal",
@@ -797,7 +816,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -805,7 +824,7 @@ exports[`Chart 2`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -827,12 +846,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -845,7 +865,7 @@ exports[`Chart 2`] = `
         "pie": Object {
           "colorScale": Array [
             "#06c",
-            "#EDEDED",
+            "#ededed",
           ],
           "height": 230,
           "padAngle": 1,
@@ -853,11 +873,12 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -879,12 +900,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -925,7 +947,7 @@ exports[`Chart 2`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -958,7 +980,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -1018,7 +1040,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1048,7 +1070,7 @@ exports[`renders component data 1`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -1056,13 +1078,15 @@ exports[`renders component data 1`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1070,8 +1094,11 @@ exports[`renders component data 1`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -1090,11 +1117,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1122,7 +1151,7 @@ exports[`renders component data 1`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1135,7 +1164,7 @@ exports[`renders component data 1`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1148,7 +1177,7 @@ exports[`renders component data 1`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1160,7 +1189,7 @@ exports[`renders component data 1`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1172,7 +1201,7 @@ exports[`renders component data 1`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1202,7 +1231,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1243,12 +1272,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1273,9 +1303,9 @@ exports[`renders component data 1`] = `
         "legend": Object {
           "colorScale": Array [
             "#06c",
-            "#EDEDED",
-            "#D2D2D2",
-            "#BBBBBB",
+            "#ededed",
+            "#d2d2d2",
+            "#bbb",
           ],
           "gutter": 20,
           "orientation": "horizontal",
@@ -1285,7 +1315,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1293,7 +1323,7 @@ exports[`renders component data 1`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -1315,12 +1345,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1333,7 +1364,7 @@ exports[`renders component data 1`] = `
         "pie": Object {
           "colorScale": Array [
             "#06c",
-            "#EDEDED",
+            "#ededed",
           ],
           "height": 230,
           "padAngle": 1,
@@ -1341,11 +1372,12 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -1367,12 +1399,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1413,7 +1446,7 @@ exports[`renders component data 1`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -1446,7 +1479,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -65,7 +65,7 @@ exports[`ChartGroup 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -73,13 +73,15 @@ exports[`ChartGroup 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -87,8 +89,11 @@ exports[`ChartGroup 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -107,11 +112,13 @@ exports[`ChartGroup 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -139,7 +146,7 @@ exports[`ChartGroup 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -152,7 +159,7 @@ exports[`ChartGroup 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -165,7 +172,7 @@ exports[`ChartGroup 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -177,7 +184,7 @@ exports[`ChartGroup 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -189,7 +196,7 @@ exports[`ChartGroup 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -219,7 +226,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -260,12 +267,13 @@ exports[`ChartGroup 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -303,7 +311,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -311,7 +319,7 @@ exports[`ChartGroup 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -333,12 +341,13 @@ exports[`ChartGroup 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -357,15 +366,17 @@ exports[`ChartGroup 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -387,12 +398,13 @@ exports[`ChartGroup 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -433,7 +445,7 @@ exports[`ChartGroup 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -466,7 +478,7 @@ exports[`ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -517,7 +529,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -547,7 +559,7 @@ exports[`ChartGroup 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -555,13 +567,15 @@ exports[`ChartGroup 2`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -569,8 +583,11 @@ exports[`ChartGroup 2`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -589,11 +606,13 @@ exports[`ChartGroup 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -621,7 +640,7 @@ exports[`ChartGroup 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -634,7 +653,7 @@ exports[`ChartGroup 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -647,7 +666,7 @@ exports[`ChartGroup 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -659,7 +678,7 @@ exports[`ChartGroup 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -671,7 +690,7 @@ exports[`ChartGroup 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -701,7 +720,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -742,12 +761,13 @@ exports[`ChartGroup 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -785,7 +805,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -793,7 +813,7 @@ exports[`ChartGroup 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -815,12 +835,13 @@ exports[`ChartGroup 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -839,15 +860,17 @@ exports[`ChartGroup 2`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -869,12 +892,13 @@ exports[`ChartGroup 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -915,7 +939,7 @@ exports[`ChartGroup 2`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -948,7 +972,7 @@ exports[`ChartGroup 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1000,7 +1024,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1030,7 +1054,7 @@ exports[`renders container children 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1038,13 +1062,15 @@ exports[`renders container children 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1052,8 +1078,11 @@ exports[`renders container children 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -1072,11 +1101,13 @@ exports[`renders container children 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1104,7 +1135,7 @@ exports[`renders container children 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1117,7 +1148,7 @@ exports[`renders container children 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1130,7 +1161,7 @@ exports[`renders container children 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1142,7 +1173,7 @@ exports[`renders container children 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1154,7 +1185,7 @@ exports[`renders container children 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1184,7 +1215,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1225,12 +1256,13 @@ exports[`renders container children 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1268,7 +1300,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1276,7 +1308,7 @@ exports[`renders container children 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1298,12 +1330,13 @@ exports[`renders container children 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1322,15 +1355,17 @@ exports[`renders container children 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1352,12 +1387,13 @@ exports[`renders container children 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1398,7 +1434,7 @@ exports[`renders container children 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -1431,7 +1467,7 @@ exports[`renders container children 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartLabel/__snapshots__/ChartLabel.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLabel/__snapshots__/ChartLabel.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Chart 1`] = `
   lineHeight={1}
   style={
     Object {
-      "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+      "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
     }
   }
   textComponent={<Text />}
@@ -22,7 +22,7 @@ exports[`Chart 2`] = `
   lineHeight={1}
   style={
     Object {
-      "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+      "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
     }
   }
   textComponent={<Text />}
@@ -37,7 +37,7 @@ exports[`renders component text 1`] = `
   lineHeight={1}
   style={
     Object {
-      "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+      "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
     }
   }
   text="This is a test"

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Chart 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -61,7 +61,7 @@ exports[`Chart 1`] = `
               },
               "axisLabel": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 100,
@@ -69,13 +69,15 @@ exports[`Chart 1`] = `
                 "textAnchor": "middle",
               },
               "grid": Object {
-                "fill": "none",
+                "fill": "transparent",
                 "pointerEvents": "painted",
                 "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
               },
               "tickLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -83,8 +85,11 @@ exports[`Chart 1`] = `
               },
               "ticks": Object {
                 "fill": "transparent",
-                "size": 1,
-                "stroke": "transparent",
+                "size": 5,
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
               },
             },
             "width": 450,
@@ -103,11 +108,13 @@ exports[`Chart 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "#06c",
+                "padding": 8,
                 "stroke": "none",
+                "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -135,7 +142,7 @@ exports[`Chart 1`] = `
               },
               "maxLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -148,7 +155,7 @@ exports[`Chart 1`] = `
               },
               "medianLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -161,7 +168,7 @@ exports[`Chart 1`] = `
               },
               "minLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -173,7 +180,7 @@ exports[`Chart 1`] = `
               },
               "q1Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -185,7 +192,7 @@ exports[`Chart 1`] = `
               },
               "q3Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -215,7 +222,7 @@ exports[`Chart 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -256,12 +263,13 @@ exports[`Chart 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -299,7 +307,7 @@ exports[`Chart 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -307,7 +315,7 @@ exports[`Chart 1`] = `
               },
               "title": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 2,
@@ -329,12 +337,13 @@ exports[`Chart 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -353,15 +362,17 @@ exports[`Chart 1`] = `
               "#004b95",
             ],
             "height": 230,
+            "padAngle": 1,
             "padding": 8,
             "style": Object {
               "data": Object {
                 "padding": 8,
+                "stroke": "transparent",
                 "strokeWidth": 1,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -383,12 +394,13 @@ exports[`Chart 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "#bee1f4",
+                "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -429,7 +441,7 @@ exports[`Chart 1`] = `
             "pointerWidth": 20,
             "style": Object {
               "fill": "#EDEDED",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 16,
@@ -462,7 +474,7 @@ exports[`Chart 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -520,7 +532,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -550,7 +562,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -558,13 +570,15 @@ exports[`Chart 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -572,8 +586,11 @@ exports[`Chart 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -592,11 +609,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -624,7 +643,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -637,7 +656,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -650,7 +669,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -662,7 +681,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -674,7 +693,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -704,7 +723,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -745,12 +764,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -788,7 +808,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -796,7 +816,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -818,12 +838,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -842,15 +863,17 @@ exports[`Chart 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -872,12 +895,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -918,7 +942,7 @@ exports[`Chart 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -951,7 +975,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1007,7 +1031,7 @@ exports[`Chart 2`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1037,7 +1061,7 @@ exports[`Chart 2`] = `
               },
               "axisLabel": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 100,
@@ -1045,13 +1069,15 @@ exports[`Chart 2`] = `
                 "textAnchor": "middle",
               },
               "grid": Object {
-                "fill": "none",
+                "fill": "transparent",
                 "pointerEvents": "painted",
                 "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
               },
               "tickLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1059,8 +1085,11 @@ exports[`Chart 2`] = `
               },
               "ticks": Object {
                 "fill": "transparent",
-                "size": 1,
-                "stroke": "transparent",
+                "size": 5,
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
               },
             },
             "width": 450,
@@ -1079,11 +1108,13 @@ exports[`Chart 2`] = `
             "style": Object {
               "data": Object {
                 "fill": "#06c",
+                "padding": 8,
                 "stroke": "none",
+                "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1111,7 +1142,7 @@ exports[`Chart 2`] = `
               },
               "maxLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1124,7 +1155,7 @@ exports[`Chart 2`] = `
               },
               "medianLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1137,7 +1168,7 @@ exports[`Chart 2`] = `
               },
               "minLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1149,7 +1180,7 @@ exports[`Chart 2`] = `
               },
               "q1Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1161,7 +1192,7 @@ exports[`Chart 2`] = `
               },
               "q3Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1191,7 +1222,7 @@ exports[`Chart 2`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1232,12 +1263,13 @@ exports[`Chart 2`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1275,7 +1307,7 @@ exports[`Chart 2`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1283,7 +1315,7 @@ exports[`Chart 2`] = `
               },
               "title": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 2,
@@ -1305,12 +1337,13 @@ exports[`Chart 2`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1329,15 +1362,17 @@ exports[`Chart 2`] = `
               "#004b95",
             ],
             "height": 230,
+            "padAngle": 1,
             "padding": 8,
             "style": Object {
               "data": Object {
                 "padding": 8,
+                "stroke": "transparent",
                 "strokeWidth": 1,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -1359,12 +1394,13 @@ exports[`Chart 2`] = `
             "style": Object {
               "data": Object {
                 "fill": "#bee1f4",
+                "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1405,7 +1441,7 @@ exports[`Chart 2`] = `
             "pointerWidth": 20,
             "style": Object {
               "fill": "#EDEDED",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 16,
@@ -1438,7 +1474,7 @@ exports[`Chart 2`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -1496,7 +1532,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1526,7 +1562,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1534,13 +1570,15 @@ exports[`Chart 2`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1548,8 +1586,11 @@ exports[`Chart 2`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -1568,11 +1609,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1600,7 +1643,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1613,7 +1656,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1626,7 +1669,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1638,7 +1681,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1650,7 +1693,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1680,7 +1723,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1721,12 +1764,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1764,7 +1808,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1772,7 +1816,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1794,12 +1838,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1818,15 +1863,17 @@ exports[`Chart 2`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1848,12 +1895,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1894,7 +1942,7 @@ exports[`Chart 2`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -1927,7 +1975,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1983,7 +2031,7 @@ exports[`renders component data 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2013,7 +2061,7 @@ exports[`renders component data 1`] = `
               },
               "axisLabel": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 100,
@@ -2021,13 +2069,15 @@ exports[`renders component data 1`] = `
                 "textAnchor": "middle",
               },
               "grid": Object {
-                "fill": "none",
+                "fill": "transparent",
                 "pointerEvents": "painted",
                 "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
               },
               "tickLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2035,8 +2085,11 @@ exports[`renders component data 1`] = `
               },
               "ticks": Object {
                 "fill": "transparent",
-                "size": 1,
-                "stroke": "transparent",
+                "size": 5,
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
               },
             },
             "width": 450,
@@ -2055,11 +2108,13 @@ exports[`renders component data 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "#06c",
+                "padding": 8,
                 "stroke": "none",
+                "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2087,7 +2142,7 @@ exports[`renders component data 1`] = `
               },
               "maxLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2100,7 +2155,7 @@ exports[`renders component data 1`] = `
               },
               "medianLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2113,7 +2168,7 @@ exports[`renders component data 1`] = `
               },
               "minLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2125,7 +2180,7 @@ exports[`renders component data 1`] = `
               },
               "q1Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2137,7 +2192,7 @@ exports[`renders component data 1`] = `
               },
               "q3Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2167,7 +2222,7 @@ exports[`renders component data 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2208,12 +2263,13 @@ exports[`renders component data 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2251,7 +2307,7 @@ exports[`renders component data 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2259,7 +2315,7 @@ exports[`renders component data 1`] = `
               },
               "title": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 2,
@@ -2281,12 +2337,13 @@ exports[`renders component data 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2305,15 +2362,17 @@ exports[`renders component data 1`] = `
               "#004b95",
             ],
             "height": 230,
+            "padAngle": 1,
             "padding": 8,
             "style": Object {
               "data": Object {
                 "padding": 8,
+                "stroke": "transparent",
                 "strokeWidth": 1,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -2335,12 +2394,13 @@ exports[`renders component data 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "#bee1f4",
+                "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2381,7 +2441,7 @@ exports[`renders component data 1`] = `
             "pointerWidth": 20,
             "style": Object {
               "fill": "#EDEDED",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 16,
@@ -2414,7 +2474,7 @@ exports[`renders component data 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -2473,7 +2533,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2503,7 +2563,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -2511,13 +2571,15 @@ exports[`renders component data 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2525,8 +2587,11 @@ exports[`renders component data 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -2545,11 +2610,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2577,7 +2644,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2590,7 +2657,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2603,7 +2670,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2615,7 +2682,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2627,7 +2694,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2657,7 +2724,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2698,12 +2765,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2741,7 +2809,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2749,7 +2817,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -2771,12 +2839,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2795,15 +2864,17 @@ exports[`renders component data 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -2825,12 +2896,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2871,7 +2943,7 @@ exports[`renders component data 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -2904,7 +2976,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -88,7 +88,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -96,13 +96,15 @@ exports[`Chart 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -110,8 +112,11 @@ exports[`Chart 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -130,11 +135,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -162,7 +169,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -175,7 +182,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -188,7 +195,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -200,7 +207,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -212,7 +219,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -242,7 +249,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -283,12 +290,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -326,7 +334,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -334,7 +342,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -356,12 +364,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -380,15 +389,17 @@ exports[`Chart 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -410,12 +421,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -456,7 +468,7 @@ exports[`Chart 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -489,7 +501,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -563,7 +575,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -593,7 +605,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -601,13 +613,15 @@ exports[`Chart 2`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -615,8 +629,11 @@ exports[`Chart 2`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -635,11 +652,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -667,7 +686,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -680,7 +699,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -693,7 +712,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -705,7 +724,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -717,7 +736,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -747,7 +766,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -788,12 +807,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -831,7 +851,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -839,7 +859,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -861,12 +881,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -885,15 +906,17 @@ exports[`Chart 2`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -915,12 +938,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -961,7 +985,7 @@ exports[`Chart 2`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -994,7 +1018,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3191,7 +3215,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3221,7 +3245,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -3229,13 +3253,15 @@ exports[`renders component data 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3243,8 +3269,11 @@ exports[`renders component data 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -3263,11 +3292,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3295,7 +3326,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3308,7 +3339,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3321,7 +3352,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3333,7 +3364,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3345,7 +3376,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3375,7 +3406,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3416,12 +3447,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3459,7 +3491,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3467,7 +3499,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -3489,12 +3521,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3513,15 +3546,17 @@ exports[`renders component data 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3543,12 +3578,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3589,7 +3625,7 @@ exports[`renders component data 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -3622,7 +3658,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -22,7 +22,10 @@ import { Chart, ChartAxis, ChartGroup, ChartLine } from '@patternfly/react-chart
       legendPosition="right"
       height={250}
       padding={{
-        right: 200
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accomodate legend
+        top: 50
       }}
       width={600}
     >
@@ -58,7 +61,10 @@ import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor } from '@patte
       legendTitle="Average number of pets"
       height={250}
       padding={{
-        right: 200
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accomodate legend
+        top: 50
       }}
       themeColor={ChartThemeColor.green}
       width={600}
@@ -124,7 +130,10 @@ import { VictoryZoomContainer } from 'victory';
       legendTitle="Average number of pets"
       height={275}
       padding={{
-        bottom: 75
+        bottom: 75, // Adjusted to accomodate legend
+        left: 50,
+        right: 50,
+        top: 50
       }}
       themeColor={ChartThemeColor.multi}
       width={450}

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`Chart 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -98,7 +98,7 @@ exports[`Chart 1`] = `
                 },
                 "axisLabel": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 100,
@@ -106,13 +106,15 @@ exports[`Chart 1`] = `
                   "textAnchor": "middle",
                 },
                 "grid": Object {
-                  "fill": "none",
+                  "fill": "transparent",
                   "pointerEvents": "painted",
                   "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
                 },
                 "tickLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -120,8 +122,11 @@ exports[`Chart 1`] = `
                 },
                 "ticks": Object {
                   "fill": "transparent",
-                  "size": 1,
-                  "stroke": "transparent",
+                  "size": 5,
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
                 },
               },
               "width": 450,
@@ -140,11 +145,13 @@ exports[`Chart 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "#06c",
+                  "padding": 8,
                   "stroke": "none",
+                  "strokeWidth": 0,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -172,7 +179,7 @@ exports[`Chart 1`] = `
                 },
                 "maxLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -185,7 +192,7 @@ exports[`Chart 1`] = `
                 },
                 "medianLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -198,7 +205,7 @@ exports[`Chart 1`] = `
                 },
                 "minLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -210,7 +217,7 @@ exports[`Chart 1`] = `
                 },
                 "q1Labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -222,7 +229,7 @@ exports[`Chart 1`] = `
                 },
                 "q3Labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -252,7 +259,7 @@ exports[`Chart 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -293,12 +300,13 @@ exports[`Chart 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
+                  "opacity": 1,
                   "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -336,7 +344,7 @@ exports[`Chart 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -344,7 +352,7 @@ exports[`Chart 1`] = `
                 },
                 "title": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 2,
@@ -366,12 +374,13 @@ exports[`Chart 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
+                  "opacity": 1,
                   "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -390,15 +399,17 @@ exports[`Chart 1`] = `
                 "#004b95",
               ],
               "height": 230,
+              "padAngle": 1,
               "padding": 8,
               "style": Object {
                 "data": Object {
                   "padding": 8,
+                  "stroke": "transparent",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
@@ -420,12 +431,13 @@ exports[`Chart 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "#bee1f4",
+                  "opacity": 1,
                   "stroke": "transparent",
                   "strokeWidth": 0,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -466,7 +478,7 @@ exports[`Chart 1`] = `
               "pointerWidth": 20,
               "style": Object {
                 "fill": "#EDEDED",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 16,
@@ -499,7 +511,7 @@ exports[`Chart 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
@@ -543,7 +555,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -573,7 +585,7 @@ exports[`Chart 1`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -581,13 +593,15 @@ exports[`Chart 1`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -595,8 +609,11 @@ exports[`Chart 1`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -615,11 +632,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -647,7 +666,7 @@ exports[`Chart 1`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -660,7 +679,7 @@ exports[`Chart 1`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -673,7 +692,7 @@ exports[`Chart 1`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -685,7 +704,7 @@ exports[`Chart 1`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -697,7 +716,7 @@ exports[`Chart 1`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -727,7 +746,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -768,12 +787,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -811,7 +831,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -819,7 +839,7 @@ exports[`Chart 1`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -841,12 +861,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -865,15 +886,17 @@ exports[`Chart 1`] = `
             "#004b95",
           ],
           "height": 230,
+          "padAngle": 1,
           "padding": 8,
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -895,12 +918,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -941,7 +965,7 @@ exports[`Chart 1`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -974,7 +998,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -1020,7 +1044,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1050,7 +1074,7 @@ exports[`Chart 1`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -1058,13 +1082,15 @@ exports[`Chart 1`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1072,8 +1098,11 @@ exports[`Chart 1`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -1092,11 +1121,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1124,7 +1155,7 @@ exports[`Chart 1`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1137,7 +1168,7 @@ exports[`Chart 1`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1150,7 +1181,7 @@ exports[`Chart 1`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1162,7 +1193,7 @@ exports[`Chart 1`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1174,7 +1205,7 @@ exports[`Chart 1`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1204,7 +1235,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1245,12 +1276,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1288,7 +1320,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1296,7 +1328,7 @@ exports[`Chart 1`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -1318,12 +1350,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1342,15 +1375,17 @@ exports[`Chart 1`] = `
             "#004b95",
           ],
           "height": 230,
+          "padAngle": 1,
           "padding": 8,
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -1372,12 +1407,13 @@ exports[`Chart 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -1418,7 +1454,7 @@ exports[`Chart 1`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -1451,7 +1487,7 @@ exports[`Chart 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -1540,7 +1576,7 @@ exports[`Chart 2`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1570,7 +1606,7 @@ exports[`Chart 2`] = `
                 },
                 "axisLabel": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 100,
@@ -1578,13 +1614,15 @@ exports[`Chart 2`] = `
                   "textAnchor": "middle",
                 },
                 "grid": Object {
-                  "fill": "none",
+                  "fill": "transparent",
                   "pointerEvents": "painted",
                   "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
                 },
                 "tickLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1592,8 +1630,11 @@ exports[`Chart 2`] = `
                 },
                 "ticks": Object {
                   "fill": "transparent",
-                  "size": 1,
-                  "stroke": "transparent",
+                  "size": 5,
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
                 },
               },
               "width": 450,
@@ -1612,11 +1653,13 @@ exports[`Chart 2`] = `
               "style": Object {
                 "data": Object {
                   "fill": "#06c",
+                  "padding": 8,
                   "stroke": "none",
+                  "strokeWidth": 0,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1644,7 +1687,7 @@ exports[`Chart 2`] = `
                 },
                 "maxLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1657,7 +1700,7 @@ exports[`Chart 2`] = `
                 },
                 "medianLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1670,7 +1713,7 @@ exports[`Chart 2`] = `
                 },
                 "minLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1682,7 +1725,7 @@ exports[`Chart 2`] = `
                 },
                 "q1Labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1694,7 +1737,7 @@ exports[`Chart 2`] = `
                 },
                 "q3Labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1724,7 +1767,7 @@ exports[`Chart 2`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1765,12 +1808,13 @@ exports[`Chart 2`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
+                  "opacity": 1,
                   "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1808,7 +1852,7 @@ exports[`Chart 2`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1816,7 +1860,7 @@ exports[`Chart 2`] = `
                 },
                 "title": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 2,
@@ -1838,12 +1882,13 @@ exports[`Chart 2`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
+                  "opacity": 1,
                   "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1862,15 +1907,17 @@ exports[`Chart 2`] = `
                 "#004b95",
               ],
               "height": 230,
+              "padAngle": 1,
               "padding": 8,
               "style": Object {
                 "data": Object {
                   "padding": 8,
+                  "stroke": "transparent",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
@@ -1892,12 +1939,13 @@ exports[`Chart 2`] = `
               "style": Object {
                 "data": Object {
                   "fill": "#bee1f4",
+                  "opacity": 1,
                   "stroke": "transparent",
                   "strokeWidth": 0,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -1938,7 +1986,7 @@ exports[`Chart 2`] = `
               "pointerWidth": 20,
               "style": Object {
                 "fill": "#EDEDED",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 16,
@@ -1971,7 +2019,7 @@ exports[`Chart 2`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
@@ -2015,7 +2063,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2045,7 +2093,7 @@ exports[`Chart 2`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -2053,13 +2101,15 @@ exports[`Chart 2`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2067,8 +2117,11 @@ exports[`Chart 2`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -2087,11 +2140,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2119,7 +2174,7 @@ exports[`Chart 2`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2132,7 +2187,7 @@ exports[`Chart 2`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2145,7 +2200,7 @@ exports[`Chart 2`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2157,7 +2212,7 @@ exports[`Chart 2`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2169,7 +2224,7 @@ exports[`Chart 2`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2199,7 +2254,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2240,12 +2295,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2283,7 +2339,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2291,7 +2347,7 @@ exports[`Chart 2`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -2313,12 +2369,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2337,15 +2394,17 @@ exports[`Chart 2`] = `
             "#004b95",
           ],
           "height": 230,
+          "padAngle": 1,
           "padding": 8,
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -2367,12 +2426,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2413,7 +2473,7 @@ exports[`Chart 2`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -2446,7 +2506,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -2492,7 +2552,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2522,7 +2582,7 @@ exports[`Chart 2`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -2530,13 +2590,15 @@ exports[`Chart 2`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2544,8 +2606,11 @@ exports[`Chart 2`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -2564,11 +2629,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2596,7 +2663,7 @@ exports[`Chart 2`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2609,7 +2676,7 @@ exports[`Chart 2`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2622,7 +2689,7 @@ exports[`Chart 2`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2634,7 +2701,7 @@ exports[`Chart 2`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2646,7 +2713,7 @@ exports[`Chart 2`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2676,7 +2743,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2717,12 +2784,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2760,7 +2828,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2768,7 +2836,7 @@ exports[`Chart 2`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -2790,12 +2858,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2814,15 +2883,17 @@ exports[`Chart 2`] = `
             "#004b95",
           ],
           "height": 230,
+          "padAngle": 1,
           "padding": 8,
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -2844,12 +2915,13 @@ exports[`Chart 2`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -2890,7 +2962,7 @@ exports[`Chart 2`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -2923,7 +2995,7 @@ exports[`Chart 2`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -3004,7 +3076,7 @@ exports[`renders component data 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3034,7 +3106,7 @@ exports[`renders component data 1`] = `
                 },
                 "axisLabel": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 100,
@@ -3042,13 +3114,15 @@ exports[`renders component data 1`] = `
                   "textAnchor": "middle",
                 },
                 "grid": Object {
-                  "fill": "none",
+                  "fill": "transparent",
                   "pointerEvents": "painted",
                   "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
                 },
                 "tickLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3056,8 +3130,11 @@ exports[`renders component data 1`] = `
                 },
                 "ticks": Object {
                   "fill": "transparent",
-                  "size": 1,
-                  "stroke": "transparent",
+                  "size": 5,
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
                 },
               },
               "width": 450,
@@ -3076,11 +3153,13 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "#06c",
+                  "padding": 8,
                   "stroke": "none",
+                  "strokeWidth": 0,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3108,7 +3187,7 @@ exports[`renders component data 1`] = `
                 },
                 "maxLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3121,7 +3200,7 @@ exports[`renders component data 1`] = `
                 },
                 "medianLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3134,7 +3213,7 @@ exports[`renders component data 1`] = `
                 },
                 "minLabels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3146,7 +3225,7 @@ exports[`renders component data 1`] = `
                 },
                 "q1Labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3158,7 +3237,7 @@ exports[`renders component data 1`] = `
                 },
                 "q3Labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3188,7 +3267,7 @@ exports[`renders component data 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3229,12 +3308,13 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
+                  "opacity": 1,
                   "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3272,7 +3352,7 @@ exports[`renders component data 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3280,7 +3360,7 @@ exports[`renders component data 1`] = `
                 },
                 "title": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 2,
@@ -3302,12 +3382,13 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "transparent",
+                  "opacity": 1,
                   "stroke": "#73bcf7",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3326,15 +3407,17 @@ exports[`renders component data 1`] = `
                 "#004b95",
               ],
               "height": 230,
+              "padAngle": 1,
               "padding": 8,
               "style": Object {
                 "data": Object {
                   "padding": 8,
+                  "stroke": "transparent",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
@@ -3356,12 +3439,13 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "data": Object {
                   "fill": "#bee1f4",
+                  "opacity": 1,
                   "stroke": "transparent",
                   "strokeWidth": 0,
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 10,
@@ -3402,7 +3486,7 @@ exports[`renders component data 1`] = `
               "pointerWidth": 20,
               "style": Object {
                 "fill": "#EDEDED",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 16,
@@ -3435,7 +3519,7 @@ exports[`renders component data 1`] = `
                 },
                 "labels": Object {
                   "fill": "#151515",
-                  "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                  "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
@@ -3479,7 +3563,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3509,7 +3593,7 @@ exports[`renders component data 1`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -3517,13 +3601,15 @@ exports[`renders component data 1`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3531,8 +3617,11 @@ exports[`renders component data 1`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -3551,11 +3640,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3583,7 +3674,7 @@ exports[`renders component data 1`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3596,7 +3687,7 @@ exports[`renders component data 1`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3609,7 +3700,7 @@ exports[`renders component data 1`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3621,7 +3712,7 @@ exports[`renders component data 1`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3633,7 +3724,7 @@ exports[`renders component data 1`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3663,7 +3754,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3704,12 +3795,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3747,7 +3839,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3755,7 +3847,7 @@ exports[`renders component data 1`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -3777,12 +3869,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3801,15 +3894,17 @@ exports[`renders component data 1`] = `
             "#004b95",
           ],
           "height": 230,
+          "padAngle": 1,
           "padding": 8,
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -3831,12 +3926,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3877,7 +3973,7 @@ exports[`renders component data 1`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -3910,7 +4006,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -3956,7 +4052,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -3986,7 +4082,7 @@ exports[`renders component data 1`] = `
             },
             "axisLabel": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 100,
@@ -3994,13 +4090,15 @@ exports[`renders component data 1`] = `
               "textAnchor": "middle",
             },
             "grid": Object {
-              "fill": "none",
+              "fill": "transparent",
               "pointerEvents": "painted",
               "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
             },
             "tickLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -4008,8 +4106,11 @@ exports[`renders component data 1`] = `
             },
             "ticks": Object {
               "fill": "transparent",
-              "size": 1,
-              "stroke": "transparent",
+              "size": 5,
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
             },
           },
           "width": 450,
@@ -4028,11 +4129,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#06c",
+              "padding": 8,
               "stroke": "none",
+              "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -4060,7 +4163,7 @@ exports[`renders component data 1`] = `
             },
             "maxLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -4073,7 +4176,7 @@ exports[`renders component data 1`] = `
             },
             "medianLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -4086,7 +4189,7 @@ exports[`renders component data 1`] = `
             },
             "minLabels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -4098,7 +4201,7 @@ exports[`renders component data 1`] = `
             },
             "q1Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -4110,7 +4213,7 @@ exports[`renders component data 1`] = `
             },
             "q3Labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -4140,7 +4243,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -4181,12 +4284,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -4224,7 +4328,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -4232,7 +4336,7 @@ exports[`renders component data 1`] = `
             },
             "title": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 2,
@@ -4254,12 +4358,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "transparent",
+              "opacity": 1,
               "stroke": "#73bcf7",
               "strokeWidth": 2,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -4278,15 +4383,17 @@ exports[`renders component data 1`] = `
             "#004b95",
           ],
           "height": 230,
+          "padAngle": 1,
           "padding": 8,
           "style": Object {
             "data": Object {
               "padding": 8,
+              "stroke": "transparent",
               "strokeWidth": 1,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
@@ -4308,12 +4415,13 @@ exports[`renders component data 1`] = `
           "style": Object {
             "data": Object {
               "fill": "#bee1f4",
+              "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 10,
@@ -4354,7 +4462,7 @@ exports[`renders component data 1`] = `
           "pointerWidth": 20,
           "style": Object {
             "fill": "#EDEDED",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 16,
@@ -4387,7 +4495,7 @@ exports[`renders component data 1`] = `
             },
             "labels": Object {
               "fill": "#151515",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Chart 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -61,7 +61,7 @@ exports[`Chart 1`] = `
               },
               "axisLabel": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 100,
@@ -69,13 +69,15 @@ exports[`Chart 1`] = `
                 "textAnchor": "middle",
               },
               "grid": Object {
-                "fill": "none",
+                "fill": "transparent",
                 "pointerEvents": "painted",
                 "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
               },
               "tickLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -83,8 +85,11 @@ exports[`Chart 1`] = `
               },
               "ticks": Object {
                 "fill": "transparent",
-                "size": 1,
-                "stroke": "transparent",
+                "size": 5,
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
               },
             },
             "width": 450,
@@ -103,11 +108,13 @@ exports[`Chart 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "#06c",
+                "padding": 8,
                 "stroke": "none",
+                "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -135,7 +142,7 @@ exports[`Chart 1`] = `
               },
               "maxLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -148,7 +155,7 @@ exports[`Chart 1`] = `
               },
               "medianLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -161,7 +168,7 @@ exports[`Chart 1`] = `
               },
               "minLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -173,7 +180,7 @@ exports[`Chart 1`] = `
               },
               "q1Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -185,7 +192,7 @@ exports[`Chart 1`] = `
               },
               "q3Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -215,7 +222,7 @@ exports[`Chart 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -256,12 +263,13 @@ exports[`Chart 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -299,7 +307,7 @@ exports[`Chart 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -307,7 +315,7 @@ exports[`Chart 1`] = `
               },
               "title": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 2,
@@ -329,12 +337,13 @@ exports[`Chart 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -353,15 +362,17 @@ exports[`Chart 1`] = `
               "#004b95",
             ],
             "height": 230,
+            "padAngle": 1,
             "padding": 8,
             "style": Object {
               "data": Object {
                 "padding": 8,
+                "stroke": "transparent",
                 "strokeWidth": 1,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -383,12 +394,13 @@ exports[`Chart 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "#bee1f4",
+                "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -429,7 +441,7 @@ exports[`Chart 1`] = `
             "pointerWidth": 20,
             "style": Object {
               "fill": "#EDEDED",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 16,
@@ -462,7 +474,7 @@ exports[`Chart 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -520,7 +532,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -550,7 +562,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -558,13 +570,15 @@ exports[`Chart 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -572,8 +586,11 @@ exports[`Chart 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -592,11 +609,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -624,7 +643,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -637,7 +656,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -650,7 +669,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -662,7 +681,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -674,7 +693,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -704,7 +723,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -745,12 +764,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -788,7 +808,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -796,7 +816,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -818,12 +838,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -842,15 +863,17 @@ exports[`Chart 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -872,12 +895,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -918,7 +942,7 @@ exports[`Chart 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -951,7 +975,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1007,7 +1031,7 @@ exports[`Chart 2`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1037,7 +1061,7 @@ exports[`Chart 2`] = `
               },
               "axisLabel": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 100,
@@ -1045,13 +1069,15 @@ exports[`Chart 2`] = `
                 "textAnchor": "middle",
               },
               "grid": Object {
-                "fill": "none",
+                "fill": "transparent",
                 "pointerEvents": "painted",
                 "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
               },
               "tickLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1059,8 +1085,11 @@ exports[`Chart 2`] = `
               },
               "ticks": Object {
                 "fill": "transparent",
-                "size": 1,
-                "stroke": "transparent",
+                "size": 5,
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
               },
             },
             "width": 450,
@@ -1079,11 +1108,13 @@ exports[`Chart 2`] = `
             "style": Object {
               "data": Object {
                 "fill": "#06c",
+                "padding": 8,
                 "stroke": "none",
+                "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1111,7 +1142,7 @@ exports[`Chart 2`] = `
               },
               "maxLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1124,7 +1155,7 @@ exports[`Chart 2`] = `
               },
               "medianLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1137,7 +1168,7 @@ exports[`Chart 2`] = `
               },
               "minLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1149,7 +1180,7 @@ exports[`Chart 2`] = `
               },
               "q1Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1161,7 +1192,7 @@ exports[`Chart 2`] = `
               },
               "q3Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1191,7 +1222,7 @@ exports[`Chart 2`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1232,12 +1263,13 @@ exports[`Chart 2`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1275,7 +1307,7 @@ exports[`Chart 2`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1283,7 +1315,7 @@ exports[`Chart 2`] = `
               },
               "title": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 2,
@@ -1305,12 +1337,13 @@ exports[`Chart 2`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1329,15 +1362,17 @@ exports[`Chart 2`] = `
               "#004b95",
             ],
             "height": 230,
+            "padAngle": 1,
             "padding": 8,
             "style": Object {
               "data": Object {
                 "padding": 8,
+                "stroke": "transparent",
                 "strokeWidth": 1,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -1359,12 +1394,13 @@ exports[`Chart 2`] = `
             "style": Object {
               "data": Object {
                 "fill": "#bee1f4",
+                "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -1405,7 +1441,7 @@ exports[`Chart 2`] = `
             "pointerWidth": 20,
             "style": Object {
               "fill": "#EDEDED",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 16,
@@ -1438,7 +1474,7 @@ exports[`Chart 2`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -1496,7 +1532,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1526,7 +1562,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1534,13 +1570,15 @@ exports[`Chart 2`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1548,8 +1586,11 @@ exports[`Chart 2`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -1568,11 +1609,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1600,7 +1643,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1613,7 +1656,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1626,7 +1669,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1638,7 +1681,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1650,7 +1693,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1680,7 +1723,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1721,12 +1764,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1764,7 +1808,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1772,7 +1816,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1794,12 +1838,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1818,15 +1863,17 @@ exports[`Chart 2`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1848,12 +1895,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1894,7 +1942,7 @@ exports[`Chart 2`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -1927,7 +1975,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1983,7 +2031,7 @@ exports[`renders component data 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2013,7 +2061,7 @@ exports[`renders component data 1`] = `
               },
               "axisLabel": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 100,
@@ -2021,13 +2069,15 @@ exports[`renders component data 1`] = `
                 "textAnchor": "middle",
               },
               "grid": Object {
-                "fill": "none",
+                "fill": "transparent",
                 "pointerEvents": "painted",
                 "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
               },
               "tickLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2035,8 +2085,11 @@ exports[`renders component data 1`] = `
               },
               "ticks": Object {
                 "fill": "transparent",
-                "size": 1,
-                "stroke": "transparent",
+                "size": 5,
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
               },
             },
             "width": 450,
@@ -2055,11 +2108,13 @@ exports[`renders component data 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "#06c",
+                "padding": 8,
                 "stroke": "none",
+                "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2087,7 +2142,7 @@ exports[`renders component data 1`] = `
               },
               "maxLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2100,7 +2155,7 @@ exports[`renders component data 1`] = `
               },
               "medianLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2113,7 +2168,7 @@ exports[`renders component data 1`] = `
               },
               "minLabels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2125,7 +2180,7 @@ exports[`renders component data 1`] = `
               },
               "q1Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2137,7 +2192,7 @@ exports[`renders component data 1`] = `
               },
               "q3Labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2167,7 +2222,7 @@ exports[`renders component data 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2208,12 +2263,13 @@ exports[`renders component data 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2251,7 +2307,7 @@ exports[`renders component data 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2259,7 +2315,7 @@ exports[`renders component data 1`] = `
               },
               "title": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 2,
@@ -2281,12 +2337,13 @@ exports[`renders component data 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "transparent",
+                "opacity": 1,
                 "stroke": "#73bcf7",
                 "strokeWidth": 2,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2305,15 +2362,17 @@ exports[`renders component data 1`] = `
               "#004b95",
             ],
             "height": 230,
+            "padAngle": 1,
             "padding": 8,
             "style": Object {
               "data": Object {
                 "padding": 8,
+                "stroke": "transparent",
                 "strokeWidth": 1,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -2335,12 +2394,13 @@ exports[`renders component data 1`] = `
             "style": Object {
               "data": Object {
                 "fill": "#bee1f4",
+                "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 10,
@@ -2381,7 +2441,7 @@ exports[`renders component data 1`] = `
             "pointerWidth": 20,
             "style": Object {
               "fill": "#EDEDED",
-              "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 16,
@@ -2414,7 +2474,7 @@ exports[`renders component data 1`] = `
               },
               "labels": Object {
                 "fill": "#151515",
-                "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
@@ -2476,7 +2536,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2506,7 +2566,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -2514,13 +2574,15 @@ exports[`renders component data 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2528,8 +2590,11 @@ exports[`renders component data 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -2548,11 +2613,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2580,7 +2647,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2593,7 +2660,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2606,7 +2673,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2618,7 +2685,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2630,7 +2697,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2660,7 +2727,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2701,12 +2768,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2744,7 +2812,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2752,7 +2820,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -2774,12 +2842,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2798,15 +2867,17 @@ exports[`renders component data 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -2828,12 +2899,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -2874,7 +2946,7 @@ exports[`renders component data 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -2907,7 +2979,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -64,7 +64,7 @@ exports[`Chart 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -72,13 +72,15 @@ exports[`Chart 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -86,8 +88,11 @@ exports[`Chart 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -106,11 +111,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -138,7 +145,7 @@ exports[`Chart 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -151,7 +158,7 @@ exports[`Chart 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -164,7 +171,7 @@ exports[`Chart 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -176,7 +183,7 @@ exports[`Chart 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -188,7 +195,7 @@ exports[`Chart 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -218,7 +225,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -259,12 +266,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -302,7 +310,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -310,7 +318,7 @@ exports[`Chart 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -332,12 +340,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -356,15 +365,17 @@ exports[`Chart 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -386,12 +397,13 @@ exports[`Chart 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -432,7 +444,7 @@ exports[`Chart 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -465,7 +477,7 @@ exports[`Chart 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -515,7 +527,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -545,7 +557,7 @@ exports[`Chart 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -553,13 +565,15 @@ exports[`Chart 2`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -567,8 +581,11 @@ exports[`Chart 2`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -587,11 +604,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -619,7 +638,7 @@ exports[`Chart 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -632,7 +651,7 @@ exports[`Chart 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -645,7 +664,7 @@ exports[`Chart 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -657,7 +676,7 @@ exports[`Chart 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -669,7 +688,7 @@ exports[`Chart 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -699,7 +718,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -740,12 +759,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -783,7 +803,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -791,7 +811,7 @@ exports[`Chart 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -813,12 +833,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -837,15 +858,17 @@ exports[`Chart 2`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -867,12 +890,13 @@ exports[`Chart 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -913,7 +937,7 @@ exports[`Chart 2`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -946,7 +970,7 @@ exports[`Chart 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3146,7 +3170,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3176,7 +3200,7 @@ exports[`renders component data 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -3184,13 +3208,15 @@ exports[`renders component data 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3198,8 +3224,11 @@ exports[`renders component data 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -3218,11 +3247,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3250,7 +3281,7 @@ exports[`renders component data 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3263,7 +3294,7 @@ exports[`renders component data 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3276,7 +3307,7 @@ exports[`renders component data 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3288,7 +3319,7 @@ exports[`renders component data 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3300,7 +3331,7 @@ exports[`renders component data 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3330,7 +3361,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3371,12 +3402,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3414,7 +3446,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3422,7 +3454,7 @@ exports[`renders component data 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -3444,12 +3476,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3468,15 +3501,17 @@ exports[`renders component data 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -3498,12 +3533,13 @@ exports[`renders component data 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -3544,7 +3580,7 @@ exports[`renders component data 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -3577,7 +3613,7 @@ exports[`renders component data 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -21,7 +21,10 @@ import { Chart, ChartStack } from '@patternfly/react-charts';
       legendPosition="right"
       height={250}
       padding={{
-        right: 200
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accomodate legend
+        top: 50
       }}
       width={600}
     >
@@ -49,7 +52,10 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
       legendPosition="bottom"
       height={275}
       padding={{
-        bottom: 75
+        bottom: 75, // Adjusted to accomodate legend
+        left: 50,
+        right: 50, 
+        top: 50
       }}
       themeColor={ChartThemeColor.gold}
       width={450}
@@ -81,7 +87,10 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
       legendPosition="bottom"
       height={275}
       padding={{
-        bottom: 75
+        bottom: 75, // Adjusted to accomodate legend
+        left: 50,
+        right: 50, 
+        top: 50
       }}
       themeColor={ChartThemeColor.multi}
       width={450}

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/styles/common-styles.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/styles/common-styles.ts
@@ -1,12 +1,16 @@
-import { global_FontFamily_sans_serif } from '@patternfly/react-tokens';
+import {
+  chart_global_FontFamily,
+  chart_global_label_Margin,
+  chart_legend_Margin,
+} from '@patternfly/react-tokens';
 
 export const CommonStyles = {
   label: {
-    fontFamily: global_FontFamily_sans_serif.value,
-    margin: 8
+    fontFamily: chart_global_FontFamily.value,
+    margin: chart_global_label_Margin.value,
   },
   legend: {
-    margin: 16,
-    position: 'right'
+    margin: chart_legend_Margin.value,
+    position: 'right' // Todo: Replace with PF-core var when available
   },
 };

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/styles/donut-styles.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/styles/donut-styles.ts
@@ -1,17 +1,22 @@
-// TODO Replace label props with PF css when available
+/* eslint-disable camelcase */
+import {
+  chart_global_FontSize_sm,
+  chart_global_FontSize_2xl,
+  chart_donut_label_subtitle_Fill
+} from '@patternfly/react-tokens';
 
 // Donut styles
 export const DonutStyles = {
   label: {
     subTitle: {
       // Victory props only
-      fill: '#bbb',
-      fontSize: 14
+      fill: chart_donut_label_subtitle_Fill.value,
+      fontSize: chart_global_FontSize_sm.value
     },
-    subTitlePosition: 'center',
+    subTitlePosition: 'center', // Todo: Replace with PF-core var when available
     title: {
       // Victory props only
-      fontSize: 24
+      fontSize: chart_global_FontSize_2xl.value
     }
   }
 };

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/styles/donut-utilization-styles.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/styles/donut-utilization-styles.ts
@@ -1,8 +1,15 @@
-// TODO Replace label props with PF css when available
+/* eslint-disable camelcase */
+import {
+  chart_donut_threshold_warning_Color,
+  chart_donut_threshold_danger_Color,
+} from '@patternfly/react-tokens';
 
 // Donut utilization styles
 export const DonutUtilizationStyles = {
   thresholds: {
-    colorScale: ['#F0AB00', '#C9190B']
+    colorScale: [
+      chart_donut_threshold_warning_Color.value,
+      chart_donut_threshold_danger_Color.value
+    ]
   }
 };

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/axis-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/axis-theme.ts
@@ -1,5 +1,10 @@
-// TODO Replace label props with PF css when available
-const COLOR_AXIS_FILL = 'transparent';
+/* eslint-disable camelcase */
+import {
+  chart_axis_grid_stroke_Color,
+  chart_axis_tick_stroke_Color
+} from '@patternfly/react-tokens';
+
+// Todo: Replace with PF-core var when available
 const COLOR_AXIS_STROKE = '#D2D2D2';
 
 // Axis theme
@@ -7,12 +12,10 @@ export const AxisTheme = {
   axis: {
     style: {
       grid: {
-        stroke: COLOR_AXIS_STROKE
+        stroke: COLOR_AXIS_STROKE // chart_axis_grid_stroke_Color.value << should not be 'transparent'
       },
       ticks: {
-        size: 5,
-        stroke: COLOR_AXIS_STROKE,
-        strokeWidth: 1
+        stroke: COLOR_AXIS_STROKE, // chart_axis_tick_stroke_Color.value << should not be 'transparent'
       }
     }
   },

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/base-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/base-theme.ts
@@ -1,36 +1,130 @@
 /* eslint-disable camelcase */
-import { global_FontFamily_sans_serif } from '@patternfly/react-tokens';
+import {
+  chart_global_FontFamily,
+  chart_global_letter_spacing,
+  chart_global_FontSize_sm,
+  chart_global_label_Padding,
+  chart_global_label_stroke,
+  chart_global_label_text_anchor,
+  chart_global_layout_Padding,
+  chart_global_layout_Height,
+  chart_global_layout_Width,
+  chart_global_stroke_line_cap,
+  chart_global_stroke_line_join,
+  chart_area_data_Fill,
+  chart_area_Opacity,
+  chart_area_stroke_Width,
+  chart_axis_axis_stroke_Width,
+  chart_axis_axis_stroke_Color,
+  chart_axis_axis_Fill,
+  chart_axis_axis_label_Padding,
+  chart_axis_axis_label_stroke_Color,
+  chart_axis_grid_Fill,
+  chart_axis_grid_PointerEvents,
+  chart_axis_tick_Fill,
+  chart_axis_tick_Width,
+  chart_axis_tick_label_Fill,
+  chart_bar_Width,
+  chart_bar_data_stroke,
+  chart_bar_data_Fill,
+  chart_bar_data_Padding,
+  chart_bar_data_stroke_Width,
+  chart_boxplot_max_Padding,
+  chart_boxplot_max_stroke_Color,
+  chart_boxplot_max_stroke_Width,
+  chart_boxplot_median_Padding,
+  chart_boxplot_median_stroke_Color,
+  chart_boxplot_median_stroke_Width,
+  chart_boxplot_min_Padding,
+  chart_boxplot_min_stroke_Width,
+  chart_boxplot_min_stroke_Color,
+  chart_boxplot_lower_quartile_Padding,
+  chart_boxplot_lower_quartile_Fill,
+  chart_boxplot_upper_quartile_Padding,
+  chart_boxplot_upper_quartile_Fill,
+  chart_boxplot_box_Width,
+  chart_candelstick_data_stroke_Width,
+  chart_candelstick_data_stroke_Color,
+  chart_candelstick_candle_positive_Color,
+  chart_candelstick_candle_negative_Color,
+  chart_errorbar_BorderWidth,
+  chart_errorbar_data_Fill,
+  chart_errorbar_data_Opacity,
+  chart_errorbar_data_stroke_Width,
+  chart_errorbar_data_stroke_Color,
+  chart_legend_gutter_Width,
+  chart_legend_orientation,
+  chart_legend_title_orientation,
+  chart_legend_data_type,
+  chart_legend_title_Padding,
+  chart_line_data_Fill,
+  chart_line_data_Opacity,
+  chart_line_data_stroke_Width,
+  chart_line_data_stroke_Color,
+  chart_pie_Padding,
+  chart_pie_data_Padding,
+  chart_pie_data_stroke_Width,
+  chart_pie_data_stroke_Color,
+  chart_pie_labels_Padding,
+  chart_pie_angle_Padding,
+  chart_pie_Height,
+  chart_pie_Width,
+  chart_scatter_data_stroke_Color,
+  chart_scatter_data_stroke_Width,
+  chart_scatter_data_Opacity,
+  chart_scatter_data_Fill,
+  chart_stack_data_stroke_Width,
+  chart_tooltip_corner_radius,
+  chart_tooltip_pointer_length,
+  chart_tooltip_flyoutStyle_corner_radius,
+  chart_tooltip_flyoutStyle_stroke_Width,
+  chart_tooltip_flyoutStyle_PointerEvents,
+  chart_tooltip_flyoutStyle_stroke_Color,
+  chart_tooltip_flyoutStyle_Fill,
+  chart_tooltip_pointer_Width,
+  chart_tooltip_Padding,
+  chart_tooltip_PointerEvents,
+  chart_voronoi_data_Fill,
+  chart_voronoi_data_stroke_Color,
+  chart_voronoi_data_stroke_Width,
+  chart_voronoi_labels_Padding,
+  chart_voronoi_labels_PointerEvents,
+  chart_voronoi_flyout_stroke_Width,
+  chart_voronoi_flyout_PointerEvents,
+  chart_voronoi_flyout_stroke_Color,
+  chart_voronoi_flyout_stroke_Fill,
+} from '@patternfly/react-tokens';
 
-// TODO Replace values with PF css variable when available
+// Note: Values must be in pixles
 
 // Typography
-const TYPOGRAPHY_FONT_FAMILY = global_FontFamily_sans_serif.value;
-const TYPOGRAPHY_LETTER_SPACING = 'normal';
-const TYPOGRAPHY_FONT_SIZE = 14; // Value must be in pixles
+const TYPOGRAPHY_FONT_FAMILY = chart_global_FontFamily.value;
+const TYPOGRAPHY_LETTER_SPACING = chart_global_letter_spacing.value;
+const TYPOGRAPHY_FONT_SIZE = chart_global_FontSize_sm.value;
 
 // Labels
 const LABEL_PROPS = {
   fontFamily: TYPOGRAPHY_FONT_FAMILY,
   fontSize: TYPOGRAPHY_FONT_SIZE,
   letterSpacing: TYPOGRAPHY_LETTER_SPACING,
-  padding: 10, // Value must be in pixles
-  stroke: 'transparent'
+  padding: chart_global_label_Padding.value,
+  stroke: chart_global_label_stroke.value
 };
 const LABEL_CENTERED_PROPS = {
   ...LABEL_PROPS,
-  textAnchor: 'middle'
+  textAnchor: chart_global_label_text_anchor.value
 };
 
 // Layout
 const LAYOUT_PROPS = {
-  padding: 50,
-  height: 300,
-  width: 450
+  padding: chart_global_layout_Padding.value,
+  height: chart_global_layout_Height.value,
+  width: chart_global_layout_Width.value
 };
 
 // Strokes
-const STROKE_LINE_CAP = 'round';
-const STROKE_LINE_JOIN = 'round';
+const STROKE_LINE_CAP = chart_global_stroke_line_cap.value;
+const STROKE_LINE_JOIN = chart_global_stroke_line_join.value;
 
 // Victory theme properties only
 export const BaseTheme = {
@@ -38,8 +132,9 @@ export const BaseTheme = {
     ...LAYOUT_PROPS,
     style: {
       data: {
-        fillOpacity: 0.4,
-        strokeWidth: 2
+        fill: chart_area_data_Fill.value,
+        fillOpacity: chart_area_Opacity.value,
+        strokeWidth: chart_area_stroke_Width.value
       },
       labels: LABEL_CENTERED_PROPS
     }
@@ -48,33 +143,47 @@ export const BaseTheme = {
     ...LAYOUT_PROPS,
     style: {
       axis: {
-        strokeWidth: 1,
+        fill: chart_axis_axis_Fill.value,
+        strokeWidth: chart_axis_axis_stroke_Width.value,
+        stroke: chart_axis_axis_stroke_Color.value,
         strokeLinecap: STROKE_LINE_CAP,
         strokeLinejoin: STROKE_LINE_JOIN
       },
       axisLabel: {
         ...LABEL_CENTERED_PROPS,
-        padding: 100
+        padding: chart_axis_axis_label_Padding.value,
+        stroke: chart_axis_axis_label_stroke_Color.value
       },
       grid: {
-        fill: 'none',
-        stroke: 'none', // Todo: Need to show for one axis only
-        pointerEvents: 'painted'
+        fill: chart_axis_grid_Fill.value,
+        stroke: 'none',
+        pointerEvents: chart_axis_grid_PointerEvents.value,
+        strokeLinecap: STROKE_LINE_CAP,
+        strokeLinejoin: STROKE_LINE_JOIN
       },
       ticks: {
-        fill: 'transparent',
-        size: 1,
-        stroke: 'transparent'
+        fill: chart_axis_tick_Fill.value,
+        size: 5, // chart_axis_tick_Width.value, // Todo: value should be 5
+        stroke: 'none',
+        strokeLinecap: STROKE_LINE_CAP,
+        strokeLinejoin: STROKE_LINE_JOIN,
+        strokeWidth: chart_axis_tick_Width.value
       },
-      tickLabels: LABEL_PROPS
+      tickLabels: {
+        ...LABEL_PROPS,
+        fill: chart_axis_tick_label_Fill.value
+      }
     }
   },
   bar: {
     ...LAYOUT_PROPS,
-    barWidth: 10,
+    barWidth: chart_bar_Width.value,
     style: {
       data: {
-        stroke: 'none'
+        fill: chart_bar_data_Fill.value,
+        padding: chart_bar_data_Padding.value,
+        stroke: chart_bar_data_stroke.value,
+        strokeWidth: chart_bar_data_stroke_Width.value
       },
       labels: LABEL_PROPS
     }
@@ -83,55 +192,62 @@ export const BaseTheme = {
     ...LAYOUT_PROPS,
     style: {
       max: {
-        padding: 8,
-        strokeWidth: 1
+        padding: chart_boxplot_max_Padding.value,
+        stroke: chart_boxplot_max_stroke_Color.value,
+        strokeWidth: chart_boxplot_max_stroke_Width.value
       },
       maxLabels: LABEL_PROPS,
       median: {
-        padding: 8,
-        strokeWidth: 1
+        padding: chart_boxplot_median_Padding.value,
+        stroke: chart_boxplot_median_stroke_Color.value,
+        strokeWidth: chart_boxplot_median_stroke_Width.value
       },
       medianLabels: LABEL_PROPS,
       min: {
-        padding: 8,
-        strokeWidth: 1
+        padding: chart_boxplot_min_Padding.value,
+        stroke: chart_boxplot_min_stroke_Color.value,
+        strokeWidth: chart_boxplot_min_stroke_Width.value
       },
       minLabels: LABEL_PROPS,
       q1: {
-        padding: 8
+        fill: chart_boxplot_lower_quartile_Fill.value,
+        padding: chart_boxplot_lower_quartile_Padding.value
       },
       q1Labels: LABEL_PROPS,
       q3: {
-        padding: 8
+        fill: chart_boxplot_upper_quartile_Fill.value,
+        padding: chart_boxplot_upper_quartile_Padding.value
       },
       q3Labels: LABEL_PROPS
     },
-    boxWidth: 20
+    boxWidth: chart_boxplot_box_Width.value
   },
   candlestick: {
     ...LAYOUT_PROPS,
+    candleColors: {
+      positive: chart_candelstick_candle_positive_Color.value,
+      negative: chart_candelstick_candle_negative_Color.value
+    },
     style: {
       data: {
-        strokeWidth: 1
+        stroke: chart_candelstick_data_stroke_Color.value,
+        strokeWidth: chart_candelstick_data_stroke_Width.value
       },
       labels: LABEL_CENTERED_PROPS
     }
   },
   chart: {
-    ...LAYOUT_PROPS,
-    style: {
-      parent: {
-        border: `1px solid`
-      }
-    }
+    ...LAYOUT_PROPS
   },
   errorbar: {
     ...LAYOUT_PROPS,
-    borderWidth: 8,
+    borderWidth: chart_errorbar_BorderWidth.value,
     style: {
       data: {
-        fill: 'transparent',
-        strokeWidth: 2
+        fill: chart_errorbar_data_Fill.value,
+        opacity: chart_errorbar_data_Opacity.value,
+        stroke: chart_errorbar_data_stroke_Color.value,
+        strokeWidth: chart_errorbar_data_stroke_Width.value
       },
       labels: LABEL_CENTERED_PROPS
     }
@@ -140,18 +256,18 @@ export const BaseTheme = {
     ...LAYOUT_PROPS
   },
   legend: {
-    gutter: 20,
-    orientation: 'horizontal',
-    titleOrientation: 'top',
+    gutter: chart_legend_gutter_Width.value,
+    orientation: chart_legend_orientation.value,
+    titleOrientation: chart_legend_title_orientation.value,
     style: {
       data: {
-        type: 'square'
+        type: chart_legend_data_type.value
       },
       labels: LABEL_PROPS,
       title: {
         ...LABEL_PROPS,
         fontSize: TYPOGRAPHY_FONT_SIZE,
-        padding: 2
+        padding: chart_legend_title_Padding.value
       }
     }
   },
@@ -159,34 +275,39 @@ export const BaseTheme = {
     ...LAYOUT_PROPS,
     style: {
       data: {
-        fill: 'transparent',
-        strokeWidth: 2
+        fill: chart_line_data_Fill.value,
+        opacity: chart_line_data_Opacity.value,
+        stroke: chart_line_data_stroke_Color.value,
+        strokeWidth: chart_line_data_stroke_Width.value
       },
       labels: LABEL_CENTERED_PROPS
     }
   },
   pie: {
-    padding: 8,
+    padding: chart_pie_Padding.value,
+    padAngle: chart_pie_angle_Padding.value, // Todo: Should be zero?
     style: {
       data: {
-        padding: 8,
-        // stroke: 'transparent',
-        strokeWidth: 1
+        padding: chart_pie_data_Padding.value,
+        stroke: chart_pie_data_stroke_Color.value,
+        strokeWidth: chart_pie_data_stroke_Width.value
       },
       labels: {
         ...LABEL_PROPS,
-        padding: 8
+        padding: chart_pie_labels_Padding.value
       }
     },
-    height: 230,
-    width: 230
+    height: chart_pie_Height.value,
+    width: chart_pie_Width.value
   },
   scatter: {
     ...LAYOUT_PROPS,
     style: {
       data: {
-        stroke: 'transparent',
-        strokeWidth: 0
+        fill: chart_scatter_data_Fill.value,
+        opacity: chart_scatter_data_Opacity.value,
+        stroke: chart_scatter_data_stroke_Color.value,
+        strokeWidth: chart_scatter_data_stroke_Width.value
       },
       labels: LABEL_CENTERED_PROPS
     }
@@ -195,42 +316,46 @@ export const BaseTheme = {
     ...LAYOUT_PROPS,
     style: {
       data: {
-        strokeWidth: 1
+        strokeWidth: chart_stack_data_stroke_Width.value
       }
     }
   },
   tooltip: {
-    cornerRadius: 0,
+    cornerRadius: chart_tooltip_corner_radius.value,
     flyoutStyle: {
-      cornerRadius: 0,
-      strokeWidth: 0,
-      pointerEvents: 'none'
+      cornerRadius: chart_tooltip_flyoutStyle_corner_radius.value,
+      fill: chart_tooltip_flyoutStyle_Fill.value,
+      pointerEvents: chart_tooltip_flyoutStyle_PointerEvents.value,
+      stroke: chart_tooltip_flyoutStyle_stroke_Color.value,
+      strokeWidth: chart_tooltip_flyoutStyle_stroke_Width.value
     },
-    pointerLength: 10,
-    pointerWidth: 20,
+    pointerLength: chart_tooltip_pointer_length.value,
+    pointerWidth: chart_tooltip_pointer_Width.value,
     style: {
       ...LABEL_CENTERED_PROPS,
-      padding: 16,
-      pointerEvents: 'none'
+      padding: chart_tooltip_Padding.value,
+      pointerEvents: chart_tooltip_PointerEvents.value
     }
   },
   voronoi: {
     ...LAYOUT_PROPS,
     style: {
       data: {
-        fill: 'transparent',
-        stroke: 'transparent',
-        strokeWidth: 0
+        fill: chart_voronoi_data_Fill.value,
+        stroke: chart_voronoi_data_stroke_Color.value,
+        strokeWidth: chart_voronoi_data_stroke_Width.value
       },
       labels: {
         ...LABEL_CENTERED_PROPS,
-        padding: 8,
-        pointerEvents: 'none'
+        padding: chart_voronoi_labels_Padding.value,
+        pointerEvents: chart_voronoi_labels_PointerEvents.value
       },
       // Note: These properties override tooltip
       flyout: {
-        strokeWidth: 1,
-        pointerEvents: 'none'
+        fill: chart_voronoi_flyout_stroke_Fill.value,
+        pointerEvents: chart_voronoi_flyout_PointerEvents.value,
+        stroke: chart_voronoi_flyout_stroke_Color.value,
+        strokeWidth: chart_voronoi_flyout_stroke_Width.value,
       }
     }
   }

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/bullet-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/bullet-theme.ts
@@ -1,0 +1,18 @@
+/* eslint-disable camelcase */
+import {
+  chart_bullet_Height,
+  chart_bullet_items_per_row,
+  chart_bullet_legend_Height,
+  chart_bullet_range_Width,
+  chart_bullet_threshold_error_Color,
+  chart_bullet_threshold_error_Width,
+  chart_bullet_value_Width,
+  chart_bullet_comparative_measure_line_warning_stroke_Color,
+  chart_bullet_comparative_measure_line_warning_BorderWidth,
+  chart_bullet_comparative_measure_line_error_stroke_Color,
+  chart_bullet_comparative_measure_line_error_BorderWidth,
+  chart_bullet_zero_line_stroke_Color,
+  chart_bullet_zero_line_BorderWidth,
+  chart_bullet_negative_primary_measure_stroke_Color,
+  chart_bullet_negative_primary_measure_BorderWidth,
+} from '@patternfly/react-tokens';

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-theme.ts
@@ -1,10 +1,15 @@
-// TODO Replace label props with PF css when available
+/* eslint-disable camelcase */
+import {
+  chart_donut_pie_Height,
+  chart_donut_pie_angle_Padding,
+  chart_donut_pie_Width,
+} from '@patternfly/react-tokens';
 
 // Donut theme
 export const DonutTheme = {
   pie: {
-    height: 230,
-    padAngle: 1,
-    width: 230
+    height: chart_donut_pie_Height.value,
+    padAngle: chart_donut_pie_angle_Padding.value,
+    width: chart_donut_pie_Width.value
   }
 };

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-threshold-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-threshold-theme.ts
@@ -1,22 +1,39 @@
-// TODO Replace label props with PF css when available
+/* eslint-disable camelcase */
+import {
+  chart_donut_threshold_first_Color,
+  chart_donut_threshold_second_Color,
+  chart_donut_threshold_third_Color,
+  chart_donut_threshold_dynamic_pie_Height,
+  chart_donut_threshold_dynamic_pie_Width,
+  chart_donut_threshold_static_pie_Height,
+  chart_donut_threshold_static_pie_angle_Padding,
+  chart_donut_threshold_static_pie_Width,
+} from '@patternfly/react-tokens';
 
 // Donut threshold dynamic theme
 export const DonutThresholdDynamicTheme = {
   legend: {
-    colorScale: ['#D2D2D2', '#BBBBBB']
+    colorScale: [
+      chart_donut_threshold_second_Color.value,
+      chart_donut_threshold_third_Color.value
+    ]
   },
   pie: {
-    height: 202,
-    width: 202
+    height: chart_donut_threshold_dynamic_pie_Height.value,
+    width: chart_donut_threshold_dynamic_pie_Width.value
   }
 };
 
 // Donut threshold static theme
 export const DonutThresholdStaticTheme = {
   pie: {
-    colorScale: ['#EDEDED', '#D2D2D2', '#BBBBBB'],
-    height: 230,
-    padAngle: 1,
-    width: 230
+    colorScale: [
+      chart_donut_threshold_first_Color.value,
+      chart_donut_threshold_second_Color.value,
+      chart_donut_threshold_third_Color.value
+    ],
+    height: chart_donut_threshold_static_pie_Height.value,
+    padAngle: chart_donut_threshold_static_pie_angle_Padding.value,
+    width: chart_donut_threshold_static_pie_Width.value
   }
 };

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-utilization-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/donut-utilization-theme.ts
@@ -1,20 +1,34 @@
-// TODO Replace label props with PF css when available
+/* eslint-disable camelcase */
+import {
+  chart_donut_threshold_first_Color,
+  chart_donut_threshold_second_Color,
+  chart_donut_threshold_third_Color,
+  chart_donut_utilization_dynamic_pie_Height,
+  chart_donut_utilization_dynamic_pie_angle_Padding,
+  chart_donut_utilization_dynamic_pie_Width,
+} from '@patternfly/react-tokens';
 
 // Donut utilization dynamic theme
 export const DonutUtilizationDynamicTheme = {
   pie: {
-    height: 230,
-    padAngle: 1,
-    width: 230
+    height: chart_donut_utilization_dynamic_pie_Height.value,
+    padAngle: chart_donut_utilization_dynamic_pie_angle_Padding.value,
+    width: chart_donut_utilization_dynamic_pie_Width.value
   }
 };
 
 // Donut utilization static theme
 export const DonutUtilizationStaticTheme = {
   legend: {
-    colorScale: ['#EDEDED', '#D2D2D2', '#BBBBBB']
+    colorScale: [
+      chart_donut_threshold_first_Color.value,
+      chart_donut_threshold_second_Color.value,
+      chart_donut_threshold_third_Color.value
+    ],
   },
   pie: {
-    colorScale: ['#EDEDED']
+    colorScale: [
+      chart_donut_threshold_first_Color.value
+    ]
   }
 };

--- a/packages/patternfly-4/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`ChartTooltip 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -71,7 +71,7 @@ exports[`ChartTooltip 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -79,13 +79,15 @@ exports[`ChartTooltip 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -93,8 +95,11 @@ exports[`ChartTooltip 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -113,11 +118,13 @@ exports[`ChartTooltip 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -145,7 +152,7 @@ exports[`ChartTooltip 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -158,7 +165,7 @@ exports[`ChartTooltip 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -171,7 +178,7 @@ exports[`ChartTooltip 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -183,7 +190,7 @@ exports[`ChartTooltip 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -195,7 +202,7 @@ exports[`ChartTooltip 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -225,7 +232,7 @@ exports[`ChartTooltip 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -266,12 +273,13 @@ exports[`ChartTooltip 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -309,7 +317,7 @@ exports[`ChartTooltip 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -317,7 +325,7 @@ exports[`ChartTooltip 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -339,12 +347,13 @@ exports[`ChartTooltip 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -363,15 +372,17 @@ exports[`ChartTooltip 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -393,12 +404,13 @@ exports[`ChartTooltip 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -439,7 +451,7 @@ exports[`ChartTooltip 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -472,7 +484,7 @@ exports[`ChartTooltip 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -529,7 +541,7 @@ exports[`ChartTooltip 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -559,7 +571,7 @@ exports[`ChartTooltip 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -567,13 +579,15 @@ exports[`ChartTooltip 2`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -581,8 +595,11 @@ exports[`ChartTooltip 2`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -601,11 +618,13 @@ exports[`ChartTooltip 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -633,7 +652,7 @@ exports[`ChartTooltip 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -646,7 +665,7 @@ exports[`ChartTooltip 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -659,7 +678,7 @@ exports[`ChartTooltip 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -671,7 +690,7 @@ exports[`ChartTooltip 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -683,7 +702,7 @@ exports[`ChartTooltip 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -713,7 +732,7 @@ exports[`ChartTooltip 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -754,12 +773,13 @@ exports[`ChartTooltip 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -797,7 +817,7 @@ exports[`ChartTooltip 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -805,7 +825,7 @@ exports[`ChartTooltip 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -827,12 +847,13 @@ exports[`ChartTooltip 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -851,15 +872,17 @@ exports[`ChartTooltip 2`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -881,12 +904,13 @@ exports[`ChartTooltip 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -927,7 +951,7 @@ exports[`ChartTooltip 2`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -960,7 +984,7 @@ exports[`ChartTooltip 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1037,7 +1061,7 @@ exports[`allows tooltip via container component 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1067,7 +1091,7 @@ exports[`allows tooltip via container component 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1075,13 +1099,15 @@ exports[`allows tooltip via container component 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1089,8 +1115,11 @@ exports[`allows tooltip via container component 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -1109,11 +1138,13 @@ exports[`allows tooltip via container component 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1141,7 +1172,7 @@ exports[`allows tooltip via container component 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1154,7 +1185,7 @@ exports[`allows tooltip via container component 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1167,7 +1198,7 @@ exports[`allows tooltip via container component 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1179,7 +1210,7 @@ exports[`allows tooltip via container component 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1191,7 +1222,7 @@ exports[`allows tooltip via container component 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1221,7 +1252,7 @@ exports[`allows tooltip via container component 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1262,12 +1293,13 @@ exports[`allows tooltip via container component 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1305,7 +1337,7 @@ exports[`allows tooltip via container component 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1313,7 +1345,7 @@ exports[`allows tooltip via container component 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1335,12 +1367,13 @@ exports[`allows tooltip via container component 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1359,15 +1392,17 @@ exports[`allows tooltip via container component 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1389,12 +1424,13 @@ exports[`allows tooltip via container component 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1435,7 +1471,7 @@ exports[`allows tooltip via container component 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -1468,7 +1504,7 @@ exports[`allows tooltip via container component 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -80,7 +80,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -88,13 +88,15 @@ exports[`ChartVoronoiContainer 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -102,8 +104,11 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -122,11 +127,13 @@ exports[`ChartVoronoiContainer 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -154,7 +161,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -167,7 +174,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -180,7 +187,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -192,7 +199,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -204,7 +211,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -234,7 +241,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -275,12 +282,13 @@ exports[`ChartVoronoiContainer 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -318,7 +326,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -326,7 +334,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -348,12 +356,13 @@ exports[`ChartVoronoiContainer 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -372,15 +381,17 @@ exports[`ChartVoronoiContainer 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -402,12 +413,13 @@ exports[`ChartVoronoiContainer 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -448,7 +460,7 @@ exports[`ChartVoronoiContainer 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -481,7 +493,7 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -548,7 +560,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -578,7 +590,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -586,13 +598,15 @@ exports[`ChartVoronoiContainer 2`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -600,8 +614,11 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -620,11 +637,13 @@ exports[`ChartVoronoiContainer 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -652,7 +671,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -665,7 +684,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -678,7 +697,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -690,7 +709,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -702,7 +721,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -732,7 +751,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -773,12 +792,13 @@ exports[`ChartVoronoiContainer 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -816,7 +836,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -824,7 +844,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -846,12 +866,13 @@ exports[`ChartVoronoiContainer 2`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -870,15 +891,17 @@ exports[`ChartVoronoiContainer 2`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -900,12 +923,13 @@ exports[`ChartVoronoiContainer 2`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -946,7 +970,7 @@ exports[`ChartVoronoiContainer 2`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -979,7 +1003,7 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1056,7 +1080,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1086,7 +1110,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "axisLabel": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 100,
@@ -1094,13 +1118,15 @@ exports[`renders container via ChartGroup 1`] = `
             "textAnchor": "middle",
           },
           "grid": Object {
-            "fill": "none",
+            "fill": "transparent",
             "pointerEvents": "painted",
             "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
           },
           "tickLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1108,8 +1134,11 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "ticks": Object {
             "fill": "transparent",
-            "size": 1,
-            "stroke": "transparent",
+            "size": 5,
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
           },
         },
         "width": 450,
@@ -1128,11 +1157,13 @@ exports[`renders container via ChartGroup 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#06c",
+            "padding": 8,
             "stroke": "none",
+            "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1160,7 +1191,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "maxLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1173,7 +1204,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "medianLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1186,7 +1217,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "minLabels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1198,7 +1229,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "q1Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1210,7 +1241,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "q3Labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1240,7 +1271,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1281,12 +1312,13 @@ exports[`renders container via ChartGroup 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1324,7 +1356,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1332,7 +1364,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "title": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 2,
@@ -1354,12 +1386,13 @@ exports[`renders container via ChartGroup 1`] = `
         "style": Object {
           "data": Object {
             "fill": "transparent",
+            "opacity": 1,
             "stroke": "#73bcf7",
             "strokeWidth": 2,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1378,15 +1411,17 @@ exports[`renders container via ChartGroup 1`] = `
           "#004b95",
         ],
         "height": 230,
+        "padAngle": 1,
         "padding": 8,
         "style": Object {
           "data": Object {
             "padding": 8,
+            "stroke": "transparent",
             "strokeWidth": 1,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
@@ -1408,12 +1443,13 @@ exports[`renders container via ChartGroup 1`] = `
         "style": Object {
           "data": Object {
             "fill": "#bee1f4",
+            "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 10,
@@ -1454,7 +1490,7 @@ exports[`renders container via ChartGroup 1`] = `
         "pointerWidth": 20,
         "style": Object {
           "fill": "#EDEDED",
-          "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
           "fontSize": 14,
           "letterSpacing": "normal",
           "padding": 16,
@@ -1487,7 +1523,7 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "labels": Object {
             "fill": "#151515",
-            "fontFamily": "overpass,overpass,open sans,-apple-system,blinkmacsystemfont,Segoe UI,roboto,Helvetica Neue,arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol",
+            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,

--- a/packages/patternfly-4/react-tokens/src/generateTokens.js
+++ b/packages/patternfly-4/react-tokens/src/generateTokens.js
@@ -1,4 +1,4 @@
-/* eslint-disable global-require,import/no-dynamic-require */
+/* eslint-disable global-require,import/no-dynamic-require,no-restricted-globals */
 const glob = require('glob');
 const { dirname, resolve, join } = require('path');
 const { parse } = require('css');
@@ -36,9 +36,11 @@ cssFiles.forEach(filePath => {
           const computedValue = tokens[formatCustomPropertyName(match)];
           return computedValue ? computedValue.value : `var(${match})`;
         });
+        // Avoid stringifying numeric chart values
+        const chartNum = decl.property.startsWith('--pf-chart-') && !isNaN(populatedValue);
         tokens[key] = {
           name: property,
-          value: populatedValue,
+          value: chartNum ? Number(populatedValue).valueOf() : populatedValue,
           var: `var(${property})`
         };
       }


### PR DESCRIPTION
This updates the chart theme to use pf-core vars -- the majority of changes are to base-theme.ts.

Also adds some padding to chart examples to address #2438.

fixes https://github.com/patternfly/patternfly-react/issues/2280
fixes https://github.com/patternfly/patternfly-react/pull/2438

A couple minor pf-core tweaks will need to be added in a later PR.
https://github.com/patternfly/patternfly-next/issues/2011