### PR TITLE
fix(options menu): update examples to trigger select on the whole item

### DIFF
--- a/packages/patternfly-4/react-core/src/components/OptionsMenu/OptionsMenu.md
+++ b/packages/patternfly-4/react-core/src/components/OptionsMenu/OptionsMenu.md
@@ -38,24 +38,20 @@ class SingleOption extends React.Component {
       };
       
       this.onSelect = event => {
-        const id = event.target.id;
+        const id = event.currentTarget.id;
         this.setState(() => {
           return { selectedOption: id };
         });
       };
       
-       this.handleChildClick = event => {
-             event.stopPropagation();
-             event.preventDefault();
-        }
     }
     
   render() {
     const { selectedOption, toggleTemplateText, isOpen } = this.state;
     const menuItems = [
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={selectedOption === "singleOption1"} id="singleOption1" key="option 1">Option 1</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={selectedOption === "singleOption2"} id="singleOption2" key="option 2">Option 2</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={selectedOption === "singleOption3"} id="singleOption3" key="option 3">Option 3</OptionsMenuItem>
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={selectedOption === "singleOption1"} id="singleOption1" key="option 1">Option 1</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={selectedOption === "singleOption2"} id="singleOption2" key="option 2">Option 2</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={selectedOption === "singleOption3"} id="singleOption3" key="option 3">Option 3</OptionsMenuItem>
     ];
     const toggle = <OptionsMenuToggle onToggle={this.onToggle} toggleTemplate={toggleTemplateText} />
 
@@ -127,20 +123,15 @@ class MultipleOptions extends React.Component {
           });
       };
       
