### PR TITLE
fix(Dropdown): adds aria-label for icon only example

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.md
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.md
@@ -457,7 +457,7 @@ class IconDropdown extends React.Component {
       <Dropdown
         onSelect={this.onSelect}
         toggle={
-          <DropdownToggle iconComponent={null} onToggle={this.onToggle}>
+          <DropdownToggle iconComponent={null} onToggle={this.onToggle} aria-label="Applications">
             <ThIcon />
           </DropdownToggle>
         }


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Closes #1837. It appears that list item 1 of this issue has already been addressed, and an aria label already exists on the kebab example of dropdown. This PR adds an aria-label to the "icon only" example of Dropdown. 

