### PR TITLE
chore(charts): tweak aria title for area chart

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -79,7 +79,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patte
   <div className="area-chart-legend-bottom">
     <Chart
       ariaDesc="Average number of pets"
-      ariaTitle="Donut chart example"
+      ariaTitle="Area chart example"
       containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
       legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
       legendPosition="bottom"
@@ -168,7 +168,7 @@ class MultiColorChart extends React.Component {
         <div className="area-chart-legend-bottom-responsive">
           <Chart
             ariaDesc="Average number of pets"
-            ariaTitle="Donut chart example"
+            ariaTitle="Area chart example"
             containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
             legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
             legendPosition="bottom-left"


### PR DESCRIPTION
Simple fix for the area chart examples.

ariaTitle="Donut chart example"

should be:

ariaTitle="Area chart example"

Fixes https://github.com/patternfly/patternfly-react/issues/2509
