### PR TITLE
feat(Select): update typeahead filtered list when children change

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Select/Select.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.tsx
@@ -99,6 +99,12 @@ export class Select extends React.Component<SelectProps, SelectState> {
     if (!prevState.openedOnEnter && this.state.openedOnEnter) {
       this.refCollection[0].focus();
     }
+
+    if (prevProps.children !== this.props.children) {
+      this.setState({
+        typeaheadFilteredChildren: React.Children.toArray(this.props.children)
+      });
+    }
   };
 
   onEnter = () => {


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Fixes typeahead select children not updating properly when children is changed.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Refer to issue**: #2090

<!-- feel free to add additional comments -->
