### PR TITLE
docs(Badge): add space between badges in the examples

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Badge/Badge.md
+++ b/packages/patternfly-4/react-core/src/components/Badge/Badge.md
@@ -14,8 +14,11 @@ import { Badge } from '@patternfly/react-core';
 ReadBadge = () => (
   <React.Fragment>
     <Badge isRead>7</Badge>
+    {' '}
     <Badge isRead>24</Badge>
+    {' '}
     <Badge isRead>240</Badge>
+    {' '}
     <Badge isRead>999+</Badge>
   </React.Fragment>
 );
@@ -29,8 +32,11 @@ import { Badge } from '@patternfly/react-core';
 UnreadBadge = () => (
   <React.Fragment>
     <Badge>7</Badge>
+    {' '}
     <Badge>24</Badge>
+    {' '}
     <Badge>240</Badge>
+    {' '}
     <Badge>999+</Badge>
   </React.Fragment>
 );


### PR DESCRIPTION
**What**:

closes #2520 

Add a space between two badges at the Badge example in the documents to match it to the PF4 core documents.

//cc @jschuler 