### PR TITLE
fix(Dropdown): Provide option to not autofocus on first item

### DIFF
--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/__snapshots__/ApplicationLauncher.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/__snapshots__/ApplicationLauncher.test.js.snap
@@ -88,6 +88,7 @@ exports[`ApplicationLauncher dropup + right aligned 1`] = `
 >
   <DropdownWithContext
     aria-label="Application launcher"
+    autoFocus={true}
     className=""
     direction="up"
     dropdownItems={
@@ -367,6 +368,7 @@ exports[`ApplicationLauncher dropup 1`] = `
 >
   <DropdownWithContext
     aria-label="Application launcher"
+    autoFocus={true}
     className=""
     direction="up"
     dropdownItems={
@@ -646,6 +648,7 @@ exports[`ApplicationLauncher expanded 1`] = `
 >
   <DropdownWithContext
     aria-label="Application launcher"
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={
@@ -834,6 +837,7 @@ exports[`ApplicationLauncher expanded 1`] = `
       </DropdownToggle>
       <DropdownMenu
         aria-labelledby="pf-toggle-id-4"
+        autoFocus={true}
         className=""
         component="ul"
         isGrouped={false}
@@ -843,6 +847,7 @@ exports[`ApplicationLauncher expanded 1`] = `
       >
         <ul
           aria-labelledby="pf-toggle-id-4"
+          autoFocus={true}
           className="pf-c-app-launcher__menu"
           hidden={false}
           role="menu"
@@ -1263,6 +1268,7 @@ exports[`ApplicationLauncher regular 1`] = `
 >
   <DropdownWithContext
     aria-label="Application launcher"
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={
@@ -1542,6 +1548,7 @@ exports[`ApplicationLauncher right aligned 1`] = `
 >
   <DropdownWithContext
     aria-label="Application launcher"
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={

--- a/packages/patternfly-4/react-core/src/components/DataList/__snapshots__/DataList.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/DataList/__snapshots__/DataList.test.js.snap
@@ -46,6 +46,7 @@ exports[`DataList DataListAction dropdown 1`] = `
   className="pf-c-data-list__item-action"
 >
   <Dropdown
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.js
@@ -24,6 +24,10 @@ const propTypes = {
   dropdownItems: PropTypes.array,
   /** Flag to indicate if menu is opened */
   isOpen: PropTypes.bool,
+  /** Flag to indicate if the first dropdown item should gain initial focus, set false when adding
+   * a specific auto-focus item (like a current selection) otherwise leave as true (this is only applicable
+   * when passing an array of dropdownItems) */
+  autoFocus: PropTypes.bool,
   /** Display the toggle with no border or background */
   isPlain: PropTypes.bool,
   /** Indicates where menu will be aligned horizontally */
@@ -45,6 +49,7 @@ const defaultProps = {
   className: '',
   dropdownItems: [],
   isOpen: false,
+  autoFocus: true,
   isPlain: false,
   isGrouped: false,
   position: DropdownPosition.left,
@@ -68,6 +73,7 @@ export class DropdownWithContext extends React.Component {
       direction,
       dropdownItems,
       isOpen,
+      autoFocus,
       isPlain,
       isGrouped,
       onSelect,
@@ -116,6 +122,7 @@ export class DropdownWithContext extends React.Component {
               <DropdownMenu
                 component={component}
                 isOpen={isOpen}
+                autoFocus={autoFocus}
                 position={position}
                 aria-labelledby={id}
                 openedOnEnter={this.openedOnEnter}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.md
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.md
@@ -63,6 +63,63 @@ class SimpleDropdown extends React.Component {
 }
 ```
 
+## Dropdown with initial selection
+
+```js
+import React from 'react';
+import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownPosition, DropdownDirection, KebabToggle } from '@patternfly/react-core';
+import { ThIcon } from '@patternfly/react-icons';
+
+class IntialSelectionDropdown extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false
+    };
+    this.onToggle = isOpen => {
+      this.setState({
+        isOpen
+      });
+    };
+    this.onSelect = event => {
+      this.setState({
+        isOpen: !this.state.isOpen
+      });
+    };
+  }
+
+  render() {
+    const { isOpen } = this.state;
+    const dropdownItems = [
+      <DropdownItem key="link">Link</DropdownItem>,
+      <DropdownItem key="action" component="button" autoFocus>
+        Action
+      </DropdownItem>,
+      <DropdownItem key="disabled link" isDisabled>
+        Disabled Link
+      </DropdownItem>,
+      <DropdownItem key="disabled action" isDisabled component="button">
+        Disabled Action
+      </DropdownItem>,
+      <DropdownSeparator key="separator" />,
+      <DropdownItem key="separated link">Separated Link</DropdownItem>,
+      <DropdownItem key="separated action" component="button">
+        Separated Action
+      </DropdownItem>
+    ];
+    return (
+      <Dropdown
+        onSelect={this.onSelect}
+        toggle={<DropdownToggle onToggle={this.onToggle}>Dropdown</DropdownToggle>}
+        isOpen={isOpen}
+        dropdownItems={dropdownItems}
+        autoFocus={false}
+      />
+    );
+  }
+}
+```
+
 ## Dropdown with groups
 
 ```js
@@ -584,7 +641,23 @@ class DropdownPanel extends React.Component {
         toggle={<DropdownToggle onToggle={this.onToggle}>Expanded Dropdown</DropdownToggle>}
         isOpen={isOpen}
       >
-        <div>[Panel contents here]</div>
+        <ul className="pf-c-dropdown__menu">
+          <DropdownItem key="link">Link</DropdownItem>
+          <DropdownItem key="action" component="button" autoFocus>
+            Action
+          </DropdownItem>
+          <DropdownItem key="disabled link" isDisabled>
+            Disabled Link
+          </DropdownItem>
+          <DropdownItem key="disabled action" isDisabled component="button">
+            Disabled Action
+          </DropdownItem>
+          <DropdownSeparator key="separator" />
+          <DropdownItem key="separated link">Separated Link</DropdownItem>
+          <DropdownItem key="separated action" component="button">
+            Separated Action
+          </DropdownItem>
+        </ul>
       </Dropdown>
     );
   }

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownMenu.js
@@ -17,6 +17,9 @@ const propTypes = {
   isOpen: PropTypes.bool,
   /** Flag to indicate if menu should be opened on enter */
   openedOnEnter: PropTypes.bool,
+  /** Flag to indicate if the first dropdown item should gain initial focus, set false when adding
+   * a specific auto-focus item (like a current selection) otherwise leave as true */
+  autoFocus: PropTypes.bool,
   /** Indicates which component will be used as dropdown menu */
   component: componentShape,
   /** Indicates where menu will be alligned horizontally */
@@ -32,6 +35,7 @@ const defaultProps = {
   className: '',
   isOpen: true,
   openedOnEnter: false,
+  autoFocus: true,
   position: DropdownPosition.left,
   component: 'ul',
   isGrouped: false
@@ -41,14 +45,18 @@ class DropdownMenu extends React.Component {
   refsCollection = [];
 
   componentDidMount() {
-    const focusTarget =
-      this.refsCollection.filter(
-        ref => ref && ((ref.current && !ref.current.hasAttribute('disabled')) || !ref.hasAttribute('disabled'))
-      )[0] || null;
-    if (this.props.component === 'ul') focusTarget && focusTarget.focus();
-    else {
-      (focusTarget.current.focus && focusTarget.current.focus()) ||
-        (focusTarget && ReactDOM.findDOMNode(focusTarget.current).focus()); // eslint-disable-line react/no-find-dom-node
+    const { autoFocus } = this.props;
+
+    if (this.props.component === 'ul' && autoFocus) {
+      const focusTarget =
+        this.refsCollection.filter(
+          ref => ref && ((ref.current && !ref.current.hasAttribute('disabled')) || !ref.hasAttribute('disabled'))
+        )[0] || null;
+      if (this.props.component === 'ul') focusTarget && focusTarget.focus();
+      else {
+        (focusTarget.current.focus && focusTarget.current.focus()) ||
+          (focusTarget && ReactDOM.findDOMNode(focusTarget.current).focus()); // eslint-disable-line react/no-find-dom-node
+      }
     }
   }
 

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`KebabToggle basic 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="down"
   dropdownItems={Array []}
@@ -27,6 +28,7 @@ exports[`KebabToggle basic 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={Array []}
@@ -129,6 +131,7 @@ exports[`KebabToggle basic 1`] = `
       </Kebab>
       <DropdownMenu
         aria-labelledby="Dropdown Toggle"
+        autoFocus={true}
         className=""
         component="div"
         isGrouped={false}
@@ -143,6 +146,7 @@ exports[`KebabToggle basic 1`] = `
         >
           <div
             aria-labelledby="Dropdown Toggle"
+            autoFocus={true}
           >
             <div
               className="pf-c-dropdown__menu-item"
@@ -162,6 +166,7 @@ exports[`KebabToggle basic 1`] = `
 
 exports[`KebabToggle dropup + right aligned 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="up"
   dropdownItems={
@@ -313,6 +318,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="up"
     dropdownItems={
@@ -546,6 +552,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
 
 exports[`KebabToggle dropup 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="up"
   dropdownItems={
@@ -697,6 +704,7 @@ exports[`KebabToggle dropup 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="up"
     dropdownItems={
@@ -930,6 +938,7 @@ exports[`KebabToggle dropup 1`] = `
 
 exports[`KebabToggle expanded 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="down"
   dropdownItems={
@@ -1081,6 +1090,7 @@ exports[`KebabToggle expanded 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={
@@ -1309,6 +1319,7 @@ exports[`KebabToggle expanded 1`] = `
       </Kebab>
       <DropdownMenu
         aria-labelledby="Dropdown Toggle"
+        autoFocus={true}
         className=""
         component="ul"
         isGrouped={false}
@@ -1318,6 +1329,7 @@ exports[`KebabToggle expanded 1`] = `
       >
         <ul
           aria-labelledby="Dropdown Toggle"
+          autoFocus={true}
           className="pf-c-dropdown__menu"
           hidden={false}
           role="menu"
@@ -1575,6 +1587,7 @@ exports[`KebabToggle expanded 1`] = `
 
 exports[`KebabToggle plain 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="down"
   dropdownItems={
@@ -1726,6 +1739,7 @@ exports[`KebabToggle plain 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={
@@ -1959,6 +1973,7 @@ exports[`KebabToggle plain 1`] = `
 
 exports[`KebabToggle regular 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="down"
   dropdownItems={
@@ -2110,6 +2125,7 @@ exports[`KebabToggle regular 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={
@@ -2343,6 +2359,7 @@ exports[`KebabToggle regular 1`] = `
 
 exports[`KebabToggle right aligned 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="down"
   dropdownItems={
@@ -2494,6 +2511,7 @@ exports[`KebabToggle right aligned 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={
@@ -2727,6 +2745,7 @@ exports[`KebabToggle right aligned 1`] = `
 
 exports[`dropdown basic 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="down"
   dropdownItems={Array []}
@@ -2753,6 +2772,7 @@ exports[`dropdown basic 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={Array []}
@@ -2860,6 +2880,7 @@ exports[`dropdown basic 1`] = `
       </DropdownToggle>
       <DropdownMenu
         aria-labelledby="Dropdown Toggle"
+        autoFocus={true}
         className=""
         component="div"
         isGrouped={false}
@@ -2874,6 +2895,7 @@ exports[`dropdown basic 1`] = `
         >
           <div
             aria-labelledby="Dropdown Toggle"
+            autoFocus={true}
           >
             <div
               className="pf-c-dropdown__menu-item"
@@ -2893,6 +2915,7 @@ exports[`dropdown basic 1`] = `
 
 exports[`dropdown dropup + right aligned 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="up"
   dropdownItems={
@@ -3045,6 +3068,7 @@ exports[`dropdown dropup + right aligned 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="up"
     dropdownItems={
@@ -3283,6 +3307,7 @@ exports[`dropdown dropup + right aligned 1`] = `
 
 exports[`dropdown dropup 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="up"
   dropdownItems={
@@ -3435,6 +3460,7 @@ exports[`dropdown dropup 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="up"
     dropdownItems={
@@ -3673,6 +3699,7 @@ exports[`dropdown dropup 1`] = `
 
 exports[`dropdown expanded 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="down"
   dropdownItems={
@@ -3825,6 +3852,7 @@ exports[`dropdown expanded 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={
@@ -4058,6 +4086,7 @@ exports[`dropdown expanded 1`] = `
       </DropdownToggle>
       <DropdownMenu
         aria-labelledby="Dropdown Toggle"
+        autoFocus={true}
         className=""
         component="ul"
         isGrouped={false}
@@ -4067,6 +4096,7 @@ exports[`dropdown expanded 1`] = `
       >
         <ul
           aria-labelledby="Dropdown Toggle"
+          autoFocus={true}
           className="pf-c-dropdown__menu"
           hidden={false}
           role="menu"
@@ -4324,6 +4354,7 @@ exports[`dropdown expanded 1`] = `
 
 exports[`dropdown regular 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="down"
   dropdownItems={
@@ -4476,6 +4507,7 @@ exports[`dropdown regular 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={
@@ -4714,6 +4746,7 @@ exports[`dropdown regular 1`] = `
 
 exports[`dropdown right aligned 1`] = `
 <Dropdown
+  autoFocus={true}
   className=""
   direction="down"
   dropdownItems={
@@ -4866,6 +4899,7 @@ exports[`dropdown right aligned 1`] = `
   }
 >
   <DropdownWithContext
+    autoFocus={true}
     className=""
     direction="down"
     dropdownItems={

--- a/packages/patternfly-4/react-core/src/components/Pagination/__snapshots__/Pagination.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/Pagination/__snapshots__/Pagination.test.js.snap
@@ -60,6 +60,7 @@ exports[`component render custom pagination toggle 1`] = `
           :
         </span>
         <Dropdown
+          autoFocus={true}
           className=""
           direction="down"
           dropdownItems={
@@ -170,6 +171,7 @@ exports[`component render custom pagination toggle 1`] = `
           }
         >
           <DropdownWithContext
+            autoFocus={true}
             className=""
             direction="down"
             dropdownItems={
@@ -670,6 +672,7 @@ exports[`component render custom perPageOptions 1`] = `
           :
         </span>
         <Dropdown
+          autoFocus={true}
           className=""
           direction="down"
           dropdownItems={
@@ -716,6 +719,7 @@ exports[`component render custom perPageOptions 1`] = `
           }
         >
           <DropdownWithContext
+            autoFocus={true}
             className=""
             direction="down"
             dropdownItems={
@@ -1176,6 +1180,7 @@ exports[`component render custom start end 1`] = `
           :
         </span>
         <Dropdown
+          autoFocus={true}
           className=""
           direction="down"
           dropdownItems={
@@ -1286,6 +1291,7 @@ exports[`component render custom start end 1`] = `
           }
         >
           <DropdownWithContext
+            autoFocus={true}
             className=""
             direction="down"
             dropdownItems={
@@ -1790,6 +1796,7 @@ exports[`component render empty per page options 1`] = `
           :
         </span>
         <Dropdown
+          autoFocus={true}
           className=""
           direction="down"
           dropdownItems={Array []}
@@ -1815,6 +1822,7 @@ exports[`component render empty per page options 1`] = `
           }
         >
           <DropdownWithContext
+            autoFocus={true}
             className=""
             direction="down"
             dropdownItems={Array []}
@@ -2155,6 +2163,7 @@ exports[`component render last page 1`] = `
           :
         </span>
         <Dropdown
+          autoFocus={true}
           className=""
           direction="down"
           dropdownItems={
@@ -2265,6 +2274,7 @@ exports[`component render last page 1`] = `
           }
         >
           <DropdownWithContext
+            autoFocus={true}
             className=""
             direction="down"
             dropdownItems={
@@ -2788,6 +2798,7 @@ exports[`component render limited number of pages 1`] = `
           :
         </span>
         <Dropdown
+          autoFocus={true}
           className=""
           direction="down"
           dropdownItems={
@@ -2898,6 +2909,7 @@ exports[`component render limited number of pages 1`] = `
           }
         >
           <DropdownWithContext
+            autoFocus={true}
             className=""
             direction="down"
             dropdownItems={
@@ -3420,6 +3432,7 @@ exports[`component render no items 1`] = `
           :
         </span>
         <Dropdown
+          autoFocus={true}
           className=""
           direction="down"
           dropdownItems={
@@ -3530,6 +3543,7 @@ exports[`component render no items 1`] = `
           }
         >
           <DropdownWithContext
+            autoFocus={true}
             className=""
             direction="down"
             dropdownItems={
@@ -4048,6 +4062,7 @@ exports[`component render should render correctly bottom 1`] = `
           :
         </span>
         <Dropdown
+          autoFocus={true}
           className=""
           direction="down"
           dropdownItems={
@@ -4158,6 +4173,7 @@ exports[`component render should render correctly bottom 1`] = `
           }
         >
           <DropdownWithContext
+            autoFocus={true}
             className=""
             direction="down"
             dropdownItems={
@@ -4680,6 +4696,7 @@ exports[`component render should render correctly top 1`] = `
           :
         </span>
         <Dropdown
+          autoFocus={true}
           className=""
           direction="down"
           dropdownItems={
@@ -4790,6 +4807,7 @@ exports[`component render should render correctly top 1`] = `
           }
         >
           <DropdownWithContext
+            autoFocus={true}
             className=""
             direction="down"
             dropdownItems={
@@ -5318,6 +5336,7 @@ exports[`component render titles 1`] = `
           :
         </span>
         <Dropdown
+          autoFocus={true}
           className=""
           direction="down"
           dropdownItems={
@@ -5428,6 +5447,7 @@ exports[`component render titles 1`] = `
           }
         >
           <DropdownWithContext
+            autoFocus={true}
             className=""
             direction="down"
             dropdownItems={
@@ -5944,6 +5964,7 @@ exports[`component render up drop direction 1`] = `
           :
         </span>
         <Dropdown
+          autoFocus={true}
           className=""
           direction="up"
           dropdownItems={
@@ -6054,6 +6075,7 @@ exports[`component render up drop direction 1`] = `
           }
         >
           <DropdownWithContext
+            autoFocus={true}
             className=""
             direction="up"
             dropdownItems={


### PR DESCRIPTION
**What**:
Fixes Dropdown to not autofocus when custom children are given. Also provides the option to not autofocus on the first item for the case where the application wants to set autoFocus on one of the items.

**Additional issues**:

Fixes #2472 