-       this.handleChildClick = event => {
-         event.stopPropagation();
-         event.preventDefault();
-       }
-      
       this.onSelectColumn = event => {
-        const id = event.target.id;
+        const id = event.currentTarget.id;
         this.setState(() => {
           return { sortColumn: id };
         });
       };
       
       this.onSelectDirection = event => {
-        const id = event.target.id;
+        const id = event.currentTarget.id;
         this.setState(() => {
           return { sortDirection: id };
         });
@@ -151,15 +142,15 @@ class MultipleOptions extends React.Component {
     const { sortColumn, sortDirection, toggleTemplateText, isOpen } = this.state;
     const menuItems = [
         <OptionsMenuItemGroup key="first group" aria-label="Sort Column">
-          <OptionsMenuItem onSelect={this.onSelectColumn} handleChildClick={this.handleChildClick} isSelected={sortColumn === "name"} id="name" key="name">Name</OptionsMenuItem>
-          <OptionsMenuItem onSelect={this.onSelectColumn} handleChildClick={this.handleChildClick} isSelected={sortColumn === "date"} id="date" key="date">Date</OptionsMenuItem>
-          <OptionsMenuItem isDisabled onSelect={this.onSelectColumn} handleChildClick={this.handleChildClick} isSelected={sortColumn === "disabled"} id="disabled" key="disabled">Disabled</OptionsMenuItem>
-          <OptionsMenuItem onSelect={this.onSelectColumn} handleChildClick={this.handleChildClick} isSelected={sortColumn === "size"} id="size" key="size">Size</OptionsMenuItem>
+          <OptionsMenuItem onSelect={this.onSelectColumn} isSelected={sortColumn === "name"} id="name" key="name">Name</OptionsMenuItem>
+          <OptionsMenuItem onSelect={this.onSelectColumn} isSelected={sortColumn === "date"} id="date" key="date">Date</OptionsMenuItem>
+          <OptionsMenuItem isDisabled onSelect={this.onSelectColumn} isSelected={sortColumn === "disabled"} id="disabled" key="disabled">Disabled</OptionsMenuItem>
+          <OptionsMenuItem onSelect={this.onSelectColumn} isSelected={sortColumn === "size"} id="size" key="size">Size</OptionsMenuItem>
         </OptionsMenuItemGroup>,
         <OptionsMenuSeparator key="separator"/>,
         <OptionsMenuItemGroup key="second group" aria-label="Sort Direction">
-          <OptionsMenuItem onSelect={this.onSelectDirection} handleChildClick={this.handleChildClick} isSelected={sortDirection === "ascending"} id="ascending" key="ascending">Ascending</OptionsMenuItem>
-          <OptionsMenuItem onSelect={this.onSelectDirection} handleChildClick={this.handleChildClick} isSelected={sortDirection === "descending"} id="descending" key="descending">Descending</OptionsMenuItem>
+          <OptionsMenuItem onSelect={this.onSelectDirection} isSelected={sortDirection === "ascending"} id="ascending" key="ascending">Ascending</OptionsMenuItem>
+          <OptionsMenuItem onSelect={this.onSelectDirection} isSelected={sortDirection === "descending"} id="descending" key="descending">Descending</OptionsMenuItem>
         </OptionsMenuItemGroup>
       ];
     const toggle = <OptionsMenuToggle onToggle={this.onToggle} toggleTemplate={toggleTemplateText} />
@@ -208,30 +199,25 @@ class Plain extends React.Component {
       };
       
       this.onSelect = event => {
-        const id = event.target.id;
+        const id = event.currentTarget.id;
         this.setState((prevState) => {
           return { [id]: !prevState[id] };
         });
       };
-      
-      this.handleChildClick = event => {
-        event.stopPropagation();
-        event.preventDefault();
-      }
     }
 
   render() {
     const { isOpen, isDisabledOpen, plainOption1, plainOption2, plainOption3, disabledPlainOption1, disabledPlainOption2, disabledPlainOption3 } = this.state
     const menuItems = [
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={plainOption1} id="plainOption1" key="option 1">Option 1</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={plainOption2} id="plainOption2" key="option 2">Option 2</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={plainOption3} id="plainOption3" key="option 3">Option 3</OptionsMenuItem>
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={plainOption1} id="plainOption1" key="option 1">Option 1</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={plainOption2} id="plainOption2" key="option 2">Option 2</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={plainOption3} id="plainOption3" key="option 3">Option 3</OptionsMenuItem>
     ];
 
     const disabledMenuItems = [
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={disabledPlainOption1} id="disabledPlainOption1" key="disabled option 1">Option 1</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={disabledPlainOption2} id="disabledPlainOption2" key="disabled option 2">Option 2</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={disabledPlainOption3} id="disabledPlainOption3" key="disabled option 3">Option 3</OptionsMenuItem>
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={disabledPlainOption1} id="disabledPlainOption1" key="disabled option 1">Option 1</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={disabledPlainOption2} id="disabledPlainOption2" key="disabled option 2">Option 2</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={disabledPlainOption3} id="disabledPlainOption3" key="disabled option 3">Option 3</OptionsMenuItem>
     ];
     const toggleTemplate = <SortAmountDownIcon aria-hidden="true"/>
     
@@ -280,25 +266,19 @@ class Top extends React.Component {
     };
     
     this.onSelect = event => {
-      const id = event.target.id;
+      const id = event.currentTarget.id;
       this.setState((prevState) => {
         return { [id]: !prevState[id] };
       });
     };
-    
-    this.handleChildClick = event => {
-      event.stopPropagation();
-      event.preventDefault();
-    }
-           
   }
 
   render() {
     const { isOpen, topOption1, topOption2, topOption3, toggleTemplateText } = this.state
     const menuItems = [
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={topOption1} id="topOption1" key="option 1">Option 1</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={topOption2} id="topOption2" key="option 2">Option 2</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={topOption3} id="topOption3" key="option 3">Option 3</OptionsMenuItem>
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={topOption1} id="topOption1" key="option 1">Option 1</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={topOption2} id="topOption2" key="option 2">Option 2</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={topOption3} id="topOption3" key="option 3">Option 3</OptionsMenuItem>
     ];
     const toggle = <OptionsMenuToggle onToggle={this.onToggle} toggleTemplate={toggleTemplateText} />
 
@@ -337,25 +317,19 @@ class AlignRight extends React.Component {
     };
     
     this.onSelect = event => {
-      const id = event.target.id;
+      const id = event.currentTarget.id;
       this.setState((prevState) => {
         return { [id]: !prevState[id] };
       });
     };
-    
-    this.handleChildClick = event => {
-      event.stopPropagation();
-      event.preventDefault();
-    }
-        
   }
 
   render() {
     const { isOpen, toggleTemplateText, rightOption1, rightOption2, rightOption3 } = this.state;
     const menuItems = [
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={rightOption1} id="rightOption1" key="option 1">Right option 1</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={rightOption2} id="rightOption2" key="option 2">Right option 2</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={rightOption3} id="rightOption3" key="option 3">Right option 3</OptionsMenuItem>
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={rightOption1} id="rightOption1" key="option 1">Right option 1</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={rightOption2} id="rightOption2" key="option 2">Right option 2</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={rightOption3} id="rightOption3" key="option 3">Right option 3</OptionsMenuItem>
     ];
     const toggle = <OptionsMenuToggle onToggle={this.onToggle} toggleTemplate={toggleTemplateText} />
 
@@ -396,7 +370,7 @@ class PlainWithText extends React.Component {
       };
       
       this.onSelect = event => {
-        const id = event.target.id;
+        const id = event.currentTarget.id;
         this.setState((prevState) => {
           return { [id]: !prevState[id] };
         });
@@ -407,19 +381,14 @@ class PlainWithText extends React.Component {
           isOpen: !this.state.isOpen
         });
       };
-      
-      this.handleChildClick = event => {
-        event.stopPropagation();
-        event.preventDefault();
-      }
     }
 
   render() {
     const { isOpen, toggleText, buttonContents } = this.state;
     const menuItems = [
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={this.state.customOption1} id="customOption1" key="option 1">Option 1</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={this.state.customOption2} id="customOption2" key="option 2">Option 2</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={this.state.customOption3} id="customOption3" key="option 3">Option 3</OptionsMenuItem>
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={this.state.customOption1} id="customOption1" key="option 1">Option 1</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={this.state.customOption2} id="customOption2" key="option 2">Option 2</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} isSelected={this.state.customOption3} id="customOption3" key="option 3">Option 3</OptionsMenuItem>
     ];
     const toggle = <OptionsMenuToggleWithText toggleText={toggleText} toggleButtonContents={buttonContents} onToggle={this.onToggle} />;
 

