### PR TITLE
feat(Tooltip): Added support for aria prop from Tippy library

### DIFF
--- a/packages/patternfly-4/react-core/src/components/ClipboardCopy/__snapshots__/ClipboardCopyButton.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/ClipboardCopy/__snapshots__/ClipboardCopyButton.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`copy button render 1`] = `
 <Tooltip
   appendTo={[Function]}
+  aria="describedby"
   className=""
   content={
     <div>

--- a/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/Tooltip.tsx
@@ -46,6 +46,8 @@ export interface TooltipProps {
   isAppLauncher?: boolean;
   /** Distance of the tooltip to its target, defaults to 15 */
   distance?: number;
+  /** Aria-labelledby or aria-describedby for tooltip */
+  aria?: 'describedby' | 'labelledby';
 };
 
 export class Tooltip extends React.Component<TooltipProps> {
@@ -61,7 +63,8 @@ export class Tooltip extends React.Component<TooltipProps> {
     zIndex: 9999,
     maxWidth: tooltipMaxWidth && tooltipMaxWidth.value,
     isAppLauncher: false,
-    distance: 15
+    distance: 15,
+    aria: 'describedby'
   };
 
   storeTippyInstance = (tip:TippyInstance) => {
@@ -103,6 +106,7 @@ export class Tooltip extends React.Component<TooltipProps> {
       maxWidth,
       isAppLauncher,
       distance,
+      aria,
       ...rest
     } = this.props;
     const content = (
@@ -117,6 +121,7 @@ export class Tooltip extends React.Component<TooltipProps> {
     );
     return (
       <PopoverBase
+        aria={aria}
         onCreate={this.storeTippyInstance}
         maxWidth={maxWidth}
         zIndex={zIndex}

--- a/packages/patternfly-4/react-core/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`tooltip renders 1`] = `
 <PopoverBase
   animateFill={false}
   appendTo={[Function]}
+  aria="describedby"
   content={
     <div
       className="pf-c-tooltip"

--- a/packages/patternfly-4/react-topology/src/components/TopologyControlBar/__snapshots__/TopologyControlBar.test.tsx.snap
+++ b/packages/patternfly-4/react-topology/src/components/TopologyControlBar/__snapshots__/TopologyControlBar.test.tsx.snap
@@ -159,6 +159,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
             >
               <Tooltip
                 appendTo={[Function]}
+                aria="describedby"
                 className=""
                 content="test zoom in tooltip"
                 distance={15}
@@ -174,6 +175,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                 <PopoverBase
                   animateFill={false}
                   appendTo={[Function]}
+                  aria="describedby"
                   content={
                     <div
                       className="pf-c-tooltip"
@@ -291,6 +293,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
             >
               <Tooltip
                 appendTo={[Function]}
+                aria="describedby"
                 className=""
                 content="Zoom Out"
                 distance={15}
@@ -306,6 +309,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                 <PopoverBase
                   animateFill={false}
                   appendTo={[Function]}
+                  aria="describedby"
                   content={
                     <div
                       className="pf-c-tooltip"
@@ -446,6 +450,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
             >
               <Tooltip
                 appendTo={[Function]}
+                aria="describedby"
                 className=""
                 content="Reset View"
                 distance={15}
@@ -461,6 +466,7 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
                 <PopoverBase
                   animateFill={false}
                   appendTo={[Function]}
+                  aria="describedby"
                   content={
                     <div
                       className="pf-c-tooltip"
@@ -810,6 +816,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
             >
               <Tooltip
                 appendTo={[Function]}
+                aria="describedby"
                 className=""
                 content="Zoom In"
                 distance={15}
@@ -825,6 +832,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                 <PopoverBase
                   animateFill={false}
                   appendTo={[Function]}
+                  aria="describedby"
                   content={
                     <div
                       className="pf-c-tooltip"
@@ -965,6 +973,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
             >
               <Tooltip
                 appendTo={[Function]}
+                aria="describedby"
                 className=""
                 content="Zoom Out"
                 distance={15}
@@ -980,6 +989,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                 <PopoverBase
                   animateFill={false}
                   appendTo={[Function]}
+                  aria="describedby"
                   content={
                     <div
                       className="pf-c-tooltip"
@@ -1120,6 +1130,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
             >
               <Tooltip
                 appendTo={[Function]}
+                aria="describedby"
                 className=""
                 content="Fit to Screen"
                 distance={15}
@@ -1135,6 +1146,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                 <PopoverBase
                   animateFill={false}
                   appendTo={[Function]}
+                  aria="describedby"
                   content={
                     <div
                       className="pf-c-tooltip"
@@ -1275,6 +1287,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
             >
               <Tooltip
                 appendTo={[Function]}
+                aria="describedby"
                 className=""
                 content="Reset View"
                 distance={15}
@@ -1290,6 +1303,7 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
                 <PopoverBase
                   animateFill={false}
                   appendTo={[Function]}
+                  aria="describedby"
                   content={
                     <div
                       className="pf-c-tooltip"


### PR DESCRIPTION
Added aria prop for aria-describedby or aria-labelledby support from the Tippy library. Default is library default.

Fixes #1458.