### PR TITLE
fix(styles): Add pickProperties to react-styles utils exports

### DIFF
--- a/packages/patternfly-4/react-styles/src/utils.d.ts
+++ b/packages/patternfly-4/react-styles/src/utils.d.ts
@@ -22,3 +22,5 @@ export function getCSSClasses(cssString: string): string[];
 export function getInsertedStyles(): string[];
 
 export function getClassName(obj: StyleDeclarationStatic | string): string;
+
+export function pickProperties(object: any, properties: string[]): any;


### PR DESCRIPTION
**What**:
Adds a missing export for `pickProperties` to react-styles utils typescript

**Additional issues**:
Fixes #2479 