--- a/packages/patternfly-4/react-core/src/components/OptionsMenu/OptionsMenu.md
+++ b/packages/patternfly-4/react-core/src/components/OptionsMenu/OptionsMenu.md
@@ -43,14 +43,19 @@ class SingleOption extends React.Component {
           return { selectedOption: id };
         });
       };
+      
+       this.handleChildClick = event => {
+             event.stopPropagation();
+             event.preventDefault();
+        }
     }
     
   render() {
     const { selectedOption, toggleTemplateText, isOpen } = this.state;
     const menuItems = [
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={selectedOption === "singleOption1"} id="singleOption1" key="option 1">Option 1</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={selectedOption === "singleOption2"} id="singleOption2" key="option 2">Option 2</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={selectedOption === "singleOption3"} id="singleOption3" key="option 3">Option 3</OptionsMenuItem>
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={selectedOption === "singleOption1"} id="singleOption1" key="option 1">Option 1</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={selectedOption === "singleOption2"} id="singleOption2" key="option 2">Option 2</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={selectedOption === "singleOption3"} id="singleOption3" key="option 3">Option 3</OptionsMenuItem>
     ];
     const toggle = <OptionsMenuToggle onToggle={this.onToggle} toggleTemplate={toggleTemplateText} />
 
@@ -122,6 +127,11 @@ class MultipleOptions extends React.Component {
           });
       };
       
