### PR TITLE
docs(react-tokens): Update link to react-tokens page in the readme

### DIFF
--- a/packages/patternfly-4/react-tokens/README.md
+++ b/packages/patternfly-4/react-tokens/README.md
@@ -37,4 +37,4 @@ global_BackgroundColor_100.value === '#fff'; // true
 global_BackgroundColor_100.var === 'var(--pf-global--BackgroundColor--100)'; //true
 ```
 
-[token-page]: https://patternfly-react.surge.sh/patternfly-4/styles/tokens
+[token-page]: https://patternfly-react.surge.sh/patternfly-4/tokens/Global%20CSS%20variables/


### PR DESCRIPTION
**What**:

Link to react-tokens page was broken. Updated to point to the Global CSS Variables page.
