### PR TITLE
Chart: Add bottom-left legend position

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { isFinite } from 'lodash';
 
 import {
   AnimatePropTypeInterface,
-  BlockProps,
   D3Scale,
   DomainPropType,
   DomainPaddingPropType,
@@ -196,9 +194,9 @@ export interface ChartProps extends VictoryChartProps {
    */
   legendOrientation?: 'horizontal' | 'vertical';
   /**
-   * The legend position relation to the area chart. Valid values are 'bottom' and 'right'
+   * The legend position relation to the area chart. Valid values are 'bottom', 'bottom-left', and 'right'
    */
-  legendPosition?: 'bottom' | 'right';
+  legendPosition?: 'bottom' | 'bottom-left' | 'right';
   /**
    * The maxDomain prop defines a maximum domain value for a chart. This prop is useful in situations where the maximum
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
@@ -389,6 +387,9 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     let dy = defaultPadding.top || 0;
     if (legendPosition === ChartLegendPosition.bottom) {
       dy += ChartCommonStyles.legend.margin;
+    } else if (legendPosition === ChartLegendPosition.bottomLeft) {
+      dy += ChartCommonStyles.legend.margin;
+      dx += defaultPadding.left > 10 ? defaultPadding.left - 10 : -10;
     } else if (legendPosition === ChartLegendPosition.right) {
       dx += defaultPadding.left;
     }

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -8,10 +8,10 @@ propComponents: ['Chart', 'ChartArea', 'ChartGroup', 'ChartVoronoiContainer']
 import { Chart, ChartArea, ChartAxis, ChartGroup, ChartLabel, ChartLegendWrapper, ChartVoronoiContainer } from '@patternfly/react-charts';
 import './chart-area.scss';
 
-## Cyan area chart with tooltip and right-aligned legend
+## Simple area chart with tooltip and right-aligned legend
 ```js
 import React from 'react';
-import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '@patternfly/react-charts';
 
 <div>
   <div className="area-chart-legend-right">
@@ -28,7 +28,6 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiC
         top: 50
       }}
       maxDomain={{y: 9}}
-      themeColor={ChartThemeColor.cyan}
       width={800}
     >
       <ChartAxis />
@@ -69,7 +68,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor, ChartVoronoiC
 </div>
 ```
 
-## Multi-color area chart with tooltip and bottom-aligned legend
+## Cyan area chart with tooltip and bottom-aligned legend
 ```js
 import React from 'react';
 import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patternfly/react-charts';
@@ -80,6 +79,66 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patte
       containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
       legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
       legendPosition="bottom"
+      height={225}
+      padding={{
+        bottom: 75, // Adjusted to accomodate legend
+        left: 50,
+        right: 50,
+        top: 50,
+      }}
+      maxDomain={{y: 9}}
+      themeColor={ChartThemeColor.cyan}
+      width={650}
+    >
+      <ChartAxis />
+      <ChartAxis dependentAxis showGrid />
+      <ChartGroup>
+        <ChartArea
+          data={[
+            { name: 'Cats', x: 1, y: 3 },
+            { name: 'Cats', x: 2, y: 4 },
+            { name: 'Cats', x: 3, y: 8 },
+            { name: 'Cats', x: 4, y: 6 }
+          ]}
+          interpolation="basis"
+        />
+        <ChartArea
+          data={[
+            { name: 'Birds', x: 1, y: 2 },
+            { name: 'Birds', x: 2, y: 3 },
+            { name: 'Birds', x: 3, y: 4 },
+            { name: 'Birds', x: 4, y: 5 },
+            { name: 'Birds', x: 5, y: 6 }
+          ]}
+          interpolation="basis"
+        />
+        <ChartArea
+          data={[
+            { name: 'Dogs', x: 1, y: 1 },
+            { name: 'Dogs', x: 2, y: 2 },
+            { name: 'Dogs', x: 3, y: 3 },
+            { name: 'Dogs', x: 4, y: 2 },
+            { name: 'Dogs', x: 5, y: 4 }
+          ]}
+          interpolation="basis"
+        />
+      </ChartGroup>
+    </Chart>
+  </div>
+</div>
+```
+
+## Multi-color area chart with tooltip and bottom-left-aligned legend
+```js
+import React from 'react';
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patternfly/react-charts';
+
+<div>
+  <div className="area-chart-legend-bottom">
+    <Chart
+      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
+      legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
+      legendPosition="bottom-left"
       height={225}
       padding={{
         bottom: 75, // Adjusted to accomodate legend

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -14,8 +14,7 @@ import {
 import { getDonutTheme } from '../ChartUtils/chart-theme';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
-import { ChartLegendPosition } from "../ChartLegend";
-import { ChartPie, ChartPieProps } from '../ChartPie';
+import { ChartPie, ChartPieLegendPosition, ChartPieProps } from '../ChartPie';
 import { ChartCommonStyles, ChartDonutStyles, ChartThemeDefinition } from '../ChartTheme';
 import { ChartTooltip } from '../ChartTooltip';
 import { getLabelX, getLabelY } from "../ChartUtils";
@@ -460,7 +459,7 @@ export interface ChartDonutProps extends ChartPieProps {
 export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
   donutDx = 0,
   donutDy = 0,
-  legendPosition = ChartCommonStyles.legend.position as ChartLegendPosition,
+  legendPosition = ChartCommonStyles.legend.position as ChartPieLegendPosition,
   standalone = true,
   subTitle,
   subTitleComponent = <ChartLabel />,

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -24,6 +24,7 @@ export enum ChartLegendOrientation {
 
 export enum ChartLegendPosition {
   bottom = 'bottom',
+  bottomLeft = 'bottom-left',
   right = 'right'
 };
 

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegendWrapper.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegendWrapper.tsx
@@ -83,9 +83,9 @@ export interface ChartLegendWrapperProps {
    */
   orientation?: 'horizontal' | 'vertical';
   /**
-   * The legend position relation to the donut chart. Valid values are 'bottom' and 'right'
+   * The legend position relation to the donut chart. Valid values are 'bottom', 'bottom-left', and 'right'
    */
-  position?: 'bottom' | 'right';
+  position?: 'bottom' | 'bottom-left' | 'right';
   /**
    * Specifies the height the svg viewBox of the chart container. This value should be given as a
    * number of pixels.

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -13,7 +13,7 @@ import {
   VictoryStyleInterface
 } from 'victory';
 import { ChartContainer } from '../ChartContainer';
-import { ChartLegend, ChartLegendOrientation, ChartLegendPosition, ChartLegendWrapper } from "../ChartLegend";
+import { ChartLegend, ChartLegendOrientation, ChartLegendWrapper } from "../ChartLegend";
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
 import { ChartTooltip } from '../ChartTooltip';
 import { getChartOrigin, getTheme } from '../ChartUtils';
@@ -22,6 +22,11 @@ export enum ChartPieLabelPosition {
   centroid = 'centroid',
   endAngle = 'endAngle',
   startAngle = 'startAngle'
+};
+
+export enum ChartPieLegendPosition {
+  bottom = 'bottom',
+  right = 'right'
 };
 
 export enum ChartPieSortOrder {
@@ -411,7 +416,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   legendData,
   legendDx = 0,
   legendDy = 0,
-  legendPosition = ChartCommonStyles.legend.position as ChartLegendPosition,
+  legendPosition = ChartCommonStyles.legend.position as ChartPieLegendPosition,
   standalone = true,
   themeColor,
   themeVariant,

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-legend.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-legend.ts
@@ -90,6 +90,8 @@ export const getLegendX = ({
     case 'bottom':
       return svgWidth > legendDimensions.width - textSizeWorkAround
         ? Math.round((svgWidth - (legendDimensions.width - textSizeWorkAround)) / 2) + dx : dx;
+    case 'bottom-left':
+      return dx;
     case 'right':
       return chartWidth + ChartCommonStyles.legend.margin + dx;
     default:
@@ -120,6 +122,7 @@ export const getLegendY = ({
 
   switch (legendPosition) {
     case 'bottom':
+    case 'bottom-left':
       return chartHeight + ChartCommonStyles.legend.margin + dy;
     case 'left':
       return dHeight > lHeight ? Math.round((dHeight - lHeight) / 2) + dy : dy;


### PR DESCRIPTION
Cost Management needs to align legends on the bottom-left, for its area charts. This change adds support for a bottom-left aligned legend.

![Screen Shot 2019-07-03 at 9 35 50 AM](https://user-images.githubusercontent.com/17481322/60596352-d4004500-9d76-11e9-88b6-de2b42d8bc16.png)

fixes https://github.com/patternfly/patternfly-react/issues/2441
