### PR TITLE
fix(chart): ensure dynamic chart size is never less than zero

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -551,12 +551,14 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
             childProps.themeVariant || themeVariant);
         const legendPos = childProps.legendPosition || legendPosition;
         const subTitlePos = childProps.subTitlePosition || subTitlePosition;
+        const donutSizeDiff = theme.pie.height - dynamicTheme.pie.height; // static - dynamic chart heights
+        const childDountSize = donutSize > donutSizeDiff ? donutSize - donutSizeDiff : 0; // not visible < 50px
         return React.cloneElement(child, {
           data: childData,
           donutDx: getDonutDx(dynamicTheme, legendPos),
           donutDy: getDonutDy(dynamicTheme),
-          donutHeight: donutSize - (theme.pie.height - dynamicTheme.pie.height),
-          donutWidth: donutSize - (theme.pie.width - dynamicTheme.pie.width),
+          donutHeight: childDountSize,
+          donutWidth: childDountSize,
           endAngle: 360 * (datum[0]._y ? datum[0]._y / 100 : 0),
           height,
           invert,


### PR DESCRIPTION
The donut threshold chart generates a 'width must be a non-negative' warning when `donutWidth` values are zero.

This change ensures the dynamic chart size is never less than zero.

Fixes https://github.com/patternfly/patternfly-react/issues/2587
