### PR TITLE
fix(react-table): check empty array in areAllRowsSelected

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.js
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.js
@@ -180,8 +180,12 @@ export const TableContext = React.createContext();
 class Table extends React.Component {
   isSelected = row => row.selected === true;
 
-  areAllRowsSelected = rows =>
-    rows.every(row => this.isSelected(row) || (row.hasOwnProperty('parent') && !row.showSelect));
+  areAllRowsSelected = rows => {
+    if (rows === undefined || rows.length === 0) {
+      return false;
+    }
+    return rows.every(row => this.isSelected(row) || (row.hasOwnProperty('parent') && !row.showSelect));
+  };
 
   render() {
     const {


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
If an empty array is passed for `rows` (along with `onSelect` for the "Selectable table" variation), currently the "all rows selection" checkbox in the top left will be set true b/c `rows.every` evaluates true with an empty array.

```
const isSelected = row => row.selected === true; 
let rowsArray = []; 
rowsArray.every(item => isSelected(row));
```
returns `true` when called.

Noted this while testing selection downstream today...

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