+       this.handleChildClick = event => {
+         event.stopPropagation();
+         event.preventDefault();
+       }
+      
       this.onSelectColumn = event => {
         const id = event.target.id;
         this.setState(() => {
@@ -141,15 +151,15 @@ class MultipleOptions extends React.Component {
     const { sortColumn, sortDirection, toggleTemplateText, isOpen } = this.state;
     const menuItems = [
         <OptionsMenuItemGroup key="first group" aria-label="Sort Column">
-          <OptionsMenuItem onSelect={this.onSelectColumn} isSelected={sortColumn === "name"} id="name" key="name">Name</OptionsMenuItem>
-          <OptionsMenuItem onSelect={this.onSelectColumn} isSelected={sortColumn === "date"} id="date" key="date">Date</OptionsMenuItem>
-          <OptionsMenuItem isDisabled onSelect={this.onSelectColumn} isSelected={sortColumn === "disabled"} id="disabled" key="disabled">Disabled</OptionsMenuItem>
-          <OptionsMenuItem onSelect={this.onSelectColumn} isSelected={sortColumn === "size"} id="size" key="size">Size</OptionsMenuItem>
+          <OptionsMenuItem onSelect={this.onSelectColumn} handleChildClick={this.handleChildClick} isSelected={sortColumn === "name"} id="name" key="name">Name</OptionsMenuItem>
+          <OptionsMenuItem onSelect={this.onSelectColumn} handleChildClick={this.handleChildClick} isSelected={sortColumn === "date"} id="date" key="date">Date</OptionsMenuItem>
+          <OptionsMenuItem isDisabled onSelect={this.onSelectColumn} handleChildClick={this.handleChildClick} isSelected={sortColumn === "disabled"} id="disabled" key="disabled">Disabled</OptionsMenuItem>
+          <OptionsMenuItem onSelect={this.onSelectColumn} handleChildClick={this.handleChildClick} isSelected={sortColumn === "size"} id="size" key="size">Size</OptionsMenuItem>
         </OptionsMenuItemGroup>,
         <OptionsMenuSeparator key="separator"/>,
         <OptionsMenuItemGroup key="second group" aria-label="Sort Direction">
-          <OptionsMenuItem onSelect={this.onSelectDirection} isSelected={sortDirection === "ascending"} id="ascending" key="ascending">Ascending</OptionsMenuItem>
-          <OptionsMenuItem onSelect={this.onSelectDirection} isSelected={sortDirection === "descending"} id="descending" key="descending">Descending</OptionsMenuItem>
+          <OptionsMenuItem onSelect={this.onSelectDirection} handleChildClick={this.handleChildClick} isSelected={sortDirection === "ascending"} id="ascending" key="ascending">Ascending</OptionsMenuItem>
+          <OptionsMenuItem onSelect={this.onSelectDirection} handleChildClick={this.handleChildClick} isSelected={sortDirection === "descending"} id="descending" key="descending">Descending</OptionsMenuItem>
         </OptionsMenuItemGroup>
       ];
     const toggle = <OptionsMenuToggle onToggle={this.onToggle} toggleTemplate={toggleTemplateText} />
@@ -203,20 +213,25 @@ class Plain extends React.Component {
           return { [id]: !prevState[id] };
         });
       };
+      
+      this.handleChildClick = event => {
+        event.stopPropagation();
+        event.preventDefault();
+      }
     }
 
   render() {
     const { isOpen, isDisabledOpen, plainOption1, plainOption2, plainOption3, disabledPlainOption1, disabledPlainOption2, disabledPlainOption3 } = this.state
     const menuItems = [
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={plainOption1} id="plainOption1" key="option 1">Option 1</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={plainOption2} id="plainOption2" key="option 2">Option 2</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={plainOption3} id="plainOption3" key="option 3">Option 3</OptionsMenuItem>
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={plainOption1} id="plainOption1" key="option 1">Option 1</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={plainOption2} id="plainOption2" key="option 2">Option 2</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={plainOption3} id="plainOption3" key="option 3">Option 3</OptionsMenuItem>
     ];
 
     const disabledMenuItems = [
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={disabledPlainOption1} id="disabledPlainOption1" key="disabled option 1">Option 1</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={disabledPlainOption2} id="disabledPlainOption2" key="disabled option 2">Option 2</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={disabledPlainOption3} id="disabledPlainOption3" key="disabled option 3">Option 3</OptionsMenuItem>
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={disabledPlainOption1} id="disabledPlainOption1" key="disabled option 1">Option 1</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={disabledPlainOption2} id="disabledPlainOption2" key="disabled option 2">Option 2</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={disabledPlainOption3} id="disabledPlainOption3" key="disabled option 3">Option 3</OptionsMenuItem>
     ];
     const toggleTemplate = <SortAmountDownIcon aria-hidden="true"/>
     
@@ -270,14 +285,20 @@ class Top extends React.Component {
         return { [id]: !prevState[id] };
       });
     };
