### PR TITLE
fix(page): skip to content should point to primary content container

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Page/Page.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Page/Page.test.tsx
@@ -55,7 +55,7 @@ test('Check page to verify breadcrumb is created', () => {
     </Breadcrumb>
   );
   const view = mount(
-    <Page {...props} header={Header} sidebar={Sidebar} breadcrumb={PageBreadcrumb}>
+    <Page {...props} header={Header} sidebar={Sidebar} breadcrumb={<PageBreadcrumb />}>
       <PageSection variant="default">Section with default background</PageSection>
       <PageSection variant="light">Section with light background</PageSection>
       <PageSection variant="dark">Section with dark background</PageSection>
@@ -63,9 +63,10 @@ test('Check page to verify breadcrumb is created', () => {
     </Page>
   );
   expect(view).toMatchSnapshot();
+  expect(view.find(`.pf-c-page__main`).getDOMNode().id).toBe('');
 });
 
-test('Check page to verify skip to content is created', () => {
+test('Check page to verify skip to content points to main content region', () => {
   const Header = <PageHeader logo="Logo" toolbar="Toolbar" avatar=" | Avatar" topNav="Navigation" />;
   const Sidebar = <PageSidebar isNavOpen />;
   const PageBreadcrumb = (
@@ -78,7 +79,8 @@ test('Check page to verify skip to content is created', () => {
       </BreadcrumbItem>
     </Breadcrumb>
   );
-  const PageSkipToContent = <SkipToContent href="#main-content-page-layout-default-nav">Skip to Content</SkipToContent>;
+  const mainId = 'main-content-page-layout-test-nav';
+  const PageSkipToContent = <SkipToContent href={`#${mainId}`}>Skip to Content</SkipToContent>;
   const view = mount(
     <Page
       {...props}
@@ -86,6 +88,7 @@ test('Check page to verify skip to content is created', () => {
       sidebar={Sidebar}
       breadcrumb={PageBreadcrumb}
       skipToContent={PageSkipToContent}
+      mainContainerId={mainId}
     >
       <PageSection variant="default">Section with default background</PageSection>
       <PageSection variant="light">Section with light background</PageSection>
@@ -94,4 +97,6 @@ test('Check page to verify skip to content is created', () => {
     </Page>
   );
   expect(view).toMatchSnapshot();
+  expect(view.find(`.pf-c-page`).getDOMNode().id).toBe(props.id);
+  expect(view.find(`.pf-c-page__main`).getDOMNode().id).toBe(mainId);
 });

--- a/packages/patternfly-4/react-core/src/components/Page/Page.tsx
+++ b/packages/patternfly-4/react-core/src/components/Page/Page.tsx
@@ -24,6 +24,8 @@ export interface PageProps extends React.HTMLProps<HTMLDivElement> {
   sidebar?: React.ReactNode;
   /** Skip to content component for the page */
   skipToContent?: React.ReactElement;
+  /** an id to use for the [role="main"] element */
+  mainContainerId?: string;
   /**
    * If true, manages the sidebar open/close state and there is no need to pass the isNavOpen boolean into
    * the sidebar component or add a callback onNavToggle function into the PageHeader component
@@ -59,7 +61,8 @@ export class Page extends React.Component<PageProps, PageState> {
     sidebar: null as React.ReactNode,
     skipToContent: null as React.ReactElement,
     isManagedSidebar: false,
-    onPageResize: ():void => null
+    onPageResize: ():void => null,
+    mainContainerId: null as string
   };
 
   componentDidMount() {
@@ -110,6 +113,7 @@ export class Page extends React.Component<PageProps, PageState> {
       header,
       sidebar,
       skipToContent,
+      mainContainerId,
       isManagedSidebar,
       onPageResize,
       ...rest
@@ -128,9 +132,8 @@ export class Page extends React.Component<PageProps, PageState> {
           {skipToContent}
           {header}
           {sidebar}
-          <main role="main" className={css(styles.pageMain)}>
+          <main role="main" id={mainContainerId} className={css(styles.pageMain)} tabIndex={-1}>
             {breadcrumb && <section className={css(styles.pageMainBreadcrumb)}>{breadcrumb}</section>}
-            {skipToContent && <a id={skipToContent.props.href.replace(/#*/, '')} />}
             {children}
           </main>
         </div>

--- a/packages/patternfly-4/react-core/src/components/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Page/__snapshots__/Page.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
   }
   id="PageId"
   isManagedSidebar={false}
+  mainContainerId={null}
   onPageResize={[Function]}
   sidebar={
     <Unknown
@@ -74,7 +75,9 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
     </Component>
     <main
       className="pf-c-page__main"
+      id={null}
       role="main"
+      tabIndex={-1}
     >
       <Component
         variant="default"
@@ -132,6 +135,7 @@ exports[`Check page to verify breadcrumb is created 1`] = `
   }
   id="PageId"
   isManagedSidebar={false}
+  mainContainerId={null}
   onPageResize={[Function]}
   sidebar={
     <Unknown
@@ -191,7 +195,9 @@ exports[`Check page to verify breadcrumb is created 1`] = `
     </Component>
     <main
       className="pf-c-page__main"
+      id={null}
       role="main"
+      tabIndex={-1}
     >
       <section
         className="pf-c-page__main-breadcrumb"
@@ -276,6 +282,7 @@ exports[`Check page to verify skip to content is created 1`] = `
   }
   id="PageId"
   isManagedSidebar={false}
+  mainContainerId={null}
   onPageResize={[Function]}
   sidebar={
     <Unknown
@@ -357,7 +364,9 @@ exports[`Check page to verify skip to content is created 1`] = `
     </Component>
     <main
       className="pf-c-page__main"
+      id={null}
       role="main"
+      tabIndex={-1}
     >
       <section
         className="pf-c-page__main-breadcrumb"
@@ -518,9 +527,6 @@ exports[`Check page to verify skip to content is created 1`] = `
           </nav>
         </Component>
       </section>
-      <a
-        id="main-content-page-layout-default-nav"
-      />
       <Component
         variant="default"
       >
@@ -577,6 +583,7 @@ exports[`Check page vertical layout example against snapshot 1`] = `
   }
   id="PageId"
   isManagedSidebar={false}
+  mainContainerId={null}
   onPageResize={[Function]}
   sidebar={
     <Unknown
@@ -635,7 +642,9 @@ exports[`Check page vertical layout example against snapshot 1`] = `
     </Component>
     <main
       className="pf-c-page__main"
+      id={null}
       role="main"
+      tabIndex={-1}
     >
       <Component
         variant="default"

--- a/packages/patternfly-4/react-core/src/components/Page/__snapshots__/Page.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Page/__snapshots__/Page.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`Check page horizontal layout example against snapshot 1`] = `
 exports[`Check page to verify breadcrumb is created 1`] = `
 <Page
   aria-label="Page layout"
-  breadcrumb={[Function]}
+  breadcrumb={<PageBreadcrumb />}
   className="my-page-class"
   header={
     <Unknown
@@ -202,7 +202,163 @@ exports[`Check page to verify breadcrumb is created 1`] = `
       <section
         className="pf-c-page__main-breadcrumb"
       >
-        <Component />
+        <PageBreadcrumb>
+          <Component>
+            <nav
+              aria-label="Breadcrumb"
+              className="pf-c-breadcrumb"
+            >
+              <ol
+                className="pf-c-breadcrumb__list"
+              >
+                <Component>
+                  <li
+                    className="pf-c-breadcrumb__item"
+                  >
+                    Section Home
+                    <span
+                      className="pf-c-breadcrumb__item-divider"
+                    >
+                      <AngleRightIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                        title={null}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 256 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            transform=""
+                          />
+                        </svg>
+                      </AngleRightIcon>
+                    </span>
+                  </li>
+                </Component>
+                <Component
+                  to="#"
+                >
+                  <li
+                    className="pf-c-breadcrumb__item"
+                  >
+                    <a
+                      className="pf-c-breadcrumb__link"
+                      href="#"
+                      target={null}
+                    >
+                      Section Title
+                    </a>
+                    <span
+                      className="pf-c-breadcrumb__item-divider"
+                    >
+                      <AngleRightIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                        title={null}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 256 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            transform=""
+                          />
+                        </svg>
+                      </AngleRightIcon>
+                    </span>
+                  </li>
+                </Component>
+                <Component
+                  to="#"
+                >
+                  <li
+                    className="pf-c-breadcrumb__item"
+                  >
+                    <a
+                      className="pf-c-breadcrumb__link"
+                      href="#"
+                      target={null}
+                    >
+                      Section Title
+                    </a>
+                    <span
+                      className="pf-c-breadcrumb__item-divider"
+                    >
+                      <AngleRightIcon
+                        color="currentColor"
+                        noVerticalAlign={false}
+                        size="sm"
+                        title={null}
+                      >
+                        <svg
+                          aria-hidden={true}
+                          aria-labelledby={null}
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          style={
+                            Object {
+                              "verticalAlign": "-0.125em",
+                            }
+                          }
+                          viewBox="0 0 256 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                            transform=""
+                          />
+                        </svg>
+                      </AngleRightIcon>
+                    </span>
+                  </li>
+                </Component>
+                <Component
+                  isActive={true}
+                  to="#"
+                >
+                  <li
+                    className="pf-c-breadcrumb__item"
+                  >
+                    <a
+                      aria-current="page"
+                      className="pf-c-breadcrumb__link pf-m-current"
+                      href="#"
+                      target={null}
+                    >
+                      Section Landing
+                    </a>
+                  </li>
+                </Component>
+              </ol>
+            </nav>
+          </Component>
+        </PageBreadcrumb>
       </section>
       <Component
         variant="default"
@@ -245,7 +401,7 @@ exports[`Check page to verify breadcrumb is created 1`] = `
 </Page>
 `;
 
-exports[`Check page to verify skip to content is created 1`] = `
+exports[`Check page to verify skip to content points to main content region 1`] = `
 <Page
   aria-label="Page layout"
   breadcrumb={
@@ -282,7 +438,7 @@ exports[`Check page to verify skip to content is created 1`] = `
   }
   id="PageId"
   isManagedSidebar={false}
-  mainContainerId={null}
+  mainContainerId="main-content-page-layout-test-nav"
   onPageResize={[Function]}
   sidebar={
     <Unknown
@@ -293,7 +449,7 @@ exports[`Check page to verify skip to content is created 1`] = `
     <SkipToContent
       className=""
       component="a"
-      href="#main-content-page-layout-default-nav"
+      href="#main-content-page-layout-test-nav"
       show={false}
     >
       Skip to Content
@@ -308,12 +464,12 @@ exports[`Check page to verify skip to content is created 1`] = `
     <SkipToContent
       className=""
       component="a"
-      href="#main-content-page-layout-default-nav"
+      href="#main-content-page-layout-test-nav"
       show={false}
     >
       <a
         className="pf-c-button pf-m-primary pf-c-skip-to-content"
-        href="#main-content-page-layout-default-nav"
+        href="#main-content-page-layout-test-nav"
       >
         Skip to Content
       </a>
@@ -364,7 +520,7 @@ exports[`Check page to verify skip to content is created 1`] = `
     </Component>
     <main
       className="pf-c-page__main"
-      id={null}
+      id="main-content-page-layout-test-nav"
       role="main"
       tabIndex={-1}
     >

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.js
@@ -169,8 +169,9 @@ class PageLayoutDefaultNav extends React.Component {
       />
     );
     const Sidebar = <PageSidebar nav={PageNav} />;
+    const pageId = 'main-content-page-layout-default-nav';
     const PageSkipToContent = (
-      <SkipToContent href="#main-content-page-layout-default-nav"> Skip to Content</SkipToContent>
+      <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>
     );
 
     const PageBreadcrumb = (
@@ -192,6 +193,7 @@ class PageLayoutDefaultNav extends React.Component {
           isManagedSidebar
           skipToContent={PageSkipToContent}
           breadcrumb={PageBreadcrumb}
+          mainContainerId={pageId}
         >
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutDefaultNav.js
@@ -170,9 +170,7 @@ class PageLayoutDefaultNav extends React.Component {
     );
     const Sidebar = <PageSidebar nav={PageNav} />;
     const pageId = 'main-content-page-layout-default-nav';
-    const PageSkipToContent = (
-      <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>
-    );
+    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>;
 
     const PageBreadcrumb = (
       <Breadcrumb>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.js
@@ -204,9 +204,7 @@ class PageLayoutExpandableNav extends React.Component {
       </Breadcrumb>
     );
     const pageId = 'main-content-page-layout-expandable-nav';
-    const PageSkipToContent = (
-      <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>
-    );
+    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>;
 
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutExpandableNav.js
@@ -203,8 +203,9 @@ class PageLayoutExpandableNav extends React.Component {
         </BreadcrumbItem>
       </Breadcrumb>
     );
+    const pageId = 'main-content-page-layout-expandable-nav';
     const PageSkipToContent = (
-      <SkipToContent href="#main-content-page-layout-expandable-nav">Skip to Content</SkipToContent>
+      <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>
     );
 
     return (
@@ -215,6 +216,7 @@ class PageLayoutExpandableNav extends React.Component {
           isManagedSidebar
           skipToContent={PageSkipToContent}
           breadcrumb={PageBreadcrumb}
+          mainContainerId={pageId}
         >
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.js
@@ -182,7 +182,13 @@ class PageLayoutGroupsNav extends React.Component {
 
     return (
       <React.Fragment>
-        <Page header={Header} sidebar={Sidebar} isManagedSidebar skipToContent={PageSkipToContent} mainContainerId={pageId}>
+        <Page
+          header={Header}
+          sidebar={Sidebar}
+          isManagedSidebar
+          skipToContent={PageSkipToContent}
+          mainContainerId={pageId}
+        >
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main Title</Text>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutGroupsNav.js
@@ -177,11 +177,12 @@ class PageLayoutGroupsNav extends React.Component {
       />
     );
     const Sidebar = <PageSidebar nav={PageNav} />;
-    const PageSkipToContent = <SkipToContent href="#main-content-page-layout-group-nav">Skip to Content</SkipToContent>;
+    const pageId = 'main-content-page-layout-group-nav';
+    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>;
 
     return (
       <React.Fragment>
-        <Page header={Header} sidebar={Sidebar} isManagedSidebar skipToContent={PageSkipToContent}>
+        <Page header={Header} sidebar={Sidebar} isManagedSidebar skipToContent={PageSkipToContent} mainContainerId={pageId}>
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main Title</Text>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.js
@@ -179,10 +179,8 @@ class PageLayoutHorizontalNav extends React.Component {
         </BreadcrumbItem>
       </Breadcrumb>
     );
-    const pageId = 'main-content-page-layout-horizontal-nav'
-    const PageSkipToContent = (
-      <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>
-    );
+    const pageId = 'main-content-page-layout-horizontal-nav';
+    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>;
 
     return (
       <React.Fragment>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutHorizontalNav.js
@@ -179,14 +179,14 @@ class PageLayoutHorizontalNav extends React.Component {
         </BreadcrumbItem>
       </Breadcrumb>
     );
-
+    const pageId = 'main-content-page-layout-horizontal-nav'
     const PageSkipToContent = (
-      <SkipToContent href="#main-content-page-layout-default-nav">Skip to Content</SkipToContent>
+      <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>
     );
 
     return (
       <React.Fragment>
-        <Page header={Header} skipToContent={PageSkipToContent} breadcrumb={PageBreadcrumb}>
+        <Page header={Header} skipToContent={PageSkipToContent} breadcrumb={PageBreadcrumb} mainContainerId={pageId}>
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main Title</Text>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutManualNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutManualNav.js
@@ -198,13 +198,17 @@ class PageLayoutManualNav extends React.Component {
     );
     const Sidebar = <PageSidebar nav={PageNav} isNavOpen={isMobileView ? isNavOpenMobile : isNavOpenDesktop} />;
     const pageId = 'main-content-page-layout-manual-nav';
-    const PageSkipToContent = (
-      <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>
-    );
+    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>;
 
     return (
       <React.Fragment>
-        <Page header={Header} sidebar={Sidebar} onPageResize={this.onPageResize} skipToContent={PageSkipToContent} mainContainerId={pageId}>
+        <Page
+          header={Header}
+          sidebar={Sidebar}
+          onPageResize={this.onPageResize}
+          skipToContent={PageSkipToContent}
+          mainContainerId={pageId}
+        >
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main Title</Text>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutManualNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutManualNav.js
@@ -197,13 +197,14 @@ class PageLayoutManualNav extends React.Component {
       />
     );
     const Sidebar = <PageSidebar nav={PageNav} isNavOpen={isMobileView ? isNavOpenMobile : isNavOpenDesktop} />;
+    const pageId = 'main-content-page-layout-manual-nav';
     const PageSkipToContent = (
-      <SkipToContent href="#main-content-page-layout-default-nav">Skip to Content</SkipToContent>
+      <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>
     );
 
     return (
       <React.Fragment>
-        <Page header={Header} sidebar={Sidebar} onPageResize={this.onPageResize} skipToContent={PageSkipToContent}>
+        <Page header={Header} sidebar={Sidebar} onPageResize={this.onPageResize} skipToContent={PageSkipToContent} mainContainerId={pageId}>
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main Title</Text>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.js
@@ -167,13 +167,14 @@ class PageLayoutSimpleNav extends React.Component {
       />
     );
     const Sidebar = <PageSidebar nav={PageNav} />;
+    const pageId = 'main-content-page-layout-simple-nav';
     const PageSkipToContent = (
-      <SkipToContent href="#main-content-page-layout-default-nav">Skip to Content</SkipToContent>
+      <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>
     );
 
     return (
       <React.Fragment>
-        <Page header={Header} sidebar={Sidebar} isManagedSidebar skipToContent={PageSkipToContent}>
+        <Page header={Header} sidebar={Sidebar} isManagedSidebar skipToContent={PageSkipToContent} mainContainerId={pageId}>
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main Title</Text>

--- a/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.js
+++ b/packages/patternfly-4/react-core/src/demos/PageLayout/examples/PageLayoutSimpleNav.js
@@ -168,13 +168,17 @@ class PageLayoutSimpleNav extends React.Component {
     );
     const Sidebar = <PageSidebar nav={PageNav} />;
     const pageId = 'main-content-page-layout-simple-nav';
-    const PageSkipToContent = (
-      <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>
-    );
+    const PageSkipToContent = <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>;
 
     return (
       <React.Fragment>
-        <Page header={Header} sidebar={Sidebar} isManagedSidebar skipToContent={PageSkipToContent} mainContainerId={pageId}>
+        <Page
+          header={Header}
+          sidebar={Sidebar}
+          isManagedSidebar
+          skipToContent={PageSkipToContent}
+          mainContainerId={pageId}
+        >
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
               <Text component="h1">Main Title</Text>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/App.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Page, Nav, NavList, NavItem, NavVariants, PageSection } from '@patternfly/react-core';
+import { Page, Nav, NavList, NavItem, NavVariants, PageSection, SkipToContent } from '@patternfly/react-core';
 import { AppHeader, AppSidebar } from './components';
 import { BrowserRouter as Router, Route, Link } from 'react-router-dom';
 import Demos from './Demos';
@@ -46,10 +46,20 @@ class App extends React.Component {
     );
   };
 
+  private pageId = 'ts-demo-app-page-id';
+  private getSkipToContentLink = () => (
+    <SkipToContent href={`#${this.pageId}`}>Skip to Content</SkipToContent>
+  );
+
   render() {
     return (
       <Router>
-        <Page header={<AppHeader />} sidebar={<AppSidebar nav={this.getNav()} />} isManagedSidebar>
+        <Page
+          header={<AppHeader />}
+          sidebar={<AppSidebar nav={this.getNav()} />}
+          skipToContent={this.getSkipToContentLink()}
+          isManagedSidebar
+          mainContainerId={this.pageId}>
           {this.getPages()}
         </Page>
       </Router>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/PageDemo/PageDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/PageDemo/PageDemo.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Page, PageHeader, PageSidebar, PageSection, PageSectionVariants } from '@patternfly/react-core';
+import {
+  Page,
+  PageHeader,
+  PageSidebar,
+  PageSection,
+  PageSectionVariants,
+  SkipToContent
+} from '@patternfly/react-core';
 
 export class PageDemo extends React.Component {
   state = {
@@ -35,10 +42,14 @@ export class PageDemo extends React.Component {
         logoComponent={'div'}
       />
     );
-    const Sidebar = <PageSidebar nav="Navigation" isNavOpen={isNavOpen} />;
+    const pageId = 'page-demo-page-id';
+    const PageSkipToContent = (
+      <SkipToContent href={`#${pageId}`}>Skip to Content</SkipToContent>
+    );
+    const Sidebar = <PageSidebar id="page-demo-sidebar" nav="Navigation" isNavOpen={isNavOpen} />;
 
     return (
-      <Page header={Header} sidebar={Sidebar}>
+      <Page header={Header} sidebar={Sidebar} mainContainerId={pageId} skipToContent={PageSkipToContent}>
         <PageSection variant={PageSectionVariants.darker}>Section with darker background</PageSection>
         <PageSection variant={PageSectionVariants.dark}>Section with dark background</PageSection>
         <PageSection variant={PageSectionVariants.light}>Section with light background</PageSection>


### PR DESCRIPTION
**What**: Currently, skip to content link sends users to an in-page anchor that sits alongside the main page content container. This generally has the desired effect for sighted keyboard users, however, for screen reader users (SRU) this basically leads to a dead end. It's a dead-end in that the target anchor doesn't contain the page content, so nothing further is announced after the element has been focused.

I think what would be better is if we allow the main content container to carry an id, which can be used as the target of the `SkipToContent` component. Doing this along with supplying a `tabindex="-1"` for the main content area gives us a solid hook for informing SRU of general route changes and informing them of what content is now available.

For sighted users, I don't think this will cause any difference in behavior (we may want to add a style like `outline: none` to the primary page container, although I don't recommend this.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: https://github.com/patternfly/patternfly-react/issues/2591

These changes are driven by a technique suggested in https://dequeuniversity.com where in response to dynamic content changes (like navigating to a new "Page" in a SPA) we want to send focus to the new content so that it is announced and SRU receive some feedback about the new content.
