### PR TITLE
fix(docs): make name column not wrap

### DIFF
--- a/packages/patternfly-4/react-docs/src/components/componentDocs/propsTable.js
+++ b/packages/patternfly-4/react-docs/src/components/componentDocs/propsTable.js
@@ -37,7 +37,7 @@ export const PropsTable = ({ caption, propList }) => (
       {propList &&
         propList.map(prop => (
           <tr key={prop.name}>
-            <td>{prop.name}</td>
+            <td className="pf-m-fit-content">{prop.name}</td>
             <td>{renderType(prop)}</td>
             <td className="pf-c-table__icon">{prop.required && <ExclamationCircleIcon />}</td>
             <td>{prop.defaultValue && prop.defaultValue.value}</td>


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Not wrapping the `type` column looks rather ugly and doesn't resize well @dlabrecq , so I hope you can settle for just not wrapping the name.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: Fixes #2503 

<!-- feel free to add additional comments -->
