### PR TITLE
fix(charts): Adjust pf-core vars & add tooltip examples

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
@@ -30,7 +30,7 @@ import { getPaddingForSide } from '../ChartUtils/chart-padding';
  */
 export interface ChartProps extends VictoryChartProps {
   /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-area/
+   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-chart/
    */
   ' '?: any;
   /**

--- a/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.tsx.snap
@@ -2169,13 +2169,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2199,13 +2198,12 @@ exports[`Chart 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2221,7 +2219,7 @@ exports[`Chart 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2258,7 +2256,6 @@ exports[`Chart 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2282,11 +2279,10 @@ exports[`Chart 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2295,11 +2291,10 @@ exports[`Chart 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2308,11 +2303,10 @@ exports[`Chart 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2320,11 +2314,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2332,11 +2325,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2348,8 +2340,8 @@ exports[`Chart 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -2362,11 +2354,10 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2387,11 +2378,6 @@ exports[`Chart 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -2409,11 +2395,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2451,7 +2436,6 @@ exports[`Chart 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2459,7 +2443,6 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2483,11 +2466,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2515,12 +2497,11 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -2537,13 +2518,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2566,7 +2546,6 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -2584,14 +2563,9 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -2617,13 +2591,13 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -4804,13 +4778,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -4834,13 +4807,12 @@ exports[`Chart 2`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -4856,7 +4828,7 @@ exports[`Chart 2`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -4893,7 +4865,6 @@ exports[`Chart 2`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -4917,11 +4888,10 @@ exports[`Chart 2`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -4930,11 +4900,10 @@ exports[`Chart 2`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -4943,11 +4912,10 @@ exports[`Chart 2`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -4955,11 +4923,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -4967,11 +4934,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -4983,8 +4949,8 @@ exports[`Chart 2`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -4997,11 +4963,10 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -5022,11 +4987,6 @@ exports[`Chart 2`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -5044,11 +5004,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -5086,7 +5045,6 @@ exports[`Chart 2`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -5094,7 +5052,6 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -5118,11 +5075,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -5150,12 +5106,11 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -5172,13 +5127,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -5201,7 +5155,6 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -5219,14 +5172,9 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -5252,13 +5200,13 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -7444,13 +7392,12 @@ exports[`renders axis and component children 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7474,13 +7421,12 @@ exports[`renders axis and component children 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7496,7 +7442,7 @@ exports[`renders axis and component children 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7533,7 +7479,6 @@ exports[`renders axis and component children 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7557,11 +7502,10 @@ exports[`renders axis and component children 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7570,11 +7514,10 @@ exports[`renders axis and component children 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7583,11 +7526,10 @@ exports[`renders axis and component children 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7595,11 +7537,10 @@ exports[`renders axis and component children 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7607,11 +7548,10 @@ exports[`renders axis and component children 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7623,8 +7563,8 @@ exports[`renders axis and component children 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -7637,11 +7577,10 @@ exports[`renders axis and component children 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7662,11 +7601,6 @@ exports[`renders axis and component children 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -7684,11 +7618,10 @@ exports[`renders axis and component children 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7726,7 +7659,6 @@ exports[`renders axis and component children 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7734,7 +7666,6 @@ exports[`renders axis and component children 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7758,11 +7689,10 @@ exports[`renders axis and component children 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7790,12 +7720,11 @@ exports[`renders axis and component children 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -7812,13 +7741,12 @@ exports[`renders axis and component children 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -7841,7 +7769,6 @@ exports[`renders axis and component children 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -7859,14 +7786,9 @@ exports[`renders axis and component children 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -7892,13 +7814,13 @@ exports[`renders axis and component children 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.tsx.snap
@@ -52,13 +52,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -82,13 +81,12 @@ exports[`Chart 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -104,7 +102,7 @@ exports[`Chart 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -141,7 +139,6 @@ exports[`Chart 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -165,11 +162,10 @@ exports[`Chart 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -178,11 +174,10 @@ exports[`Chart 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -191,11 +186,10 @@ exports[`Chart 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -203,11 +197,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -215,11 +208,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -231,8 +223,8 @@ exports[`Chart 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -245,11 +237,10 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -270,11 +261,6 @@ exports[`Chart 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -292,11 +278,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -334,7 +319,6 @@ exports[`Chart 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -342,7 +326,6 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -366,11 +349,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -398,12 +380,11 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -420,13 +401,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -449,7 +429,6 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -467,14 +446,9 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -500,13 +474,13 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -569,13 +543,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -599,13 +572,12 @@ exports[`Chart 2`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -621,7 +593,7 @@ exports[`Chart 2`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -658,7 +630,6 @@ exports[`Chart 2`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -682,11 +653,10 @@ exports[`Chart 2`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -695,11 +665,10 @@ exports[`Chart 2`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -708,11 +677,10 @@ exports[`Chart 2`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -720,11 +688,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -732,11 +699,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -748,8 +714,8 @@ exports[`Chart 2`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -762,11 +728,10 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -787,11 +752,6 @@ exports[`Chart 2`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -809,11 +769,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -851,7 +810,6 @@ exports[`Chart 2`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -859,7 +817,6 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -883,11 +840,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -915,12 +871,11 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -937,13 +892,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -966,7 +920,6 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -984,14 +937,9 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -1017,13 +965,13 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -1110,13 +1058,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1140,13 +1087,12 @@ exports[`renders component data 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1162,7 +1108,7 @@ exports[`renders component data 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1199,7 +1145,6 @@ exports[`renders component data 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1223,11 +1168,10 @@ exports[`renders component data 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1236,11 +1180,10 @@ exports[`renders component data 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1249,11 +1192,10 @@ exports[`renders component data 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1261,11 +1203,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1273,11 +1214,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1289,8 +1229,8 @@ exports[`renders component data 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -1303,11 +1243,10 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1328,11 +1267,6 @@ exports[`renders component data 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -1350,11 +1284,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1392,7 +1325,6 @@ exports[`renders component data 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1400,7 +1332,6 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1424,11 +1355,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1456,12 +1386,11 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -1478,13 +1407,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1507,7 +1435,6 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -1525,14 +1452,9 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -1558,13 +1480,13 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -128,64 +128,94 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patte
 </div>
 ```
 
-## Multi-color area chart with tooltip and bottom-left-aligned legend
+## Multi-color chart with tooltip, bottom-aligned legend, and responsive width
 ```js
 import React from 'react';
 import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patternfly/react-charts';
 
-<div>
-  <div className="area-chart-legend-bottom">
-    <Chart
-      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
-      legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
-      legendPosition="bottom-left"
-      height={225}
-      padding={{
-        bottom: 75, // Adjusted to accomodate legend
-        left: 50,
-        right: 50,
-        top: 50,
-      }}
-      maxDomain={{y: 9}}
-      themeColor={ChartThemeColor.multi}
-      width={650}
-    >
-      <ChartAxis />
-      <ChartAxis dependentAxis showGrid />
-      <ChartGroup>
-        <ChartArea
-          data={[
-            { name: 'Cats', x: 1, y: 3 },
-            { name: 'Cats', x: 2, y: 4 },
-            { name: 'Cats', x: 3, y: 8 },
-            { name: 'Cats', x: 4, y: 6 }
-          ]}
-          interpolation="basis"
-        />
-        <ChartArea
-          data={[
-            { name: 'Birds', x: 1, y: 2 },
-            { name: 'Birds', x: 2, y: 3 },
-            { name: 'Birds', x: 3, y: 4 },
-            { name: 'Birds', x: 4, y: 5 },
-            { name: 'Birds', x: 5, y: 6 }
-          ]}
-          interpolation="basis"
-        />
-        <ChartArea
-          data={[
-            { name: 'Dogs', x: 1, y: 1 },
-            { name: 'Dogs', x: 2, y: 2 },
-            { name: 'Dogs', x: 3, y: 3 },
-            { name: 'Dogs', x: 4, y: 2 },
-            { name: 'Dogs', x: 5, y: 4 }
-          ]}
-          interpolation="basis"
-        />
-      </ChartGroup>
-    </Chart>
-  </div>
-</div>
+class MultiColorChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.containerRef = React.createRef();
+    this.state = {
+      width: 0
+    };
+    this.handleResize = () => {
+      this.setState({ width: this.containerRef.current.clientWidth });
+    };
+  }
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({ width: this.containerRef.current.clientWidth });
+      window.addEventListener('resize', this.handleResize);
+    });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  render() {
+    const { width } = this.state;
+    
+    return (
+      <div ref={this.containerRef}>
+        <div className="area-chart-legend-bottom-responsive">
+          <Chart
+            containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
+            legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
+            legendPosition="bottom-left"
+            height={225}
+            padding={{
+              bottom: 75, // Adjusted to accomodate legend
+              left: 50,
+              right: 50,
+              top: 50,
+            }}
+            maxDomain={{y: 9}}
+            themeColor={ChartThemeColor.multi}
+            width={width}
+          >
+            <ChartAxis />
+            <ChartAxis dependentAxis showGrid />
+            <ChartGroup>
+              <ChartArea
+                data={[
+                  { name: 'Cats', x: 1, y: 3 },
+                  { name: 'Cats', x: 2, y: 4 },
+                  { name: 'Cats', x: 3, y: 8 },
+                  { name: 'Cats', x: 4, y: 6 }
+                ]}
+                interpolation="basis"
+              />
+             <ChartArea
+               data={[
+                  { name: 'Birds', x: 1, y: 2 },
+                  { name: 'Birds', x: 2, y: 3 },
+                  { name: 'Birds', x: 3, y: 4 },
+                  { name: 'Birds', x: 4, y: 5 },
+                  { name: 'Birds', x: 5, y: 6 }
+                ]}
+                interpolation="basis"
+              />
+              <ChartArea
+                data={[
+                  { name: 'Dogs', x: 1, y: 1 },
+                  { name: 'Dogs', x: 2, y: 2 },
+                  { name: 'Dogs', x: 3, y: 3 },
+                  { name: 'Dogs', x: 4, y: 2 },
+                  { name: 'Dogs', x: 5, y: 4 }
+                ]}
+                interpolation="basis"
+              />
+            </ChartGroup>
+          </Chart>
+        </div>
+      </div>
+    );
+  }
+}
 ```
 
 ## Sparkline chart
@@ -197,7 +227,8 @@ import { ChartArea, ChartGroup, ChartLabel } from '@patternfly/react-charts';
   <div className="sparkline-container">
     <div className="sparkline-chart">
       <ChartGroup
-        height={100}
+        containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} voronoiDimension="x" />}
+        height={75}
         padding={0}
         width={400}
       >

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/chart-area.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/chart-area.scss
@@ -5,13 +5,17 @@
       width: 650px;
     }
 
+    .area-chart-legend-bottom-responsive {
+      height: 225px;
+    }
+
     .area-chart-legend-right {
       height: 200px;
       width: 800px;
     }
 
     .sparkline-chart {
-      height: 100px;
+      height: 75px;
       width: 400px;
     }
 
@@ -19,6 +23,9 @@
       margin-left: 50px;
       margin-top: 50px;
       height: 135px;
+      & svg {
+        overflow: visible;
+      }
     }
   }
 }

--- a/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
@@ -52,13 +52,12 @@ exports[`ChartAxis 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -82,13 +81,12 @@ exports[`ChartAxis 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -104,7 +102,7 @@ exports[`ChartAxis 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -141,7 +139,6 @@ exports[`ChartAxis 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -165,11 +162,10 @@ exports[`ChartAxis 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -178,11 +174,10 @@ exports[`ChartAxis 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -191,11 +186,10 @@ exports[`ChartAxis 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -203,11 +197,10 @@ exports[`ChartAxis 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -215,11 +208,10 @@ exports[`ChartAxis 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -231,8 +223,8 @@ exports[`ChartAxis 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -245,11 +237,10 @@ exports[`ChartAxis 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -270,11 +261,6 @@ exports[`ChartAxis 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -292,11 +278,10 @@ exports[`ChartAxis 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -334,7 +319,6 @@ exports[`ChartAxis 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -342,7 +326,6 @@ exports[`ChartAxis 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -366,11 +349,10 @@ exports[`ChartAxis 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -398,12 +380,11 @@ exports[`ChartAxis 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -420,13 +401,12 @@ exports[`ChartAxis 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -449,7 +429,6 @@ exports[`ChartAxis 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -467,14 +446,9 @@ exports[`ChartAxis 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -500,13 +474,13 @@ exports[`ChartAxis 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -584,13 +558,12 @@ exports[`ChartAxis 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -614,13 +587,12 @@ exports[`ChartAxis 2`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -636,7 +608,7 @@ exports[`ChartAxis 2`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -673,7 +645,6 @@ exports[`ChartAxis 2`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -697,11 +668,10 @@ exports[`ChartAxis 2`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -710,11 +680,10 @@ exports[`ChartAxis 2`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -723,11 +692,10 @@ exports[`ChartAxis 2`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -735,11 +703,10 @@ exports[`ChartAxis 2`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -747,11 +714,10 @@ exports[`ChartAxis 2`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -763,8 +729,8 @@ exports[`ChartAxis 2`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -777,11 +743,10 @@ exports[`ChartAxis 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -802,11 +767,6 @@ exports[`ChartAxis 2`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -824,11 +784,10 @@ exports[`ChartAxis 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -866,7 +825,6 @@ exports[`ChartAxis 2`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -874,7 +832,6 @@ exports[`ChartAxis 2`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -898,11 +855,10 @@ exports[`ChartAxis 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -930,12 +886,11 @@ exports[`ChartAxis 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -952,13 +907,12 @@ exports[`ChartAxis 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -981,7 +935,6 @@ exports[`ChartAxis 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -999,14 +952,9 @@ exports[`ChartAxis 2`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -1032,13 +980,13 @@ exports[`ChartAxis 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -3241,13 +3189,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3271,13 +3218,12 @@ exports[`renders component data 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3293,7 +3239,7 @@ exports[`renders component data 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3330,7 +3276,6 @@ exports[`renders component data 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3354,11 +3299,10 @@ exports[`renders component data 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3367,11 +3311,10 @@ exports[`renders component data 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3380,11 +3323,10 @@ exports[`renders component data 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3392,11 +3334,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3404,11 +3345,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3420,8 +3360,8 @@ exports[`renders component data 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -3434,11 +3374,10 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3459,11 +3398,6 @@ exports[`renders component data 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -3481,11 +3415,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3523,7 +3456,6 @@ exports[`renders component data 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3531,7 +3463,6 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3555,11 +3486,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3587,12 +3517,11 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -3609,13 +3538,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3638,7 +3566,6 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -3656,14 +3583,9 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -3689,13 +3611,13 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.tsx.snap
@@ -67,13 +67,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -97,13 +96,12 @@ exports[`Chart 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -119,7 +117,7 @@ exports[`Chart 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -156,7 +154,6 @@ exports[`Chart 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -180,11 +177,10 @@ exports[`Chart 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -193,11 +189,10 @@ exports[`Chart 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -206,11 +201,10 @@ exports[`Chart 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -218,11 +212,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -230,11 +223,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -246,8 +238,8 @@ exports[`Chart 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -260,11 +252,10 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -285,11 +276,6 @@ exports[`Chart 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -307,11 +293,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -349,7 +334,6 @@ exports[`Chart 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -357,7 +341,6 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -381,11 +364,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -413,12 +395,11 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -435,13 +416,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -464,7 +444,6 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -482,14 +461,9 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -515,13 +489,13 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -599,13 +573,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -629,13 +602,12 @@ exports[`Chart 2`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -651,7 +623,7 @@ exports[`Chart 2`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -688,7 +660,6 @@ exports[`Chart 2`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -712,11 +683,10 @@ exports[`Chart 2`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -725,11 +695,10 @@ exports[`Chart 2`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -738,11 +707,10 @@ exports[`Chart 2`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -750,11 +718,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -762,11 +729,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -778,8 +744,8 @@ exports[`Chart 2`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -792,11 +758,10 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -817,11 +782,6 @@ exports[`Chart 2`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -839,11 +799,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -881,7 +840,6 @@ exports[`Chart 2`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -889,7 +847,6 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -913,11 +870,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -945,12 +901,11 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -967,13 +922,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -996,7 +950,6 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -1014,14 +967,9 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -1047,13 +995,13 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -3241,13 +3189,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3271,13 +3218,12 @@ exports[`renders component data 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3293,7 +3239,7 @@ exports[`renders component data 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3330,7 +3276,6 @@ exports[`renders component data 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3354,11 +3299,10 @@ exports[`renders component data 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3367,11 +3311,10 @@ exports[`renders component data 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3380,11 +3323,10 @@ exports[`renders component data 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3392,11 +3334,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3404,11 +3345,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3420,8 +3360,8 @@ exports[`renders component data 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -3434,11 +3374,10 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3459,11 +3398,6 @@ exports[`renders component data 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -3481,11 +3415,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3523,7 +3456,6 @@ exports[`renders component data 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3531,7 +3463,6 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3555,11 +3486,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3587,12 +3517,11 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -3609,13 +3538,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3638,7 +3566,6 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -3656,14 +3583,9 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -3689,13 +3611,13 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -8,7 +8,7 @@ propComponents: ['Chart', 'ChartBar', 'ChartGroup']
 import { Chart, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-charts';
 import './chart-bar.scss';
 
-## Simple bar chart with right-aligned legend
+## Simple bar chart with tooltip and right-aligned legend
 ```js
 import React from 'react';
 import { Chart, ChartBar } from '@patternfly/react-charts';
@@ -16,6 +16,7 @@ import { Chart, ChartBar } from '@patternfly/react-charts';
 <div>
   <div className="bar-chart-legend-right">
     <Chart
+      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} voronoiDimension="x" />}
       domain={{y: [0,9]}}
       domainPadding={{ x: [30, 25] }}
       legendData={[{ name: 'Cats' }]}
@@ -39,12 +40,12 @@ import { Chart, ChartBar } from '@patternfly/react-charts';
 ## Purple bar chart with tooltip and right-aligned legend
 ```js
 import React from 'react';
-import { Chart, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-charts';
+import { Chart, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
 
 <div>
   <div className="bar-chart-legend-right">
     <Chart
-      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
+      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} voronoiDimension="x" />}
       domainPadding={{ x: [30, 25] }}
       legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }, { name: 'Mice' }]}
       legendOrientation="vertical"
@@ -88,7 +89,7 @@ import { Chart, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-
       padding={{
         bottom: 75, // Adjusted to accomodate legend
         left: 50,
-        right: 50,
+        right: 100, // Adjusted to accomodate tooltip
         top: 50
       }}
       themeColor={ChartThemeColor.multi}

--- a/packages/patternfly-4/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
@@ -24,13 +24,12 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "fillOpacity": 0.4,
-                "stroke": "#73bcf7",
+                "stroke": "transparent",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -54,13 +53,12 @@ exports[`Chart 1`] = `
             "style": Object {
               "axis": Object {
                 "fill": "transparent",
-                "stroke": "#D2D2D2",
+                "stroke": "#d2d2d2",
                 "strokeLinecap": "round",
                 "strokeLinejoin": "round",
                 "strokeWidth": 1,
               },
               "axisLabel": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -76,7 +74,7 @@ exports[`Chart 1`] = `
                 "strokeLinejoin": "round",
               },
               "tickLabels": Object {
-                "fill": "#151515",
+                "fill": "#4d5258",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -113,7 +111,6 @@ exports[`Chart 1`] = `
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -137,11 +134,10 @@ exports[`Chart 1`] = `
             "style": Object {
               "max": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "maxLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -150,11 +146,10 @@ exports[`Chart 1`] = `
               },
               "median": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "medianLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -163,11 +158,10 @@ exports[`Chart 1`] = `
               },
               "min": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "minLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -175,11 +169,10 @@ exports[`Chart 1`] = `
                 "stroke": "transparent",
               },
               "q1": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q1Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -187,11 +180,10 @@ exports[`Chart 1`] = `
                 "stroke": "transparent",
               },
               "q3": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q3Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -203,8 +195,8 @@ exports[`Chart 1`] = `
           },
           "candlestick": Object {
             "candleColors": Object {
-              "negative": "#73bcf7",
-              "positive": "#bee1f4",
+              "negative": "#151515",
+              "positive": "#fff",
             },
             "colorScale": Array [
               "#06c",
@@ -217,11 +209,10 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -242,11 +233,6 @@ exports[`Chart 1`] = `
             ],
             "height": 300,
             "padding": 50,
-            "style": Object {
-              "parent": Object {
-                "border": "1px solid #bee1f4",
-              },
-            },
             "width": 450,
           },
           "errorbar": Object {
@@ -264,11 +250,10 @@ exports[`Chart 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -306,7 +291,6 @@ exports[`Chart 1`] = `
                 "type": "square",
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -314,7 +298,6 @@ exports[`Chart 1`] = `
                 "stroke": "transparent",
               },
               "title": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -338,11 +321,10 @@ exports[`Chart 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -370,12 +352,11 @@ exports[`Chart 1`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
               },
             },
             "width": 230,
@@ -392,13 +373,12 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -421,7 +401,6 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#fff",
                 "strokeWidth": 1,
               },
             },
@@ -439,14 +418,9 @@ exports[`Chart 1`] = `
             "pointerLength": 10,
             "pointerWidth": 20,
             "style": Object {
-              "fill": "#EDEDED",
-              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-              "fontSize": 14,
-              "letterSpacing": "normal",
+              "fill": "#ededed",
               "padding": 16,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
-              "textAnchor": "middle",
             },
           },
           "voronoi": Object {
@@ -472,13 +446,13 @@ exports[`Chart 1`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
+                "fill": "#ededed",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
                 "textAnchor": "middle",
               },
             },
@@ -524,13 +498,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -554,13 +527,12 @@ exports[`Chart 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -576,7 +548,7 @@ exports[`Chart 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -613,7 +585,6 @@ exports[`Chart 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -637,11 +608,10 @@ exports[`Chart 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -650,11 +620,10 @@ exports[`Chart 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -663,11 +632,10 @@ exports[`Chart 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -675,11 +643,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -687,11 +654,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -703,8 +669,8 @@ exports[`Chart 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -717,11 +683,10 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -742,11 +707,6 @@ exports[`Chart 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -764,11 +724,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -806,7 +765,6 @@ exports[`Chart 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -814,7 +772,6 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -838,11 +795,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -870,12 +826,11 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -892,13 +847,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -921,7 +875,6 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -939,14 +892,9 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -972,13 +920,13 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -1022,13 +970,12 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "fillOpacity": 0.4,
-                "stroke": "#73bcf7",
+                "stroke": "transparent",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1052,13 +999,12 @@ exports[`Chart 2`] = `
             "style": Object {
               "axis": Object {
                 "fill": "transparent",
-                "stroke": "#D2D2D2",
+                "stroke": "#d2d2d2",
                 "strokeLinecap": "round",
                 "strokeLinejoin": "round",
                 "strokeWidth": 1,
               },
               "axisLabel": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1074,7 +1020,7 @@ exports[`Chart 2`] = `
                 "strokeLinejoin": "round",
               },
               "tickLabels": Object {
-                "fill": "#151515",
+                "fill": "#4d5258",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1111,7 +1057,6 @@ exports[`Chart 2`] = `
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1135,11 +1080,10 @@ exports[`Chart 2`] = `
             "style": Object {
               "max": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "maxLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1148,11 +1092,10 @@ exports[`Chart 2`] = `
               },
               "median": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "medianLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1161,11 +1104,10 @@ exports[`Chart 2`] = `
               },
               "min": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "minLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1173,11 +1115,10 @@ exports[`Chart 2`] = `
                 "stroke": "transparent",
               },
               "q1": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q1Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1185,11 +1126,10 @@ exports[`Chart 2`] = `
                 "stroke": "transparent",
               },
               "q3": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q3Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1201,8 +1141,8 @@ exports[`Chart 2`] = `
           },
           "candlestick": Object {
             "candleColors": Object {
-              "negative": "#73bcf7",
-              "positive": "#bee1f4",
+              "negative": "#151515",
+              "positive": "#fff",
             },
             "colorScale": Array [
               "#06c",
@@ -1215,11 +1155,10 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1240,11 +1179,6 @@ exports[`Chart 2`] = `
             ],
             "height": 300,
             "padding": 50,
-            "style": Object {
-              "parent": Object {
-                "border": "1px solid #bee1f4",
-              },
-            },
             "width": 450,
           },
           "errorbar": Object {
@@ -1262,11 +1196,10 @@ exports[`Chart 2`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1304,7 +1237,6 @@ exports[`Chart 2`] = `
                 "type": "square",
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1312,7 +1244,6 @@ exports[`Chart 2`] = `
                 "stroke": "transparent",
               },
               "title": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1336,11 +1267,10 @@ exports[`Chart 2`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1368,12 +1298,11 @@ exports[`Chart 2`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
               },
             },
             "width": 230,
@@ -1390,13 +1319,12 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1419,7 +1347,6 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#fff",
                 "strokeWidth": 1,
               },
             },
@@ -1437,14 +1364,9 @@ exports[`Chart 2`] = `
             "pointerLength": 10,
             "pointerWidth": 20,
             "style": Object {
-              "fill": "#EDEDED",
-              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-              "fontSize": 14,
-              "letterSpacing": "normal",
+              "fill": "#ededed",
               "padding": 16,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
-              "textAnchor": "middle",
             },
           },
           "voronoi": Object {
@@ -1470,13 +1392,13 @@ exports[`Chart 2`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
+                "fill": "#ededed",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
                 "textAnchor": "middle",
               },
             },
@@ -1522,13 +1444,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1552,13 +1473,12 @@ exports[`Chart 2`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1574,7 +1494,7 @@ exports[`Chart 2`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1611,7 +1531,6 @@ exports[`Chart 2`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1635,11 +1554,10 @@ exports[`Chart 2`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1648,11 +1566,10 @@ exports[`Chart 2`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1661,11 +1578,10 @@ exports[`Chart 2`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1673,11 +1589,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1685,11 +1600,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1701,8 +1615,8 @@ exports[`Chart 2`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -1715,11 +1629,10 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1740,11 +1653,6 @@ exports[`Chart 2`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -1762,11 +1670,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1804,7 +1711,6 @@ exports[`Chart 2`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1812,7 +1718,6 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1836,11 +1741,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1868,12 +1772,11 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -1890,13 +1793,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1919,7 +1821,6 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -1937,14 +1838,9 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -1970,13 +1866,13 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -2020,13 +1916,12 @@ exports[`renders container via ChartLegend 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "fillOpacity": 0.4,
-                "stroke": "#73bcf7",
+                "stroke": "transparent",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2050,13 +1945,12 @@ exports[`renders container via ChartLegend 1`] = `
             "style": Object {
               "axis": Object {
                 "fill": "transparent",
-                "stroke": "#D2D2D2",
+                "stroke": "#d2d2d2",
                 "strokeLinecap": "round",
                 "strokeLinejoin": "round",
                 "strokeWidth": 1,
               },
               "axisLabel": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2072,7 +1966,7 @@ exports[`renders container via ChartLegend 1`] = `
                 "strokeLinejoin": "round",
               },
               "tickLabels": Object {
-                "fill": "#151515",
+                "fill": "#4d5258",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2109,7 +2003,6 @@ exports[`renders container via ChartLegend 1`] = `
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2133,11 +2026,10 @@ exports[`renders container via ChartLegend 1`] = `
             "style": Object {
               "max": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "maxLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2146,11 +2038,10 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "median": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "medianLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2159,11 +2050,10 @@ exports[`renders container via ChartLegend 1`] = `
               },
               "min": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "minLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2171,11 +2061,10 @@ exports[`renders container via ChartLegend 1`] = `
                 "stroke": "transparent",
               },
               "q1": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q1Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2183,11 +2072,10 @@ exports[`renders container via ChartLegend 1`] = `
                 "stroke": "transparent",
               },
               "q3": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q3Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2199,8 +2087,8 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "candlestick": Object {
             "candleColors": Object {
-              "negative": "#73bcf7",
-              "positive": "#bee1f4",
+              "negative": "#151515",
+              "positive": "#fff",
             },
             "colorScale": Array [
               "#06c",
@@ -2213,11 +2101,10 @@ exports[`renders container via ChartLegend 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2238,11 +2125,6 @@ exports[`renders container via ChartLegend 1`] = `
             ],
             "height": 300,
             "padding": 50,
-            "style": Object {
-              "parent": Object {
-                "border": "1px solid #bee1f4",
-              },
-            },
             "width": 450,
           },
           "errorbar": Object {
@@ -2260,11 +2142,10 @@ exports[`renders container via ChartLegend 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2302,7 +2183,6 @@ exports[`renders container via ChartLegend 1`] = `
                 "type": "square",
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2310,7 +2190,6 @@ exports[`renders container via ChartLegend 1`] = `
                 "stroke": "transparent",
               },
               "title": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2334,11 +2213,10 @@ exports[`renders container via ChartLegend 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2366,12 +2244,11 @@ exports[`renders container via ChartLegend 1`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
               },
             },
             "width": 230,
@@ -2388,13 +2265,12 @@ exports[`renders container via ChartLegend 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2417,7 +2293,6 @@ exports[`renders container via ChartLegend 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#fff",
                 "strokeWidth": 1,
               },
             },
@@ -2435,14 +2310,9 @@ exports[`renders container via ChartLegend 1`] = `
             "pointerLength": 10,
             "pointerWidth": 20,
             "style": Object {
-              "fill": "#EDEDED",
-              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-              "fontSize": 14,
-              "letterSpacing": "normal",
+              "fill": "#ededed",
               "padding": 16,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
-              "textAnchor": "middle",
             },
           },
           "voronoi": Object {
@@ -2468,13 +2338,13 @@ exports[`renders container via ChartLegend 1`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
+                "fill": "#ededed",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
                 "textAnchor": "middle",
               },
             },
@@ -2521,13 +2391,12 @@ exports[`renders container via ChartLegend 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2551,13 +2420,12 @@ exports[`renders container via ChartLegend 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2573,7 +2441,7 @@ exports[`renders container via ChartLegend 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2610,7 +2478,6 @@ exports[`renders container via ChartLegend 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2634,11 +2501,10 @@ exports[`renders container via ChartLegend 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2647,11 +2513,10 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2660,11 +2525,10 @@ exports[`renders container via ChartLegend 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2672,11 +2536,10 @@ exports[`renders container via ChartLegend 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2684,11 +2547,10 @@ exports[`renders container via ChartLegend 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2700,8 +2562,8 @@ exports[`renders container via ChartLegend 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -2714,11 +2576,10 @@ exports[`renders container via ChartLegend 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2739,11 +2600,6 @@ exports[`renders container via ChartLegend 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -2761,11 +2617,10 @@ exports[`renders container via ChartLegend 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2803,7 +2658,6 @@ exports[`renders container via ChartLegend 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2811,7 +2665,6 @@ exports[`renders container via ChartLegend 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2835,11 +2688,10 @@ exports[`renders container via ChartLegend 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2867,12 +2719,11 @@ exports[`renders container via ChartLegend 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -2889,13 +2740,12 @@ exports[`renders container via ChartLegend 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2918,7 +2768,6 @@ exports[`renders container via ChartLegend 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -2936,14 +2785,9 @@ exports[`renders container via ChartLegend 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -2969,13 +2813,13 @@ exports[`renders container via ChartLegend 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
@@ -24,13 +24,12 @@ exports[`Chart 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#151515",
                   "fillOpacity": 0.4,
-                  "stroke": "#73bcf7",
+                  "stroke": "transparent",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -54,13 +53,12 @@ exports[`Chart 1`] = `
               "style": Object {
                 "axis": Object {
                   "fill": "transparent",
-                  "stroke": "#D2D2D2",
+                  "stroke": "#d2d2d2",
                   "strokeLinecap": "round",
                   "strokeLinejoin": "round",
                   "strokeWidth": 1,
                 },
                 "axisLabel": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -76,7 +74,7 @@ exports[`Chart 1`] = `
                   "strokeLinejoin": "round",
                 },
                 "tickLabels": Object {
-                  "fill": "#151515",
+                  "fill": "#4d5258",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -113,7 +111,6 @@ exports[`Chart 1`] = `
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -137,11 +134,10 @@ exports[`Chart 1`] = `
               "style": Object {
                 "max": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "maxLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -150,11 +146,10 @@ exports[`Chart 1`] = `
                 },
                 "median": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "medianLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -163,11 +158,10 @@ exports[`Chart 1`] = `
                 },
                 "min": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "minLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -175,11 +169,10 @@ exports[`Chart 1`] = `
                   "stroke": "transparent",
                 },
                 "q1": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#8b8d8f",
                   "padding": 8,
                 },
                 "q1Labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -187,11 +180,10 @@ exports[`Chart 1`] = `
                   "stroke": "transparent",
                 },
                 "q3": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#8b8d8f",
                   "padding": 8,
                 },
                 "q3Labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -203,8 +195,8 @@ exports[`Chart 1`] = `
             },
             "candlestick": Object {
               "candleColors": Object {
-                "negative": "#73bcf7",
-                "positive": "#bee1f4",
+                "negative": "#151515",
+                "positive": "#fff",
               },
               "colorScale": Array [
                 "#06c",
@@ -217,11 +209,10 @@ exports[`Chart 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -242,11 +233,6 @@ exports[`Chart 1`] = `
               ],
               "height": 300,
               "padding": 50,
-              "style": Object {
-                "parent": Object {
-                  "border": "1px solid #bee1f4",
-                },
-              },
               "width": 450,
             },
             "errorbar": Object {
@@ -264,11 +250,10 @@ exports[`Chart 1`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -306,7 +291,6 @@ exports[`Chart 1`] = `
                   "type": "square",
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -314,7 +298,6 @@ exports[`Chart 1`] = `
                   "stroke": "transparent",
                 },
                 "title": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -338,11 +321,10 @@ exports[`Chart 1`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -371,12 +353,11 @@ exports[`Chart 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
-                  "stroke": "#EDEDED",
+                  "stroke": "transparent",
                 },
               },
               "width": 230,
@@ -393,13 +374,12 @@ exports[`Chart 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#151515",
                   "opacity": 1,
                   "stroke": "transparent",
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -422,7 +402,6 @@ exports[`Chart 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "stroke": "#fff",
                   "strokeWidth": 1,
                 },
               },
@@ -440,14 +419,9 @@ exports[`Chart 1`] = `
               "pointerLength": 10,
               "pointerWidth": 20,
               "style": Object {
-                "fill": "#EDEDED",
-                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-                "fontSize": 14,
-                "letterSpacing": "normal",
+                "fill": "#ededed",
                 "padding": 16,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -473,13 +447,13 @@ exports[`Chart 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
+                  "fill": "#ededed",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
                   "pointerEvents": "none",
-                  "stroke": "#EDEDED",
+                  "stroke": "transparent",
                   "textAnchor": "middle",
                 },
               },
@@ -509,13 +483,12 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -539,13 +512,12 @@ exports[`Chart 1`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -561,7 +533,7 @@ exports[`Chart 1`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -598,7 +570,6 @@ exports[`Chart 1`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -622,11 +593,10 @@ exports[`Chart 1`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -635,11 +605,10 @@ exports[`Chart 1`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -648,11 +617,10 @@ exports[`Chart 1`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -660,11 +628,10 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -672,11 +639,10 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -688,8 +654,8 @@ exports[`Chart 1`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -702,11 +668,10 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -727,11 +692,6 @@ exports[`Chart 1`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -749,11 +709,10 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -791,7 +750,6 @@ exports[`Chart 1`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -799,7 +757,6 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -823,11 +780,10 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -856,12 +812,11 @@ exports[`Chart 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -878,13 +833,12 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -907,7 +861,6 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -925,14 +878,9 @@ exports[`Chart 1`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -958,13 +906,13 @@ exports[`Chart 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },
@@ -1001,13 +949,12 @@ exports[`Chart 2`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#151515",
                   "fillOpacity": 0.4,
-                  "stroke": "#73bcf7",
+                  "stroke": "transparent",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1031,13 +978,12 @@ exports[`Chart 2`] = `
               "style": Object {
                 "axis": Object {
                   "fill": "transparent",
-                  "stroke": "#D2D2D2",
+                  "stroke": "#d2d2d2",
                   "strokeLinecap": "round",
                   "strokeLinejoin": "round",
                   "strokeWidth": 1,
                 },
                 "axisLabel": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1053,7 +999,7 @@ exports[`Chart 2`] = `
                   "strokeLinejoin": "round",
                 },
                 "tickLabels": Object {
-                  "fill": "#151515",
+                  "fill": "#4d5258",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1090,7 +1036,6 @@ exports[`Chart 2`] = `
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1114,11 +1059,10 @@ exports[`Chart 2`] = `
               "style": Object {
                 "max": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "maxLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1127,11 +1071,10 @@ exports[`Chart 2`] = `
                 },
                 "median": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "medianLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1140,11 +1083,10 @@ exports[`Chart 2`] = `
                 },
                 "min": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "minLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1152,11 +1094,10 @@ exports[`Chart 2`] = `
                   "stroke": "transparent",
                 },
                 "q1": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#8b8d8f",
                   "padding": 8,
                 },
                 "q1Labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1164,11 +1105,10 @@ exports[`Chart 2`] = `
                   "stroke": "transparent",
                 },
                 "q3": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#8b8d8f",
                   "padding": 8,
                 },
                 "q3Labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1180,8 +1120,8 @@ exports[`Chart 2`] = `
             },
             "candlestick": Object {
               "candleColors": Object {
-                "negative": "#73bcf7",
-                "positive": "#bee1f4",
+                "negative": "#151515",
+                "positive": "#fff",
               },
               "colorScale": Array [
                 "#06c",
@@ -1194,11 +1134,10 @@ exports[`Chart 2`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1219,11 +1158,6 @@ exports[`Chart 2`] = `
               ],
               "height": 300,
               "padding": 50,
-              "style": Object {
-                "parent": Object {
-                  "border": "1px solid #bee1f4",
-                },
-              },
               "width": 450,
             },
             "errorbar": Object {
@@ -1241,11 +1175,10 @@ exports[`Chart 2`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1283,7 +1216,6 @@ exports[`Chart 2`] = `
                   "type": "square",
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1291,7 +1223,6 @@ exports[`Chart 2`] = `
                   "stroke": "transparent",
                 },
                 "title": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1315,11 +1246,10 @@ exports[`Chart 2`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1348,12 +1278,11 @@ exports[`Chart 2`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
-                  "stroke": "#EDEDED",
+                  "stroke": "transparent",
                 },
               },
               "width": 230,
@@ -1370,13 +1299,12 @@ exports[`Chart 2`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#151515",
                   "opacity": 1,
                   "stroke": "transparent",
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1399,7 +1327,6 @@ exports[`Chart 2`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "stroke": "#fff",
                   "strokeWidth": 1,
                 },
               },
@@ -1417,14 +1344,9 @@ exports[`Chart 2`] = `
               "pointerLength": 10,
               "pointerWidth": 20,
               "style": Object {
-                "fill": "#EDEDED",
-                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-                "fontSize": 14,
-                "letterSpacing": "normal",
+                "fill": "#ededed",
                 "padding": 16,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -1450,13 +1372,13 @@ exports[`Chart 2`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
+                  "fill": "#ededed",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
                   "pointerEvents": "none",
-                  "stroke": "#EDEDED",
+                  "stroke": "transparent",
                   "textAnchor": "middle",
                 },
               },
@@ -1486,13 +1408,12 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1516,13 +1437,12 @@ exports[`Chart 2`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1538,7 +1458,7 @@ exports[`Chart 2`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1575,7 +1495,6 @@ exports[`Chart 2`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1599,11 +1518,10 @@ exports[`Chart 2`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1612,11 +1530,10 @@ exports[`Chart 2`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1625,11 +1542,10 @@ exports[`Chart 2`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1637,11 +1553,10 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1649,11 +1564,10 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1665,8 +1579,8 @@ exports[`Chart 2`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -1679,11 +1593,10 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1704,11 +1617,6 @@ exports[`Chart 2`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -1726,11 +1634,10 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1768,7 +1675,6 @@ exports[`Chart 2`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1776,7 +1682,6 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1800,11 +1705,10 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1833,12 +1737,11 @@ exports[`Chart 2`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -1855,13 +1758,12 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1884,7 +1786,6 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -1902,14 +1803,9 @@ exports[`Chart 2`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -1935,13 +1831,13 @@ exports[`Chart 2`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },
@@ -1994,13 +1890,12 @@ exports[`renders component data 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#151515",
                   "fillOpacity": 0.4,
-                  "stroke": "#73bcf7",
+                  "stroke": "transparent",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2024,13 +1919,12 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "axis": Object {
                   "fill": "transparent",
-                  "stroke": "#D2D2D2",
+                  "stroke": "#d2d2d2",
                   "strokeLinecap": "round",
                   "strokeLinejoin": "round",
                   "strokeWidth": 1,
                 },
                 "axisLabel": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2046,7 +1940,7 @@ exports[`renders component data 1`] = `
                   "strokeLinejoin": "round",
                 },
                 "tickLabels": Object {
-                  "fill": "#151515",
+                  "fill": "#4d5258",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2083,7 +1977,6 @@ exports[`renders component data 1`] = `
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2107,11 +2000,10 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "max": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "maxLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2120,11 +2012,10 @@ exports[`renders component data 1`] = `
                 },
                 "median": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "medianLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2133,11 +2024,10 @@ exports[`renders component data 1`] = `
                 },
                 "min": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "minLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2145,11 +2035,10 @@ exports[`renders component data 1`] = `
                   "stroke": "transparent",
                 },
                 "q1": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#8b8d8f",
                   "padding": 8,
                 },
                 "q1Labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2157,11 +2046,10 @@ exports[`renders component data 1`] = `
                   "stroke": "transparent",
                 },
                 "q3": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#8b8d8f",
                   "padding": 8,
                 },
                 "q3Labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2173,8 +2061,8 @@ exports[`renders component data 1`] = `
             },
             "candlestick": Object {
               "candleColors": Object {
-                "negative": "#73bcf7",
-                "positive": "#bee1f4",
+                "negative": "#151515",
+                "positive": "#fff",
               },
               "colorScale": Array [
                 "#06c",
@@ -2187,11 +2075,10 @@ exports[`renders component data 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2212,11 +2099,6 @@ exports[`renders component data 1`] = `
               ],
               "height": 300,
               "padding": 50,
-              "style": Object {
-                "parent": Object {
-                  "border": "1px solid #bee1f4",
-                },
-              },
               "width": 450,
             },
             "errorbar": Object {
@@ -2234,11 +2116,10 @@ exports[`renders component data 1`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2276,7 +2157,6 @@ exports[`renders component data 1`] = `
                   "type": "square",
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2284,7 +2164,6 @@ exports[`renders component data 1`] = `
                   "stroke": "transparent",
                 },
                 "title": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2308,11 +2187,10 @@ exports[`renders component data 1`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2341,12 +2219,11 @@ exports[`renders component data 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
-                  "stroke": "#EDEDED",
+                  "stroke": "transparent",
                 },
               },
               "width": 230,
@@ -2363,13 +2240,12 @@ exports[`renders component data 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#151515",
                   "opacity": 1,
                   "stroke": "transparent",
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -2392,7 +2268,6 @@ exports[`renders component data 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "stroke": "#fff",
                   "strokeWidth": 1,
                 },
               },
@@ -2410,14 +2285,9 @@ exports[`renders component data 1`] = `
               "pointerLength": 10,
               "pointerWidth": 20,
               "style": Object {
-                "fill": "#EDEDED",
-                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-                "fontSize": 14,
-                "letterSpacing": "normal",
+                "fill": "#ededed",
                 "padding": 16,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -2443,13 +2313,13 @@ exports[`renders component data 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
+                  "fill": "#ededed",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
                   "pointerEvents": "none",
-                  "stroke": "#EDEDED",
+                  "stroke": "transparent",
                   "textAnchor": "middle",
                 },
               },
@@ -2479,13 +2349,12 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2509,13 +2378,12 @@ exports[`renders component data 1`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2531,7 +2399,7 @@ exports[`renders component data 1`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2568,7 +2436,6 @@ exports[`renders component data 1`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2592,11 +2459,10 @@ exports[`renders component data 1`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2605,11 +2471,10 @@ exports[`renders component data 1`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2618,11 +2483,10 @@ exports[`renders component data 1`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2630,11 +2494,10 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2642,11 +2505,10 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2658,8 +2520,8 @@ exports[`renders component data 1`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -2672,11 +2534,10 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2697,11 +2558,6 @@ exports[`renders component data 1`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -2719,11 +2575,10 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2761,7 +2616,6 @@ exports[`renders component data 1`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2769,7 +2623,6 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2793,11 +2646,10 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2826,12 +2678,11 @@ exports[`renders component data 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -2848,13 +2699,12 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2877,7 +2727,6 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -2895,14 +2744,9 @@ exports[`renders component data 1`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -2928,13 +2772,13 @@ exports[`renders component data 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
@@ -36,13 +36,12 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -66,13 +65,12 @@ exports[`Chart 1`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -88,7 +86,7 @@ exports[`Chart 1`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -125,7 +123,6 @@ exports[`Chart 1`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -149,11 +146,10 @@ exports[`Chart 1`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -162,11 +158,10 @@ exports[`Chart 1`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -175,11 +170,10 @@ exports[`Chart 1`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -187,11 +181,10 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -199,11 +192,10 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -215,8 +207,8 @@ exports[`Chart 1`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -229,11 +221,10 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -254,11 +245,6 @@ exports[`Chart 1`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -276,11 +262,10 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -318,7 +303,6 @@ exports[`Chart 1`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -326,7 +310,6 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -350,11 +333,10 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -383,12 +365,11 @@ exports[`Chart 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -405,13 +386,12 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -434,7 +414,6 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -452,14 +431,9 @@ exports[`Chart 1`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -485,13 +459,13 @@ exports[`Chart 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },
@@ -540,13 +514,12 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -570,13 +543,12 @@ exports[`Chart 2`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -592,7 +564,7 @@ exports[`Chart 2`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -629,7 +601,6 @@ exports[`Chart 2`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -653,11 +624,10 @@ exports[`Chart 2`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -666,11 +636,10 @@ exports[`Chart 2`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -679,11 +648,10 @@ exports[`Chart 2`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -691,11 +659,10 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -703,11 +670,10 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -719,8 +685,8 @@ exports[`Chart 2`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -733,11 +699,10 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -758,11 +723,6 @@ exports[`Chart 2`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -780,11 +740,10 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -822,7 +781,6 @@ exports[`Chart 2`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -830,7 +788,6 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -854,11 +811,10 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -887,12 +843,11 @@ exports[`Chart 2`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -909,13 +864,12 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -938,7 +892,6 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -956,14 +909,9 @@ exports[`Chart 2`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -989,13 +937,13 @@ exports[`Chart 2`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },
@@ -1056,13 +1004,12 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1086,13 +1033,12 @@ exports[`renders component data 1`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1108,7 +1054,7 @@ exports[`renders component data 1`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1145,7 +1091,6 @@ exports[`renders component data 1`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1169,11 +1114,10 @@ exports[`renders component data 1`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1182,11 +1126,10 @@ exports[`renders component data 1`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1195,11 +1138,10 @@ exports[`renders component data 1`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1207,11 +1149,10 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1219,11 +1160,10 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1235,8 +1175,8 @@ exports[`renders component data 1`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -1249,11 +1189,10 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1274,11 +1213,6 @@ exports[`renders component data 1`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -1296,11 +1230,10 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1338,7 +1271,6 @@ exports[`renders component data 1`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1346,7 +1278,6 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1370,11 +1301,10 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1403,12 +1333,11 @@ exports[`renders component data 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -1425,13 +1354,12 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1454,7 +1382,6 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -1472,14 +1399,9 @@ exports[`renders component data 1`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -1505,13 +1427,13 @@ exports[`renders component data 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
@@ -35,13 +35,12 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -65,13 +64,12 @@ exports[`Chart 1`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -87,7 +85,7 @@ exports[`Chart 1`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -124,7 +122,6 @@ exports[`Chart 1`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -148,11 +145,10 @@ exports[`Chart 1`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -161,11 +157,10 @@ exports[`Chart 1`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -174,11 +169,10 @@ exports[`Chart 1`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -186,11 +180,10 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -198,11 +191,10 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -214,8 +206,8 @@ exports[`Chart 1`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -228,11 +220,10 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -253,11 +244,6 @@ exports[`Chart 1`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -275,11 +261,10 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -316,7 +301,6 @@ exports[`Chart 1`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -324,7 +308,6 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -348,11 +331,10 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -378,12 +360,11 @@ exports[`Chart 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -400,13 +381,12 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -429,7 +409,6 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -447,14 +426,9 @@ exports[`Chart 1`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -480,13 +454,13 @@ exports[`Chart 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },
@@ -534,13 +508,12 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -564,13 +537,12 @@ exports[`Chart 2`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -586,7 +558,7 @@ exports[`Chart 2`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -623,7 +595,6 @@ exports[`Chart 2`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -647,11 +618,10 @@ exports[`Chart 2`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -660,11 +630,10 @@ exports[`Chart 2`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -673,11 +642,10 @@ exports[`Chart 2`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -685,11 +653,10 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -697,11 +664,10 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -713,8 +679,8 @@ exports[`Chart 2`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -727,11 +693,10 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -752,11 +717,6 @@ exports[`Chart 2`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -774,11 +734,10 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -815,7 +774,6 @@ exports[`Chart 2`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -823,7 +781,6 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -847,11 +804,10 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -877,12 +833,11 @@ exports[`Chart 2`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -899,13 +854,12 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -928,7 +882,6 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -946,14 +899,9 @@ exports[`Chart 2`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -979,13 +927,13 @@ exports[`Chart 2`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },
@@ -1033,13 +981,12 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1063,13 +1010,12 @@ exports[`renders component data 1`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1085,7 +1031,7 @@ exports[`renders component data 1`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1122,7 +1068,6 @@ exports[`renders component data 1`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1146,11 +1091,10 @@ exports[`renders component data 1`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1159,11 +1103,10 @@ exports[`renders component data 1`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1172,11 +1115,10 @@ exports[`renders component data 1`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1184,11 +1126,10 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1196,11 +1137,10 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1212,8 +1152,8 @@ exports[`renders component data 1`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -1226,11 +1166,10 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1251,11 +1190,6 @@ exports[`renders component data 1`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -1273,11 +1207,10 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1314,7 +1247,6 @@ exports[`renders component data 1`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1322,7 +1254,6 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1346,11 +1277,10 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1376,12 +1306,11 @@ exports[`renders component data 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -1398,13 +1327,12 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1427,7 +1355,6 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -1445,14 +1372,9 @@ exports[`renders component data 1`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -1478,13 +1400,13 @@ exports[`renders component data 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },

--- a/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.tsx.snap
@@ -28,13 +28,12 @@ exports[`ChartGroup 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -58,13 +57,12 @@ exports[`ChartGroup 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -80,7 +78,7 @@ exports[`ChartGroup 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -117,7 +115,6 @@ exports[`ChartGroup 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -141,11 +138,10 @@ exports[`ChartGroup 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -154,11 +150,10 @@ exports[`ChartGroup 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -167,11 +162,10 @@ exports[`ChartGroup 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -179,11 +173,10 @@ exports[`ChartGroup 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -191,11 +184,10 @@ exports[`ChartGroup 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -207,8 +199,8 @@ exports[`ChartGroup 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -221,11 +213,10 @@ exports[`ChartGroup 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -246,11 +237,6 @@ exports[`ChartGroup 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -268,11 +254,10 @@ exports[`ChartGroup 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -310,7 +295,6 @@ exports[`ChartGroup 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -318,7 +302,6 @@ exports[`ChartGroup 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -342,11 +325,10 @@ exports[`ChartGroup 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -374,12 +356,11 @@ exports[`ChartGroup 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -396,13 +377,12 @@ exports[`ChartGroup 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -425,7 +405,6 @@ exports[`ChartGroup 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -443,14 +422,9 @@ exports[`ChartGroup 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -476,13 +450,13 @@ exports[`ChartGroup 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -521,13 +495,12 @@ exports[`ChartGroup 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -551,13 +524,12 @@ exports[`ChartGroup 2`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -573,7 +545,7 @@ exports[`ChartGroup 2`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -610,7 +582,6 @@ exports[`ChartGroup 2`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -634,11 +605,10 @@ exports[`ChartGroup 2`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -647,11 +617,10 @@ exports[`ChartGroup 2`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -660,11 +629,10 @@ exports[`ChartGroup 2`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -672,11 +640,10 @@ exports[`ChartGroup 2`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -684,11 +651,10 @@ exports[`ChartGroup 2`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -700,8 +666,8 @@ exports[`ChartGroup 2`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -714,11 +680,10 @@ exports[`ChartGroup 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -739,11 +704,6 @@ exports[`ChartGroup 2`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -761,11 +721,10 @@ exports[`ChartGroup 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -803,7 +762,6 @@ exports[`ChartGroup 2`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -811,7 +769,6 @@ exports[`ChartGroup 2`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -835,11 +792,10 @@ exports[`ChartGroup 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -867,12 +823,11 @@ exports[`ChartGroup 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -889,13 +844,12 @@ exports[`ChartGroup 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -918,7 +872,6 @@ exports[`ChartGroup 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -936,14 +889,9 @@ exports[`ChartGroup 2`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -969,13 +917,13 @@ exports[`ChartGroup 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -1015,13 +963,12 @@ exports[`renders container children 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1045,13 +992,12 @@ exports[`renders container children 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1067,7 +1013,7 @@ exports[`renders container children 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1104,7 +1050,6 @@ exports[`renders container children 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1128,11 +1073,10 @@ exports[`renders container children 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1141,11 +1085,10 @@ exports[`renders container children 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1154,11 +1097,10 @@ exports[`renders container children 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1166,11 +1108,10 @@ exports[`renders container children 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1178,11 +1119,10 @@ exports[`renders container children 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1194,8 +1134,8 @@ exports[`renders container children 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -1208,11 +1148,10 @@ exports[`renders container children 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1233,11 +1172,6 @@ exports[`renders container children 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -1255,11 +1189,10 @@ exports[`renders container children 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1297,7 +1230,6 @@ exports[`renders container children 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1305,7 +1237,6 @@ exports[`renders container children 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1329,11 +1260,10 @@ exports[`renders container children 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1361,12 +1291,11 @@ exports[`renders container children 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -1383,13 +1312,12 @@ exports[`renders container children 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1412,7 +1340,6 @@ exports[`renders container children 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -1430,14 +1357,9 @@ exports[`renders container children 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -1463,13 +1385,13 @@ exports[`renders container children 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
@@ -24,13 +24,12 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "fillOpacity": 0.4,
-                "stroke": "#73bcf7",
+                "stroke": "transparent",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -54,13 +53,12 @@ exports[`Chart 1`] = `
             "style": Object {
               "axis": Object {
                 "fill": "transparent",
-                "stroke": "#D2D2D2",
+                "stroke": "#d2d2d2",
                 "strokeLinecap": "round",
                 "strokeLinejoin": "round",
                 "strokeWidth": 1,
               },
               "axisLabel": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -76,7 +74,7 @@ exports[`Chart 1`] = `
                 "strokeLinejoin": "round",
               },
               "tickLabels": Object {
-                "fill": "#151515",
+                "fill": "#4d5258",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -113,7 +111,6 @@ exports[`Chart 1`] = `
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -137,11 +134,10 @@ exports[`Chart 1`] = `
             "style": Object {
               "max": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "maxLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -150,11 +146,10 @@ exports[`Chart 1`] = `
               },
               "median": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "medianLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -163,11 +158,10 @@ exports[`Chart 1`] = `
               },
               "min": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "minLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -175,11 +169,10 @@ exports[`Chart 1`] = `
                 "stroke": "transparent",
               },
               "q1": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q1Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -187,11 +180,10 @@ exports[`Chart 1`] = `
                 "stroke": "transparent",
               },
               "q3": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q3Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -203,8 +195,8 @@ exports[`Chart 1`] = `
           },
           "candlestick": Object {
             "candleColors": Object {
-              "negative": "#73bcf7",
-              "positive": "#bee1f4",
+              "negative": "#151515",
+              "positive": "#fff",
             },
             "colorScale": Array [
               "#06c",
@@ -217,11 +209,10 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -242,11 +233,6 @@ exports[`Chart 1`] = `
             ],
             "height": 300,
             "padding": 50,
-            "style": Object {
-              "parent": Object {
-                "border": "1px solid #bee1f4",
-              },
-            },
             "width": 450,
           },
           "errorbar": Object {
@@ -264,11 +250,10 @@ exports[`Chart 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -306,7 +291,6 @@ exports[`Chart 1`] = `
                 "type": "square",
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -314,7 +298,6 @@ exports[`Chart 1`] = `
                 "stroke": "transparent",
               },
               "title": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -338,11 +321,10 @@ exports[`Chart 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -370,12 +352,11 @@ exports[`Chart 1`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
               },
             },
             "width": 230,
@@ -392,13 +373,12 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -421,7 +401,6 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#fff",
                 "strokeWidth": 1,
               },
             },
@@ -439,14 +418,9 @@ exports[`Chart 1`] = `
             "pointerLength": 10,
             "pointerWidth": 20,
             "style": Object {
-              "fill": "#EDEDED",
-              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-              "fontSize": 14,
-              "letterSpacing": "normal",
+              "fill": "#ededed",
               "padding": 16,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
-              "textAnchor": "middle",
             },
           },
           "voronoi": Object {
@@ -472,13 +446,13 @@ exports[`Chart 1`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
+                "fill": "#ededed",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
                 "textAnchor": "middle",
               },
             },
@@ -524,13 +498,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -554,13 +527,12 @@ exports[`Chart 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -576,7 +548,7 @@ exports[`Chart 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -613,7 +585,6 @@ exports[`Chart 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -637,11 +608,10 @@ exports[`Chart 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -650,11 +620,10 @@ exports[`Chart 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -663,11 +632,10 @@ exports[`Chart 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -675,11 +643,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -687,11 +654,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -703,8 +669,8 @@ exports[`Chart 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -717,11 +683,10 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -742,11 +707,6 @@ exports[`Chart 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -764,11 +724,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -806,7 +765,6 @@ exports[`Chart 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -814,7 +772,6 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -838,11 +795,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -870,12 +826,11 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -892,13 +847,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -921,7 +875,6 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -939,14 +892,9 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -972,13 +920,13 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -1022,13 +970,12 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "fillOpacity": 0.4,
-                "stroke": "#73bcf7",
+                "stroke": "transparent",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1052,13 +999,12 @@ exports[`Chart 2`] = `
             "style": Object {
               "axis": Object {
                 "fill": "transparent",
-                "stroke": "#D2D2D2",
+                "stroke": "#d2d2d2",
                 "strokeLinecap": "round",
                 "strokeLinejoin": "round",
                 "strokeWidth": 1,
               },
               "axisLabel": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1074,7 +1020,7 @@ exports[`Chart 2`] = `
                 "strokeLinejoin": "round",
               },
               "tickLabels": Object {
-                "fill": "#151515",
+                "fill": "#4d5258",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1111,7 +1057,6 @@ exports[`Chart 2`] = `
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1135,11 +1080,10 @@ exports[`Chart 2`] = `
             "style": Object {
               "max": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "maxLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1148,11 +1092,10 @@ exports[`Chart 2`] = `
               },
               "median": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "medianLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1161,11 +1104,10 @@ exports[`Chart 2`] = `
               },
               "min": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "minLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1173,11 +1115,10 @@ exports[`Chart 2`] = `
                 "stroke": "transparent",
               },
               "q1": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q1Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1185,11 +1126,10 @@ exports[`Chart 2`] = `
                 "stroke": "transparent",
               },
               "q3": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q3Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1201,8 +1141,8 @@ exports[`Chart 2`] = `
           },
           "candlestick": Object {
             "candleColors": Object {
-              "negative": "#73bcf7",
-              "positive": "#bee1f4",
+              "negative": "#151515",
+              "positive": "#fff",
             },
             "colorScale": Array [
               "#06c",
@@ -1215,11 +1155,10 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1240,11 +1179,6 @@ exports[`Chart 2`] = `
             ],
             "height": 300,
             "padding": 50,
-            "style": Object {
-              "parent": Object {
-                "border": "1px solid #bee1f4",
-              },
-            },
             "width": 450,
           },
           "errorbar": Object {
@@ -1262,11 +1196,10 @@ exports[`Chart 2`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1304,7 +1237,6 @@ exports[`Chart 2`] = `
                 "type": "square",
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1312,7 +1244,6 @@ exports[`Chart 2`] = `
                 "stroke": "transparent",
               },
               "title": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1336,11 +1267,10 @@ exports[`Chart 2`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1368,12 +1298,11 @@ exports[`Chart 2`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
               },
             },
             "width": 230,
@@ -1390,13 +1319,12 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1419,7 +1347,6 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#fff",
                 "strokeWidth": 1,
               },
             },
@@ -1437,14 +1364,9 @@ exports[`Chart 2`] = `
             "pointerLength": 10,
             "pointerWidth": 20,
             "style": Object {
-              "fill": "#EDEDED",
-              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-              "fontSize": 14,
-              "letterSpacing": "normal",
+              "fill": "#ededed",
               "padding": 16,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
-              "textAnchor": "middle",
             },
           },
           "voronoi": Object {
@@ -1470,13 +1392,13 @@ exports[`Chart 2`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
+                "fill": "#ededed",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
                 "textAnchor": "middle",
               },
             },
@@ -1522,13 +1444,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1552,13 +1473,12 @@ exports[`Chart 2`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1574,7 +1494,7 @@ exports[`Chart 2`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1611,7 +1531,6 @@ exports[`Chart 2`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1635,11 +1554,10 @@ exports[`Chart 2`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1648,11 +1566,10 @@ exports[`Chart 2`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1661,11 +1578,10 @@ exports[`Chart 2`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1673,11 +1589,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1685,11 +1600,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1701,8 +1615,8 @@ exports[`Chart 2`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -1715,11 +1629,10 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1740,11 +1653,6 @@ exports[`Chart 2`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -1762,11 +1670,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1804,7 +1711,6 @@ exports[`Chart 2`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1812,7 +1718,6 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1836,11 +1741,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1868,12 +1772,11 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -1890,13 +1793,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1919,7 +1821,6 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -1937,14 +1838,9 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -1970,13 +1866,13 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -2020,13 +1916,12 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "fillOpacity": 0.4,
-                "stroke": "#73bcf7",
+                "stroke": "transparent",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2050,13 +1945,12 @@ exports[`renders component data 1`] = `
             "style": Object {
               "axis": Object {
                 "fill": "transparent",
-                "stroke": "#D2D2D2",
+                "stroke": "#d2d2d2",
                 "strokeLinecap": "round",
                 "strokeLinejoin": "round",
                 "strokeWidth": 1,
               },
               "axisLabel": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2072,7 +1966,7 @@ exports[`renders component data 1`] = `
                 "strokeLinejoin": "round",
               },
               "tickLabels": Object {
-                "fill": "#151515",
+                "fill": "#4d5258",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2109,7 +2003,6 @@ exports[`renders component data 1`] = `
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2133,11 +2026,10 @@ exports[`renders component data 1`] = `
             "style": Object {
               "max": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "maxLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2146,11 +2038,10 @@ exports[`renders component data 1`] = `
               },
               "median": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "medianLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2159,11 +2050,10 @@ exports[`renders component data 1`] = `
               },
               "min": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "minLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2171,11 +2061,10 @@ exports[`renders component data 1`] = `
                 "stroke": "transparent",
               },
               "q1": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q1Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2183,11 +2072,10 @@ exports[`renders component data 1`] = `
                 "stroke": "transparent",
               },
               "q3": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q3Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2199,8 +2087,8 @@ exports[`renders component data 1`] = `
           },
           "candlestick": Object {
             "candleColors": Object {
-              "negative": "#73bcf7",
-              "positive": "#bee1f4",
+              "negative": "#151515",
+              "positive": "#fff",
             },
             "colorScale": Array [
               "#06c",
@@ -2213,11 +2101,10 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2238,11 +2125,6 @@ exports[`renders component data 1`] = `
             ],
             "height": 300,
             "padding": 50,
-            "style": Object {
-              "parent": Object {
-                "border": "1px solid #bee1f4",
-              },
-            },
             "width": 450,
           },
           "errorbar": Object {
@@ -2260,11 +2142,10 @@ exports[`renders component data 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2302,7 +2183,6 @@ exports[`renders component data 1`] = `
                 "type": "square",
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2310,7 +2190,6 @@ exports[`renders component data 1`] = `
                 "stroke": "transparent",
               },
               "title": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2334,11 +2213,10 @@ exports[`renders component data 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2366,12 +2244,11 @@ exports[`renders component data 1`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
               },
             },
             "width": 230,
@@ -2388,13 +2265,12 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2417,7 +2293,6 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#fff",
                 "strokeWidth": 1,
               },
             },
@@ -2435,14 +2310,9 @@ exports[`renders component data 1`] = `
             "pointerLength": 10,
             "pointerWidth": 20,
             "style": Object {
-              "fill": "#EDEDED",
-              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-              "fontSize": 14,
-              "letterSpacing": "normal",
+              "fill": "#ededed",
               "padding": 16,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
-              "textAnchor": "middle",
             },
           },
           "voronoi": Object {
@@ -2468,13 +2338,13 @@ exports[`renders component data 1`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
+                "fill": "#ededed",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
                 "textAnchor": "middle",
               },
             },
@@ -2521,13 +2391,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2551,13 +2420,12 @@ exports[`renders component data 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2573,7 +2441,7 @@ exports[`renders component data 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2610,7 +2478,6 @@ exports[`renders component data 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2634,11 +2501,10 @@ exports[`renders component data 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2647,11 +2513,10 @@ exports[`renders component data 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2660,11 +2525,10 @@ exports[`renders component data 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2672,11 +2536,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2684,11 +2547,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2700,8 +2562,8 @@ exports[`renders component data 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -2714,11 +2576,10 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2739,11 +2600,6 @@ exports[`renders component data 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -2761,11 +2617,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2803,7 +2658,6 @@ exports[`renders component data 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2811,7 +2665,6 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2835,11 +2688,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2867,12 +2719,11 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -2889,13 +2740,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2918,7 +2768,6 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -2936,14 +2785,9 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -2969,13 +2813,13 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.tsx.snap
@@ -51,13 +51,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -81,13 +80,12 @@ exports[`Chart 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -103,7 +101,7 @@ exports[`Chart 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -140,7 +138,6 @@ exports[`Chart 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -164,11 +161,10 @@ exports[`Chart 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -177,11 +173,10 @@ exports[`Chart 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -190,11 +185,10 @@ exports[`Chart 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -202,11 +196,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -214,11 +207,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -230,8 +222,8 @@ exports[`Chart 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -244,11 +236,10 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -269,11 +260,6 @@ exports[`Chart 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -291,11 +277,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -333,7 +318,6 @@ exports[`Chart 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -341,7 +325,6 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -365,11 +348,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -397,12 +379,11 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -419,13 +400,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -448,7 +428,6 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -466,14 +445,9 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -499,13 +473,13 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -567,13 +541,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -597,13 +570,12 @@ exports[`Chart 2`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -619,7 +591,7 @@ exports[`Chart 2`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -656,7 +628,6 @@ exports[`Chart 2`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -680,11 +651,10 @@ exports[`Chart 2`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -693,11 +663,10 @@ exports[`Chart 2`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -706,11 +675,10 @@ exports[`Chart 2`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -718,11 +686,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -730,11 +697,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -746,8 +712,8 @@ exports[`Chart 2`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -760,11 +726,10 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -785,11 +750,6 @@ exports[`Chart 2`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -807,11 +767,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -849,7 +808,6 @@ exports[`Chart 2`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -857,7 +815,6 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -881,11 +838,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -913,12 +869,11 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -935,13 +890,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -964,7 +918,6 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -982,14 +935,9 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -1015,13 +963,13 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -3206,13 +3154,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3236,13 +3183,12 @@ exports[`renders component data 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3258,7 +3204,7 @@ exports[`renders component data 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3295,7 +3241,6 @@ exports[`renders component data 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3319,11 +3264,10 @@ exports[`renders component data 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3332,11 +3276,10 @@ exports[`renders component data 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3345,11 +3288,10 @@ exports[`renders component data 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3357,11 +3299,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3369,11 +3310,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3385,8 +3325,8 @@ exports[`renders component data 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -3399,11 +3339,10 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3424,11 +3363,6 @@ exports[`renders component data 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -3446,11 +3380,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3488,7 +3421,6 @@ exports[`renders component data 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3496,7 +3428,6 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3520,11 +3451,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3552,12 +3482,11 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -3574,13 +3503,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3603,7 +3531,6 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -3621,14 +3548,9 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -3654,13 +3576,13 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -5,11 +5,11 @@ typescript: true
 propComponents: ['Chart', 'ChartAxis', 'ChartGroup', 'ChartLegend', 'ChartLine']
 ---
 
-import { Chart, ChartAxis, ChartGroup, ChartLegend, ChartLine, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLegend, ChartLine, ChartThemeColor, ChartTooltip, ChartThemeVariant } from '@patternfly/react-charts';
 import { VictoryZoomContainer } from 'victory';
 import './chart-line.scss';
 
-## Simple line chart with right-aligned legend
+## Simple line chart with tooltip and right-aligned legend
 ```js
 import React from 'react';
 import { Chart, ChartAxis, ChartGroup, ChartLine } from '@patternfly/react-charts';
@@ -17,6 +17,7 @@ import { Chart, ChartAxis, ChartGroup, ChartLine } from '@patternfly/react-chart
 <div>
   <div className="line-chart-legend-right">
     <Chart
+      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
       legendData={[{ name: 'Cats' }]}
       legendOrientation="vertical"
       legendPosition="right"
@@ -118,7 +119,7 @@ import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor } from '@patte
 ## Multi-color line chart with x-axis zoom and bottom-aligned legend
 ```js
 import React from 'react';
-import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartTooltip } from '@patternfly/react-charts';
 import { VictoryZoomContainer } from 'victory';
 
 <div>

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
@@ -61,13 +61,12 @@ exports[`Chart 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#151515",
                   "fillOpacity": 0.4,
-                  "stroke": "#73bcf7",
+                  "stroke": "transparent",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -91,13 +90,12 @@ exports[`Chart 1`] = `
               "style": Object {
                 "axis": Object {
                   "fill": "transparent",
-                  "stroke": "#D2D2D2",
+                  "stroke": "#d2d2d2",
                   "strokeLinecap": "round",
                   "strokeLinejoin": "round",
                   "strokeWidth": 1,
                 },
                 "axisLabel": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -113,7 +111,7 @@ exports[`Chart 1`] = `
                   "strokeLinejoin": "round",
                 },
                 "tickLabels": Object {
-                  "fill": "#151515",
+                  "fill": "#4d5258",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -150,7 +148,6 @@ exports[`Chart 1`] = `
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -174,11 +171,10 @@ exports[`Chart 1`] = `
               "style": Object {
                 "max": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "maxLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -187,11 +183,10 @@ exports[`Chart 1`] = `
                 },
                 "median": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "medianLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -200,11 +195,10 @@ exports[`Chart 1`] = `
                 },
                 "min": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "minLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -212,11 +206,10 @@ exports[`Chart 1`] = `
                   "stroke": "transparent",
                 },
                 "q1": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#8b8d8f",
                   "padding": 8,
                 },
                 "q1Labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -224,11 +217,10 @@ exports[`Chart 1`] = `
                   "stroke": "transparent",
                 },
                 "q3": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#8b8d8f",
                   "padding": 8,
                 },
                 "q3Labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -240,8 +232,8 @@ exports[`Chart 1`] = `
             },
             "candlestick": Object {
               "candleColors": Object {
-                "negative": "#73bcf7",
-                "positive": "#bee1f4",
+                "negative": "#151515",
+                "positive": "#fff",
               },
               "colorScale": Array [
                 "#06c",
@@ -254,11 +246,10 @@ exports[`Chart 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -279,11 +270,6 @@ exports[`Chart 1`] = `
               ],
               "height": 300,
               "padding": 50,
-              "style": Object {
-                "parent": Object {
-                  "border": "1px solid #bee1f4",
-                },
-              },
               "width": 450,
             },
             "errorbar": Object {
@@ -301,11 +287,10 @@ exports[`Chart 1`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -343,7 +328,6 @@ exports[`Chart 1`] = `
                   "type": "square",
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -351,7 +335,6 @@ exports[`Chart 1`] = `
                   "stroke": "transparent",
                 },
                 "title": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -375,11 +358,10 @@ exports[`Chart 1`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -407,12 +389,11 @@ exports[`Chart 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
-                  "stroke": "#EDEDED",
+                  "stroke": "transparent",
                 },
               },
               "width": 230,
@@ -429,13 +410,12 @@ exports[`Chart 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#151515",
                   "opacity": 1,
                   "stroke": "transparent",
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -458,7 +438,6 @@ exports[`Chart 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "stroke": "#fff",
                   "strokeWidth": 1,
                 },
               },
@@ -476,14 +455,9 @@ exports[`Chart 1`] = `
               "pointerLength": 10,
               "pointerWidth": 20,
               "style": Object {
-                "fill": "#EDEDED",
-                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-                "fontSize": 14,
-                "letterSpacing": "normal",
+                "fill": "#ededed",
                 "padding": 16,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -509,13 +483,13 @@ exports[`Chart 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
+                  "fill": "#ededed",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
                   "pointerEvents": "none",
-                  "stroke": "#EDEDED",
+                  "stroke": "transparent",
                   "textAnchor": "middle",
                 },
               },
@@ -547,13 +521,12 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -577,13 +550,12 @@ exports[`Chart 1`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -599,7 +571,7 @@ exports[`Chart 1`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -636,7 +608,6 @@ exports[`Chart 1`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -660,11 +631,10 @@ exports[`Chart 1`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -673,11 +643,10 @@ exports[`Chart 1`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -686,11 +655,10 @@ exports[`Chart 1`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -698,11 +666,10 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -710,11 +677,10 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -726,8 +692,8 @@ exports[`Chart 1`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -740,11 +706,10 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -765,11 +730,6 @@ exports[`Chart 1`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -787,11 +747,10 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -829,7 +788,6 @@ exports[`Chart 1`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -837,7 +795,6 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -861,11 +818,10 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -893,12 +849,11 @@ exports[`Chart 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -915,13 +870,12 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -944,7 +898,6 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -962,14 +915,9 @@ exports[`Chart 1`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -995,13 +943,13 @@ exports[`Chart 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },
@@ -1035,13 +983,12 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1065,13 +1012,12 @@ exports[`Chart 1`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1087,7 +1033,7 @@ exports[`Chart 1`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1124,7 +1070,6 @@ exports[`Chart 1`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1148,11 +1093,10 @@ exports[`Chart 1`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1161,11 +1105,10 @@ exports[`Chart 1`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1174,11 +1117,10 @@ exports[`Chart 1`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1186,11 +1128,10 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1198,11 +1139,10 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1214,8 +1154,8 @@ exports[`Chart 1`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -1228,11 +1168,10 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1253,11 +1192,6 @@ exports[`Chart 1`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -1275,11 +1209,10 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1317,7 +1250,6 @@ exports[`Chart 1`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1325,7 +1257,6 @@ exports[`Chart 1`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1349,11 +1280,10 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1381,12 +1311,11 @@ exports[`Chart 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -1403,13 +1332,12 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -1432,7 +1360,6 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -1450,14 +1377,9 @@ exports[`Chart 1`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -1483,13 +1405,13 @@ exports[`Chart 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },
@@ -1566,13 +1488,12 @@ exports[`Chart 2`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#151515",
                   "fillOpacity": 0.4,
-                  "stroke": "#73bcf7",
+                  "stroke": "transparent",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1596,13 +1517,12 @@ exports[`Chart 2`] = `
               "style": Object {
                 "axis": Object {
                   "fill": "transparent",
-                  "stroke": "#D2D2D2",
+                  "stroke": "#d2d2d2",
                   "strokeLinecap": "round",
                   "strokeLinejoin": "round",
                   "strokeWidth": 1,
                 },
                 "axisLabel": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1618,7 +1538,7 @@ exports[`Chart 2`] = `
                   "strokeLinejoin": "round",
                 },
                 "tickLabels": Object {
-                  "fill": "#151515",
+                  "fill": "#4d5258",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1655,7 +1575,6 @@ exports[`Chart 2`] = `
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1679,11 +1598,10 @@ exports[`Chart 2`] = `
               "style": Object {
                 "max": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "maxLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1692,11 +1610,10 @@ exports[`Chart 2`] = `
                 },
                 "median": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "medianLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1705,11 +1622,10 @@ exports[`Chart 2`] = `
                 },
                 "min": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "minLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1717,11 +1633,10 @@ exports[`Chart 2`] = `
                   "stroke": "transparent",
                 },
                 "q1": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#8b8d8f",
                   "padding": 8,
                 },
                 "q1Labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1729,11 +1644,10 @@ exports[`Chart 2`] = `
                   "stroke": "transparent",
                 },
                 "q3": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#8b8d8f",
                   "padding": 8,
                 },
                 "q3Labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1745,8 +1659,8 @@ exports[`Chart 2`] = `
             },
             "candlestick": Object {
               "candleColors": Object {
-                "negative": "#73bcf7",
-                "positive": "#bee1f4",
+                "negative": "#151515",
+                "positive": "#fff",
               },
               "colorScale": Array [
                 "#06c",
@@ -1759,11 +1673,10 @@ exports[`Chart 2`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1784,11 +1697,6 @@ exports[`Chart 2`] = `
               ],
               "height": 300,
               "padding": 50,
-              "style": Object {
-                "parent": Object {
-                  "border": "1px solid #bee1f4",
-                },
-              },
               "width": 450,
             },
             "errorbar": Object {
@@ -1806,11 +1714,10 @@ exports[`Chart 2`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1848,7 +1755,6 @@ exports[`Chart 2`] = `
                   "type": "square",
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1856,7 +1762,6 @@ exports[`Chart 2`] = `
                   "stroke": "transparent",
                 },
                 "title": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1880,11 +1785,10 @@ exports[`Chart 2`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1912,12 +1816,11 @@ exports[`Chart 2`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
-                  "stroke": "#EDEDED",
+                  "stroke": "transparent",
                 },
               },
               "width": 230,
@@ -1934,13 +1837,12 @@ exports[`Chart 2`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#151515",
                   "opacity": 1,
                   "stroke": "transparent",
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -1963,7 +1865,6 @@ exports[`Chart 2`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "stroke": "#fff",
                   "strokeWidth": 1,
                 },
               },
@@ -1981,14 +1882,9 @@ exports[`Chart 2`] = `
               "pointerLength": 10,
               "pointerWidth": 20,
               "style": Object {
-                "fill": "#EDEDED",
-                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-                "fontSize": 14,
-                "letterSpacing": "normal",
+                "fill": "#ededed",
                 "padding": 16,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -2014,13 +1910,13 @@ exports[`Chart 2`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
+                  "fill": "#ededed",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
                   "pointerEvents": "none",
-                  "stroke": "#EDEDED",
+                  "stroke": "transparent",
                   "textAnchor": "middle",
                 },
               },
@@ -2052,13 +1948,12 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2082,13 +1977,12 @@ exports[`Chart 2`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2104,7 +1998,7 @@ exports[`Chart 2`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2141,7 +2035,6 @@ exports[`Chart 2`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2165,11 +2058,10 @@ exports[`Chart 2`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2178,11 +2070,10 @@ exports[`Chart 2`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2191,11 +2082,10 @@ exports[`Chart 2`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2203,11 +2093,10 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2215,11 +2104,10 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2231,8 +2119,8 @@ exports[`Chart 2`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -2245,11 +2133,10 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2270,11 +2157,6 @@ exports[`Chart 2`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -2292,11 +2174,10 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2334,7 +2215,6 @@ exports[`Chart 2`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2342,7 +2222,6 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2366,11 +2245,10 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2398,12 +2276,11 @@ exports[`Chart 2`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -2420,13 +2297,12 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2449,7 +2325,6 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -2467,14 +2342,9 @@ exports[`Chart 2`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -2500,13 +2370,13 @@ exports[`Chart 2`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },
@@ -2540,13 +2410,12 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2570,13 +2439,12 @@ exports[`Chart 2`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2592,7 +2460,7 @@ exports[`Chart 2`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2629,7 +2497,6 @@ exports[`Chart 2`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2653,11 +2520,10 @@ exports[`Chart 2`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2666,11 +2532,10 @@ exports[`Chart 2`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2679,11 +2544,10 @@ exports[`Chart 2`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2691,11 +2555,10 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2703,11 +2566,10 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2719,8 +2581,8 @@ exports[`Chart 2`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -2733,11 +2595,10 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2758,11 +2619,6 @@ exports[`Chart 2`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -2780,11 +2636,10 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2822,7 +2677,6 @@ exports[`Chart 2`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2830,7 +2684,6 @@ exports[`Chart 2`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2854,11 +2707,10 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2886,12 +2738,11 @@ exports[`Chart 2`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -2908,13 +2759,12 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -2937,7 +2787,6 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -2955,14 +2804,9 @@ exports[`Chart 2`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -2988,13 +2832,13 @@ exports[`Chart 2`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },
@@ -3063,13 +2907,12 @@ exports[`renders component data 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#151515",
                   "fillOpacity": 0.4,
-                  "stroke": "#73bcf7",
+                  "stroke": "transparent",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3093,13 +2936,12 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "axis": Object {
                   "fill": "transparent",
-                  "stroke": "#D2D2D2",
+                  "stroke": "#d2d2d2",
                   "strokeLinecap": "round",
                   "strokeLinejoin": "round",
                   "strokeWidth": 1,
                 },
                 "axisLabel": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3115,7 +2957,7 @@ exports[`renders component data 1`] = `
                   "strokeLinejoin": "round",
                 },
                 "tickLabels": Object {
-                  "fill": "#151515",
+                  "fill": "#4d5258",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3152,7 +2994,6 @@ exports[`renders component data 1`] = `
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3176,11 +3017,10 @@ exports[`renders component data 1`] = `
               "style": Object {
                 "max": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "maxLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3189,11 +3029,10 @@ exports[`renders component data 1`] = `
                 },
                 "median": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "medianLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3202,11 +3041,10 @@ exports[`renders component data 1`] = `
                 },
                 "min": Object {
                   "padding": 8,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "minLabels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3214,11 +3052,10 @@ exports[`renders component data 1`] = `
                   "stroke": "transparent",
                 },
                 "q1": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#8b8d8f",
                   "padding": 8,
                 },
                 "q1Labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3226,11 +3063,10 @@ exports[`renders component data 1`] = `
                   "stroke": "transparent",
                 },
                 "q3": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#8b8d8f",
                   "padding": 8,
                 },
                 "q3Labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3242,8 +3078,8 @@ exports[`renders component data 1`] = `
             },
             "candlestick": Object {
               "candleColors": Object {
-                "negative": "#73bcf7",
-                "positive": "#bee1f4",
+                "negative": "#151515",
+                "positive": "#fff",
               },
               "colorScale": Array [
                 "#06c",
@@ -3256,11 +3092,10 @@ exports[`renders component data 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3281,11 +3116,6 @@ exports[`renders component data 1`] = `
               ],
               "height": 300,
               "padding": 50,
-              "style": Object {
-                "parent": Object {
-                  "border": "1px solid #bee1f4",
-                },
-              },
               "width": 450,
             },
             "errorbar": Object {
@@ -3303,11 +3133,10 @@ exports[`renders component data 1`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3345,7 +3174,6 @@ exports[`renders component data 1`] = `
                   "type": "square",
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3353,7 +3181,6 @@ exports[`renders component data 1`] = `
                   "stroke": "transparent",
                 },
                 "title": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3377,11 +3204,10 @@ exports[`renders component data 1`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#73bcf7",
+                  "stroke": "#151515",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3409,12 +3235,11 @@ exports[`renders component data 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
-                  "stroke": "#EDEDED",
+                  "stroke": "transparent",
                 },
               },
               "width": 230,
@@ -3431,13 +3256,12 @@ exports[`renders component data 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#bee1f4",
+                  "fill": "#151515",
                   "opacity": 1,
                   "stroke": "transparent",
                   "strokeWidth": 0,
                 },
                 "labels": Object {
-                  "fill": "#151515",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
@@ -3460,7 +3284,6 @@ exports[`renders component data 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "stroke": "#fff",
                   "strokeWidth": 1,
                 },
               },
@@ -3478,14 +3301,9 @@ exports[`renders component data 1`] = `
               "pointerLength": 10,
               "pointerWidth": 20,
               "style": Object {
-                "fill": "#EDEDED",
-                "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-                "fontSize": 14,
-                "letterSpacing": "normal",
+                "fill": "#ededed",
                 "padding": 16,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
-                "textAnchor": "middle",
               },
             },
             "voronoi": Object {
@@ -3511,13 +3329,13 @@ exports[`renders component data 1`] = `
                   "strokeWidth": 1,
                 },
                 "labels": Object {
-                  "fill": "#151515",
+                  "fill": "#ededed",
                   "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                   "fontSize": 14,
                   "letterSpacing": "normal",
                   "padding": 8,
                   "pointerEvents": "none",
-                  "stroke": "#EDEDED",
+                  "stroke": "transparent",
                   "textAnchor": "middle",
                 },
               },
@@ -3549,13 +3367,12 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3579,13 +3396,12 @@ exports[`renders component data 1`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3601,7 +3417,7 @@ exports[`renders component data 1`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3638,7 +3454,6 @@ exports[`renders component data 1`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3662,11 +3477,10 @@ exports[`renders component data 1`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3675,11 +3489,10 @@ exports[`renders component data 1`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3688,11 +3501,10 @@ exports[`renders component data 1`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3700,11 +3512,10 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3712,11 +3523,10 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3728,8 +3538,8 @@ exports[`renders component data 1`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -3742,11 +3552,10 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3767,11 +3576,6 @@ exports[`renders component data 1`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -3789,11 +3593,10 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3831,7 +3634,6 @@ exports[`renders component data 1`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3839,7 +3641,6 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3863,11 +3664,10 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3895,12 +3695,11 @@ exports[`renders component data 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -3917,13 +3716,12 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -3946,7 +3744,6 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -3964,14 +3761,9 @@ exports[`renders component data 1`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -3997,13 +3789,13 @@ exports[`renders component data 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },
@@ -4037,13 +3829,12 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "fillOpacity": 0.4,
-              "stroke": "#73bcf7",
+              "stroke": "transparent",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4067,13 +3858,12 @@ exports[`renders component data 1`] = `
           "style": Object {
             "axis": Object {
               "fill": "transparent",
-              "stroke": "#D2D2D2",
+              "stroke": "#d2d2d2",
               "strokeLinecap": "round",
               "strokeLinejoin": "round",
               "strokeWidth": 1,
             },
             "axisLabel": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4089,7 +3879,7 @@ exports[`renders component data 1`] = `
               "strokeLinejoin": "round",
             },
             "tickLabels": Object {
-              "fill": "#151515",
+              "fill": "#4d5258",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4126,7 +3916,6 @@ exports[`renders component data 1`] = `
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4150,11 +3939,10 @@ exports[`renders component data 1`] = `
           "style": Object {
             "max": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "maxLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4163,11 +3951,10 @@ exports[`renders component data 1`] = `
             },
             "median": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "medianLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4176,11 +3963,10 @@ exports[`renders component data 1`] = `
             },
             "min": Object {
               "padding": 8,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "minLabels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4188,11 +3974,10 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "q1": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q1Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4200,11 +3985,10 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "q3": Object {
-              "fill": "#bee1f4",
+              "fill": "#8b8d8f",
               "padding": 8,
             },
             "q3Labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4216,8 +4000,8 @@ exports[`renders component data 1`] = `
         },
         "candlestick": Object {
           "candleColors": Object {
-            "negative": "#73bcf7",
-            "positive": "#bee1f4",
+            "negative": "#151515",
+            "positive": "#fff",
           },
           "colorScale": Array [
             "#06c",
@@ -4230,11 +4014,10 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4255,11 +4038,6 @@ exports[`renders component data 1`] = `
           ],
           "height": 300,
           "padding": 50,
-          "style": Object {
-            "parent": Object {
-              "border": "1px solid #bee1f4",
-            },
-          },
           "width": 450,
         },
         "errorbar": Object {
@@ -4277,11 +4055,10 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4319,7 +4096,6 @@ exports[`renders component data 1`] = `
               "type": "square",
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4327,7 +4103,6 @@ exports[`renders component data 1`] = `
               "stroke": "transparent",
             },
             "title": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4351,11 +4126,10 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#73bcf7",
+              "stroke": "#151515",
               "strokeWidth": 2,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4383,12 +4157,11 @@ exports[`renders component data 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
             },
           },
           "width": 230,
@@ -4405,13 +4178,12 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#bee1f4",
+              "fill": "#151515",
               "opacity": 1,
               "stroke": "transparent",
               "strokeWidth": 0,
             },
             "labels": Object {
-              "fill": "#151515",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
@@ -4434,7 +4206,6 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "stroke": "#fff",
               "strokeWidth": 1,
             },
           },
@@ -4452,14 +4223,9 @@ exports[`renders component data 1`] = `
           "pointerLength": 10,
           "pointerWidth": 20,
           "style": Object {
-            "fill": "#EDEDED",
-            "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-            "fontSize": 14,
-            "letterSpacing": "normal",
+            "fill": "#ededed",
             "padding": 16,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
-            "textAnchor": "middle",
           },
         },
         "voronoi": Object {
@@ -4485,13 +4251,13 @@ exports[`renders component data 1`] = `
               "strokeWidth": 1,
             },
             "labels": Object {
-              "fill": "#151515",
+              "fill": "#ededed",
               "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
               "fontSize": 14,
               "letterSpacing": "normal",
               "padding": 8,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
+              "stroke": "transparent",
               "textAnchor": "middle",
             },
           },

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
@@ -24,13 +24,12 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "fillOpacity": 0.4,
-                "stroke": "#73bcf7",
+                "stroke": "transparent",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -54,13 +53,12 @@ exports[`Chart 1`] = `
             "style": Object {
               "axis": Object {
                 "fill": "transparent",
-                "stroke": "#D2D2D2",
+                "stroke": "#d2d2d2",
                 "strokeLinecap": "round",
                 "strokeLinejoin": "round",
                 "strokeWidth": 1,
               },
               "axisLabel": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -76,7 +74,7 @@ exports[`Chart 1`] = `
                 "strokeLinejoin": "round",
               },
               "tickLabels": Object {
-                "fill": "#151515",
+                "fill": "#4d5258",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -113,7 +111,6 @@ exports[`Chart 1`] = `
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -137,11 +134,10 @@ exports[`Chart 1`] = `
             "style": Object {
               "max": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "maxLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -150,11 +146,10 @@ exports[`Chart 1`] = `
               },
               "median": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "medianLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -163,11 +158,10 @@ exports[`Chart 1`] = `
               },
               "min": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "minLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -175,11 +169,10 @@ exports[`Chart 1`] = `
                 "stroke": "transparent",
               },
               "q1": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q1Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -187,11 +180,10 @@ exports[`Chart 1`] = `
                 "stroke": "transparent",
               },
               "q3": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q3Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -203,8 +195,8 @@ exports[`Chart 1`] = `
           },
           "candlestick": Object {
             "candleColors": Object {
-              "negative": "#73bcf7",
-              "positive": "#bee1f4",
+              "negative": "#151515",
+              "positive": "#fff",
             },
             "colorScale": Array [
               "#06c",
@@ -217,11 +209,10 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -242,11 +233,6 @@ exports[`Chart 1`] = `
             ],
             "height": 300,
             "padding": 50,
-            "style": Object {
-              "parent": Object {
-                "border": "1px solid #bee1f4",
-              },
-            },
             "width": 450,
           },
           "errorbar": Object {
@@ -264,11 +250,10 @@ exports[`Chart 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -306,7 +291,6 @@ exports[`Chart 1`] = `
                 "type": "square",
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -314,7 +298,6 @@ exports[`Chart 1`] = `
                 "stroke": "transparent",
               },
               "title": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -338,11 +321,10 @@ exports[`Chart 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -370,12 +352,11 @@ exports[`Chart 1`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
               },
             },
             "width": 230,
@@ -392,13 +373,12 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -421,7 +401,6 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#fff",
                 "strokeWidth": 1,
               },
             },
@@ -439,14 +418,9 @@ exports[`Chart 1`] = `
             "pointerLength": 10,
             "pointerWidth": 20,
             "style": Object {
-              "fill": "#EDEDED",
-              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-              "fontSize": 14,
-              "letterSpacing": "normal",
+              "fill": "#ededed",
               "padding": 16,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
-              "textAnchor": "middle",
             },
           },
           "voronoi": Object {
@@ -472,13 +446,13 @@ exports[`Chart 1`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
+                "fill": "#ededed",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
                 "textAnchor": "middle",
               },
             },
@@ -524,13 +498,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -554,13 +527,12 @@ exports[`Chart 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -576,7 +548,7 @@ exports[`Chart 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -613,7 +585,6 @@ exports[`Chart 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -637,11 +608,10 @@ exports[`Chart 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -650,11 +620,10 @@ exports[`Chart 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -663,11 +632,10 @@ exports[`Chart 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -675,11 +643,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -687,11 +654,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -703,8 +669,8 @@ exports[`Chart 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -717,11 +683,10 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -742,11 +707,6 @@ exports[`Chart 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -764,11 +724,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -806,7 +765,6 @@ exports[`Chart 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -814,7 +772,6 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -838,11 +795,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -870,12 +826,11 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -892,13 +847,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -921,7 +875,6 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -939,14 +892,9 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -972,13 +920,13 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -1022,13 +970,12 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "fillOpacity": 0.4,
-                "stroke": "#73bcf7",
+                "stroke": "transparent",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1052,13 +999,12 @@ exports[`Chart 2`] = `
             "style": Object {
               "axis": Object {
                 "fill": "transparent",
-                "stroke": "#D2D2D2",
+                "stroke": "#d2d2d2",
                 "strokeLinecap": "round",
                 "strokeLinejoin": "round",
                 "strokeWidth": 1,
               },
               "axisLabel": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1074,7 +1020,7 @@ exports[`Chart 2`] = `
                 "strokeLinejoin": "round",
               },
               "tickLabels": Object {
-                "fill": "#151515",
+                "fill": "#4d5258",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1111,7 +1057,6 @@ exports[`Chart 2`] = `
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1135,11 +1080,10 @@ exports[`Chart 2`] = `
             "style": Object {
               "max": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "maxLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1148,11 +1092,10 @@ exports[`Chart 2`] = `
               },
               "median": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "medianLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1161,11 +1104,10 @@ exports[`Chart 2`] = `
               },
               "min": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "minLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1173,11 +1115,10 @@ exports[`Chart 2`] = `
                 "stroke": "transparent",
               },
               "q1": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q1Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1185,11 +1126,10 @@ exports[`Chart 2`] = `
                 "stroke": "transparent",
               },
               "q3": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q3Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1201,8 +1141,8 @@ exports[`Chart 2`] = `
           },
           "candlestick": Object {
             "candleColors": Object {
-              "negative": "#73bcf7",
-              "positive": "#bee1f4",
+              "negative": "#151515",
+              "positive": "#fff",
             },
             "colorScale": Array [
               "#06c",
@@ -1215,11 +1155,10 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1240,11 +1179,6 @@ exports[`Chart 2`] = `
             ],
             "height": 300,
             "padding": 50,
-            "style": Object {
-              "parent": Object {
-                "border": "1px solid #bee1f4",
-              },
-            },
             "width": 450,
           },
           "errorbar": Object {
@@ -1262,11 +1196,10 @@ exports[`Chart 2`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1304,7 +1237,6 @@ exports[`Chart 2`] = `
                 "type": "square",
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1312,7 +1244,6 @@ exports[`Chart 2`] = `
                 "stroke": "transparent",
               },
               "title": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1336,11 +1267,10 @@ exports[`Chart 2`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1368,12 +1298,11 @@ exports[`Chart 2`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
               },
             },
             "width": 230,
@@ -1390,13 +1319,12 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -1419,7 +1347,6 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#fff",
                 "strokeWidth": 1,
               },
             },
@@ -1437,14 +1364,9 @@ exports[`Chart 2`] = `
             "pointerLength": 10,
             "pointerWidth": 20,
             "style": Object {
-              "fill": "#EDEDED",
-              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-              "fontSize": 14,
-              "letterSpacing": "normal",
+              "fill": "#ededed",
               "padding": 16,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
-              "textAnchor": "middle",
             },
           },
           "voronoi": Object {
@@ -1470,13 +1392,13 @@ exports[`Chart 2`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
+                "fill": "#ededed",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
                 "textAnchor": "middle",
               },
             },
@@ -1522,13 +1444,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1552,13 +1473,12 @@ exports[`Chart 2`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1574,7 +1494,7 @@ exports[`Chart 2`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1611,7 +1531,6 @@ exports[`Chart 2`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1635,11 +1554,10 @@ exports[`Chart 2`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1648,11 +1566,10 @@ exports[`Chart 2`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1661,11 +1578,10 @@ exports[`Chart 2`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1673,11 +1589,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1685,11 +1600,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1701,8 +1615,8 @@ exports[`Chart 2`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -1715,11 +1629,10 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1740,11 +1653,6 @@ exports[`Chart 2`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -1762,11 +1670,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1804,7 +1711,6 @@ exports[`Chart 2`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1812,7 +1718,6 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1836,11 +1741,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1868,12 +1772,11 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -1890,13 +1793,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1919,7 +1821,6 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -1937,14 +1838,9 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -1970,13 +1866,13 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -2020,13 +1916,12 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "fillOpacity": 0.4,
-                "stroke": "#73bcf7",
+                "stroke": "transparent",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2050,13 +1945,12 @@ exports[`renders component data 1`] = `
             "style": Object {
               "axis": Object {
                 "fill": "transparent",
-                "stroke": "#D2D2D2",
+                "stroke": "#d2d2d2",
                 "strokeLinecap": "round",
                 "strokeLinejoin": "round",
                 "strokeWidth": 1,
               },
               "axisLabel": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2072,7 +1966,7 @@ exports[`renders component data 1`] = `
                 "strokeLinejoin": "round",
               },
               "tickLabels": Object {
-                "fill": "#151515",
+                "fill": "#4d5258",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2109,7 +2003,6 @@ exports[`renders component data 1`] = `
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2133,11 +2026,10 @@ exports[`renders component data 1`] = `
             "style": Object {
               "max": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "maxLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2146,11 +2038,10 @@ exports[`renders component data 1`] = `
               },
               "median": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "medianLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2159,11 +2050,10 @@ exports[`renders component data 1`] = `
               },
               "min": Object {
                 "padding": 8,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "minLabels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2171,11 +2061,10 @@ exports[`renders component data 1`] = `
                 "stroke": "transparent",
               },
               "q1": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q1Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2183,11 +2072,10 @@ exports[`renders component data 1`] = `
                 "stroke": "transparent",
               },
               "q3": Object {
-                "fill": "#bee1f4",
+                "fill": "#8b8d8f",
                 "padding": 8,
               },
               "q3Labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2199,8 +2087,8 @@ exports[`renders component data 1`] = `
           },
           "candlestick": Object {
             "candleColors": Object {
-              "negative": "#73bcf7",
-              "positive": "#bee1f4",
+              "negative": "#151515",
+              "positive": "#fff",
             },
             "colorScale": Array [
               "#06c",
@@ -2213,11 +2101,10 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2238,11 +2125,6 @@ exports[`renders component data 1`] = `
             ],
             "height": 300,
             "padding": 50,
-            "style": Object {
-              "parent": Object {
-                "border": "1px solid #bee1f4",
-              },
-            },
             "width": 450,
           },
           "errorbar": Object {
@@ -2260,11 +2142,10 @@ exports[`renders component data 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2302,7 +2183,6 @@ exports[`renders component data 1`] = `
                 "type": "square",
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2310,7 +2190,6 @@ exports[`renders component data 1`] = `
                 "stroke": "transparent",
               },
               "title": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2334,11 +2213,10 @@ exports[`renders component data 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#73bcf7",
+                "stroke": "#151515",
                 "strokeWidth": 2,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2366,12 +2244,11 @@ exports[`renders component data 1`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
               },
             },
             "width": 230,
@@ -2388,13 +2265,12 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#bee1f4",
+                "fill": "#151515",
                 "opacity": 1,
                 "stroke": "transparent",
                 "strokeWidth": 0,
               },
               "labels": Object {
-                "fill": "#151515",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
@@ -2417,7 +2293,6 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "stroke": "#fff",
                 "strokeWidth": 1,
               },
             },
@@ -2435,14 +2310,9 @@ exports[`renders component data 1`] = `
             "pointerLength": 10,
             "pointerWidth": 20,
             "style": Object {
-              "fill": "#EDEDED",
-              "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-              "fontSize": 14,
-              "letterSpacing": "normal",
+              "fill": "#ededed",
               "padding": 16,
               "pointerEvents": "none",
-              "stroke": "#EDEDED",
-              "textAnchor": "middle",
             },
           },
           "voronoi": Object {
@@ -2468,13 +2338,13 @@ exports[`renders component data 1`] = `
                 "strokeWidth": 1,
               },
               "labels": Object {
-                "fill": "#151515",
+                "fill": "#ededed",
                 "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
                 "fontSize": 14,
                 "letterSpacing": "normal",
                 "padding": 8,
                 "pointerEvents": "none",
-                "stroke": "#EDEDED",
+                "stroke": "transparent",
                 "textAnchor": "middle",
               },
             },
@@ -2524,13 +2394,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2554,13 +2423,12 @@ exports[`renders component data 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2576,7 +2444,7 @@ exports[`renders component data 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2613,7 +2481,6 @@ exports[`renders component data 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2637,11 +2504,10 @@ exports[`renders component data 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2650,11 +2516,10 @@ exports[`renders component data 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2663,11 +2528,10 @@ exports[`renders component data 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2675,11 +2539,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2687,11 +2550,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2703,8 +2565,8 @@ exports[`renders component data 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -2717,11 +2579,10 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2742,11 +2603,6 @@ exports[`renders component data 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -2764,11 +2620,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2806,7 +2661,6 @@ exports[`renders component data 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2814,7 +2668,6 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2838,11 +2691,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2870,12 +2722,11 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -2892,13 +2743,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -2921,7 +2771,6 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -2939,14 +2788,9 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -2972,13 +2816,13 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.tsx.snap
@@ -27,13 +27,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -57,13 +56,12 @@ exports[`Chart 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -79,7 +77,7 @@ exports[`Chart 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -116,7 +114,6 @@ exports[`Chart 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -140,11 +137,10 @@ exports[`Chart 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -153,11 +149,10 @@ exports[`Chart 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -166,11 +161,10 @@ exports[`Chart 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -178,11 +172,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -190,11 +183,10 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -206,8 +198,8 @@ exports[`Chart 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -220,11 +212,10 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -245,11 +236,6 @@ exports[`Chart 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -267,11 +253,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -309,7 +294,6 @@ exports[`Chart 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -317,7 +301,6 @@ exports[`Chart 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -341,11 +324,10 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -373,12 +355,11 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -395,13 +376,12 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -424,7 +404,6 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -442,14 +421,9 @@ exports[`Chart 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -475,13 +449,13 @@ exports[`Chart 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -519,13 +493,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -549,13 +522,12 @@ exports[`Chart 2`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -571,7 +543,7 @@ exports[`Chart 2`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -608,7 +580,6 @@ exports[`Chart 2`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -632,11 +603,10 @@ exports[`Chart 2`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -645,11 +615,10 @@ exports[`Chart 2`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -658,11 +627,10 @@ exports[`Chart 2`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -670,11 +638,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -682,11 +649,10 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -698,8 +664,8 @@ exports[`Chart 2`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -712,11 +678,10 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -737,11 +702,6 @@ exports[`Chart 2`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -759,11 +719,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -801,7 +760,6 @@ exports[`Chart 2`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -809,7 +767,6 @@ exports[`Chart 2`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -833,11 +790,10 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -865,12 +821,11 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -887,13 +842,12 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -916,7 +870,6 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -934,14 +887,9 @@ exports[`Chart 2`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -967,13 +915,13 @@ exports[`Chart 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -3161,13 +3109,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3191,13 +3138,12 @@ exports[`renders component data 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3213,7 +3159,7 @@ exports[`renders component data 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3250,7 +3196,6 @@ exports[`renders component data 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3274,11 +3219,10 @@ exports[`renders component data 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3287,11 +3231,10 @@ exports[`renders component data 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3300,11 +3243,10 @@ exports[`renders component data 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3312,11 +3254,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3324,11 +3265,10 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3340,8 +3280,8 @@ exports[`renders component data 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -3354,11 +3294,10 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3379,11 +3318,6 @@ exports[`renders component data 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -3401,11 +3335,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3443,7 +3376,6 @@ exports[`renders component data 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3451,7 +3383,6 @@ exports[`renders component data 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3475,11 +3406,10 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3507,12 +3437,11 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -3529,13 +3458,12 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -3558,7 +3486,6 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -3576,14 +3503,9 @@ exports[`renders component data 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -3609,13 +3531,13 @@ exports[`renders component data 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -5,13 +5,13 @@ typescript: true
 propComponents: ['Chart', 'ChartBar', 'ChartStack']
 ---
 
-import { Chart, ChartBar, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
+import { Chart, ChartBar, ChartStack, ChartThemeColor, ChartTooltip } from '@patternfly/react-charts';
 import './chart-stack.scss';
 
-## Simple stack chart with right-aligned legend
+## Simple stack chart with tooltip and right-aligned legend
 ```js
 import React from 'react';
-import { Chart, ChartStack } from '@patternfly/react-charts';
+import { Chart, ChartStack,ChartTooltip } from '@patternfly/react-charts';
 
 <div>
   <div className="stack-chart-legend-right">
@@ -29,17 +29,49 @@ import { Chart, ChartStack } from '@patternfly/react-charts';
       width={600}
     >
       <ChartStack domainPadding={{x: [10, 2]}}>
-        <ChartBar data={[{ name: 'Cats', x: '2015', y: 1 }, { name: 'Cats', x: '2016', y: 2 }, { name: 'Cats', x: '2017', y: 5 }, { name: 'Cats', x: '2018', y: 3 }]} />
-        <ChartBar data={[{ name: 'Dogs', x: '2015', y: 2 }, { name: 'Dogs', x: '2016', y: 1 }, { name: 'Dogs', x: '2017', y: 7 }, { name: 'Dogs', x: '2018', y: 4 }]} />
-        <ChartBar data={[{ name: 'Birds', x: '2015', y: 4 }, { name: 'Birds', x: '2016', y: 4 }, { name: 'Birds', x: '2017', y: 9 }, { name: 'Birds', x: '2018', y: 7 }]} />
-        <ChartBar data={[{ name: 'Mice', x: '2015', y: 3 }, { name: 'Mice', x: '2016', y: 3 }, { name: 'Mice', x: '2017', y: 8 }, { name: 'Mice', x: '2018', y: 5 }]} />
+        <ChartBar 
+          data={[
+            { name: 'Cats', x: '2015', y: 1, label: 'Cats: 1' }, 
+            { name: 'Cats', x: '2016', y: 2, label: 'Cats: 2' }, 
+            { name: 'Cats', x: '2017', y: 5, label: 'Cats: 5' }, 
+            { name: 'Cats', x: '2018', y: 3, label: 'Cats: 3' }
+          ]} 
+          labelComponent={<ChartTooltip />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Dogs', x: '2015', y: 2, label: 'Dogs: 2' }, 
+            { name: 'Dogs', x: '2016', y: 1, label: 'Dogs: 1' }, 
+            { name: 'Dogs', x: '2017', y: 7, label: 'Dogs: 7' }, 
+            { name: 'Dogs', x: '2018', y: 4, label: 'Dogs: 4' }
+          ]}
+          labelComponent={<ChartTooltip />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Birds', x: '2015', y: 4, label: 'Birds: 4' }, 
+            { name: 'Birds', x: '2016', y: 4, label: 'Birds: 4' }, 
+            { name: 'Birds', x: '2017', y: 9, label: 'Birds: 9' }, 
+            { name: 'Birds', x: '2018', y: 7, label: 'Birds: 7' }
+          ]}
+          labelComponent={<ChartTooltip />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Mice', x: '2015', y: 3, label: 'Mice: 3' }, 
+            { name: 'Mice', x: '2016', y: 3, label: 'Mice: 3' }, 
+            { name: 'Mice', x: '2017', y: 8, label: 'Mice: 8' }, 
+            { name: 'Mice', x: '2018', y: 5, label: 'Mice: 5' }
+          ]}
+          labelComponent={<ChartTooltip />}
+        />
       </ChartStack>
     </Chart>
   </div>
 </div>
 ```
 
-## Gold, horizontal stack chart with bottom-aligned legend
+## Gold, horizontal stack chart with tooltip and bottom-aligned legend
 ```js
 import React from 'react';
 import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
@@ -63,18 +95,49 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
       <ChartAxis />
       <ChartAxis dependentAxis showGrid />
       <ChartStack domainPadding={{x: [10, 2]}}>
-        <ChartBar data={[{ name: 'Cats', x: '2015', y: 1 }, { name: 'Cats', x: '2016', y: 2 }, { name: 'Cats', x: '2017', y: 5 }, { name: 'Cats', x: '2018', y: 3 }]} />
-        <ChartBar data={[{ name: 'Dogs', x: '2015', y: 2 }, { name: 'Dogs', x: '2016', y: 1 }, { name: 'Dogs', x: '2017', y: 7 }, { name: 'Dogs', x: '2018', y: 4 }]} />
-        <ChartBar data={[{ name: 'Birds', x: '2015', y: 4 }, { name: 'Birds', x: '2016', y: 4 }, { name: 'Birds', x: '2017', y: 9 }, { name: 'Birds', x: '2018', y: 7 }]} />
-        <ChartBar data={[{ name: 'Mice', x: '2015', y: 3 }, { name: 'Mice', x: '2016', y: 3 }, { name: 'Mice', x: '2017', y: 8 }, { name: 'Mice', x: '2018', y: 5 }]} />
+        <ChartBar 
+          data={[
+            { name: 'Cats', x: '2015', y: 1, label: 'Cats: 1' }, 
+            { name: 'Cats', x: '2016', y: 2, label: 'Cats: 2' }, 
+            { name: 'Cats', x: '2017', y: 5, label: 'Cats: 5' }, 
+            { name: 'Cats', x: '2018', y: 3, label: 'Cats: 3' }
+          ]} 
+          labelComponent={<ChartTooltip />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Dogs', x: '2015', y: 2, label: 'Dogs: 2' }, 
+            { name: 'Dogs', x: '2016', y: 1, label: 'Dogs: 1' }, 
+            { name: 'Dogs', x: '2017', y: 7, label: 'Dogs: 7' }, 
+            { name: 'Dogs', x: '2018', y: 4, label: 'Dogs: 4' }
+          ]}
+          labelComponent={<ChartTooltip />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Birds', x: '2015', y: 4, label: 'Birds: 4' }, 
+            { name: 'Birds', x: '2016', y: 4, label: 'Birds: 4' }, 
+            { name: 'Birds', x: '2017', y: 9, label: 'Birds: 9' }, 
+            { name: 'Birds', x: '2018', y: 7, label: 'Birds: 7' }
+          ]}
+          labelComponent={<ChartTooltip />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Mice', x: '2015', y: 3, label: 'Mice: 3' }, 
+            { name: 'Mice', x: '2016', y: 3, label: 'Mice: 3' }, 
+            { name: 'Mice', x: '2017', y: 8, label: 'Mice: 8' }, 
+            { name: 'Mice', x: '2018', y: 5, label: 'Mice: 5' }
+          ]}
+          labelComponent={<ChartTooltip />}
+        />
       </ChartStack>
-      
     </Chart>
   </div>
 </div>
 ```
 
-## Multi-color, horizontal stack chart with bottom-aligned legend
+## Multi-color, horizontal stack chart with tooltip and bottom-aligned legend
 ```js
 import React from 'react';
 import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
@@ -98,10 +161,42 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
       <ChartAxis />
       <ChartAxis dependentAxis showGrid />
       <ChartStack domainPadding={{x: [10, 2]}} horizontal>
-        <ChartBar data={[{ name: 'Cats', x: '2015', y: 1 }, { name: 'Cats', x: '2016', y: 2 }, { name: 'Cats', x: '2017', y: 5 }, { name: 'Cats', x: '2018', y: 3 }]} />
-        <ChartBar data={[{ name: 'Dogs', x: '2015', y: 2 }, { name: 'Dogs', x: '2016', y: 1 }, { name: 'Dogs', x: '2017', y: 7 }, { name: 'Dogs', x: '2018', y: 4 }]} />
-        <ChartBar data={[{ name: 'Birds', x: '2015', y: 4 }, { name: 'Birds', x: '2016', y: 4 }, { name: 'Birds', x: '2017', y: 9 }, { name: 'Birds', x: '2018', y: 7 }]} />
-        <ChartBar data={[{ name: 'Mice', x: '2015', y: 3 }, { name: 'Mice', x: '2016', y: 3 }, { name: 'Mice', x: '2017', y: 8 }, { name: 'Mice', x: '2018', y: 5 }]} />
+        <ChartBar 
+          data={[
+            { name: 'Cats', x: '2015', y: 1, label: 'Cats: 1' }, 
+            { name: 'Cats', x: '2016', y: 2, label: 'Cats: 2' }, 
+            { name: 'Cats', x: '2017', y: 5, label: 'Cats: 5' }, 
+            { name: 'Cats', x: '2018', y: 3, label: 'Cats: 3' }
+          ]} 
+          labelComponent={<ChartTooltip />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Dogs', x: '2015', y: 2, label: 'Dogs: 2' }, 
+            { name: 'Dogs', x: '2016', y: 1, label: 'Dogs: 1' }, 
+            { name: 'Dogs', x: '2017', y: 7, label: 'Dogs: 7' }, 
+            { name: 'Dogs', x: '2018', y: 4, label: 'Dogs: 4' }
+          ]}
+          labelComponent={<ChartTooltip />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Birds', x: '2015', y: 4, label: 'Birds: 4' }, 
+            { name: 'Birds', x: '2016', y: 4, label: 'Birds: 4' }, 
+            { name: 'Birds', x: '2017', y: 9, label: 'Birds: 9' }, 
+            { name: 'Birds', x: '2018', y: 7, label: 'Birds: 7' }
+          ]}
+          labelComponent={<ChartTooltip />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Mice', x: '2015', y: 3, label: 'Mice: 3' }, 
+            { name: 'Mice', x: '2016', y: 3, label: 'Mice: 3' }, 
+            { name: 'Mice', x: '2017', y: 8, label: 'Mice: 8' }, 
+            { name: 'Mice', x: '2018', y: 5, label: 'Mice: 5' }
+          ]}
+          labelComponent={<ChartTooltip />}
+        />
       </ChartStack>
     </Chart>
   </div>

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/base-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/base-theme.ts
@@ -3,6 +3,7 @@ import {
   chart_global_FontFamily,
   chart_global_letter_spacing,
   chart_global_FontSize_sm,
+  chart_global_label_Fill,
   chart_global_label_Padding,
   chart_global_label_stroke,
   chart_global_label_text_anchor,
@@ -76,6 +77,7 @@ import {
   chart_stack_data_stroke_Width,
   chart_tooltip_corner_radius,
   chart_tooltip_pointer_length,
+  chart_tooltip_Fill,
   chart_tooltip_flyoutStyle_corner_radius,
   chart_tooltip_flyoutStyle_stroke_Width,
   chart_tooltip_flyoutStyle_PointerEvents,
@@ -87,6 +89,7 @@ import {
   chart_voronoi_data_Fill,
   chart_voronoi_data_stroke_Color,
   chart_voronoi_data_stroke_Width,
+  chart_voronoi_labels_Fill,
   chart_voronoi_labels_Padding,
   chart_voronoi_labels_PointerEvents,
   chart_voronoi_flyout_stroke_Width,
@@ -134,6 +137,7 @@ export const BaseTheme = {
       data: {
         fill: chart_area_data_Fill.value,
         fillOpacity: chart_area_Opacity.value,
+        stroke: chart_global_label_stroke.value,
         strokeWidth: chart_area_stroke_Width.value
       },
       labels: LABEL_CENTERED_PROPS
@@ -323,15 +327,15 @@ export const BaseTheme = {
     cornerRadius: chart_tooltip_corner_radius.value,
     flyoutStyle: {
       cornerRadius: chart_tooltip_flyoutStyle_corner_radius.value,
-      fill: chart_tooltip_flyoutStyle_Fill.value,
+      fill: chart_tooltip_flyoutStyle_Fill.value, // background
       pointerEvents: chart_tooltip_flyoutStyle_PointerEvents.value,
-      stroke: chart_tooltip_flyoutStyle_stroke_Color.value,
+      stroke: chart_tooltip_flyoutStyle_stroke_Color.value, // border
       strokeWidth: chart_tooltip_flyoutStyle_stroke_Width.value
     },
     pointerLength: chart_tooltip_pointer_length.value,
     pointerWidth: chart_tooltip_pointer_Width.value,
     style: {
-      ...LABEL_CENTERED_PROPS,
+      fill: chart_tooltip_Fill.value, // text
       padding: chart_tooltip_Padding.value,
       pointerEvents: chart_tooltip_PointerEvents.value
     }
@@ -346,14 +350,15 @@ export const BaseTheme = {
       },
       labels: {
         ...LABEL_CENTERED_PROPS,
+        fill: chart_voronoi_labels_Fill.value, // text
         padding: chart_voronoi_labels_Padding.value,
         pointerEvents: chart_voronoi_labels_PointerEvents.value
       },
       // Note: These properties override tooltip
       flyout: {
-        fill: chart_voronoi_flyout_stroke_Fill.value,
+        fill: chart_voronoi_flyout_stroke_Fill.value, // background
         pointerEvents: chart_voronoi_flyout_PointerEvents.value,
-        stroke: chart_voronoi_flyout_stroke_Color.value,
+        stroke: chart_voronoi_flyout_stroke_Color.value, // border
         strokeWidth: chart_voronoi_flyout_stroke_Width.value,
       }
     }

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/color-theme.ts
@@ -1,216 +1,60 @@
 interface ColorThemeInterface {
-  COLOR_AXIS_FILL: string;
-  COLOR_AXIS_STROKE: string;
-  COLOR_FILL: string;
-  COLOR_LABEL: string;
   COLOR_SCALE: string[];
-  COLOR_STACK_STROKE: string;
-  COLOR_STROKE: string;
-  COLOR_TOOLTIP_FILL: string;
-  COLOR_TOOLTIP_STROKE: string;
-  COLOR_TOOLTIP_FLYOUT_FILL: string;
-  COLOR_TOOLTIP_FLYOUT_STROKE: string;
 }
 
 // Victory theme properties only
 export const ColorTheme = (props: ColorThemeInterface) => {
   const {
-    COLOR_AXIS_FILL,
-    COLOR_AXIS_STROKE,
-    COLOR_FILL,
-    COLOR_LABEL,
-    COLOR_SCALE,
-    COLOR_STACK_STROKE,
-    COLOR_STROKE,
-    COLOR_TOOLTIP_FILL,
-    COLOR_TOOLTIP_STROKE,
-    COLOR_TOOLTIP_FLYOUT_FILL,
-    COLOR_TOOLTIP_FLYOUT_STROKE
+    COLOR_SCALE
   } = props;
 
   return {
     area: {
-      colorScale: COLOR_SCALE,
-      style: {
-        data: {
-          fill: COLOR_FILL,
-          stroke: COLOR_STROKE
-        },
-        labels: {
-          fill: COLOR_LABEL
-        }
-      }
+      colorScale: COLOR_SCALE
     },
     axis: {
-      colorScale: COLOR_SCALE,
-      style: {
-        axis: {
-          fill: COLOR_AXIS_FILL,
-          stroke: COLOR_AXIS_STROKE
-        },
-        axisLabel: {
-          fill: COLOR_LABEL
-        },
-        tickLabels: {
-          fill: COLOR_LABEL
-        }
-      }
+      colorScale: COLOR_SCALE
     },
     bar: {
       colorScale: COLOR_SCALE,
       style: {
         data: {
           fill: COLOR_SCALE[0]
-        },
-        labels: {
-          fill: COLOR_LABEL
         }
       }
     },
     boxplot: {
-      colorScale: COLOR_SCALE,
-      style: {
-        max: {
-          stroke: COLOR_STROKE
-        },
-        maxLabels: {
-          fill: COLOR_LABEL
-        },
-        median: {
-          stroke: COLOR_STROKE
-        },
-        medianLabels: {
-          fill: COLOR_LABEL
-        },
-        min: {
-          stroke: COLOR_STROKE
-        },
-        minLabels: {
-          fill: COLOR_LABEL
-        },
-        q1: {
-          fill: COLOR_FILL
-        },
-        q1Labels: {
-          fill: COLOR_LABEL
-        },
-        q3: {
-          fill: COLOR_FILL
-        },
-        q3Labels: {
-          fill: COLOR_LABEL
-        }
-      }
+      colorScale: COLOR_SCALE
     },
     candlestick: {
-      colorScale: COLOR_SCALE,
-      style: {
-        data: {
-          stroke: COLOR_STROKE
-        },
-        labels: {
-          fill: COLOR_LABEL
-        }
-      },
-      candleColors: {
-        positive: COLOR_FILL,
-        negative: COLOR_STROKE
-      }
+      colorScale: COLOR_SCALE
     },
     chart: {
-      colorScale: COLOR_SCALE,
-      style: {
-        parent: {
-          border: `1px solid ${COLOR_FILL}`
-        }
-      }
+      colorScale: COLOR_SCALE
     },
     errorbar: {
-      colorScale: COLOR_SCALE,
-      style: {
-        data: {
-          stroke: COLOR_STROKE
-        },
-        labels: {
-          fill: COLOR_LABEL
-        }
-      }
+      colorScale: COLOR_SCALE
     },
     group: {
       colorScale: COLOR_SCALE
     },
     legend: {
-      colorScale: COLOR_SCALE,
-      style: {
-        labels: {
-          fill: COLOR_LABEL
-        },
-        title: {
-          fill: COLOR_LABEL
-        }
-      }
+      colorScale: COLOR_SCALE
     },
     line: {
-      colorScale: COLOR_SCALE,
-      style: {
-        data: {
-          stroke: COLOR_STROKE
-        },
-        labels: {
-          fill: COLOR_LABEL
-        }
-      }
+      colorScale: COLOR_SCALE
     },
     pie: {
-      colorScale: COLOR_SCALE,
-      style: {
-        labels: {
-          fill: COLOR_LABEL,
-          stroke: COLOR_TOOLTIP_STROKE
-        }
-      }
+      colorScale: COLOR_SCALE
     },
     scatter: {
-      colorScale: COLOR_SCALE,
-      style: {
-        data: {
-          fill: COLOR_FILL
-        },
-        labels: {
-          fill: COLOR_LABEL
-        }
-      }
+      colorScale: COLOR_SCALE
     },
     stack: {
-      colorScale: COLOR_SCALE,
-      style: {
-        data: {
-          stroke: COLOR_STACK_STROKE
-        }
-      }
-    },
-    tooltip: {
-      flyoutStyle: {
-        fill: COLOR_TOOLTIP_FLYOUT_FILL,
-        stroke: COLOR_TOOLTIP_FLYOUT_STROKE
-      },
-      style: {
-        fill: COLOR_TOOLTIP_FILL,
-        stroke: COLOR_TOOLTIP_STROKE
-      }
+      colorScale: COLOR_SCALE
     },
     voronoi: {
-      colorScale: COLOR_SCALE,
-      style: {
-        labels: {
-          fill: COLOR_LABEL,
-          stroke: COLOR_TOOLTIP_STROKE
-        },
-        flyout: {
-          fill: COLOR_TOOLTIP_FLYOUT_FILL,
-          stroke: COLOR_TOOLTIP_FLYOUT_STROKE
-        }
-      }
+      colorScale: COLOR_SCALE
     }
   };
 };

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/blue-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/blue-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_blue_200,
   chart_color_blue_300,
   chart_color_blue_400,
-  chart_color_blue_500,
-  global_active_color_200,
-  global_active_color_300,
-  global_Color_dark_200,
-  global_Color_light_100
+  chart_color_blue_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_light_100.value;
-const COLOR_STACK_STROKE = global_Color_dark_200.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#151515';
-const COLOR_TOOLTIP_STROKE = '#151515';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#EDEDED';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -37,15 +19,5 @@ const COLOR_SCALE = [
 ];
 
 export const DarkBlueColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
+  COLOR_SCALE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/cyan-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/cyan-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_cyan_200,
   chart_color_cyan_300,
   chart_color_cyan_400,
-  chart_color_cyan_500,
-  global_active_color_200,
-  global_active_color_300,
-  global_Color_dark_200,
-  global_Color_light_100
+  chart_color_cyan_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_light_100.value;
-const COLOR_STACK_STROKE = global_Color_dark_200.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#151515';
-const COLOR_TOOLTIP_STROKE = '#151515';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#EDEDED';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -37,15 +19,5 @@ const COLOR_SCALE = [
 ];
 
 export const DarkCyanColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
-});
+  COLOR_SCALE
+}) ;

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/gold-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/gold-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_gold_200,
   chart_color_gold_300,
   chart_color_gold_400,
-  chart_color_gold_500,
-  global_active_color_200,
-  global_active_color_300,
-  global_Color_dark_200,
-  global_Color_light_100
+  chart_color_gold_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_light_100.value;
-const COLOR_STACK_STROKE = global_Color_dark_200.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#151515';
-const COLOR_TOOLTIP_STROKE = '#151515';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#EDEDED';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -33,19 +15,10 @@ const COLOR_SCALE = [
   chart_color_gold_100.value,
   chart_color_gold_500.value,
   chart_color_gold_200.value,
-  chart_color_gold_400.value
+  chart_color_gold_400.value,
+
 ];
 
 export const DarkGoldColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
-});
+  COLOR_SCALE
+}) ;

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/gray-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/gray-color-theme.ts
@@ -4,29 +4,11 @@ import {
   chart_color_black_200,
   chart_color_black_300,
   chart_color_black_400,
-  chart_color_black_500,
-  global_active_color_200,
-  global_active_color_300,
-  global_Color_dark_200,
-  global_Color_light_100
+  chart_color_black_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
 
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_light_100.value;
-const COLOR_STACK_STROKE = global_Color_dark_200.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#151515';
-const COLOR_TOOLTIP_STROKE = '#151515';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#EDEDED';
-
-// Color variants
+// Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
 const COLOR_SCALE = [
   chart_color_black_300.value,
@@ -37,15 +19,5 @@ const COLOR_SCALE = [
 ];
 
 export const DarkGrayColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
+  COLOR_SCALE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/green-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/green-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_green_200,
   chart_color_green_300,
   chart_color_green_400,
-  chart_color_green_500,
-  global_active_color_200,
-  global_active_color_300,
-  global_Color_dark_200,
-  global_Color_light_100
+  chart_color_green_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_light_100.value;
-const COLOR_STACK_STROKE = global_Color_dark_200.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#151515';
-const COLOR_TOOLTIP_STROKE = '#151515';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#EDEDED';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -37,15 +19,5 @@ const COLOR_SCALE = [
 ];
 
 export const DarkGreenColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
+  COLOR_SCALE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/multi-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/multi-color-theme.ts
@@ -34,27 +34,9 @@ import {
   chart_color_black_200,
   chart_color_black_300,
   chart_color_black_400,
-  chart_color_black_500,
-  global_active_color_200,
-  global_active_color_300,
-  global_Color_dark_200,
-  global_Color_light_100
+  chart_color_black_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_light_100.value;
-const COLOR_STACK_STROKE = global_Color_dark_200.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#151515';
-const COLOR_TOOLTIP_STROKE = '#151515';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#EDEDED';
 
 // The color order below improves the color contrast in unordered charts
 // See https://github.com/patternfly/patternfly-next/issues/1551
@@ -97,15 +79,5 @@ const COLOR_SCALE = [
 ];
 
 export const DarkMultiColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
+  COLOR_SCALE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/orange-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/orange-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_orange_200,
   chart_color_orange_300,
   chart_color_orange_400,
-  chart_color_orange_500,
-  global_active_color_200,
-  global_active_color_300,
-  global_Color_dark_200,
-  global_Color_light_100
+  chart_color_orange_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_light_100.value;
-const COLOR_STACK_STROKE = global_Color_dark_200.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#151515';
-const COLOR_TOOLTIP_STROKE = '#151515';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#EDEDED';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -33,19 +15,10 @@ const COLOR_SCALE = [
   chart_color_orange_100.value,
   chart_color_orange_500.value,
   chart_color_orange_200.value,
-  chart_color_orange_400.value
+  chart_color_orange_400.value,
+
 ];
 
 export const DarkOrangeColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
+  COLOR_SCALE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/purple-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/purple-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_purple_200,
   chart_color_purple_300,
   chart_color_purple_400,
-  chart_color_purple_500,
-  global_active_color_200,
-  global_active_color_300,
-  global_Color_dark_200,
-  global_Color_light_100
+  chart_color_purple_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_light_100.value;
-const COLOR_STACK_STROKE = global_Color_dark_200.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#151515';
-const COLOR_TOOLTIP_STROKE = '#151515';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#EDEDED';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -37,15 +19,5 @@ const COLOR_SCALE = [
 ];
 
 export const DarkPurpleColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
+  COLOR_SCALE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/blue-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/blue-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_blue_200,
   chart_color_blue_300,
   chart_color_blue_400,
-  chart_color_blue_500,
-  global_active_color_200,
-  global_active_color_300,
-  global_Color_dark_100,
-  global_Color_light_100
+  chart_color_blue_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_dark_100.value;
-const COLOR_STACK_STROKE = global_Color_light_100.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#EDEDED';
-const COLOR_TOOLTIP_STROKE = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#151515';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#151515';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -37,15 +19,5 @@ const COLOR_SCALE = [
 ];
 
 export const LightBlueColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
+  COLOR_SCALE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/cyan-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/cyan-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_cyan_200,
   chart_color_cyan_300,
   chart_color_cyan_400,
-  chart_color_cyan_500,
-  global_Color_dark_100,
-  global_Color_light_100,
-  global_active_color_200,
-  global_active_color_300,
+  chart_color_cyan_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_dark_100.value;
-const COLOR_STACK_STROKE = global_Color_light_100.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#EDEDED';
-const COLOR_TOOLTIP_STROKE = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#151515';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#151515';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -37,15 +19,5 @@ const COLOR_SCALE = [
 ];
 
 export const LightCyanColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
-}) ;
+  COLOR_SCALE
+});

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/gold-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/gold-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_gold_200,
   chart_color_gold_300,
   chart_color_gold_400,
-  chart_color_gold_500,
-  global_Color_dark_100,
-  global_Color_light_100,
-  global_active_color_200,
-  global_active_color_300,
+  chart_color_gold_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_dark_100.value;
-const COLOR_STACK_STROKE = global_Color_light_100.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#EDEDED';
-const COLOR_TOOLTIP_STROKE = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#151515';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#151515';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -38,15 +20,5 @@ const COLOR_SCALE = [
 ];
 
 export const LightGoldColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
-}) ;
+  COLOR_SCALE
+});

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/gray-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/gray-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_black_200,
   chart_color_black_300,
   chart_color_black_400,
-  chart_color_black_500,
-  global_active_color_200,
-  global_active_color_300,
-  global_Color_dark_100,
-  global_Color_light_100
+  chart_color_black_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_dark_100.value;
-const COLOR_STACK_STROKE = global_Color_light_100.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#EDEDED';
-const COLOR_TOOLTIP_STROKE = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#151515';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#151515';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -37,15 +19,5 @@ const COLOR_SCALE = [
 ];
 
 export const LightGrayColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
+  COLOR_SCALE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/green-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/green-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_green_200,
   chart_color_green_300,
   chart_color_green_400,
-  chart_color_green_500,
-  global_Color_dark_100,
-  global_Color_light_100,
-  global_active_color_200,
-  global_active_color_300,
+  chart_color_green_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_dark_100.value;
-const COLOR_STACK_STROKE = global_Color_light_100.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#EDEDED';
-const COLOR_TOOLTIP_STROKE = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#151515';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#151515';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -37,15 +19,5 @@ const COLOR_SCALE = [
 ];
 
 export const LightGreenColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
-}) ;
+  COLOR_SCALE
+});

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/multi-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/multi-color-theme.ts
@@ -34,27 +34,9 @@ import {
   chart_color_black_200,
   chart_color_black_300,
   chart_color_black_400,
-  chart_color_black_500,
-  global_active_color_200,
-  global_active_color_300,
-  global_Color_dark_100,
-  global_Color_light_100
+  chart_color_black_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_dark_100.value;
-const COLOR_STACK_STROKE = global_Color_light_100.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#EDEDED';
-const COLOR_TOOLTIP_STROKE = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#151515';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#151515';
 
 // The color order below improves the color contrast in unordered charts
 // See https://github.com/patternfly/patternfly-next/issues/1551
@@ -97,15 +79,5 @@ const COLOR_SCALE = [
 ];
 
 export const LightMultiColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
+  COLOR_SCALE
 });

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/orange-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/orange-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_orange_200,
   chart_color_orange_300,
   chart_color_orange_400,
-  chart_color_orange_500,
-  global_Color_dark_100,
-  global_Color_light_100,
-  global_active_color_200,
-  global_active_color_300,
+  chart_color_orange_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_dark_100.value;
-const COLOR_STACK_STROKE = global_Color_light_100.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#EDEDED';
-const COLOR_TOOLTIP_STROKE = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#151515';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#151515';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -38,15 +20,5 @@ const COLOR_SCALE = [
 ];
 
 export const LightOrangeColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
-}) ;
+  COLOR_SCALE
+});

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/purple-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/purple-color-theme.ts
@@ -4,27 +4,9 @@ import {
   chart_color_purple_200,
   chart_color_purple_300,
   chart_color_purple_400,
-  chart_color_purple_500,
-  global_Color_dark_100,
-  global_Color_light_100,
-  global_active_color_200,
-  global_active_color_300,
+  chart_color_purple_500
 } from '@patternfly/react-tokens';
 import { ColorTheme } from '../color-theme';
-
-// TODO Replace values with PF css variable when available
-
-// Colors
-const COLOR_AXIS_FILL = 'transparent';
-const COLOR_AXIS_STROKE = '#D2D2D2';
-const COLOR_FILL = global_active_color_200.value;
-const COLOR_LABEL = global_Color_dark_100.value;
-const COLOR_STACK_STROKE = global_Color_light_100.value;
-const COLOR_STROKE = global_active_color_300.value;
-const COLOR_TOOLTIP_FILL = '#EDEDED';
-const COLOR_TOOLTIP_STROKE = '#EDEDED';
-const COLOR_TOOLTIP_FLYOUT_FILL = '#151515';
-const COLOR_TOOLTIP_FLYOUT_STROKE = '#151515';
 
 // Color scale
 // See https://docs.google.com/document/d/1cw10pJFXWruB1SA8TQwituxn5Ss6KpxYPCOYGrH8qAY/edit
@@ -37,15 +19,5 @@ const COLOR_SCALE = [
 ];
 
 export const LightPurpleColorTheme = ColorTheme({
-  COLOR_AXIS_FILL,
-  COLOR_AXIS_STROKE,
-  COLOR_FILL,
-  COLOR_LABEL,
-  COLOR_SCALE,
-  COLOR_STACK_STROKE,
-  COLOR_STROKE,
-  COLOR_TOOLTIP_FILL,
-  COLOR_TOOLTIP_STROKE,
-  COLOR_TOOLTIP_FLYOUT_FILL,
-  COLOR_TOOLTIP_FLYOUT_STROKE
-}) ;
+  COLOR_SCALE
+});

--- a/packages/patternfly-4/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
@@ -34,13 +34,12 @@ exports[`ChartTooltip 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -64,13 +63,12 @@ exports[`ChartTooltip 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -86,7 +84,7 @@ exports[`ChartTooltip 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -123,7 +121,6 @@ exports[`ChartTooltip 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -147,11 +144,10 @@ exports[`ChartTooltip 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -160,11 +156,10 @@ exports[`ChartTooltip 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -173,11 +168,10 @@ exports[`ChartTooltip 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -185,11 +179,10 @@ exports[`ChartTooltip 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -197,11 +190,10 @@ exports[`ChartTooltip 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -213,8 +205,8 @@ exports[`ChartTooltip 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -227,11 +219,10 @@ exports[`ChartTooltip 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -252,11 +243,6 @@ exports[`ChartTooltip 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -274,11 +260,10 @@ exports[`ChartTooltip 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -316,7 +301,6 @@ exports[`ChartTooltip 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -324,7 +308,6 @@ exports[`ChartTooltip 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -348,11 +331,10 @@ exports[`ChartTooltip 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -380,12 +362,11 @@ exports[`ChartTooltip 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -402,13 +383,12 @@ exports[`ChartTooltip 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -431,7 +411,6 @@ exports[`ChartTooltip 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -449,14 +428,9 @@ exports[`ChartTooltip 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -482,13 +456,13 @@ exports[`ChartTooltip 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -533,13 +507,12 @@ exports[`ChartTooltip 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -563,13 +536,12 @@ exports[`ChartTooltip 2`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -585,7 +557,7 @@ exports[`ChartTooltip 2`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -622,7 +594,6 @@ exports[`ChartTooltip 2`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -646,11 +617,10 @@ exports[`ChartTooltip 2`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -659,11 +629,10 @@ exports[`ChartTooltip 2`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -672,11 +641,10 @@ exports[`ChartTooltip 2`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -684,11 +652,10 @@ exports[`ChartTooltip 2`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -696,11 +663,10 @@ exports[`ChartTooltip 2`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -712,8 +678,8 @@ exports[`ChartTooltip 2`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -726,11 +692,10 @@ exports[`ChartTooltip 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -751,11 +716,6 @@ exports[`ChartTooltip 2`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -773,11 +733,10 @@ exports[`ChartTooltip 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -815,7 +774,6 @@ exports[`ChartTooltip 2`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -823,7 +781,6 @@ exports[`ChartTooltip 2`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -847,11 +804,10 @@ exports[`ChartTooltip 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -879,12 +835,11 @@ exports[`ChartTooltip 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -901,13 +856,12 @@ exports[`ChartTooltip 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -930,7 +884,6 @@ exports[`ChartTooltip 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -948,14 +901,9 @@ exports[`ChartTooltip 2`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -981,13 +929,13 @@ exports[`ChartTooltip 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -1052,13 +1000,12 @@ exports[`allows tooltip via container component 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1082,13 +1029,12 @@ exports[`allows tooltip via container component 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1104,7 +1050,7 @@ exports[`allows tooltip via container component 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1141,7 +1087,6 @@ exports[`allows tooltip via container component 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1165,11 +1110,10 @@ exports[`allows tooltip via container component 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1178,11 +1122,10 @@ exports[`allows tooltip via container component 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1191,11 +1134,10 @@ exports[`allows tooltip via container component 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1203,11 +1145,10 @@ exports[`allows tooltip via container component 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1215,11 +1156,10 @@ exports[`allows tooltip via container component 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1231,8 +1171,8 @@ exports[`allows tooltip via container component 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -1245,11 +1185,10 @@ exports[`allows tooltip via container component 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1270,11 +1209,6 @@ exports[`allows tooltip via container component 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -1292,11 +1226,10 @@ exports[`allows tooltip via container component 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1334,7 +1267,6 @@ exports[`allows tooltip via container component 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1342,7 +1274,6 @@ exports[`allows tooltip via container component 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1366,11 +1297,10 @@ exports[`allows tooltip via container component 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1398,12 +1328,11 @@ exports[`allows tooltip via container component 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -1420,13 +1349,12 @@ exports[`allows tooltip via container component 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1449,7 +1377,6 @@ exports[`allows tooltip via container component 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -1467,14 +1394,9 @@ exports[`allows tooltip via container component 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -1500,13 +1422,13 @@ exports[`allows tooltip via container component 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },

--- a/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.tsx.snap
@@ -43,13 +43,12 @@ exports[`ChartVoronoiContainer 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -73,13 +72,12 @@ exports[`ChartVoronoiContainer 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -95,7 +93,7 @@ exports[`ChartVoronoiContainer 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -132,7 +130,6 @@ exports[`ChartVoronoiContainer 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -156,11 +153,10 @@ exports[`ChartVoronoiContainer 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -169,11 +165,10 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -182,11 +177,10 @@ exports[`ChartVoronoiContainer 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -194,11 +188,10 @@ exports[`ChartVoronoiContainer 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -206,11 +199,10 @@ exports[`ChartVoronoiContainer 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -222,8 +214,8 @@ exports[`ChartVoronoiContainer 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -236,11 +228,10 @@ exports[`ChartVoronoiContainer 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -261,11 +252,6 @@ exports[`ChartVoronoiContainer 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -283,11 +269,10 @@ exports[`ChartVoronoiContainer 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -325,7 +310,6 @@ exports[`ChartVoronoiContainer 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -333,7 +317,6 @@ exports[`ChartVoronoiContainer 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -357,11 +340,10 @@ exports[`ChartVoronoiContainer 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -389,12 +371,11 @@ exports[`ChartVoronoiContainer 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -411,13 +392,12 @@ exports[`ChartVoronoiContainer 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -440,7 +420,6 @@ exports[`ChartVoronoiContainer 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -458,14 +437,9 @@ exports[`ChartVoronoiContainer 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -491,13 +465,13 @@ exports[`ChartVoronoiContainer 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -552,13 +526,12 @@ exports[`ChartVoronoiContainer 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -582,13 +555,12 @@ exports[`ChartVoronoiContainer 2`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -604,7 +576,7 @@ exports[`ChartVoronoiContainer 2`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -641,7 +613,6 @@ exports[`ChartVoronoiContainer 2`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -665,11 +636,10 @@ exports[`ChartVoronoiContainer 2`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -678,11 +648,10 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -691,11 +660,10 @@ exports[`ChartVoronoiContainer 2`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -703,11 +671,10 @@ exports[`ChartVoronoiContainer 2`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -715,11 +682,10 @@ exports[`ChartVoronoiContainer 2`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -731,8 +697,8 @@ exports[`ChartVoronoiContainer 2`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -745,11 +711,10 @@ exports[`ChartVoronoiContainer 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -770,11 +735,6 @@ exports[`ChartVoronoiContainer 2`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -792,11 +752,10 @@ exports[`ChartVoronoiContainer 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -834,7 +793,6 @@ exports[`ChartVoronoiContainer 2`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -842,7 +800,6 @@ exports[`ChartVoronoiContainer 2`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -866,11 +823,10 @@ exports[`ChartVoronoiContainer 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -898,12 +854,11 @@ exports[`ChartVoronoiContainer 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -920,13 +875,12 @@ exports[`ChartVoronoiContainer 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -949,7 +903,6 @@ exports[`ChartVoronoiContainer 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -967,14 +920,9 @@ exports[`ChartVoronoiContainer 2`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -1000,13 +948,13 @@ exports[`ChartVoronoiContainer 2`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },
@@ -1071,13 +1019,12 @@ exports[`renders container via ChartGroup 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "fillOpacity": 0.4,
-            "stroke": "#73bcf7",
+            "stroke": "transparent",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1101,13 +1048,12 @@ exports[`renders container via ChartGroup 1`] = `
         "style": Object {
           "axis": Object {
             "fill": "transparent",
-            "stroke": "#D2D2D2",
+            "stroke": "#d2d2d2",
             "strokeLinecap": "round",
             "strokeLinejoin": "round",
             "strokeWidth": 1,
           },
           "axisLabel": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1123,7 +1069,7 @@ exports[`renders container via ChartGroup 1`] = `
             "strokeLinejoin": "round",
           },
           "tickLabels": Object {
-            "fill": "#151515",
+            "fill": "#4d5258",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1160,7 +1106,6 @@ exports[`renders container via ChartGroup 1`] = `
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1184,11 +1129,10 @@ exports[`renders container via ChartGroup 1`] = `
         "style": Object {
           "max": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "maxLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1197,11 +1141,10 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "median": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "medianLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1210,11 +1153,10 @@ exports[`renders container via ChartGroup 1`] = `
           },
           "min": Object {
             "padding": 8,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "minLabels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1222,11 +1164,10 @@ exports[`renders container via ChartGroup 1`] = `
             "stroke": "transparent",
           },
           "q1": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q1Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1234,11 +1175,10 @@ exports[`renders container via ChartGroup 1`] = `
             "stroke": "transparent",
           },
           "q3": Object {
-            "fill": "#bee1f4",
+            "fill": "#8b8d8f",
             "padding": 8,
           },
           "q3Labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1250,8 +1190,8 @@ exports[`renders container via ChartGroup 1`] = `
       },
       "candlestick": Object {
         "candleColors": Object {
-          "negative": "#73bcf7",
-          "positive": "#bee1f4",
+          "negative": "#151515",
+          "positive": "#fff",
         },
         "colorScale": Array [
           "#06c",
@@ -1264,11 +1204,10 @@ exports[`renders container via ChartGroup 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1289,11 +1228,6 @@ exports[`renders container via ChartGroup 1`] = `
         ],
         "height": 300,
         "padding": 50,
-        "style": Object {
-          "parent": Object {
-            "border": "1px solid #bee1f4",
-          },
-        },
         "width": 450,
       },
       "errorbar": Object {
@@ -1311,11 +1245,10 @@ exports[`renders container via ChartGroup 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1353,7 +1286,6 @@ exports[`renders container via ChartGroup 1`] = `
             "type": "square",
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1361,7 +1293,6 @@ exports[`renders container via ChartGroup 1`] = `
             "stroke": "transparent",
           },
           "title": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1385,11 +1316,10 @@ exports[`renders container via ChartGroup 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#73bcf7",
+            "stroke": "#151515",
             "strokeWidth": 2,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1417,12 +1347,11 @@ exports[`renders container via ChartGroup 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
           },
         },
         "width": 230,
@@ -1439,13 +1368,12 @@ exports[`renders container via ChartGroup 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#bee1f4",
+            "fill": "#151515",
             "opacity": 1,
             "stroke": "transparent",
             "strokeWidth": 0,
           },
           "labels": Object {
-            "fill": "#151515",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
@@ -1468,7 +1396,6 @@ exports[`renders container via ChartGroup 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "stroke": "#fff",
             "strokeWidth": 1,
           },
         },
@@ -1486,14 +1413,9 @@ exports[`renders container via ChartGroup 1`] = `
         "pointerLength": 10,
         "pointerWidth": 20,
         "style": Object {
-          "fill": "#EDEDED",
-          "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
-          "fontSize": 14,
-          "letterSpacing": "normal",
+          "fill": "#ededed",
           "padding": 16,
           "pointerEvents": "none",
-          "stroke": "#EDEDED",
-          "textAnchor": "middle",
         },
       },
       "voronoi": Object {
@@ -1519,13 +1441,13 @@ exports[`renders container via ChartGroup 1`] = `
             "strokeWidth": 1,
           },
           "labels": Object {
-            "fill": "#151515",
+            "fill": "#ededed",
             "fontFamily": "overpass, overpass, open sans, -apple-system, blinkmacsystemfont, Segoe UI, roboto, Helvetica Neue, arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
             "fontSize": 14,
             "letterSpacing": "normal",
             "padding": 8,
             "pointerEvents": "none",
-            "stroke": "#EDEDED",
+            "stroke": "transparent",
             "textAnchor": "middle",
           },
         },


### PR DESCRIPTION
Adjusted/added pf-core vars to ensure custom tooltip colors are displayed correctly. Previously, the background and label were the same black color, so the text wasn't visible.

We were also applying old, hard coded color properties over the pf-core vars, so the theme had to be cleaned up a bit.

Added the `voronoiDimension` prop to fix the tooltip hover for our bar chart examples. Then, modified the stack chart example to show how similar tooltips are applied without a voronoi container.

Also modified an area chart example, showing how width can be responsive (per @priley86 's request).

Fixes https://github.com/patternfly/patternfly-react/issues/2496
Fixes https://github.com/patternfly/patternfly-react/issues/2482