+    
+    this.handleChildClick = event => {
+      event.stopPropagation();
+      event.preventDefault();
+    }
+           
   }
 
   render() {
     const { isOpen, topOption1, topOption2, topOption3, toggleTemplateText } = this.state
     const menuItems = [
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={topOption1} id="topOption1" key="option 1">Option 1</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={topOption2} id="topOption2" key="option 2">Option 2</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={topOption3} id="topOption3" key="option 3">Option 3</OptionsMenuItem>
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={topOption1} id="topOption1" key="option 1">Option 1</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={topOption2} id="topOption2" key="option 2">Option 2</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={topOption3} id="topOption3" key="option 3">Option 3</OptionsMenuItem>
     ];
     const toggle = <OptionsMenuToggle onToggle={this.onToggle} toggleTemplate={toggleTemplateText} />
 
@@ -321,14 +342,20 @@ class AlignRight extends React.Component {
         return { [id]: !prevState[id] };
       });
     };
+    
+    this.handleChildClick = event => {
+      event.stopPropagation();
+      event.preventDefault();
+    }
+        
   }
 
   render() {
     const { isOpen, toggleTemplateText, rightOption1, rightOption2, rightOption3 } = this.state;
     const menuItems = [
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={rightOption1} id="rightOption1" key="option 1">Right option 1</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={rightOption2} id="rightOption2" key="option 2">Right option 2</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={rightOption3} id="rightOption3" key="option 3">Right option 3</OptionsMenuItem>
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={rightOption1} id="rightOption1" key="option 1">Right option 1</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={rightOption2} id="rightOption2" key="option 2">Right option 2</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={rightOption3} id="rightOption3" key="option 3">Right option 3</OptionsMenuItem>
     ];
     const toggle = <OptionsMenuToggle onToggle={this.onToggle} toggleTemplate={toggleTemplateText} />
 
@@ -380,14 +407,19 @@ class PlainWithText extends React.Component {
           isOpen: !this.state.isOpen
         });
       };
+      
+      this.handleChildClick = event => {
+        event.stopPropagation();
+        event.preventDefault();
+      }
     }
 
   render() {
     const { isOpen, toggleText, buttonContents } = this.state;
     const menuItems = [
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={this.state.customOption1} id="customOption1" key="option 1">Option 1</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={this.state.customOption2} id="customOption2" key="option 2">Option 2</OptionsMenuItem>,
-      <OptionsMenuItem onSelect={this.onSelect} isSelected={this.state.customOption3} id="customOption3" key="option 3">Option 3</OptionsMenuItem>
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={this.state.customOption1} id="customOption1" key="option 1">Option 1</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={this.state.customOption2} id="customOption2" key="option 2">Option 2</OptionsMenuItem>,
+      <OptionsMenuItem onSelect={this.onSelect} handleChildClick={this.handleChildClick} isSelected={this.state.customOption3} id="customOption3" key="option 3">Option 3</OptionsMenuItem>
     ];
     const toggle = <OptionsMenuToggleWithText toggleText={toggleText} toggleButtonContents={buttonContents} onToggle={this.onToggle} />;
 

--- a/packages/patternfly-4/react-core/src/components/OptionsMenu/OptionsMenuItem.tsx
+++ b/packages/patternfly-4/react-core/src/components/OptionsMenu/OptionsMenuItem.tsx
@@ -16,9 +16,12 @@ export interface OptionsMenuItemProps extends Omit<React.HTMLProps<HTMLButtonEle
   isDisabled?: boolean;
   /** Callback for when this Options menu item is selected */
   onSelect?: (event: React.MouseEvent<HTMLButtonElement>|React.KeyboardEvent) => void;
+  /** Prevents event bubbling from child components in button element */
+  handleChildClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   /** Unique id of this Options menu item */
   id?: string;
 }
