### PR TITLE
feat(Select): adds direction prop to Select

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Select/Select.md
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.md
@@ -5,7 +5,7 @@ propComponents: ['Select', 'SelectOption', 'SelectGroup']
 typescript: true
 ---
 
-import { Select, SelectOption, SelectVariant, SelectGroup, Checkbox } from '@patternfly/react-core';
+import { Select, SelectOption, SelectVariant, SelectGroup, SelectDirection, Checkbox } from '@patternfly/react-core';
 
 ## Single select input
 
@@ -29,7 +29,8 @@ class SingleSelectInput extends React.Component {
     this.state = {
       isExpanded: false,
       selected: null,
-      isDisabled: false
+      isDisabled: false,
+      direction: 'down'
     };
 
     this.onToggle = isExpanded => {
@@ -61,10 +62,22 @@ class SingleSelectInput extends React.Component {
         isDisabled: checked
       })
     }
+
+    this.toggleDirection = () => {
+      if(this.state.direction === 'up') {
+        this.setState({
+          direction: SelectDirection.down
+        });
+      } else {
+        this.setState({
+          direction: SelectDirection.up
+        })
+      }
+    }
   }
 
   render() {
-    const { isExpanded, selected, isDisabled } = this.state;
+    const { isExpanded, selected, isDisabled, direction } = this.state;
     const titleId = 'title-id';
     return (
       <div>
@@ -80,6 +93,7 @@ class SingleSelectInput extends React.Component {
           isExpanded={isExpanded}
           ariaLabelledBy={titleId}
           isDisabled={isDisabled}
+          direction={direction}
         >
           {this.options.map((option, index) => (
             <SelectOption
@@ -97,6 +111,14 @@ class SingleSelectInput extends React.Component {
           aria-label="disabled checkbox"
           id="toggle-disabled"
           name="toggle-disabled"
+        />
+        <Checkbox
+          label="Expands up"
+          isChecked={direction === 'up'}
+          onChange={this.toggleDirection}
+          aria-label="direction checkbox"
+          id="toggle-direction"
+          name="toggle-direction"
         />
       </div>
     );

--- a/packages/patternfly-4/react-core/src/components/Select/Select.md
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.md
@@ -30,7 +30,7 @@ class SingleSelectInput extends React.Component {
       isExpanded: false,
       selected: null,
       isDisabled: false,
-      direction: 'down'
+      direction: SelectDirection.down
     };
 
     this.onToggle = isExpanded => {
@@ -64,7 +64,7 @@ class SingleSelectInput extends React.Component {
     }
 
     this.toggleDirection = () => {
-      if(this.state.direction === 'up') {
+      if(this.state.direction === SelectDirection.up) {
         this.setState({
           direction: SelectDirection.down
         });
@@ -114,7 +114,7 @@ class SingleSelectInput extends React.Component {
         />
         <Checkbox
           label="Expands up"
-          isChecked={direction === 'up'}
+          isChecked={direction === SelectDirection.up}
           onChange={this.toggleDirection}
           aria-label="direction checkbox"
           id="toggle-direction"

--- a/packages/patternfly-4/react-core/src/components/Select/Select.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.test.tsx
@@ -5,7 +5,7 @@ import { SelectOption, SelectOptionObject } from './SelectOption';
 import { CheckboxSelectOption } from './CheckboxSelectOption';
 import { SelectGroup } from './SelectGroup';
 import { CheckboxSelectGroup } from './CheckboxSelectGroup';
-import { SelectVariant } from './selectConstants';
+import { SelectVariant, SelectDirection } from './selectConstants';
 
 class User implements SelectOptionObject {
   private firstName: string;
@@ -77,6 +77,15 @@ describe('select', () => {
       );
       expect(view).toMatchSnapshot();
     });
+  });
+
+  test('renders up drection successfully', () => {
+    const view = mount(
+      <Select variant={SelectVariant.single} direction={SelectDirection.up} onSelect={jest.fn()} onToggle={jest.fn()}>
+        {selectOptions}
+      </Select>
+    );
+    expect(view).toMatchSnapshot();
   });
 
   describe('custom select filter', () => {

--- a/packages/patternfly-4/react-core/src/components/Select/Select.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.tsx
@@ -22,7 +22,7 @@ export interface SelectProps
   children: React.ReactElement[];
   /** Classes applied to the root of the Select */
   className?: string;
-  /** Flaf specifying which direction the Select menu expands */
+  /** Flag specifying which direction the Select menu expands */
   direction?: 'up' | 'down';
   /** Flag to indicate if select is expanded */
   isExpanded?: boolean;

--- a/packages/patternfly-4/react-core/src/components/Select/Select.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.tsx
@@ -8,7 +8,7 @@ import { TimesCircleIcon } from '@patternfly/react-icons';
 import { SelectMenu } from './SelectMenu';
 import { SelectOption, SelectOptionObject } from './SelectOption';
 import { SelectToggle } from './SelectToggle';
-import { SelectContext, SelectVariant } from './selectConstants';
+import { SelectContext, SelectVariant, SelectDirection } from './selectConstants';
 import { Chip, ChipGroup } from '../ChipGroup';
 import { keyHandler, getNextIndex } from '../../helpers/util';
 import { Omit } from '../../helpers/typeUtils';
@@ -22,6 +22,8 @@ export interface SelectProps
   children: React.ReactElement[];
   /** Classes applied to the root of the Select */
   className?: string;
+  /** Flaf specifying which direction the Select menu expands */
+  direction?: 'up' | 'down';
   /** Flag to indicate if select is expanded */
   isExpanded?: boolean;
   /** Flag to indicate if select options are grouped */
@@ -77,6 +79,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
   static defaultProps = {
     children: [] as React.ReactElement[],
     className: '',
+    direction: SelectDirection.down,
     toggleId: null as string,
     isExpanded: false,
     isGrouped: false,
@@ -271,6 +274,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
       children,
       className,
       variant,
+      direction,
       onToggle,
       onSelect,
       onClear,
@@ -315,7 +319,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
     }
     return (
       <div
-        className={css(styles.select, isExpanded && styles.modifiers.expanded, className)}
+        className={css(styles.select, isExpanded && styles.modifiers.expanded, direction === SelectDirection.up && styles.modifiers.top, className)}
         ref={this.parentRef}
         style={{ width }}
       >

--- a/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`checkbox select renders checkbox select groups successfully - old class
   ariaLabelledBy=""
   className=""
   direction="down"
+  isDisabled={false}
   isExpanded={true}
   isGrouped={true}
   isPlain={false}
@@ -32,10 +33,10 @@ exports[`checkbox select renders checkbox select groups successfully - old class
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-11"
+      ariaLabelledBy=" pf-toggle-id-14"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-11"
+      id="pf-toggle-id-14"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -52,9 +53,9 @@ exports[`checkbox select renders checkbox select groups successfully - old class
           >
             <button
               aria-expanded="true"
-              aria-labelledby=" pf-toggle-id-11"
+              aria-labelledby=" pf-toggle-id-14"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-11"
+              id="pf-toggle-id-14"
               type="button"
             >
               <div
@@ -249,16 +250,10 @@ exports[`checkbox select renders checkbox select groups successfully - old class
       <button
         aria-expanded={true}
         aria-haspopup={null}
-<<<<<<< HEAD
-        aria-labelledby=" pf-toggle-id-13"
+        aria-labelledby=" pf-toggle-id-14"
         className="pf-c-select__toggle"
         disabled={false}
-        id="pf-toggle-id-13"
-=======
-        aria-labelledby=" pf-toggle-id-11"
-        className="pf-c-select__toggle"
-        id="pf-toggle-id-11"
->>>>>>> feat(Select): adds direction prop to Select
+        id="pf-toggle-id-14"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -637,11 +632,8 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={true}
   isGrouped={true}
   isPlain={false}
@@ -664,17 +656,10 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-12"
+      ariaLabelledBy=" pf-toggle-id-13"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-12"
-=======
-      ariaLabelledBy=" pf-toggle-id-10"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-10"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-13"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -691,15 +676,9 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
           >
             <button
               aria-expanded="true"
-<<<<<<< HEAD
-              aria-labelledby=" pf-toggle-id-12"
+              aria-labelledby=" pf-toggle-id-13"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-12"
-=======
-              aria-labelledby=" pf-toggle-id-10"
-              class="pf-c-select__toggle"
-              id="pf-toggle-id-10"
->>>>>>> feat(Select): adds direction prop to Select
+              id="pf-toggle-id-13"
               type="button"
             >
               <div
@@ -894,16 +873,10 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
       <button
         aria-expanded={true}
         aria-haspopup={null}
-<<<<<<< HEAD
-        aria-labelledby=" pf-toggle-id-12"
+        aria-labelledby=" pf-toggle-id-13"
         className="pf-c-select__toggle"
         disabled={false}
-        id="pf-toggle-id-12"
-=======
-        aria-labelledby=" pf-toggle-id-10"
-        className="pf-c-select__toggle"
-        id="pf-toggle-id-10"
->>>>>>> feat(Select): adds direction prop to Select
+        id="pf-toggle-id-13"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -1306,11 +1279,8 @@ exports[`checkbox select renders closed successfully - old classes 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={false}
   isGrouped={false}
   isPlain={false}
@@ -1333,17 +1303,10 @@ exports[`checkbox select renders closed successfully - old classes 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-8"
+      ariaLabelledBy=" pf-toggle-id-9"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-8"
-=======
-      ariaLabelledBy=" pf-toggle-id-7"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-7"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-9"
       isActive={false}
       isDisabled={false}
       isExpanded={false}
@@ -1360,15 +1323,9 @@ exports[`checkbox select renders closed successfully - old classes 1`] = `
           >
             <button
               aria-expanded="false"
-<<<<<<< HEAD
-              aria-labelledby=" pf-toggle-id-8"
+              aria-labelledby=" pf-toggle-id-9"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-8"
-=======
-              aria-labelledby=" pf-toggle-id-7"
-              class="pf-c-select__toggle"
-              id="pf-toggle-id-7"
->>>>>>> feat(Select): adds direction prop to Select
+              id="pf-toggle-id-9"
               type="button"
             >
               <div
@@ -1404,16 +1361,10 @@ exports[`checkbox select renders closed successfully - old classes 1`] = `
       <button
         aria-expanded={false}
         aria-haspopup={null}
-<<<<<<< HEAD
-        aria-labelledby=" pf-toggle-id-8"
+        aria-labelledby=" pf-toggle-id-9"
         className="pf-c-select__toggle"
         disabled={false}
-        id="pf-toggle-id-8"
-=======
-        aria-labelledby=" pf-toggle-id-7"
-        className="pf-c-select__toggle"
-        id="pf-toggle-id-7"
->>>>>>> feat(Select): adds direction prop to Select
+        id="pf-toggle-id-9"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -1468,11 +1419,8 @@ exports[`checkbox select renders closed successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={false}
   isGrouped={false}
   isPlain={false}
@@ -1495,17 +1443,10 @@ exports[`checkbox select renders closed successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-7"
+      ariaLabelledBy=" pf-toggle-id-8"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-7"
-=======
-      ariaLabelledBy=" pf-toggle-id-6"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-6"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-8"
       isActive={false}
       isDisabled={false}
       isExpanded={false}
@@ -1522,15 +1463,9 @@ exports[`checkbox select renders closed successfully 1`] = `
           >
             <button
               aria-expanded="false"
-<<<<<<< HEAD
-              aria-labelledby=" pf-toggle-id-7"
+              aria-labelledby=" pf-toggle-id-8"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-7"
-=======
-              aria-labelledby=" pf-toggle-id-6"
-              class="pf-c-select__toggle"
-              id="pf-toggle-id-6"
->>>>>>> feat(Select): adds direction prop to Select
+              id="pf-toggle-id-8"
               type="button"
             >
               <div
@@ -1566,16 +1501,10 @@ exports[`checkbox select renders closed successfully 1`] = `
       <button
         aria-expanded={false}
         aria-haspopup={null}
-<<<<<<< HEAD
-        aria-labelledby=" pf-toggle-id-7"
+        aria-labelledby=" pf-toggle-id-8"
         className="pf-c-select__toggle"
         disabled={false}
-        id="pf-toggle-id-7"
-=======
-        aria-labelledby=" pf-toggle-id-6"
-        className="pf-c-select__toggle"
-        id="pf-toggle-id-6"
->>>>>>> feat(Select): adds direction prop to Select
+        id="pf-toggle-id-8"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -1630,11 +1559,8 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -1657,17 +1583,10 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-10"
+      ariaLabelledBy=" pf-toggle-id-11"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-10"
-=======
-      ariaLabelledBy=" pf-toggle-id-9"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-9"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-11"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -1684,15 +1603,9 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
           >
             <button
               aria-expanded="true"
-<<<<<<< HEAD
-              aria-labelledby=" pf-toggle-id-10"
+              aria-labelledby=" pf-toggle-id-11"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-10"
-=======
-              aria-labelledby=" pf-toggle-id-9"
-              class="pf-c-select__toggle"
-              id="pf-toggle-id-9"
->>>>>>> feat(Select): adds direction prop to Select
+              id="pf-toggle-id-11"
               type="button"
             >
               <div
@@ -1804,16 +1717,10 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
       <button
         aria-expanded={true}
         aria-haspopup={null}
-<<<<<<< HEAD
-        aria-labelledby=" pf-toggle-id-10"
+        aria-labelledby=" pf-toggle-id-11"
         className="pf-c-select__toggle"
         disabled={false}
-        id="pf-toggle-id-10"
-=======
-        aria-labelledby=" pf-toggle-id-9"
-        className="pf-c-select__toggle"
-        id="pf-toggle-id-9"
->>>>>>> feat(Select): adds direction prop to Select
+        id="pf-toggle-id-11"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -2034,11 +1941,8 @@ exports[`checkbox select renders expanded successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -2061,17 +1965,10 @@ exports[`checkbox select renders expanded successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-9"
+      ariaLabelledBy=" pf-toggle-id-10"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-9"
-=======
-      ariaLabelledBy=" pf-toggle-id-8"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-8"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-10"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -2088,15 +1985,9 @@ exports[`checkbox select renders expanded successfully 1`] = `
           >
             <button
               aria-expanded="true"
-<<<<<<< HEAD
-              aria-labelledby=" pf-toggle-id-9"
+              aria-labelledby=" pf-toggle-id-10"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-9"
-=======
-              aria-labelledby=" pf-toggle-id-8"
-              class="pf-c-select__toggle"
-              id="pf-toggle-id-8"
->>>>>>> feat(Select): adds direction prop to Select
+              id="pf-toggle-id-10"
               type="button"
             >
               <div
@@ -2208,16 +2099,10 @@ exports[`checkbox select renders expanded successfully 1`] = `
       <button
         aria-expanded={true}
         aria-haspopup={null}
-<<<<<<< HEAD
-        aria-labelledby=" pf-toggle-id-9"
+        aria-labelledby=" pf-toggle-id-10"
         className="pf-c-select__toggle"
         disabled={false}
-        id="pf-toggle-id-9"
-=======
-        aria-labelledby=" pf-toggle-id-8"
-        className="pf-c-select__toggle"
-        id="pf-toggle-id-8"
->>>>>>> feat(Select): adds direction prop to Select
+        id="pf-toggle-id-10"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -2450,11 +2335,8 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -2477,17 +2359,10 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-11"
+      ariaLabelledBy=" pf-toggle-id-12"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-11"
-=======
-      ariaLabelledBy=" pf-toggle-id-4"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-4"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-12"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -2504,9 +2379,9 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
           >
             <button
               aria-expanded="true"
-              aria-labelledby=" pf-toggle-id-11"
+              aria-labelledby=" pf-toggle-id-12"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-11"
+              id="pf-toggle-id-12"
               type="button"
             >
               <div
@@ -2517,7 +2392,6 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
                 />
                 
               </div>
-<<<<<<< HEAD
               <svg
                 aria-hidden="true"
                 class="pf-c-select__toggle-arrow"
@@ -2527,53 +2401,6 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
                 style="vertical-align: -0.125em;"
                 viewBox="0 0 320 512"
                 width="1em"
-=======
-              
-              <button
-                aria-expanded="true"
-                aria-haspopup="listbox"
-                aria-label="Options menu"
-                aria-labelledby=" pf-toggle-id-4"
-                class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-4"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-c-select__toggle-arrow"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  style="vertical-align: -0.125em;"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                    transform=""
-                  />
-                </svg>
-              </button>
-            </div>
-            <ul
-              aria-label=""
-              aria-labelledby=""
-              class="pf-c-select__menu"
-              role="listbox"
-            >
-              <li
-                role="presentation"
-              >
-                <button
-                  class="pf-c-select__menu-item"
-                  id="Mr-0"
-                  role="option"
-                >
-                  Mr
-                </button>
-              </li>
-              <li
-                role="presentation"
->>>>>>> feat(Select): adds direction prop to Select
               >
                 <path
                   d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
@@ -2652,10 +2479,10 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
       <button
         aria-expanded={true}
         aria-haspopup={null}
-        aria-labelledby=" pf-toggle-id-11"
+        aria-labelledby=" pf-toggle-id-12"
         className="pf-c-select__toggle"
         disabled={false}
-        id="pf-toggle-id-11"
+        id="pf-toggle-id-12"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -2667,23 +2494,12 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
             className="pf-c-select__toggle-text"
           />
         </div>
-<<<<<<< HEAD
         <CaretDownIcon
           className="pf-c-select__toggle-arrow"
           color="currentColor"
           noVerticalAlign={false}
           size="sm"
           title={null}
-=======
-        <button
-          aria-expanded={true}
-          aria-haspopup="listbox"
-          aria-label="Options menu"
-          aria-labelledby=" pf-toggle-id-4"
-          className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-4"
-          onClick={[Function]}
->>>>>>> feat(Select): adds direction prop to Select
         >
           <svg
             aria-hidden={true}
@@ -2731,7 +2547,6 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
         paused={false}
         tag="div"
       >
-<<<<<<< HEAD
         <div>
           <div
             className="pf-c-select__menu"
@@ -2739,188 +2554,6 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
             <form
               className="pf-c-form"
               noValidate={true}
-=======
-        <SelectOption
-          className=""
-          id="Mr-0"
-          index={0}
-          isChecked={false}
-          isDisabled={false}
-          isFocused={null}
-          isPlaceholder={false}
-          isSelected={false}
-          key=".$0"
-          keyHandler={[Function]}
-          onClick={[Function]}
-          sendRef={[Function]}
-          value="Mr"
-        >
-          <li
-            role="presentation"
-          >
-            <button
-              aria-selected={null}
-              className="pf-c-select__menu-item"
-              id="Mr-0"
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              role="option"
-            >
-              Mr
-            </button>
-          </li>
-        </SelectOption>
-        <SelectOption
-          className=""
-          id="Mrs-1"
-          index={1}
-          isChecked={false}
-          isDisabled={false}
-          isFocused={null}
-          isPlaceholder={false}
-          isSelected={false}
-          key=".$1"
-          keyHandler={[Function]}
-          onClick={[Function]}
-          sendRef={[Function]}
-          value="Mrs"
-        >
-          <li
-            role="presentation"
-          >
-            <button
-              aria-selected={null}
-              className="pf-c-select__menu-item"
-              id="Mrs-1"
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              role="option"
-            >
-              Mrs
-            </button>
-          </li>
-        </SelectOption>
-        <SelectOption
-          className=""
-          id="Other-2"
-          index={2}
-          isChecked={false}
-          isDisabled={false}
-          isFocused={null}
-          isPlaceholder={false}
-          isSelected={false}
-          key=".$3"
-          keyHandler={[Function]}
-          onClick={[Function]}
-          sendRef={[Function]}
-          value="Other"
-        >
-          <li
-            role="presentation"
-          >
-            <button
-              aria-selected={null}
-              className="pf-c-select__menu-item"
-              id="Other-2"
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              role="option"
-            >
-              Other
-            </button>
-          </li>
-        </SelectOption>
-      </ul>
-    </SelectMenu>
-  </div>
-</Select>
-`;
-
-exports[`select renders select groups successfully 1`] = `
-<Select
-  aria-label=""
-  ariaLabelClear="Clear all"
-  ariaLabelRemove="Remove"
-  ariaLabelToggle="Options menu"
-  ariaLabelTypeAhead=""
-  ariaLabelledBy=""
-  className=""
-  direction="down"
-  isExpanded={true}
-  isGrouped={true}
-  onClear={[Function]}
-  onSelect={[MockFunction]}
-  onToggle={[MockFunction]}
-  placeholderText=""
-  selections=""
-  toggleId={null}
-  variant="single"
-  width=""
->
-  <div
-    className="pf-c-select pf-m-expanded"
-    style={
-      Object {
-        "width": "",
-      }
-    }
-  >
-    <SelectToggle
-      ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-5"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-5"
-      isActive={false}
-      isExpanded={true}
-      isFocused={false}
-      isHovered={false}
-      isPlain={false}
-      onClose={[Function]}
-      onEnter={[Function]}
-      onToggle={[MockFunction]}
-      parentRef={
-        Object {
-          "current": <div
-            class="pf-c-select pf-m-expanded"
-          >
-            <button
-              aria-expanded="true"
-              aria-haspopup="listbox"
-              aria-labelledby=" pf-toggle-id-5"
-              class="pf-c-select__toggle"
-              id="pf-toggle-id-5"
-              type="button"
-            >
-              <div
-                class="pf-c-select__toggle-wrapper"
-              >
-                <span
-                  class="pf-c-select__toggle-text"
-                />
-              </div>
-              <svg
-                aria-hidden="true"
-                class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
-              >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
-            </button>
-            <ul
-              aria-label=""
-              aria-labelledby=""
-              class="pf-c-select__menu"
-              role="listbox"
->>>>>>> feat(Select): adds direction prop to Select
             >
               <div
                 className="pf-c-form__group"
@@ -3070,6 +2703,7 @@ exports[`select custom select filter filters properly 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+  direction="down"
   isDisabled={false}
   isExpanded={true}
   isGrouped={false}
@@ -3094,10 +2728,10 @@ exports[`select custom select filter filters properly 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-5"
+      ariaLabelledBy=" pf-toggle-id-6"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-5"
+      id="pf-toggle-id-6"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -3133,9 +2767,9 @@ exports[`select custom select filter filters properly 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-                aria-labelledby=" pf-toggle-id-5"
+                aria-labelledby=" pf-toggle-id-6"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-5"
+                id="pf-toggle-id-6"
               >
                 <svg
                   aria-hidden="true"
@@ -3229,10 +2863,10 @@ exports[`select custom select filter filters properly 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-          aria-labelledby=" pf-toggle-id-5"
+          aria-labelledby=" pf-toggle-id-6"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
-          id="pf-toggle-id-5"
+          id="pf-toggle-id-6"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -3391,6 +3025,7 @@ exports[`select renders select groups successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+  direction="down"
   isDisabled={false}
   isExpanded={true}
   isGrouped={true}
@@ -3414,10 +3049,10 @@ exports[`select renders select groups successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-6"
+      ariaLabelledBy=" pf-toggle-id-7"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-6"
+      id="pf-toggle-id-7"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -3435,9 +3070,9 @@ exports[`select renders select groups successfully 1`] = `
             <button
               aria-expanded="true"
               aria-haspopup="listbox"
-              aria-labelledby=" pf-toggle-id-6"
+              aria-labelledby=" pf-toggle-id-7"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-6"
+              id="pf-toggle-id-7"
               type="button"
             >
               <div
@@ -3593,16 +3228,10 @@ exports[`select renders select groups successfully 1`] = `
       <button
         aria-expanded={true}
         aria-haspopup="listbox"
-<<<<<<< HEAD
-        aria-labelledby=" pf-toggle-id-6"
+        aria-labelledby=" pf-toggle-id-7"
         className="pf-c-select__toggle"
         disabled={false}
-        id="pf-toggle-id-6"
-=======
-        aria-labelledby=" pf-toggle-id-5"
-        className="pf-c-select__toggle"
-        id="pf-toggle-id-5"
->>>>>>> feat(Select): adds direction prop to Select
+        id="pf-toggle-id-7"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -3951,6 +3580,150 @@ exports[`select renders select groups successfully 1`] = `
 </Select>
 `;
 
+exports[`select renders up drection successfully 1`] = `
+<Select
+  aria-label=""
+  ariaLabelClear="Clear all"
+  ariaLabelRemove="Remove"
+  ariaLabelToggle="Options menu"
+  ariaLabelTypeAhead=""
+  ariaLabelledBy=""
+  className=""
+  direction="up"
+  isDisabled={false}
+  isExpanded={false}
+  isGrouped={false}
+  isPlain={false}
+  onClear={[Function]}
+  onSelect={[MockFunction]}
+  onToggle={[MockFunction]}
+  placeholderText=""
+  selections=""
+  toggleId={null}
+  variant="single"
+  width=""
+>
+  <div
+    className="pf-c-select pf-m-top"
+    style={
+      Object {
+        "width": "",
+      }
+    }
+  >
+    <SelectToggle
+      ariaLabelToggle="Options menu"
+      ariaLabelledBy=" pf-toggle-id-4"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-4"
+      isActive={false}
+      isDisabled={false}
+      isExpanded={false}
+      isFocused={false}
+      isHovered={false}
+      isPlain={false}
+      onClose={[Function]}
+      onEnter={[Function]}
+      onToggle={[MockFunction]}
+      parentRef={
+        Object {
+          "current": <div
+            class="pf-c-select pf-m-top"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby=" pf-toggle-id-4"
+              class="pf-c-select__toggle"
+              id="pf-toggle-id-4"
+              type="button"
+            >
+              <div
+                class="pf-c-select__toggle-wrapper"
+              >
+                <span
+                  class="pf-c-select__toggle-text"
+                >
+                  Mr
+                </span>
+              </div>
+              <svg
+                aria-hidden="true"
+                class="pf-c-select__toggle-arrow"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  transform=""
+                />
+              </svg>
+            </button>
+          </div>,
+        }
+      }
+      type="button"
+      variant="single"
+    >
+      <button
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        aria-labelledby=" pf-toggle-id-4"
+        className="pf-c-select__toggle"
+        disabled={false}
+        id="pf-toggle-id-4"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        type="button"
+      >
+        <div
+          className="pf-c-select__toggle-wrapper"
+        >
+          <span
+            className="pf-c-select__toggle-text"
+          >
+            Mr
+          </span>
+        </div>
+        <CaretDownIcon
+          className="pf-c-select__toggle-arrow"
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+          title={null}
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="pf-c-select__toggle-arrow"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </CaretDownIcon>
+      </button>
+    </SelectToggle>
+  </div>
+</Select>
+`;
+
 exports[`select single select renders closed successfully 1`] = `
 <Select
   aria-label=""
@@ -3960,6 +3733,7 @@ exports[`select single select renders closed successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+  direction="down"
   isDisabled={false}
   isExpanded={false}
   isGrouped={false}
@@ -4103,6 +3877,7 @@ exports[`select single select renders disabled successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+  direction="down"
   isDisabled={true}
   isExpanded={false}
   isGrouped={false}
@@ -4247,6 +4022,7 @@ exports[`select single select renders expanded successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+  direction="down"
   isDisabled={false}
   isExpanded={true}
   isGrouped={false}
@@ -4375,187 +4151,9 @@ exports[`select single select renders expanded successfully 1`] = `
                   Other
                 </button>
               </li>
-<<<<<<< HEAD
             </ul>
           </div>,
         }
-=======
-            </SelectOption>
-          </div>
-        </Component>
-      </ul>
-    </SelectMenu>
-  </div>
-</Select>
-`;
-
-exports[`select renders up drection successfully 1`] = `
-<Select
-  aria-label=""
-  ariaLabelClear="Clear all"
-  ariaLabelRemove="Remove"
-  ariaLabelToggle="Options menu"
-  ariaLabelTypeAhead=""
-  ariaLabelledBy=""
-  className=""
-  direction="up"
-  isExpanded={false}
-  isGrouped={false}
-  onClear={[Function]}
-  onSelect={[MockFunction]}
-  onToggle={[MockFunction]}
-  placeholderText=""
-  selections=""
-  toggleId={null}
-  variant="single"
-  width=""
->
-  <div
-    className="pf-c-select pf-m-top"
-    style={
-      Object {
-        "width": "",
-      }
-    }
-  >
-    <SelectToggle
-      ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-2"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-2"
-      isActive={false}
-      isExpanded={false}
-      isFocused={false}
-      isHovered={false}
-      isPlain={false}
-      onClose={[Function]}
-      onEnter={[Function]}
-      onToggle={[MockFunction]}
-      parentRef={
-        Object {
-          "current": <div
-            class="pf-c-select pf-m-top"
-          >
-            <button
-              aria-expanded="false"
-              aria-haspopup="listbox"
-              aria-labelledby=" pf-toggle-id-2"
-              class="pf-c-select__toggle"
-              id="pf-toggle-id-2"
-              type="button"
-            >
-              <div
-                class="pf-c-select__toggle-wrapper"
-              >
-                <span
-                  class="pf-c-select__toggle-text"
-                >
-                  Mr
-                </span>
-              </div>
-              <svg
-                aria-hidden="true"
-                class="pf-c-select__toggle-arrow"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                style="vertical-align: -0.125em;"
-                viewBox="0 0 320 512"
-                width="1em"
-              >
-                <path
-                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  transform=""
-                />
-              </svg>
-            </button>
-          </div>,
-        }
-      }
-      type="button"
-      variant="single"
-    >
-      <button
-        aria-expanded={false}
-        aria-haspopup="listbox"
-        aria-labelledby=" pf-toggle-id-2"
-        className="pf-c-select__toggle"
-        id="pf-toggle-id-2"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        type="button"
-      >
-        <div
-          className="pf-c-select__toggle-wrapper"
-        >
-          <span
-            className="pf-c-select__toggle-text"
-          >
-            Mr
-          </span>
-        </div>
-        <CaretDownIcon
-          className="pf-c-select__toggle-arrow"
-          color="currentColor"
-          noVerticalAlign={false}
-          size="sm"
-          title={null}
-        >
-          <svg
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="pf-c-select__toggle-arrow"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            style={
-              Object {
-                "verticalAlign": "-0.125em",
-              }
-            }
-            viewBox="0 0 320 512"
-            width="1em"
-          >
-            <path
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-              transform=""
-            />
-          </svg>
-        </CaretDownIcon>
-      </button>
-    </SelectToggle>
-  </div>
-</Select>
-`;
-
-exports[`select single select renders closed successfully 1`] = `
-<Select
-  aria-label=""
-  ariaLabelClear="Clear all"
-  ariaLabelRemove="Remove"
-  ariaLabelToggle="Options menu"
-  ariaLabelTypeAhead=""
-  ariaLabelledBy=""
-  className=""
-  direction="down"
-  isExpanded={false}
-  isGrouped={false}
-  onClear={[Function]}
-  onSelect={[MockFunction]}
-  onToggle={[MockFunction]}
-  placeholderText=""
-  selections=""
-  toggleId={null}
-  variant="single"
-  width=""
->
-  <div
-    className="pf-c-select"
-    style={
-      Object {
-        "width": "",
->>>>>>> feat(Select): adds direction prop to Select
       }
       type="button"
       variant="single"
@@ -4766,11 +4364,8 @@ exports[`select single select renders expanded successfully with custom objects 
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -5089,11 +4684,8 @@ exports[`typeahead multi select renders closed successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={false}
   isGrouped={false}
   isPlain={false}
@@ -5116,17 +4708,10 @@ exports[`typeahead multi select renders closed successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-19"
+      ariaLabelledBy=" pf-toggle-id-20"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-19"
-=======
-      ariaLabelledBy=" pf-toggle-id-17"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-17"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-20"
       isActive={false}
       isDisabled={false}
       isExpanded={false}
@@ -5163,15 +4748,9 @@ exports[`typeahead multi select renders closed successfully 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-<<<<<<< HEAD
-                aria-labelledby=" pf-toggle-id-19"
+                aria-labelledby=" pf-toggle-id-20"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-19"
-=======
-                aria-labelledby=" pf-toggle-id-17"
-                class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-17"
->>>>>>> feat(Select): adds direction prop to Select
+                id="pf-toggle-id-20"
               >
                 <svg
                   aria-hidden="true"
@@ -5222,16 +4801,10 @@ exports[`typeahead multi select renders closed successfully 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           aria-label="Options menu"
-<<<<<<< HEAD
-          aria-labelledby=" pf-toggle-id-19"
+          aria-labelledby=" pf-toggle-id-20"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
-          id="pf-toggle-id-19"
-=======
-          aria-labelledby=" pf-toggle-id-17"
-          className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-17"
->>>>>>> feat(Select): adds direction prop to Select
+          id="pf-toggle-id-20"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -5278,11 +4851,8 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -5305,17 +4875,10 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-20"
+      ariaLabelledBy=" pf-toggle-id-21"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-20"
-=======
-      ariaLabelledBy=" pf-toggle-id-18"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-18"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-21"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -5352,15 +4915,9 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-<<<<<<< HEAD
-                aria-labelledby=" pf-toggle-id-20"
+                aria-labelledby=" pf-toggle-id-21"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-20"
-=======
-                aria-labelledby=" pf-toggle-id-18"
-                class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-18"
->>>>>>> feat(Select): adds direction prop to Select
+                id="pf-toggle-id-21"
               >
                 <svg
                   aria-hidden="true"
@@ -5466,16 +5023,10 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-<<<<<<< HEAD
-          aria-labelledby=" pf-toggle-id-20"
+          aria-labelledby=" pf-toggle-id-21"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
-          id="pf-toggle-id-20"
-=======
-          aria-labelledby=" pf-toggle-id-18"
-          className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-18"
->>>>>>> feat(Select): adds direction prop to Select
+          id="pf-toggle-id-21"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -5665,11 +5216,8 @@ exports[`typeahead multi select renders selected successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -5697,17 +5245,10 @@ exports[`typeahead multi select renders selected successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-21"
+      ariaLabelledBy=" pf-toggle-id-22"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-21"
-=======
-      ariaLabelledBy=" pf-toggle-id-19"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-19"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-22"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -5813,15 +5354,9 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-<<<<<<< HEAD
-                aria-labelledby=" pf-toggle-id-21"
+                aria-labelledby=" pf-toggle-id-22"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-21"
-=======
-                aria-labelledby=" pf-toggle-id-19"
-                class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-19"
->>>>>>> feat(Select): adds direction prop to Select
+                id="pf-toggle-id-22"
               >
                 <svg
                   aria-hidden="true"
@@ -6138,16 +5673,10 @@ exports[`typeahead multi select renders selected successfully 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-<<<<<<< HEAD
-          aria-labelledby=" pf-toggle-id-21"
+          aria-labelledby=" pf-toggle-id-22"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
-          id="pf-toggle-id-21"
-=======
-          aria-labelledby=" pf-toggle-id-19"
-          className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-19"
->>>>>>> feat(Select): adds direction prop to Select
+          id="pf-toggle-id-22"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -6400,11 +5929,8 @@ exports[`typeahead multi select test onChange 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -6427,17 +5953,10 @@ exports[`typeahead multi select test onChange 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-23"
+      ariaLabelledBy=" pf-toggle-id-24"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-23"
-=======
-      ariaLabelledBy=" pf-toggle-id-21"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-21"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-24"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -6473,15 +5992,9 @@ exports[`typeahead multi select test onChange 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-<<<<<<< HEAD
-                aria-labelledby=" pf-toggle-id-23"
+                aria-labelledby=" pf-toggle-id-24"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-23"
-=======
-                aria-labelledby=" pf-toggle-id-21"
-                class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-21"
->>>>>>> feat(Select): adds direction prop to Select
+                id="pf-toggle-id-24"
               >
                 <svg
                   aria-hidden="true"
@@ -6551,16 +6064,10 @@ exports[`typeahead multi select test onChange 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-<<<<<<< HEAD
-          aria-labelledby=" pf-toggle-id-23"
+          aria-labelledby=" pf-toggle-id-24"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
-          id="pf-toggle-id-23"
-=======
-          aria-labelledby=" pf-toggle-id-21"
-          className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-21"
->>>>>>> feat(Select): adds direction prop to Select
+          id="pf-toggle-id-24"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -6657,11 +6164,8 @@ exports[`typeahead select renders closed successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={false}
   isGrouped={false}
   isPlain={false}
@@ -6684,17 +6188,10 @@ exports[`typeahead select renders closed successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-14"
+      ariaLabelledBy=" pf-toggle-id-15"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-14"
-=======
-      ariaLabelledBy=" pf-toggle-id-12"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-12"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-15"
       isActive={false}
       isDisabled={false}
       isExpanded={false}
@@ -6730,15 +6227,9 @@ exports[`typeahead select renders closed successfully 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-<<<<<<< HEAD
-                aria-labelledby=" pf-toggle-id-14"
+                aria-labelledby=" pf-toggle-id-15"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-14"
-=======
-                aria-labelledby=" pf-toggle-id-12"
-                class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-12"
->>>>>>> feat(Select): adds direction prop to Select
+                id="pf-toggle-id-15"
               >
                 <svg
                   aria-hidden="true"
@@ -6789,16 +6280,10 @@ exports[`typeahead select renders closed successfully 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           aria-label="Options menu"
-<<<<<<< HEAD
-          aria-labelledby=" pf-toggle-id-14"
+          aria-labelledby=" pf-toggle-id-15"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
-          id="pf-toggle-id-14"
-=======
-          aria-labelledby=" pf-toggle-id-12"
-          className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-12"
->>>>>>> feat(Select): adds direction prop to Select
+          id="pf-toggle-id-15"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -6845,11 +6330,8 @@ exports[`typeahead select renders expanded successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -6872,17 +6354,10 @@ exports[`typeahead select renders expanded successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-15"
+      ariaLabelledBy=" pf-toggle-id-16"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-15"
-=======
-      ariaLabelledBy=" pf-toggle-id-13"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-13"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-16"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -6918,15 +6393,9 @@ exports[`typeahead select renders expanded successfully 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-<<<<<<< HEAD
-                aria-labelledby=" pf-toggle-id-15"
+                aria-labelledby=" pf-toggle-id-16"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-15"
-=======
-                aria-labelledby=" pf-toggle-id-13"
-                class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-13"
->>>>>>> feat(Select): adds direction prop to Select
+                id="pf-toggle-id-16"
               >
                 <svg
                   aria-hidden="true"
@@ -7032,16 +6501,10 @@ exports[`typeahead select renders expanded successfully 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-<<<<<<< HEAD
-          aria-labelledby=" pf-toggle-id-15"
+          aria-labelledby=" pf-toggle-id-16"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
-          id="pf-toggle-id-15"
-=======
-          aria-labelledby=" pf-toggle-id-13"
-          className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-13"
->>>>>>> feat(Select): adds direction prop to Select
+          id="pf-toggle-id-16"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -7231,11 +6694,8 @@ exports[`typeahead select renders selected successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -7258,17 +6718,10 @@ exports[`typeahead select renders selected successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-16"
+      ariaLabelledBy=" pf-toggle-id-17"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-16"
-=======
-      ariaLabelledBy=" pf-toggle-id-14"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-14"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-17"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -7323,15 +6776,9 @@ exports[`typeahead select renders selected successfully 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-<<<<<<< HEAD
-                aria-labelledby=" pf-toggle-id-16"
+                aria-labelledby=" pf-toggle-id-17"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-16"
-=======
-                aria-labelledby=" pf-toggle-id-14"
-                class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-14"
->>>>>>> feat(Select): adds direction prop to Select
+                id="pf-toggle-id-17"
               >
                 <svg
                   aria-hidden="true"
@@ -7488,16 +6935,10 @@ exports[`typeahead select renders selected successfully 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-<<<<<<< HEAD
-          aria-labelledby=" pf-toggle-id-16"
+          aria-labelledby=" pf-toggle-id-17"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
-          id="pf-toggle-id-16"
-=======
-          aria-labelledby=" pf-toggle-id-14"
-          className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-14"
->>>>>>> feat(Select): adds direction prop to Select
+          id="pf-toggle-id-17"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -7716,11 +7157,8 @@ exports[`typeahead select test onChange 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-<<<<<<< HEAD
-  isDisabled={false}
-=======
   direction="down"
->>>>>>> feat(Select): adds direction prop to Select
+  isDisabled={false}
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -7743,17 +7181,10 @@ exports[`typeahead select test onChange 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-<<<<<<< HEAD
-      ariaLabelledBy=" pf-toggle-id-18"
+      ariaLabelledBy=" pf-toggle-id-19"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-18"
-=======
-      ariaLabelledBy=" pf-toggle-id-16"
-      className=""
-      handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-16"
->>>>>>> feat(Select): adds direction prop to Select
+      id="pf-toggle-id-19"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -7789,15 +7220,9 @@ exports[`typeahead select test onChange 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-<<<<<<< HEAD
-                aria-labelledby=" pf-toggle-id-18"
+                aria-labelledby=" pf-toggle-id-19"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-18"
-=======
-                aria-labelledby=" pf-toggle-id-16"
-                class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-16"
->>>>>>> feat(Select): adds direction prop to Select
+                id="pf-toggle-id-19"
               >
                 <svg
                   aria-hidden="true"
@@ -7867,16 +7292,10 @@ exports[`typeahead select test onChange 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-<<<<<<< HEAD
-          aria-labelledby=" pf-toggle-id-18"
+          aria-labelledby=" pf-toggle-id-19"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
-          id="pf-toggle-id-18"
-=======
-          aria-labelledby=" pf-toggle-id-16"
-          className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-16"
->>>>>>> feat(Select): adds direction prop to Select
+          id="pf-toggle-id-19"
           onClick={[Function]}
         >
           <CaretDownIcon

--- a/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`checkbox select renders checkbox select groups successfully - old class
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-  isDisabled={false}
+  direction="down"
   isExpanded={true}
   isGrouped={true}
   isPlain={false}
@@ -32,10 +32,10 @@ exports[`checkbox select renders checkbox select groups successfully - old class
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-13"
+      ariaLabelledBy=" pf-toggle-id-11"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-13"
+      id="pf-toggle-id-11"
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -52,9 +52,9 @@ exports[`checkbox select renders checkbox select groups successfully - old class
           >
             <button
               aria-expanded="true"
-              aria-labelledby=" pf-toggle-id-13"
+              aria-labelledby=" pf-toggle-id-11"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-13"
+              id="pf-toggle-id-11"
               type="button"
             >
               <div
@@ -249,10 +249,16 @@ exports[`checkbox select renders checkbox select groups successfully - old class
       <button
         aria-expanded={true}
         aria-haspopup={null}
+<<<<<<< HEAD
         aria-labelledby=" pf-toggle-id-13"
         className="pf-c-select__toggle"
         disabled={false}
         id="pf-toggle-id-13"
+=======
+        aria-labelledby=" pf-toggle-id-11"
+        className="pf-c-select__toggle"
+        id="pf-toggle-id-11"
+>>>>>>> feat(Select): adds direction prop to Select
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -631,7 +637,11 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={true}
   isGrouped={true}
   isPlain={false}
@@ -654,10 +664,17 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-12"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-12"
+=======
+      ariaLabelledBy=" pf-toggle-id-10"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-10"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -674,9 +691,15 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
           >
             <button
               aria-expanded="true"
+<<<<<<< HEAD
               aria-labelledby=" pf-toggle-id-12"
               class="pf-c-select__toggle"
               id="pf-toggle-id-12"
+=======
+              aria-labelledby=" pf-toggle-id-10"
+              class="pf-c-select__toggle"
+              id="pf-toggle-id-10"
+>>>>>>> feat(Select): adds direction prop to Select
               type="button"
             >
               <div
@@ -871,10 +894,16 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
       <button
         aria-expanded={true}
         aria-haspopup={null}
+<<<<<<< HEAD
         aria-labelledby=" pf-toggle-id-12"
         className="pf-c-select__toggle"
         disabled={false}
         id="pf-toggle-id-12"
+=======
+        aria-labelledby=" pf-toggle-id-10"
+        className="pf-c-select__toggle"
+        id="pf-toggle-id-10"
+>>>>>>> feat(Select): adds direction prop to Select
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -1277,7 +1306,11 @@ exports[`checkbox select renders closed successfully - old classes 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={false}
   isGrouped={false}
   isPlain={false}
@@ -1300,10 +1333,17 @@ exports[`checkbox select renders closed successfully - old classes 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-8"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-8"
+=======
+      ariaLabelledBy=" pf-toggle-id-7"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-7"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={false}
@@ -1320,9 +1360,15 @@ exports[`checkbox select renders closed successfully - old classes 1`] = `
           >
             <button
               aria-expanded="false"
+<<<<<<< HEAD
               aria-labelledby=" pf-toggle-id-8"
               class="pf-c-select__toggle"
               id="pf-toggle-id-8"
+=======
+              aria-labelledby=" pf-toggle-id-7"
+              class="pf-c-select__toggle"
+              id="pf-toggle-id-7"
+>>>>>>> feat(Select): adds direction prop to Select
               type="button"
             >
               <div
@@ -1358,10 +1404,16 @@ exports[`checkbox select renders closed successfully - old classes 1`] = `
       <button
         aria-expanded={false}
         aria-haspopup={null}
+<<<<<<< HEAD
         aria-labelledby=" pf-toggle-id-8"
         className="pf-c-select__toggle"
         disabled={false}
         id="pf-toggle-id-8"
+=======
+        aria-labelledby=" pf-toggle-id-7"
+        className="pf-c-select__toggle"
+        id="pf-toggle-id-7"
+>>>>>>> feat(Select): adds direction prop to Select
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -1416,7 +1468,11 @@ exports[`checkbox select renders closed successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={false}
   isGrouped={false}
   isPlain={false}
@@ -1439,10 +1495,17 @@ exports[`checkbox select renders closed successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-7"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-7"
+=======
+      ariaLabelledBy=" pf-toggle-id-6"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-6"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={false}
@@ -1459,9 +1522,15 @@ exports[`checkbox select renders closed successfully 1`] = `
           >
             <button
               aria-expanded="false"
+<<<<<<< HEAD
               aria-labelledby=" pf-toggle-id-7"
               class="pf-c-select__toggle"
               id="pf-toggle-id-7"
+=======
+              aria-labelledby=" pf-toggle-id-6"
+              class="pf-c-select__toggle"
+              id="pf-toggle-id-6"
+>>>>>>> feat(Select): adds direction prop to Select
               type="button"
             >
               <div
@@ -1497,10 +1566,16 @@ exports[`checkbox select renders closed successfully 1`] = `
       <button
         aria-expanded={false}
         aria-haspopup={null}
+<<<<<<< HEAD
         aria-labelledby=" pf-toggle-id-7"
         className="pf-c-select__toggle"
         disabled={false}
         id="pf-toggle-id-7"
+=======
+        aria-labelledby=" pf-toggle-id-6"
+        className="pf-c-select__toggle"
+        id="pf-toggle-id-6"
+>>>>>>> feat(Select): adds direction prop to Select
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -1555,7 +1630,11 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -1578,10 +1657,17 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-10"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-10"
+=======
+      ariaLabelledBy=" pf-toggle-id-9"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-9"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -1598,9 +1684,15 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
           >
             <button
               aria-expanded="true"
+<<<<<<< HEAD
               aria-labelledby=" pf-toggle-id-10"
               class="pf-c-select__toggle"
               id="pf-toggle-id-10"
+=======
+              aria-labelledby=" pf-toggle-id-9"
+              class="pf-c-select__toggle"
+              id="pf-toggle-id-9"
+>>>>>>> feat(Select): adds direction prop to Select
               type="button"
             >
               <div
@@ -1712,10 +1804,16 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
       <button
         aria-expanded={true}
         aria-haspopup={null}
+<<<<<<< HEAD
         aria-labelledby=" pf-toggle-id-10"
         className="pf-c-select__toggle"
         disabled={false}
         id="pf-toggle-id-10"
+=======
+        aria-labelledby=" pf-toggle-id-9"
+        className="pf-c-select__toggle"
+        id="pf-toggle-id-9"
+>>>>>>> feat(Select): adds direction prop to Select
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -1936,7 +2034,11 @@ exports[`checkbox select renders expanded successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -1959,10 +2061,17 @@ exports[`checkbox select renders expanded successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-9"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-9"
+=======
+      ariaLabelledBy=" pf-toggle-id-8"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-8"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -1979,9 +2088,15 @@ exports[`checkbox select renders expanded successfully 1`] = `
           >
             <button
               aria-expanded="true"
+<<<<<<< HEAD
               aria-labelledby=" pf-toggle-id-9"
               class="pf-c-select__toggle"
               id="pf-toggle-id-9"
+=======
+              aria-labelledby=" pf-toggle-id-8"
+              class="pf-c-select__toggle"
+              id="pf-toggle-id-8"
+>>>>>>> feat(Select): adds direction prop to Select
               type="button"
             >
               <div
@@ -2093,10 +2208,16 @@ exports[`checkbox select renders expanded successfully 1`] = `
       <button
         aria-expanded={true}
         aria-haspopup={null}
+<<<<<<< HEAD
         aria-labelledby=" pf-toggle-id-9"
         className="pf-c-select__toggle"
         disabled={false}
         id="pf-toggle-id-9"
+=======
+        aria-labelledby=" pf-toggle-id-8"
+        className="pf-c-select__toggle"
+        id="pf-toggle-id-8"
+>>>>>>> feat(Select): adds direction prop to Select
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -2329,7 +2450,11 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -2352,10 +2477,17 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-11"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-11"
+=======
+      ariaLabelledBy=" pf-toggle-id-4"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-4"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -2385,6 +2517,7 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
                 />
                 
               </div>
+<<<<<<< HEAD
               <svg
                 aria-hidden="true"
                 class="pf-c-select__toggle-arrow"
@@ -2394,6 +2527,53 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
                 style="vertical-align: -0.125em;"
                 viewBox="0 0 320 512"
                 width="1em"
+=======
+              
+              <button
+                aria-expanded="true"
+                aria-haspopup="listbox"
+                aria-label="Options menu"
+                aria-labelledby=" pf-toggle-id-4"
+                class="pf-c-button pf-c-select__toggle-button"
+                id="pf-toggle-id-4"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-c-select__toggle-arrow"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 320 512"
+                  width="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    transform=""
+                  />
+                </svg>
+              </button>
+            </div>
+            <ul
+              aria-label=""
+              aria-labelledby=""
+              class="pf-c-select__menu"
+              role="listbox"
+            >
+              <li
+                role="presentation"
+              >
+                <button
+                  class="pf-c-select__menu-item"
+                  id="Mr-0"
+                  role="option"
+                >
+                  Mr
+                </button>
+              </li>
+              <li
+                role="presentation"
+>>>>>>> feat(Select): adds direction prop to Select
               >
                 <path
                   d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
@@ -2487,12 +2667,23 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
             className="pf-c-select__toggle-text"
           />
         </div>
+<<<<<<< HEAD
         <CaretDownIcon
           className="pf-c-select__toggle-arrow"
           color="currentColor"
           noVerticalAlign={false}
           size="sm"
           title={null}
+=======
+        <button
+          aria-expanded={true}
+          aria-haspopup="listbox"
+          aria-label="Options menu"
+          aria-labelledby=" pf-toggle-id-4"
+          className="pf-c-button pf-c-select__toggle-button"
+          id="pf-toggle-id-4"
+          onClick={[Function]}
+>>>>>>> feat(Select): adds direction prop to Select
         >
           <svg
             aria-hidden={true}
@@ -2540,6 +2731,7 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
         paused={false}
         tag="div"
       >
+<<<<<<< HEAD
         <div>
           <div
             className="pf-c-select__menu"
@@ -2547,6 +2739,188 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
             <form
               className="pf-c-form"
               noValidate={true}
+=======
+        <SelectOption
+          className=""
+          id="Mr-0"
+          index={0}
+          isChecked={false}
+          isDisabled={false}
+          isFocused={null}
+          isPlaceholder={false}
+          isSelected={false}
+          key=".$0"
+          keyHandler={[Function]}
+          onClick={[Function]}
+          sendRef={[Function]}
+          value="Mr"
+        >
+          <li
+            role="presentation"
+          >
+            <button
+              aria-selected={null}
+              className="pf-c-select__menu-item"
+              id="Mr-0"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="option"
+            >
+              Mr
+            </button>
+          </li>
+        </SelectOption>
+        <SelectOption
+          className=""
+          id="Mrs-1"
+          index={1}
+          isChecked={false}
+          isDisabled={false}
+          isFocused={null}
+          isPlaceholder={false}
+          isSelected={false}
+          key=".$1"
+          keyHandler={[Function]}
+          onClick={[Function]}
+          sendRef={[Function]}
+          value="Mrs"
+        >
+          <li
+            role="presentation"
+          >
+            <button
+              aria-selected={null}
+              className="pf-c-select__menu-item"
+              id="Mrs-1"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="option"
+            >
+              Mrs
+            </button>
+          </li>
+        </SelectOption>
+        <SelectOption
+          className=""
+          id="Other-2"
+          index={2}
+          isChecked={false}
+          isDisabled={false}
+          isFocused={null}
+          isPlaceholder={false}
+          isSelected={false}
+          key=".$3"
+          keyHandler={[Function]}
+          onClick={[Function]}
+          sendRef={[Function]}
+          value="Other"
+        >
+          <li
+            role="presentation"
+          >
+            <button
+              aria-selected={null}
+              className="pf-c-select__menu-item"
+              id="Other-2"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="option"
+            >
+              Other
+            </button>
+          </li>
+        </SelectOption>
+      </ul>
+    </SelectMenu>
+  </div>
+</Select>
+`;
+
+exports[`select renders select groups successfully 1`] = `
+<Select
+  aria-label=""
+  ariaLabelClear="Clear all"
+  ariaLabelRemove="Remove"
+  ariaLabelToggle="Options menu"
+  ariaLabelTypeAhead=""
+  ariaLabelledBy=""
+  className=""
+  direction="down"
+  isExpanded={true}
+  isGrouped={true}
+  onClear={[Function]}
+  onSelect={[MockFunction]}
+  onToggle={[MockFunction]}
+  placeholderText=""
+  selections=""
+  toggleId={null}
+  variant="single"
+  width=""
+>
+  <div
+    className="pf-c-select pf-m-expanded"
+    style={
+      Object {
+        "width": "",
+      }
+    }
+  >
+    <SelectToggle
+      ariaLabelToggle="Options menu"
+      ariaLabelledBy=" pf-toggle-id-5"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-5"
+      isActive={false}
+      isExpanded={true}
+      isFocused={false}
+      isHovered={false}
+      isPlain={false}
+      onClose={[Function]}
+      onEnter={[Function]}
+      onToggle={[MockFunction]}
+      parentRef={
+        Object {
+          "current": <div
+            class="pf-c-select pf-m-expanded"
+          >
+            <button
+              aria-expanded="true"
+              aria-haspopup="listbox"
+              aria-labelledby=" pf-toggle-id-5"
+              class="pf-c-select__toggle"
+              id="pf-toggle-id-5"
+              type="button"
+            >
+              <div
+                class="pf-c-select__toggle-wrapper"
+              >
+                <span
+                  class="pf-c-select__toggle-text"
+                />
+              </div>
+              <svg
+                aria-hidden="true"
+                class="pf-c-select__toggle-arrow"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  transform=""
+                />
+              </svg>
+            </button>
+            <ul
+              aria-label=""
+              aria-labelledby=""
+              class="pf-c-select__menu"
+              role="listbox"
+>>>>>>> feat(Select): adds direction prop to Select
             >
               <div
                 className="pf-c-form__group"
@@ -3219,10 +3593,16 @@ exports[`select renders select groups successfully 1`] = `
       <button
         aria-expanded={true}
         aria-haspopup="listbox"
+<<<<<<< HEAD
         aria-labelledby=" pf-toggle-id-6"
         className="pf-c-select__toggle"
         disabled={false}
         id="pf-toggle-id-6"
+=======
+        aria-labelledby=" pf-toggle-id-5"
+        className="pf-c-select__toggle"
+        id="pf-toggle-id-5"
+>>>>>>> feat(Select): adds direction prop to Select
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -3995,9 +4375,187 @@ exports[`select single select renders expanded successfully 1`] = `
                   Other
                 </button>
               </li>
+<<<<<<< HEAD
             </ul>
           </div>,
         }
+=======
+            </SelectOption>
+          </div>
+        </Component>
+      </ul>
+    </SelectMenu>
+  </div>
+</Select>
+`;
+
+exports[`select renders up drection successfully 1`] = `
+<Select
+  aria-label=""
+  ariaLabelClear="Clear all"
+  ariaLabelRemove="Remove"
+  ariaLabelToggle="Options menu"
+  ariaLabelTypeAhead=""
+  ariaLabelledBy=""
+  className=""
+  direction="up"
+  isExpanded={false}
+  isGrouped={false}
+  onClear={[Function]}
+  onSelect={[MockFunction]}
+  onToggle={[MockFunction]}
+  placeholderText=""
+  selections=""
+  toggleId={null}
+  variant="single"
+  width=""
+>
+  <div
+    className="pf-c-select pf-m-top"
+    style={
+      Object {
+        "width": "",
+      }
+    }
+  >
+    <SelectToggle
+      ariaLabelToggle="Options menu"
+      ariaLabelledBy=" pf-toggle-id-2"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-2"
+      isActive={false}
+      isExpanded={false}
+      isFocused={false}
+      isHovered={false}
+      isPlain={false}
+      onClose={[Function]}
+      onEnter={[Function]}
+      onToggle={[MockFunction]}
+      parentRef={
+        Object {
+          "current": <div
+            class="pf-c-select pf-m-top"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-labelledby=" pf-toggle-id-2"
+              class="pf-c-select__toggle"
+              id="pf-toggle-id-2"
+              type="button"
+            >
+              <div
+                class="pf-c-select__toggle-wrapper"
+              >
+                <span
+                  class="pf-c-select__toggle-text"
+                >
+                  Mr
+                </span>
+              </div>
+              <svg
+                aria-hidden="true"
+                class="pf-c-select__toggle-arrow"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  transform=""
+                />
+              </svg>
+            </button>
+          </div>,
+        }
+      }
+      type="button"
+      variant="single"
+    >
+      <button
+        aria-expanded={false}
+        aria-haspopup="listbox"
+        aria-labelledby=" pf-toggle-id-2"
+        className="pf-c-select__toggle"
+        id="pf-toggle-id-2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        type="button"
+      >
+        <div
+          className="pf-c-select__toggle-wrapper"
+        >
+          <span
+            className="pf-c-select__toggle-text"
+          >
+            Mr
+          </span>
+        </div>
+        <CaretDownIcon
+          className="pf-c-select__toggle-arrow"
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+          title={null}
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="pf-c-select__toggle-arrow"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </CaretDownIcon>
+      </button>
+    </SelectToggle>
+  </div>
+</Select>
+`;
+
+exports[`select single select renders closed successfully 1`] = `
+<Select
+  aria-label=""
+  ariaLabelClear="Clear all"
+  ariaLabelRemove="Remove"
+  ariaLabelToggle="Options menu"
+  ariaLabelTypeAhead=""
+  ariaLabelledBy=""
+  className=""
+  direction="down"
+  isExpanded={false}
+  isGrouped={false}
+  onClear={[Function]}
+  onSelect={[MockFunction]}
+  onToggle={[MockFunction]}
+  placeholderText=""
+  selections=""
+  toggleId={null}
+  variant="single"
+  width=""
+>
+  <div
+    className="pf-c-select"
+    style={
+      Object {
+        "width": "",
+>>>>>>> feat(Select): adds direction prop to Select
       }
       type="button"
       variant="single"
@@ -4208,7 +4766,11 @@ exports[`select single select renders expanded successfully with custom objects 
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -4527,7 +5089,11 @@ exports[`typeahead multi select renders closed successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={false}
   isGrouped={false}
   isPlain={false}
@@ -4550,10 +5116,17 @@ exports[`typeahead multi select renders closed successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-19"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-19"
+=======
+      ariaLabelledBy=" pf-toggle-id-17"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-17"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={false}
@@ -4590,9 +5163,15 @@ exports[`typeahead multi select renders closed successfully 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
+<<<<<<< HEAD
                 aria-labelledby=" pf-toggle-id-19"
                 class="pf-c-button pf-c-select__toggle-button"
                 id="pf-toggle-id-19"
+=======
+                aria-labelledby=" pf-toggle-id-17"
+                class="pf-c-button pf-c-select__toggle-button"
+                id="pf-toggle-id-17"
+>>>>>>> feat(Select): adds direction prop to Select
               >
                 <svg
                   aria-hidden="true"
@@ -4643,10 +5222,16 @@ exports[`typeahead multi select renders closed successfully 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           aria-label="Options menu"
+<<<<<<< HEAD
           aria-labelledby=" pf-toggle-id-19"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
           id="pf-toggle-id-19"
+=======
+          aria-labelledby=" pf-toggle-id-17"
+          className="pf-c-button pf-c-select__toggle-button"
+          id="pf-toggle-id-17"
+>>>>>>> feat(Select): adds direction prop to Select
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -4693,7 +5278,11 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -4716,10 +5305,17 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-20"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-20"
+=======
+      ariaLabelledBy=" pf-toggle-id-18"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-18"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -4756,9 +5352,15 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
+<<<<<<< HEAD
                 aria-labelledby=" pf-toggle-id-20"
                 class="pf-c-button pf-c-select__toggle-button"
                 id="pf-toggle-id-20"
+=======
+                aria-labelledby=" pf-toggle-id-18"
+                class="pf-c-button pf-c-select__toggle-button"
+                id="pf-toggle-id-18"
+>>>>>>> feat(Select): adds direction prop to Select
               >
                 <svg
                   aria-hidden="true"
@@ -4864,10 +5466,16 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
+<<<<<<< HEAD
           aria-labelledby=" pf-toggle-id-20"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
           id="pf-toggle-id-20"
+=======
+          aria-labelledby=" pf-toggle-id-18"
+          className="pf-c-button pf-c-select__toggle-button"
+          id="pf-toggle-id-18"
+>>>>>>> feat(Select): adds direction prop to Select
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -5057,7 +5665,11 @@ exports[`typeahead multi select renders selected successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -5085,10 +5697,17 @@ exports[`typeahead multi select renders selected successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-21"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-21"
+=======
+      ariaLabelledBy=" pf-toggle-id-19"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-19"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -5194,9 +5813,15 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
+<<<<<<< HEAD
                 aria-labelledby=" pf-toggle-id-21"
                 class="pf-c-button pf-c-select__toggle-button"
                 id="pf-toggle-id-21"
+=======
+                aria-labelledby=" pf-toggle-id-19"
+                class="pf-c-button pf-c-select__toggle-button"
+                id="pf-toggle-id-19"
+>>>>>>> feat(Select): adds direction prop to Select
               >
                 <svg
                   aria-hidden="true"
@@ -5513,10 +6138,16 @@ exports[`typeahead multi select renders selected successfully 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
+<<<<<<< HEAD
           aria-labelledby=" pf-toggle-id-21"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
           id="pf-toggle-id-21"
+=======
+          aria-labelledby=" pf-toggle-id-19"
+          className="pf-c-button pf-c-select__toggle-button"
+          id="pf-toggle-id-19"
+>>>>>>> feat(Select): adds direction prop to Select
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -5769,7 +6400,11 @@ exports[`typeahead multi select test onChange 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -5792,10 +6427,17 @@ exports[`typeahead multi select test onChange 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-23"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-23"
+=======
+      ariaLabelledBy=" pf-toggle-id-21"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-21"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -5831,9 +6473,15 @@ exports[`typeahead multi select test onChange 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
+<<<<<<< HEAD
                 aria-labelledby=" pf-toggle-id-23"
                 class="pf-c-button pf-c-select__toggle-button"
                 id="pf-toggle-id-23"
+=======
+                aria-labelledby=" pf-toggle-id-21"
+                class="pf-c-button pf-c-select__toggle-button"
+                id="pf-toggle-id-21"
+>>>>>>> feat(Select): adds direction prop to Select
               >
                 <svg
                   aria-hidden="true"
@@ -5903,10 +6551,16 @@ exports[`typeahead multi select test onChange 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
+<<<<<<< HEAD
           aria-labelledby=" pf-toggle-id-23"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
           id="pf-toggle-id-23"
+=======
+          aria-labelledby=" pf-toggle-id-21"
+          className="pf-c-button pf-c-select__toggle-button"
+          id="pf-toggle-id-21"
+>>>>>>> feat(Select): adds direction prop to Select
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -6003,7 +6657,11 @@ exports[`typeahead select renders closed successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={false}
   isGrouped={false}
   isPlain={false}
@@ -6026,10 +6684,17 @@ exports[`typeahead select renders closed successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-14"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-14"
+=======
+      ariaLabelledBy=" pf-toggle-id-12"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-12"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={false}
@@ -6065,9 +6730,15 @@ exports[`typeahead select renders closed successfully 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
+<<<<<<< HEAD
                 aria-labelledby=" pf-toggle-id-14"
                 class="pf-c-button pf-c-select__toggle-button"
                 id="pf-toggle-id-14"
+=======
+                aria-labelledby=" pf-toggle-id-12"
+                class="pf-c-button pf-c-select__toggle-button"
+                id="pf-toggle-id-12"
+>>>>>>> feat(Select): adds direction prop to Select
               >
                 <svg
                   aria-hidden="true"
@@ -6118,10 +6789,16 @@ exports[`typeahead select renders closed successfully 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           aria-label="Options menu"
+<<<<<<< HEAD
           aria-labelledby=" pf-toggle-id-14"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
           id="pf-toggle-id-14"
+=======
+          aria-labelledby=" pf-toggle-id-12"
+          className="pf-c-button pf-c-select__toggle-button"
+          id="pf-toggle-id-12"
+>>>>>>> feat(Select): adds direction prop to Select
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -6168,7 +6845,11 @@ exports[`typeahead select renders expanded successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -6191,10 +6872,17 @@ exports[`typeahead select renders expanded successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-15"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-15"
+=======
+      ariaLabelledBy=" pf-toggle-id-13"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-13"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -6230,9 +6918,15 @@ exports[`typeahead select renders expanded successfully 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
+<<<<<<< HEAD
                 aria-labelledby=" pf-toggle-id-15"
                 class="pf-c-button pf-c-select__toggle-button"
                 id="pf-toggle-id-15"
+=======
+                aria-labelledby=" pf-toggle-id-13"
+                class="pf-c-button pf-c-select__toggle-button"
+                id="pf-toggle-id-13"
+>>>>>>> feat(Select): adds direction prop to Select
               >
                 <svg
                   aria-hidden="true"
@@ -6338,10 +7032,16 @@ exports[`typeahead select renders expanded successfully 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
+<<<<<<< HEAD
           aria-labelledby=" pf-toggle-id-15"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
           id="pf-toggle-id-15"
+=======
+          aria-labelledby=" pf-toggle-id-13"
+          className="pf-c-button pf-c-select__toggle-button"
+          id="pf-toggle-id-13"
+>>>>>>> feat(Select): adds direction prop to Select
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -6531,7 +7231,11 @@ exports[`typeahead select renders selected successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -6554,10 +7258,17 @@ exports[`typeahead select renders selected successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-16"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-16"
+=======
+      ariaLabelledBy=" pf-toggle-id-14"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-14"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -6612,9 +7323,15 @@ exports[`typeahead select renders selected successfully 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
+<<<<<<< HEAD
                 aria-labelledby=" pf-toggle-id-16"
                 class="pf-c-button pf-c-select__toggle-button"
                 id="pf-toggle-id-16"
+=======
+                aria-labelledby=" pf-toggle-id-14"
+                class="pf-c-button pf-c-select__toggle-button"
+                id="pf-toggle-id-14"
+>>>>>>> feat(Select): adds direction prop to Select
               >
                 <svg
                   aria-hidden="true"
@@ -6771,10 +7488,16 @@ exports[`typeahead select renders selected successfully 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
+<<<<<<< HEAD
           aria-labelledby=" pf-toggle-id-16"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
           id="pf-toggle-id-16"
+=======
+          aria-labelledby=" pf-toggle-id-14"
+          className="pf-c-button pf-c-select__toggle-button"
+          id="pf-toggle-id-14"
+>>>>>>> feat(Select): adds direction prop to Select
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -6993,7 +7716,11 @@ exports[`typeahead select test onChange 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
+<<<<<<< HEAD
   isDisabled={false}
+=======
+  direction="down"
+>>>>>>> feat(Select): adds direction prop to Select
   isExpanded={true}
   isGrouped={false}
   isPlain={false}
@@ -7016,10 +7743,17 @@ exports[`typeahead select test onChange 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+<<<<<<< HEAD
       ariaLabelledBy=" pf-toggle-id-18"
       className=""
       handleTypeaheadKeys={[Function]}
       id="pf-toggle-id-18"
+=======
+      ariaLabelledBy=" pf-toggle-id-16"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-16"
+>>>>>>> feat(Select): adds direction prop to Select
       isActive={false}
       isDisabled={false}
       isExpanded={true}
@@ -7055,9 +7789,15 @@ exports[`typeahead select test onChange 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
+<<<<<<< HEAD
                 aria-labelledby=" pf-toggle-id-18"
                 class="pf-c-button pf-c-select__toggle-button"
                 id="pf-toggle-id-18"
+=======
+                aria-labelledby=" pf-toggle-id-16"
+                class="pf-c-button pf-c-select__toggle-button"
+                id="pf-toggle-id-16"
+>>>>>>> feat(Select): adds direction prop to Select
               >
                 <svg
                   aria-hidden="true"
@@ -7127,10 +7867,16 @@ exports[`typeahead select test onChange 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
+<<<<<<< HEAD
           aria-labelledby=" pf-toggle-id-18"
           className="pf-c-button pf-c-select__toggle-button"
           disabled={false}
           id="pf-toggle-id-18"
+=======
+          aria-labelledby=" pf-toggle-id-16"
+          className="pf-c-button pf-c-select__toggle-button"
+          id="pf-toggle-id-16"
+>>>>>>> feat(Select): adds direction prop to Select
           onClick={[Function]}
         >
           <CaretDownIcon

--- a/packages/patternfly-4/react-core/src/components/Select/selectConstants.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/selectConstants.tsx
@@ -23,6 +23,11 @@ export enum SelectVariant {
   typeaheadMulti = 'typeaheadmulti'
 }
 
+export enum SelectDirection {
+  up = 'up',
+  down = 'down'
+}
+
 export const KeyTypes = {
   Tab: 'Tab',
   Space: ' ',

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
@@ -1,4 +1,4 @@
-import { Select, SelectOption, SelectVariant, Stack, StackItem, Title, SelectOptionObject } from '@patternfly/react-core';
+import { Select, SelectOption, SelectVariant, Stack, StackItem, Title, SelectOptionObject, Checkbox, SelectDirection } from '@patternfly/react-core';
 import React, { Component } from 'react';
 import { CartArrowDownIcon } from '@patternfly/react-icons';
 import { State } from '../../../common/State';
@@ -22,8 +22,8 @@ export interface SelectDemoState {
   plainTypeaheadMultiSelected: string[],
   plainTypeaheadMultiIsPlain: boolean,
   customTypeaheadMultiIsExpanded: boolean,
-  customTypeaheadMultiSelected: string[]
-
+  customTypeaheadMultiSelected: string[],
+  direction: string
 }
 
 export class SelectDemo extends Component<SelectDemoState> {
@@ -47,6 +47,7 @@ export class SelectDemo extends Component<SelectDemoState> {
     plainTypeaheadMultiIsPlain: true,
     customTypeaheadMultiIsExpanded: false,
     customTypeaheadMultiSelected: [],
+    direction: SelectDirection.down
   };
 
   singleOptions = [
@@ -90,6 +91,18 @@ export class SelectDemo extends Component<SelectDemoState> {
     <SelectOption key={10} value={ new State('New York', 'NY', 'Albany', 1788)} />,
     <SelectOption key={11} value={ new State('North Carolina', 'NC', 'Raleigh', 1789)} />
   ];
+
+  toggleDirection = () => {
+    if(this.state.direction === 'up') {
+      this.setState({
+        direction: SelectDirection.down
+      });
+    } else {
+      this.setState({
+        direction: SelectDirection.up
+      });
+    }
+  }
 
   singleOnToggle = (singleIsExpanded: boolean) => {
     this.setState({
@@ -306,6 +319,7 @@ export class SelectDemo extends Component<SelectDemoState> {
             selections={singleSelected}
             isExpanded={singleIsExpanded}
             ariaLabelledBy={titleId}
+            direction={this.state.direction}
           >
             {this.singleOptions.map((option, index) => (
               <SelectOption
@@ -317,6 +331,14 @@ export class SelectDemo extends Component<SelectDemoState> {
             ))}
           </Select>
         </div>
+        <Checkbox
+          label="Expands up"
+          isChecked={this.state.direction === 'up'}
+          onChange={this.toggleDirection}
+          aria-label="disabled checkbox"
+          id="toggle-disabled"
+          name="toggle-disabled"
+        />
       </StackItem>
     );
   }

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
@@ -23,7 +23,7 @@ export interface SelectDemoState {
   plainTypeaheadMultiIsPlain: boolean,
   customTypeaheadMultiIsExpanded: boolean,
   customTypeaheadMultiSelected: string[],
-  direction: string
+  direction: SelectDirection.up | SelectDirection.down
 }
 
 export class SelectDemo extends Component<SelectDemoState> {
@@ -93,7 +93,7 @@ export class SelectDemo extends Component<SelectDemoState> {
   ];
 
   toggleDirection = () => {
-    if(this.state.direction === 'up') {
+    if(this.state.direction === SelectDirection.up) {
       this.setState({
         direction: SelectDirection.down
       });
@@ -333,11 +333,11 @@ export class SelectDemo extends Component<SelectDemoState> {
         </div>
         <Checkbox
           label="Expands up"
-          isChecked={this.state.direction === 'up'}
+          isChecked={this.state.direction === SelectDirection.up}
           onChange={this.toggleDirection}
-          aria-label="disabled checkbox"
-          id="toggle-disabled"
-          name="toggle-disabled"
+          aria-label="direction checkbox"
+          id="toggle-direction"
+          name="toggle-direction"
         />
       </StackItem>
     );


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Allows user to specify the direction of the Select's menu expansion. Adds a SelectDirection enum for explicit directions. 

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Refer to issue**: #2368

<!-- feel free to add additional comments -->
