### PR TITLE
fix(ChartDonut): Replaced prop `titleComponent` by `subTitleComponent`

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -489,8 +489,8 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     if (!subTitle || subTitlePosition === ChartDonutSubTitlePosition.center) {
       return null;
     }
-    const subTitleProps = titleComponent.props ? titleComponent.props : {};
-    return React.cloneElement(titleComponent, {
+    const subTitleProps = subTitleComponent.props ? subTitleComponent.props : {};
+    return React.cloneElement(subTitleComponent, {
       style: ChartDonutStyles.label.subTitle,
       text: subTitle,
       textAnchor: subTitlePosition === 'right' ? 'start' : 'middle',


### PR DESCRIPTION
Previously `ChartDonut` component (in patternfly 4) for building `subTitle` used prop `titleComponent`, while prop
`subTitleComponent` was unused. So in this PR `titleComponent` in `getSubtitle` was replaced by
`subTitleComponent`.

fix #2486 

