### PR TITLE
Blue_300 & Purple_300 are too similar reordering for more contrast

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/multi-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/dark/multi-color-theme.ts
@@ -41,14 +41,14 @@ import { ColorTheme } from '../color-theme';
 // The color order below improves the color contrast in unordered charts
 // See https://github.com/patternfly/patternfly-next/issues/1551
 const COLOR_SCALE = [
-  chart_color_blue_300.value,
+  chart_color_blue_100.value,
   chart_color_gold_300.value,
   chart_color_green_300.value,
   chart_color_purple_300.value,
   chart_color_orange_300.value,
   chart_color_cyan_300.value,
   chart_color_black_300.value,
-  chart_color_blue_100.value,
+  chart_color_blue_300.value,
   chart_color_gold_500.value,
   chart_color_green_100.value,
   chart_color_purple_500.value,

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/multi-color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/light/multi-color-theme.ts
@@ -41,14 +41,14 @@ import { ColorTheme } from '../color-theme';
 // The color order below improves the color contrast in unordered charts
 // See https://github.com/patternfly/patternfly-next/issues/1551
 const COLOR_SCALE = [
-  chart_color_blue_300.value,
+  chart_color_blue_100.value,
   chart_color_gold_300.value,
   chart_color_green_300.value,
   chart_color_purple_300.value,
   chart_color_orange_300.value,
   chart_color_cyan_300.value,
   chart_color_black_300.value,
-  chart_color_blue_100.value,
+  chart_color_blue_300.value,
   chart_color_gold_500.value,
   chart_color_green_100.value,
   chart_color_purple_500.value,


### PR DESCRIPTION
**What**:
Blue_300 & Purple_300 are too similar for a 4 item donut reordering for additional contrast

now we'd need an 8 item donut before this issue arises again 😏 
## Looks like (now)
<img width="417" alt="Screen Shot 2019-07-18 at 4 25 38 PM" src="https://user-images.githubusercontent.com/6640236/61489476-cd79ec00-a978-11e9-94fc-bc90105d8a34.png">

## Looked like (then)
<img width="676" alt="Screen Shot 2019-07-18 at 2 18 11 PM" src="https://user-images.githubusercontent.com/6640236/61489477-cd79ec00-a978-11e9-8d88-a59303ae5787.png">

### what it might look like with eight 😱 
<img width="243" alt="Screen Shot 2019-07-18 at 4 28 26 PM" src="https://user-images.githubusercontent.com/6640236/61489631-247fc100-a979-11e9-8c06-9c720e789719.png">