+
 
 export const OptionsMenuItem: React.FunctionComponent<OptionsMenuItemProps> = ({
   children = null as React.ReactNode,
@@ -26,6 +29,7 @@ export const OptionsMenuItem: React.FunctionComponent<OptionsMenuItemProps> = ({
   isSelected = false,
   isDisabled = false,
   onSelect = () => null as any,
+  handleChildClick = () => null as any,
   id = '',
   ...props
 }: OptionsMenuItemProps) => {
@@ -42,7 +46,6 @@ export const OptionsMenuItem: React.FunctionComponent<OptionsMenuItemProps> = ({
     }
   };
 
-
   return (
     <li>
       <button
@@ -54,7 +57,7 @@ export const OptionsMenuItem: React.FunctionComponent<OptionsMenuItemProps> = ({
         id={id}
         {...props}>
         {children}
-        <i className={css(styles.optionsMenuMenuItemIcon)} aria-hidden hidden={!isSelected}><CheckIcon/></i>
+        <i onClick={handleChildClick} className={css(styles.optionsMenuMenuItemIcon)} aria-hidden hidden={!isSelected}><CheckIcon/></i>
       </button>
     </li>
   );

--- a/packages/patternfly-4/react-core/src/components/OptionsMenu/OptionsMenuItem.tsx
+++ b/packages/patternfly-4/react-core/src/components/OptionsMenu/OptionsMenuItem.tsx
@@ -16,8 +16,6 @@ export interface OptionsMenuItemProps extends Omit<React.HTMLProps<HTMLButtonEle
   isDisabled?: boolean;
   /** Callback for when this Options menu item is selected */
   onSelect?: (event: React.MouseEvent<HTMLButtonElement>|React.KeyboardEvent) => void;
-  /** Prevents event bubbling from child components in button element */
-  handleChildClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   /** Unique id of this Options menu item */
   id?: string;
 }
@@ -29,7 +27,6 @@ export const OptionsMenuItem: React.FunctionComponent<OptionsMenuItemProps> = ({
   isSelected = false,
   isDisabled = false,
   onSelect = () => null as any,
-  handleChildClick = () => null as any,
   id = '',
   ...props
 }: OptionsMenuItemProps) => {
@@ -57,7 +54,7 @@ export const OptionsMenuItem: React.FunctionComponent<OptionsMenuItemProps> = ({
         id={id}
         {...props}>
         {children}
-        <i onClick={handleChildClick} className={css(styles.optionsMenuMenuItemIcon)} aria-hidden hidden={!isSelected}><CheckIcon/></i>
+        <i className={css(styles.optionsMenuMenuItemIcon)} aria-hidden hidden={!isSelected}><CheckIcon/></i>
       </button>
     </li>
   );


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: need feedback on these changes -- this WIP PR is in reference to #2415. Currently, the new click event handler I added seems to work fine on the first three options menu demos, where you can click anywhere on the item to select/deselect it.

However, the last three demos don't seem to work with this new prop,  and when you click directly on the check mark of an item that's been selected, it still doesn't deselect the item. 

Why would this be happening?

