### PR TITLE
feat(Select): Adds the ability to pass in a user defined object

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Select/Select.md
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.md
@@ -518,12 +518,12 @@ class MultiTypeaheadSelectInputCustomObjects extends React.Component {
     }
   }
     this.options = [
-      { value: this.createState('Alabama', 'AL', 'Montgomery', 1846), disabled: false },
-      { value: this.createState('Florida', 'FL', 'Tailahassee', 1845), disabled: false },
-      { value: this.createState('New Jersey', 'NJ', 'Trenton', 1787), disabled: false },
-      { value: this.createState('New Mexico', 'NM', 'Santa Fe', 1912), disabled: false },
-      { value: this.createState('New York', 'NY', 'Albany', 1788), disabled: false },
-      { value: this.createState('North Carolina', 'NC', 'Raleigh', 1789),disabled: false }
+      <SelectOption value={ this.createState('Alabama', 'AL', 'Montgomery', 1846)} />,
+      <SelectOption value={ this.createState('Florida', 'FL', 'Tailahassee', 1845)} />,
+      <SelectOption value={ this.createState('New Jersey', 'NJ', 'Trenton', 1787)} />,
+      <SelectOption value={ this.createState('New Mexico', 'NM', 'Santa Fe', 1912)} />,
+      <SelectOption value={ this.createState('New York', 'NY', 'Albany', 1788)} />,
+      <SelectOption value={ this.createState('North Carolina', 'NC', 'Raleigh', 1789)} />
     ];
 
     this.state = {
@@ -558,6 +558,21 @@ class MultiTypeaheadSelectInputCustomObjects extends React.Component {
         isExpanded: false
       });
     };
+
+
+    this.customFilter = (e) => {
+      let input;
+      try {
+        input = new RegExp(e.target.value.toString(), 'i');
+      } catch (err) {
+        input = new RegExp(e.target.value.toString().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+      }
+      let typeaheadFilteredChildren =
+        e.target.value.toString() !== ''
+          ? this.options.filter(option => input.test(option.props.value.toString()))
+          : this.options;
+      return typeaheadFilteredChildren;
+    }
   }
 
   render() {
@@ -575,14 +590,13 @@ class MultiTypeaheadSelectInputCustomObjects extends React.Component {
           onToggle={this.onToggle}
           onSelect={this.onSelect}
           onClear={this.clearSelection}
+          onFilter={this.customFilter}
           selections={selected}
           isExpanded={isExpanded}
           ariaLabelledBy={titleId}
           placeholderText="Select a state"
         >
-          {this.options.map((option, index) => (
-            <SelectOption isDisabled={option.disabled} key={index} value={option.value} />
-          ))}
+          {this.options}
         </Select>
       </div>
     );

--- a/packages/patternfly-4/react-core/src/components/Select/Select.md
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.md
@@ -497,7 +497,98 @@ class MultiTypeaheadSelectInput extends React.Component {
   }
 }
 ```
+## Multiple typeahead select input with custom objects
 
+```js
+import React from 'react';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+
+class MultiTypeaheadSelectInputCustomObjects extends React.Component {
+  constructor(props) {
+    super(props);
+    this.createState = (name, abbreviation, capital, founded) => {
+    return {
+      name: name,
+      abbreviation: abbreviation,
+      capital: capital,
+      founded: founded,
+      toString: function() {
+        return `${this.name} (${this.abbreviation}) - Founded: ${this.founded}`;
+      }
+    }
+  }
+    this.options = [
+      { value: this.createState('Alabama', 'AL', 'Montgomery', 1846), disabled: false },
+      { value: this.createState('Florida', 'FL', 'Tailahassee', 1845), disabled: false },
+      { value: this.createState('New Jersey', 'NJ', 'Trenton', 1787), disabled: false },
+      { value: this.createState('New Mexico', 'NM', 'Santa Fe', 1912), disabled: false },
+      { value: this.createState('New York', 'NY', 'Albany', 1788), disabled: false },
+      { value: this.createState('North Carolina', 'NC', 'Raleigh', 1789),disabled: false }
+    ];
+
+    this.state = {
+      isExpanded: false,
+      selected: []
+    };
+
+    this.onToggle = isExpanded => {
+      this.setState({
+        isExpanded
+      });
+    };
+
+    this.onSelect = (event, selection) => {
+      const { selected } = this.state;
+      if (selected.includes(selection)) {
+        this.setState(
+          prevState => ({ selected: prevState.selected.filter(item => item !== selection) }),
+          () => console.log('selections: ', this.state.selected)
+        );
+      } else {
+        this.setState(
+          prevState => ({ selected: [...prevState.selected, selection] }),
+          () => console.log('selections: ', this.state.selected)
+        );
+      }
+    };
+
+    this.clearSelection = () => {
+      this.setState({
+        selected: [],
+        isExpanded: false
+      });
+    };
+  }
+
+  render() {
+    const { isExpanded, selected } = this.state;
+    const titleId = 'multi-typeahead-select-id';
+
+    return (
+      <div>
+        <span id={titleId} hidden>
+          Select a state
+        </span>
+        <Select
+          variant={SelectVariant.typeaheadMulti}
+          aria-label="Select a state"
+          onToggle={this.onToggle}
+          onSelect={this.onSelect}
+          onClear={this.clearSelection}
+          selections={selected}
+          isExpanded={isExpanded}
+          ariaLabelledBy={titleId}
+          placeholderText="Select a state"
+        >
+          {this.options.map((option, index) => (
+            <SelectOption isDisabled={option.disabled} key={index} value={option.value} />
+          ))}
+        </Select>
+      </div>
+    );
+  }
+}
+```
 ## Plain multiple typeahead select input
 
 ```js

--- a/packages/patternfly-4/react-core/src/components/Select/Select.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.test.tsx
@@ -1,11 +1,25 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { Select } from './Select';
-import { SelectOption } from './SelectOption';
+import { SelectOption, SelectOptionObject } from './SelectOption';
 import { CheckboxSelectOption } from './CheckboxSelectOption';
 import { SelectGroup } from './SelectGroup';
 import { CheckboxSelectGroup } from './CheckboxSelectGroup';
 import { SelectVariant } from './selectConstants';
+
+class User implements SelectOptionObject {
+  private firstName: string;
+  private lastName: string;
+  private title: string;
+
+  constructor(title: string, firstName: string, lastName: string) {
+    this.title = title;
+    this.firstName = firstName;
+    this.lastName = lastName;  
+  }
+
+  toString = ():string =>`${this.title}: ${this.firstName} ${this.lastName}`;
+}
 
 const selectOptions = [
   <SelectOption value="Mr" key="0" />,
@@ -19,6 +33,12 @@ const checkboxSelectOptions = [
   <CheckboxSelectOption value="Mrs" key="1" />,
   <CheckboxSelectOption value="Ms" key="2" />,
   <CheckboxSelectOption value="Other" key="3" />
+];
+
+const selectOptionsCustom = [
+  <SelectOption value={new User('Mr', 'User', 'One')} key="0" />,
+  <SelectOption value={new User('Mrs', 'New', 'User')} key="1" />,
+  <SelectOption value={new User('Ms', 'Test', 'Three')} key="2" />
 ];
 
 describe('select', () => {
@@ -36,6 +56,14 @@ describe('select', () => {
       const view = mount(
         <Select variant={SelectVariant.single} onSelect={jest.fn()} onToggle={jest.fn()} isExpanded>
           {selectOptions}
+        </Select>
+      );
+      expect(view).toMatchSnapshot();
+    });
+    test('renders expanded successfully with custom objects', () => {
+      const view = mount(
+        <Select variant={SelectVariant.single} onSelect={jest.fn()} onToggle={jest.fn()} isExpanded>
+          {selectOptionsCustom}
         </Select>
       );
       expect(view).toMatchSnapshot();
@@ -120,6 +148,15 @@ describe('checkbox select', () => {
     const view = mount(
       <Select variant={SelectVariant.checkbox} onSelect={jest.fn()} onToggle={jest.fn()} isExpanded>
         {checkboxSelectOptions}
+      </Select>
+    );
+    expect(view).toMatchSnapshot();
+  });
+
+  test('renders expanded successfully with custom objects', () => {
+    const view = mount(
+      <Select variant={SelectVariant.checkbox} onSelect={jest.fn()} onToggle={jest.fn()} isExpanded>
+        {selectOptionsCustom}
       </Select>
     );
     expect(view).toMatchSnapshot();

--- a/packages/patternfly-4/react-core/src/components/Select/Select.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.tsx
@@ -135,15 +135,15 @@ export class Select extends React.Component<SelectProps, SelectState> {
     } else {
       let input: RegExp;
       try {
-        input = new RegExp(e.target.value, 'i');
+        input = new RegExp(e.target.value.toString(), 'i');
       } catch (err) {
-        input = new RegExp(e.target.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+        input = new RegExp(e.target.value.toString().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
       }
       typeaheadFilteredChildren =
-        e.target.value !== ''
+        e.target.value.toString() !== ''
           ? React.Children.toArray(this.props.children).filter(
             (child: React.ReactNode) =>
-              this.getDisplay((child as React.ReactElement).props.value, 'text').search(input) === 0
+              this.getDisplay((child as React.ReactElement).props.value.toString(), 'text').search(input) === 0
             )
           : React.Children.toArray(this.props.children);
     }
@@ -178,7 +178,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
       React.cloneElement(child as React.ReactElement, {
         isFocused:
           typeaheadActiveChild &&
-          typeaheadActiveChild.innerText === this.getDisplay((child as React.ReactElement).props.value, 'text')
+          typeaheadActiveChild.innerText === this.getDisplay((child as React.ReactElement).props.value.toString(), 'text')
       })
     );
   }

--- a/packages/patternfly-4/react-core/src/components/Select/Select.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.tsx
@@ -6,7 +6,7 @@ import buttonStyles from '@patternfly/react-styles/css/components/Button/button'
 import { css } from '@patternfly/react-styles';
 import { TimesCircleIcon } from '@patternfly/react-icons';
 import { SelectMenu } from './SelectMenu';
-import { SelectOption } from './SelectOption';
+import { SelectOption, SelectOptionObject } from './SelectOption';
 import { SelectToggle } from './SelectToggle';
 import { SelectContext, SelectVariant } from './selectConstants';
 import { Chip, ChipGroup } from '../ChipGroup';
@@ -17,7 +17,7 @@ import { Omit } from '../../helpers/typeUtils';
 let currentId = 0;
 
 export interface SelectProps
-  extends Omit<React.HTMLProps<HTMLDivElement>, 'onSelect' | 'ref' | 'checked' | 'selected'> {
+  extends Omit<React.HTMLProps<HTMLDivElement>, 'onSelect' | 'ref' | 'checked' | 'selected' > {
   /** Content rendered inside the Select */
   children: React.ReactElement[];
   /** Classes applied to the root of the Select */
@@ -31,7 +31,7 @@ export interface SelectProps
   /** Title text of Select */
   placeholderText?: string | React.ReactNode;
   /** Selected item */
-  selections?: string[] | string;
+  selections?: string | SelectOptionObject | (string | SelectOptionObject)[];
   /** Id for select toggle element */
   toggleId?: string;
   /** Adds accessible text to Select */
@@ -47,7 +47,7 @@ export interface SelectProps
   /** Label for remove chip button of multiple type ahead select variant */
   ariaLabelRemove?: string;
   /** Callback for selection behavior */
-  onSelect?: (event: React.MouseEvent | React.ChangeEvent, value: string, isPlaceholder?: boolean) => void;
+  onSelect?: (event: React.MouseEvent | React.ChangeEvent, value: string | SelectOptionObject, isPlaceholder?: boolean) => void;
   /** Callback for toggle button behavior */
   onToggle: (isExpanded: boolean) => void;
   /** Callback for typeahead clear button */
@@ -229,13 +229,13 @@ export class Select extends React.Component<SelectProps, SelectState> {
     }
   };
 
-  getDisplay = (value: string, type: 'node' | 'text' = 'node') => {
+  getDisplay = (value: string | SelectOptionObject, type: 'node' | 'text' = 'node') => {
     if (!value) {
       return;
     }
 
     const { children } = this.props;
-    const item = children.filter(child => child.props.value === value)[0];
+    const item = children.filter(child => child.props.value.toString() === value.toString())[0];
 
     if (item && item.props.children) {
       if (type === 'node') {
@@ -243,7 +243,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
       }
       return this.findText(item);
     }
-    return item.props.value;
+    return item.props.value.toString();
   };
 
   findText: (item: React.ReactElement) => string = (item: React.ReactElement) => {
@@ -341,7 +341,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
               <React.Fragment>
                 <div className={css(styles.selectToggleWrapper)}>
                   <span className={css(styles.selectToggleText)}>{placeholderText}</span>
-                  {selections && selections.length > 0 && (
+                  {selections && (Array.isArray(selections) && selections.length > 0) && (
                     <div className={css(styles.selectToggleBadge)}>
                       <span className={css(badgeStyles.badge, badgeStyles.modifiers.read)}>{selections.length}</span>
                     </div>
@@ -387,7 +387,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
             {variant === SelectVariant.typeaheadMulti && (
               <React.Fragment>
                 <div className={css(styles.selectToggleWrapper)}>
-                  {selections && selections.length > 0 && selectedChips}
+                  {selections && (Array.isArray(selections) && selections.length > 0)&& selectedChips}
                   <input
                     className={css(formStyles.formControl, styles.selectToggleTypeahead)}
                     aria-activedescendant={typeaheadActiveChild && typeaheadActiveChild.id}
@@ -401,7 +401,7 @@ export class Select extends React.Component<SelectProps, SelectState> {
                     autoComplete="off"
                   />
                 </div>
-                {selections && selections.length > 0 && (
+                {selections && (Array.isArray(selections) && selections.length > 0) && (
                   <button
                     className={css(buttonStyles.button, buttonStyles.modifiers.plain, styles.selectToggleClear)}
                     onClick={e => {

--- a/packages/patternfly-4/react-core/src/components/Select/SelectMenu.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/SelectMenu.tsx
@@ -21,7 +21,7 @@ export interface SelectMenuProps extends Omit<React.HTMLProps<HTMLElement>, 'che
   /** Currently selected option (for single, typeahead variants) */
   selected?: string | SelectOptionObject | (string | SelectOptionObject)[];
   /** Currently checked options (for checkbox variant) */
-  checked?: string[];
+  checked?: (string | SelectOptionObject) [];
   /** Internal flag for specifiying how the menu was opened */
   openedOnEnter?: boolean;
   /** Internal callback for ref tracking */
@@ -64,7 +64,7 @@ export class SelectMenu extends React.Component<SelectMenuProps> {
         ? selected && (Array.isArray(selected) && selected.includes(child.props.value))
         : selected === child.props.value;
     return React.cloneElement(child, {
-      id: `${child.props.value}-${index}`,
+      id: `${child.props.value ? child.props.value.toString() : ''}-${index}`,
       isSelected,
       sendRef,
       keyHandler,

--- a/packages/patternfly-4/react-core/src/components/Select/SelectMenu.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/SelectMenu.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Select/select';
 import { default as formStyles } from '@patternfly/react-styles/css/components/Form/form';
 import { css } from '@patternfly/react-styles';
+import { SelectOptionObject } from './SelectOption';
 import { SelectConsumer, SelectVariant } from './selectConstants';
 import { Omit } from '../../helpers/typeUtils';
 
@@ -18,7 +19,7 @@ export interface SelectMenuProps extends Omit<React.HTMLProps<HTMLElement>, 'che
   /** Flag indicating the Select options are grouped */
   isGrouped?: boolean;
   /** Currently selected option (for single, typeahead variants) */
-  selected?: string | string[];
+  selected?: string | SelectOptionObject | (string | SelectOptionObject)[];
   /** Currently checked options (for checkbox variant) */
   checked?: string[];
   /** Internal flag for specifiying how the menu was opened */
@@ -60,7 +61,7 @@ export class SelectMenu extends React.Component<SelectMenuProps> {
     const { selected, sendRef, keyHandler } = this.props;
     const isSelected =
       selected && selected.constructor === Array
-        ? selected && selected.includes(child.props.value)
+        ? selected && (Array.isArray(selected) && selected.includes(child.props.value))
         : selected === child.props.value;
     return React.cloneElement(child, {
       id: `${child.props.value}-${index}`,

--- a/packages/patternfly-4/react-core/src/components/Select/SelectOption.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/SelectOption.test.tsx
@@ -1,7 +1,21 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
-import { SelectOption } from './SelectOption';
+import { SelectOption, SelectOptionObject } from './SelectOption';
 import { SelectProvider } from './selectConstants';
+
+class User implements SelectOptionObject {
+  private firstName: string;
+  private lastName: string;
+  private title: string;
+
+  constructor(title: string, firstName: string, lastName: string) {
+    this.title = title;
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+
+  toString = (): string => `${this.title}: ${this.firstName} ${this.lastName}`;
+}
 
 describe('select options', () => {
   test('renders with value parameter successfully', () => {
@@ -18,6 +32,27 @@ describe('select options', () => {
     const view = mount(
       <SelectProvider value={{ onSelect: () => {}, onClose: () => {}, variant: 'single' }}>
         <SelectOption value="test" sendRef={jest.fn()}>
+          <div>test display</div>
+        </SelectOption>
+      </SelectProvider>
+    );
+    expect(view).toMatchSnapshot();
+  });
+
+  test('renders with custom user object successfully', () => {
+    const view = mount(
+      <SelectProvider value={{ onSelect: () => {}, onClose: () => {}, variant: 'single' }}>
+        <SelectOption value={new User('Mr.', 'Test', 'User')} sendRef={jest.fn()} />
+      </SelectProvider>
+    );
+    expect(view).toMatchSnapshot();
+  });
+
+
+  test('renders with custom display and custom user object successfully', () => {
+    const view = mount(
+      <SelectProvider value={{ onSelect: () => {}, onClose: () => {}, variant: 'single' }}>
+        <SelectOption value={new User('Mr.', 'Test', 'User')} sendRef={jest.fn()}>
           <div>test display</div>
         </SelectOption>
       </SelectProvider>

--- a/packages/patternfly-4/react-core/src/components/Select/SelectOption.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/SelectOption.tsx
@@ -151,7 +151,7 @@ export class SelectOption extends React.Component<SelectOptionProps> {
                   checked={isChecked || false}
                   disabled={isDisabled}
                 />
-                <span className={css(checkStyles.checkLabel, isDisabled && styles.modifiers.disabled)}>{children || value}</span>
+                <span className={css(checkStyles.checkLabel, isDisabled && styles.modifiers.disabled)}>{children || value.toString()}</span>
               </label>
             )}
           </React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Select/SelectOption.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/SelectOption.tsx
@@ -6,15 +6,18 @@ import { CheckIcon } from '@patternfly/react-icons';
 import { SelectConsumer, SelectVariant, KeyTypes } from './selectConstants';
 import { Omit } from '../../helpers/typeUtils';
 
-export interface SelectOptionProps extends Omit<React.HTMLProps<HTMLElement>, 'type' | 'ref'> {
+export interface SelectOptionObject {
+  toString(): string
+}
+export interface SelectOptionProps extends Omit<React.HTMLProps<HTMLElement>, 'type' | 'ref' | 'value'> {
   /** Optional alternate display for the option */
   children?: React.ReactNode;
   /** Additional classes added to the Select Option */
   className?: string;
   /** Internal index of the option */
   index?: number;
-  /** The value for the option */
-  value: string;
+  /** The value for the option, if passing an object you most provide a toString function */
+  value: string | SelectOptionObject;
   /** Flag indicating if the option is disabled */
   isDisabled?: boolean;
   /** Flag indicating if the option acts as a placeholder */
@@ -118,7 +121,7 @@ export class SelectOption extends React.Component<SelectOptionProps> {
                   onKeyDown={this.onKeyDown}
                   type="button"
                 >
-                  {children || value}
+                  {children || value.toString()}
                   {isSelected && <CheckIcon className={css(styles.selectMenuItemIcon)} aria-hidden />}
                 </button>
               </li>
@@ -135,7 +138,7 @@ export class SelectOption extends React.Component<SelectOptionProps> {
                 onKeyDown={this.onKeyDown}
               >
                 <input
-                  id={value}
+                  id={value.toString()}
                   className={css(checkStyles.checkInput)}
                   type="checkbox"
                   onChange={event => {

--- a/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -31,10 +31,10 @@ exports[`checkbox select renders checkbox select groups successfully - old class
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-10"
+      ariaLabelledBy=" pf-toggle-id-12"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-10"
+      id="pf-toggle-id-12"
       isActive={false}
       isExpanded={true}
       isFocused={false}
@@ -50,9 +50,9 @@ exports[`checkbox select renders checkbox select groups successfully - old class
           >
             <button
               aria-expanded="true"
-              aria-labelledby=" pf-toggle-id-10"
+              aria-labelledby=" pf-toggle-id-12"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-10"
+              id="pf-toggle-id-12"
               type="button"
             >
               <div
@@ -247,9 +247,9 @@ exports[`checkbox select renders checkbox select groups successfully - old class
       <button
         aria-expanded={true}
         aria-haspopup={null}
-        aria-labelledby=" pf-toggle-id-10"
+        aria-labelledby=" pf-toggle-id-12"
         className="pf-c-select__toggle"
-        id="pf-toggle-id-10"
+        id="pf-toggle-id-12"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -650,10 +650,10 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-9"
+      ariaLabelledBy=" pf-toggle-id-11"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-9"
+      id="pf-toggle-id-11"
       isActive={false}
       isExpanded={true}
       isFocused={false}
@@ -669,9 +669,9 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
           >
             <button
               aria-expanded="true"
-              aria-labelledby=" pf-toggle-id-9"
+              aria-labelledby=" pf-toggle-id-11"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-9"
+              id="pf-toggle-id-11"
               type="button"
             >
               <div
@@ -866,9 +866,9 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
       <button
         aria-expanded={true}
         aria-haspopup={null}
-        aria-labelledby=" pf-toggle-id-9"
+        aria-labelledby=" pf-toggle-id-11"
         className="pf-c-select__toggle"
-        id="pf-toggle-id-9"
+        id="pf-toggle-id-11"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -1293,6 +1293,142 @@ exports[`checkbox select renders closed successfully - old classes 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
+      ariaLabelledBy=" pf-toggle-id-7"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-7"
+      isActive={false}
+      isExpanded={false}
+      isFocused={false}
+      isHovered={false}
+      isPlain={false}
+      onClose={[Function]}
+      onEnter={[Function]}
+      onToggle={[MockFunction]}
+      parentRef={
+        Object {
+          "current": <div
+            class="pf-c-select"
+          >
+            <button
+              aria-expanded="false"
+              aria-labelledby=" pf-toggle-id-7"
+              class="pf-c-select__toggle"
+              id="pf-toggle-id-7"
+              type="button"
+            >
+              <div
+                class="pf-c-select__toggle-wrapper"
+              >
+                <span
+                  class="pf-c-select__toggle-text"
+                />
+                
+              </div>
+              <svg
+                aria-hidden="true"
+                class="pf-c-select__toggle-arrow"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  transform=""
+                />
+              </svg>
+            </button>
+          </div>,
+        }
+      }
+      type="button"
+      variant="checkbox"
+    >
+      <button
+        aria-expanded={false}
+        aria-haspopup={null}
+        aria-labelledby=" pf-toggle-id-7"
+        className="pf-c-select__toggle"
+        id="pf-toggle-id-7"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        type="button"
+      >
+        <div
+          className="pf-c-select__toggle-wrapper"
+        >
+          <span
+            className="pf-c-select__toggle-text"
+          />
+        </div>
+        <CaretDownIcon
+          className="pf-c-select__toggle-arrow"
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+          title={null}
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="pf-c-select__toggle-arrow"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </CaretDownIcon>
+      </button>
+    </SelectToggle>
+  </div>
+</Select>
+`;
+
+exports[`checkbox select renders closed successfully 1`] = `
+<Select
+  aria-label=""
+  ariaLabelClear="Clear all"
+  ariaLabelRemove="Remove"
+  ariaLabelToggle="Options menu"
+  ariaLabelTypeAhead=""
+  ariaLabelledBy=""
+  className=""
+  isExpanded={false}
+  isGrouped={false}
+  isPlain={false}
+  onClear={[Function]}
+  onSelect={[MockFunction]}
+  onToggle={[MockFunction]}
+  placeholderText=""
+  selections=""
+  toggleId={null}
+  variant="checkbox"
+  width=""
+>
+  <div
+    className="pf-c-select"
+    style={
+      Object {
+        "width": "",
+      }
+    }
+  >
+    <SelectToggle
+      ariaLabelToggle="Options menu"
       ariaLabelledBy=" pf-toggle-id-6"
       className=""
       handleTypeaheadKeys={[Function]}
@@ -1398,7 +1534,7 @@ exports[`checkbox select renders closed successfully - old classes 1`] = `
 </Select>
 `;
 
-exports[`checkbox select renders closed successfully 1`] = `
+exports[`checkbox select renders expanded successfully - old classes 1`] = `
 <Select
   aria-label=""
   ariaLabelClear="Clear all"
@@ -1407,7 +1543,7 @@ exports[`checkbox select renders closed successfully 1`] = `
   ariaLabelTypeAhead=""
   ariaLabelledBy=""
   className=""
-  isExpanded={false}
+  isExpanded={true}
   isGrouped={false}
   isPlain={false}
   onClear={[Function]}
@@ -1420,7 +1556,7 @@ exports[`checkbox select renders closed successfully 1`] = `
   width=""
 >
   <div
-    className="pf-c-select"
+    className="pf-c-select pf-m-expanded"
     style={
       Object {
         "width": "",
@@ -1429,12 +1565,12 @@ exports[`checkbox select renders closed successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-5"
+      ariaLabelledBy=" pf-toggle-id-9"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-5"
+      id="pf-toggle-id-9"
       isActive={false}
-      isExpanded={false}
+      isExpanded={true}
       isFocused={false}
       isHovered={false}
       isPlain={false}
@@ -1444,13 +1580,13 @@ exports[`checkbox select renders closed successfully 1`] = `
       parentRef={
         Object {
           "current": <div
-            class="pf-c-select"
+            class="pf-c-select pf-m-expanded"
           >
             <button
-              aria-expanded="false"
-              aria-labelledby=" pf-toggle-id-5"
+              aria-expanded="true"
+              aria-labelledby=" pf-toggle-id-9"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-5"
+              id="pf-toggle-id-9"
               type="button"
             >
               <div
@@ -1477,6 +1613,82 @@ exports[`checkbox select renders closed successfully 1`] = `
                 />
               </svg>
             </button>
+            <div>
+              <div
+                class="pf-c-select__menu"
+              >
+                <form
+                  class="pf-c-form"
+                  novalidate=""
+                >
+                  <div
+                    class="pf-c-form__group"
+                  >
+                    <fieldset
+                      aria-label=""
+                      class="pf-c-form__fieldset"
+                    >
+                      <label
+                        class="pf-c-check pf-c-select__menu-item"
+                      >
+                        <input
+                          class="pf-c-check__input"
+                          id="Mr"
+                          type="checkbox"
+                        />
+                        <span
+                          class="pf-c-check__label"
+                        >
+                          Mr
+                        </span>
+                      </label>
+                      <label
+                        class="pf-c-check pf-c-select__menu-item"
+                      >
+                        <input
+                          class="pf-c-check__input"
+                          id="Mrs"
+                          type="checkbox"
+                        />
+                        <span
+                          class="pf-c-check__label"
+                        >
+                          Mrs
+                        </span>
+                      </label>
+                      <label
+                        class="pf-c-check pf-c-select__menu-item"
+                      >
+                        <input
+                          class="pf-c-check__input"
+                          id="Ms"
+                          type="checkbox"
+                        />
+                        <span
+                          class="pf-c-check__label"
+                        >
+                          Ms
+                        </span>
+                      </label>
+                      <label
+                        class="pf-c-check pf-c-select__menu-item"
+                      >
+                        <input
+                          class="pf-c-check__input"
+                          id="Other"
+                          type="checkbox"
+                        />
+                        <span
+                          class="pf-c-check__label"
+                        >
+                          Other
+                        </span>
+                      </label>
+                    </fieldset>
+                  </div>
+                </form>
+              </div>
+            </div>
           </div>,
         }
       }
@@ -1484,11 +1696,11 @@ exports[`checkbox select renders closed successfully 1`] = `
       variant="checkbox"
     >
       <button
-        aria-expanded={false}
+        aria-expanded={true}
         aria-haspopup={null}
-        aria-labelledby=" pf-toggle-id-5"
+        aria-labelledby=" pf-toggle-id-9"
         className="pf-c-select__toggle"
-        id="pf-toggle-id-5"
+        id="pf-toggle-id-9"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -1530,11 +1742,177 @@ exports[`checkbox select renders closed successfully 1`] = `
         </CaretDownIcon>
       </button>
     </SelectToggle>
+    <SelectMenu
+      aria-label=""
+      aria-labelledby=""
+      checked=""
+      className=""
+      isExpanded={false}
+      isGrouped={false}
+      keyHandler={[Function]}
+      openedOnEnter={false}
+      selected=""
+      sendRef={[Function]}
+    >
+      <FocusTrap
+        _createFocusTrap={[Function]}
+        active={true}
+        focusTrapOptions={
+          Object {
+            "clickOutsideDeactivates": true,
+          }
+        }
+        paused={false}
+        tag="div"
+      >
+        <div>
+          <div
+            className="pf-c-select__menu"
+          >
+            <form
+              className="pf-c-form"
+              noValidate={true}
+            >
+              <div
+                className="pf-c-form__group"
+              >
+                <fieldset
+                  aria-label=""
+                  aria-labelledby={null}
+                  className="pf-c-form__fieldset"
+                >
+                  <CheckboxSelectOption
+                    className=""
+                    index={0}
+                    isChecked=""
+                    isDisabled={false}
+                    key=".$0"
+                    keyHandler={[Function]}
+                    onClick={[Function]}
+                    sendRef={[Function]}
+                    value="Mr"
+                  >
+                    <label
+                      className="pf-c-check pf-c-select__menu-item"
+                      onKeyDown={[Function]}
+                    >
+                      <input
+                        checked={false}
+                        className="pf-c-check__input"
+                        disabled={false}
+                        id="Mr"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="pf-c-check__label"
+                      >
+                        Mr
+                      </span>
+                    </label>
+                  </CheckboxSelectOption>
+                  <CheckboxSelectOption
+                    className=""
+                    index={1}
+                    isChecked=""
+                    isDisabled={false}
+                    key=".$1"
+                    keyHandler={[Function]}
+                    onClick={[Function]}
+                    sendRef={[Function]}
+                    value="Mrs"
+                  >
+                    <label
+                      className="pf-c-check pf-c-select__menu-item"
+                      onKeyDown={[Function]}
+                    >
+                      <input
+                        checked={false}
+                        className="pf-c-check__input"
+                        disabled={false}
+                        id="Mrs"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="pf-c-check__label"
+                      >
+                        Mrs
+                      </span>
+                    </label>
+                  </CheckboxSelectOption>
+                  <CheckboxSelectOption
+                    className=""
+                    index={2}
+                    isChecked=""
+                    isDisabled={false}
+                    key=".$2"
+                    keyHandler={[Function]}
+                    onClick={[Function]}
+                    sendRef={[Function]}
+                    value="Ms"
+                  >
+                    <label
+                      className="pf-c-check pf-c-select__menu-item"
+                      onKeyDown={[Function]}
+                    >
+                      <input
+                        checked={false}
+                        className="pf-c-check__input"
+                        disabled={false}
+                        id="Ms"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="pf-c-check__label"
+                      >
+                        Ms
+                      </span>
+                    </label>
+                  </CheckboxSelectOption>
+                  <CheckboxSelectOption
+                    className=""
+                    index={3}
+                    isChecked=""
+                    isDisabled={false}
+                    key=".$3"
+                    keyHandler={[Function]}
+                    onClick={[Function]}
+                    sendRef={[Function]}
+                    value="Other"
+                  >
+                    <label
+                      className="pf-c-check pf-c-select__menu-item"
+                      onKeyDown={[Function]}
+                    >
+                      <input
+                        checked={false}
+                        className="pf-c-check__input"
+                        disabled={false}
+                        id="Other"
+                        onChange={[Function]}
+                        type="checkbox"
+                      />
+                      <span
+                        className="pf-c-check__label"
+                      >
+                        Other
+                      </span>
+                    </label>
+                  </CheckboxSelectOption>
+                </fieldset>
+              </div>
+            </form>
+          </div>
+        </div>
+      </FocusTrap>
+    </SelectMenu>
   </div>
 </Select>
 `;
 
-exports[`checkbox select renders expanded successfully - old classes 1`] = `
+exports[`checkbox select renders expanded successfully 1`] = `
 <Select
   aria-label=""
   ariaLabelClear="Clear all"
@@ -1781,11 +2159,14 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
                   aria-labelledby={null}
                   className="pf-c-form__fieldset"
                 >
-                  <CheckboxSelectOption
+                  <SelectOption
                     className=""
                     index={0}
                     isChecked=""
                     isDisabled={false}
+                    isFocused={false}
+                    isPlaceholder={false}
+                    isSelected={false}
                     key=".$0"
                     keyHandler={[Function]}
                     onClick={[Function]}
@@ -1810,12 +2191,15 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
                         Mr
                       </span>
                     </label>
-                  </CheckboxSelectOption>
-                  <CheckboxSelectOption
+                  </SelectOption>
+                  <SelectOption
                     className=""
                     index={1}
                     isChecked=""
                     isDisabled={false}
+                    isFocused={false}
+                    isPlaceholder={false}
+                    isSelected={false}
                     key=".$1"
                     keyHandler={[Function]}
                     onClick={[Function]}
@@ -1840,12 +2224,15 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
                         Mrs
                       </span>
                     </label>
-                  </CheckboxSelectOption>
-                  <CheckboxSelectOption
+                  </SelectOption>
+                  <SelectOption
                     className=""
                     index={2}
                     isChecked=""
                     isDisabled={false}
+                    isFocused={false}
+                    isPlaceholder={false}
+                    isSelected={false}
                     key=".$2"
                     keyHandler={[Function]}
                     onClick={[Function]}
@@ -1870,12 +2257,15 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
                         Ms
                       </span>
                     </label>
-                  </CheckboxSelectOption>
-                  <CheckboxSelectOption
+                  </SelectOption>
+                  <SelectOption
                     className=""
                     index={3}
                     isChecked=""
                     isDisabled={false}
+                    isFocused={false}
+                    isPlaceholder={false}
+                    isSelected={false}
                     key=".$3"
                     keyHandler={[Function]}
                     onClick={[Function]}
@@ -1900,7 +2290,7 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
                         Other
                       </span>
                     </label>
-                  </CheckboxSelectOption>
+                  </SelectOption>
                 </fieldset>
               </div>
             </form>
@@ -1912,7 +2302,7 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
 </Select>
 `;
 
-exports[`checkbox select renders expanded successfully 1`] = `
+exports[`checkbox select renders expanded successfully with custom objects 1`] = `
 <Select
   aria-label=""
   ariaLabelClear="Clear all"
@@ -1943,10 +2333,10 @@ exports[`checkbox select renders expanded successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-7"
+      ariaLabelledBy=" pf-toggle-id-10"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-7"
+      id="pf-toggle-id-10"
       isActive={false}
       isExpanded={true}
       isFocused={false}
@@ -1962,9 +2352,9 @@ exports[`checkbox select renders expanded successfully 1`] = `
           >
             <button
               aria-expanded="true"
-              aria-labelledby=" pf-toggle-id-7"
+              aria-labelledby=" pf-toggle-id-10"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-7"
+              id="pf-toggle-id-10"
               type="button"
             >
               <div
@@ -2011,13 +2401,13 @@ exports[`checkbox select renders expanded successfully 1`] = `
                       >
                         <input
                           class="pf-c-check__input"
-                          id="Mr"
+                          id="Mr: User One"
                           type="checkbox"
                         />
                         <span
                           class="pf-c-check__label"
                         >
-                          Mr
+                          Mr: User One
                         </span>
                       </label>
                       <label
@@ -2025,13 +2415,13 @@ exports[`checkbox select renders expanded successfully 1`] = `
                       >
                         <input
                           class="pf-c-check__input"
-                          id="Mrs"
+                          id="Mrs: New User"
                           type="checkbox"
                         />
                         <span
                           class="pf-c-check__label"
                         >
-                          Mrs
+                          Mrs: New User
                         </span>
                       </label>
                       <label
@@ -2039,27 +2429,13 @@ exports[`checkbox select renders expanded successfully 1`] = `
                       >
                         <input
                           class="pf-c-check__input"
-                          id="Ms"
+                          id="Ms: Test Three"
                           type="checkbox"
                         />
                         <span
                           class="pf-c-check__label"
                         >
-                          Ms
-                        </span>
-                      </label>
-                      <label
-                        class="pf-c-check pf-c-select__menu-item"
-                      >
-                        <input
-                          class="pf-c-check__input"
-                          id="Other"
-                          type="checkbox"
-                        />
-                        <span
-                          class="pf-c-check__label"
-                        >
-                          Other
+                          Ms: Test Three
                         </span>
                       </label>
                     </fieldset>
@@ -2076,9 +2452,9 @@ exports[`checkbox select renders expanded successfully 1`] = `
       <button
         aria-expanded={true}
         aria-haspopup={null}
-        aria-labelledby=" pf-toggle-id-7"
+        aria-labelledby=" pf-toggle-id-10"
         className="pf-c-select__toggle"
-        id="pf-toggle-id-7"
+        id="pf-toggle-id-10"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -2171,7 +2547,14 @@ exports[`checkbox select renders expanded successfully 1`] = `
                     keyHandler={[Function]}
                     onClick={[Function]}
                     sendRef={[Function]}
-                    value="Mr"
+                    value={
+                      User {
+                        "firstName": "User",
+                        "lastName": "One",
+                        "title": "Mr",
+                        "toString": [Function],
+                      }
+                    }
                   >
                     <label
                       className="pf-c-check pf-c-select__menu-item"
@@ -2181,14 +2564,14 @@ exports[`checkbox select renders expanded successfully 1`] = `
                         checked={false}
                         className="pf-c-check__input"
                         disabled={false}
-                        id="Mr"
+                        id="Mr: User One"
                         onChange={[Function]}
                         type="checkbox"
                       />
                       <span
                         className="pf-c-check__label"
                       >
-                        Mr
+                        Mr: User One
                       </span>
                     </label>
                   </SelectOption>
@@ -2204,7 +2587,14 @@ exports[`checkbox select renders expanded successfully 1`] = `
                     keyHandler={[Function]}
                     onClick={[Function]}
                     sendRef={[Function]}
-                    value="Mrs"
+                    value={
+                      User {
+                        "firstName": "New",
+                        "lastName": "User",
+                        "title": "Mrs",
+                        "toString": [Function],
+                      }
+                    }
                   >
                     <label
                       className="pf-c-check pf-c-select__menu-item"
@@ -2214,14 +2604,14 @@ exports[`checkbox select renders expanded successfully 1`] = `
                         checked={false}
                         className="pf-c-check__input"
                         disabled={false}
-                        id="Mrs"
+                        id="Mrs: New User"
                         onChange={[Function]}
                         type="checkbox"
                       />
                       <span
                         className="pf-c-check__label"
                       >
-                        Mrs
+                        Mrs: New User
                       </span>
                     </label>
                   </SelectOption>
@@ -2237,7 +2627,14 @@ exports[`checkbox select renders expanded successfully 1`] = `
                     keyHandler={[Function]}
                     onClick={[Function]}
                     sendRef={[Function]}
-                    value="Ms"
+                    value={
+                      User {
+                        "firstName": "Test",
+                        "lastName": "Three",
+                        "title": "Ms",
+                        "toString": [Function],
+                      }
+                    }
                   >
                     <label
                       className="pf-c-check pf-c-select__menu-item"
@@ -2247,47 +2644,14 @@ exports[`checkbox select renders expanded successfully 1`] = `
                         checked={false}
                         className="pf-c-check__input"
                         disabled={false}
-                        id="Ms"
+                        id="Ms: Test Three"
                         onChange={[Function]}
                         type="checkbox"
                       />
                       <span
                         className="pf-c-check__label"
                       >
-                        Ms
-                      </span>
-                    </label>
-                  </SelectOption>
-                  <SelectOption
-                    className=""
-                    index={3}
-                    isChecked=""
-                    isDisabled={false}
-                    isFocused={false}
-                    isPlaceholder={false}
-                    isSelected={false}
-                    key=".$3"
-                    keyHandler={[Function]}
-                    onClick={[Function]}
-                    sendRef={[Function]}
-                    value="Other"
-                  >
-                    <label
-                      className="pf-c-check pf-c-select__menu-item"
-                      onKeyDown={[Function]}
-                    >
-                      <input
-                        checked={false}
-                        className="pf-c-check__input"
-                        disabled={false}
-                        id="Other"
-                        onChange={[Function]}
-                        type="checkbox"
-                      />
-                      <span
-                        className="pf-c-check__label"
-                      >
-                        Other
+                        Ms: Test Three
                       </span>
                     </label>
                   </SelectOption>
@@ -2334,10 +2698,10 @@ exports[`select custom select filter filters properly 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-3"
+      ariaLabelledBy=" pf-toggle-id-4"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-3"
+      id="pf-toggle-id-4"
       isActive={false}
       isExpanded={true}
       isFocused={false}
@@ -2372,9 +2736,9 @@ exports[`select custom select filter filters properly 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-                aria-labelledby=" pf-toggle-id-3"
+                aria-labelledby=" pf-toggle-id-4"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-3"
+                id="pf-toggle-id-4"
               >
                 <svg
                   aria-hidden="true"
@@ -2467,9 +2831,9 @@ exports[`select custom select filter filters properly 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-          aria-labelledby=" pf-toggle-id-3"
+          aria-labelledby=" pf-toggle-id-4"
           className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-3"
+          id="pf-toggle-id-4"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -2650,10 +3014,10 @@ exports[`select renders select groups successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-4"
+      ariaLabelledBy=" pf-toggle-id-5"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-4"
+      id="pf-toggle-id-5"
       isActive={false}
       isExpanded={true}
       isFocused={false}
@@ -2670,9 +3034,9 @@ exports[`select renders select groups successfully 1`] = `
             <button
               aria-expanded="true"
               aria-haspopup="listbox"
-              aria-labelledby=" pf-toggle-id-4"
+              aria-labelledby=" pf-toggle-id-5"
               class="pf-c-select__toggle"
-              id="pf-toggle-id-4"
+              id="pf-toggle-id-5"
               type="button"
             >
               <div
@@ -2706,7 +3070,7 @@ exports[`select renders select groups successfully 1`] = `
             >
               <div
                 class="pf-c-select__menu-group"
-                id="undefined-0"
+                id="-0"
                 index="0"
               >
                 <div
@@ -2763,7 +3127,7 @@ exports[`select renders select groups successfully 1`] = `
               </div>
               <div
                 class="pf-c-select__menu-group"
-                id="undefined-1"
+                id="-1"
                 index="1"
               >
                 <div
@@ -2828,9 +3192,9 @@ exports[`select renders select groups successfully 1`] = `
       <button
         aria-expanded={true}
         aria-haspopup="listbox"
-        aria-labelledby=" pf-toggle-id-4"
+        aria-labelledby=" pf-toggle-id-5"
         className="pf-c-select__toggle"
-        id="pf-toggle-id-4"
+        id="pf-toggle-id-5"
         onClick={[Function]}
         onKeyDown={[Function]}
         type="button"
@@ -2890,7 +3254,7 @@ exports[`select renders select groups successfully 1`] = `
         role="listbox"
       >
         <Component
-          id="undefined-0"
+          id="-0"
           index={0}
           isSelected={false}
           key=".0"
@@ -2900,7 +3264,7 @@ exports[`select renders select groups successfully 1`] = `
         >
           <div
             className="pf-c-select__menu-group"
-            id="undefined-0"
+            id="-0"
             index={0}
             isSelected={false}
             keyHandler={[Function]}
@@ -3032,7 +3396,7 @@ exports[`select renders select groups successfully 1`] = `
           </div>
         </Component>
         <Component
-          id="undefined-1"
+          id="-1"
           index={1}
           isSelected={false}
           key=".1"
@@ -3042,7 +3406,7 @@ exports[`select renders select groups successfully 1`] = `
         >
           <div
             className="pf-c-select__menu-group"
-            id="undefined-1"
+            id="-1"
             index={1}
             isSelected={false}
             keyHandler={[Function]}
@@ -3657,6 +4021,322 @@ exports[`select single select renders expanded successfully 1`] = `
 </Select>
 `;
 
+exports[`select single select renders expanded successfully with custom objects 1`] = `
+<Select
+  aria-label=""
+  ariaLabelClear="Clear all"
+  ariaLabelRemove="Remove"
+  ariaLabelToggle="Options menu"
+  ariaLabelTypeAhead=""
+  ariaLabelledBy=""
+  className=""
+  isExpanded={true}
+  isGrouped={false}
+  isPlain={false}
+  onClear={[Function]}
+  onSelect={[MockFunction]}
+  onToggle={[MockFunction]}
+  placeholderText=""
+  selections=""
+  toggleId={null}
+  variant="single"
+  width=""
+>
+  <div
+    className="pf-c-select pf-m-expanded"
+    style={
+      Object {
+        "width": "",
+      }
+    }
+  >
+    <SelectToggle
+      ariaLabelToggle="Options menu"
+      ariaLabelledBy=" pf-toggle-id-2"
+      className=""
+      handleTypeaheadKeys={[Function]}
+      id="pf-toggle-id-2"
+      isActive={false}
+      isExpanded={true}
+      isFocused={false}
+      isHovered={false}
+      isPlain={false}
+      onClose={[Function]}
+      onEnter={[Function]}
+      onToggle={[MockFunction]}
+      parentRef={
+        Object {
+          "current": <div
+            class="pf-c-select pf-m-expanded"
+          >
+            <button
+              aria-expanded="true"
+              aria-haspopup="listbox"
+              aria-labelledby=" pf-toggle-id-2"
+              class="pf-c-select__toggle"
+              id="pf-toggle-id-2"
+              type="button"
+            >
+              <div
+                class="pf-c-select__toggle-wrapper"
+              >
+                <span
+                  class="pf-c-select__toggle-text"
+                >
+                  Mr: User One
+                </span>
+              </div>
+              <svg
+                aria-hidden="true"
+                class="pf-c-select__toggle-arrow"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  transform=""
+                />
+              </svg>
+            </button>
+            <ul
+              aria-label=""
+              aria-labelledby=""
+              class="pf-c-select__menu"
+              role="listbox"
+            >
+              <li
+                role="presentation"
+              >
+                <button
+                  class="pf-c-select__menu-item"
+                  id="Mr: User One-0"
+                  role="option"
+                  type="button"
+                >
+                  Mr: User One
+                </button>
+              </li>
+              <li
+                role="presentation"
+              >
+                <button
+                  class="pf-c-select__menu-item"
+                  id="Mrs: New User-1"
+                  role="option"
+                  type="button"
+                >
+                  Mrs: New User
+                </button>
+              </li>
+              <li
+                role="presentation"
+              >
+                <button
+                  class="pf-c-select__menu-item"
+                  id="Ms: Test Three-2"
+                  role="option"
+                  type="button"
+                >
+                  Ms: Test Three
+                </button>
+              </li>
+            </ul>
+          </div>,
+        }
+      }
+      type="button"
+      variant="single"
+    >
+      <button
+        aria-expanded={true}
+        aria-haspopup="listbox"
+        aria-labelledby=" pf-toggle-id-2"
+        className="pf-c-select__toggle"
+        id="pf-toggle-id-2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        type="button"
+      >
+        <div
+          className="pf-c-select__toggle-wrapper"
+        >
+          <span
+            className="pf-c-select__toggle-text"
+          >
+            Mr: User One
+          </span>
+        </div>
+        <CaretDownIcon
+          className="pf-c-select__toggle-arrow"
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+          title={null}
+        >
+          <svg
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="pf-c-select__toggle-arrow"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            style={
+              Object {
+                "verticalAlign": "-0.125em",
+              }
+            }
+            viewBox="0 0 320 512"
+            width="1em"
+          >
+            <path
+              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+              transform=""
+            />
+          </svg>
+        </CaretDownIcon>
+      </button>
+    </SelectToggle>
+    <SelectMenu
+      aria-label=""
+      aria-labelledby=""
+      className=""
+      isExpanded={false}
+      isGrouped={false}
+      keyHandler={[Function]}
+      openedOnEnter={false}
+      selected=""
+      sendRef={[Function]}
+    >
+      <ul
+        aria-label=""
+        aria-labelledby=""
+        className="pf-c-select__menu"
+        role="listbox"
+      >
+        <SelectOption
+          className=""
+          id="Mr: User One-0"
+          index={0}
+          isChecked={false}
+          isDisabled={false}
+          isFocused={false}
+          isPlaceholder={false}
+          isSelected={false}
+          key=".$0"
+          keyHandler={[Function]}
+          onClick={[Function]}
+          sendRef={[Function]}
+          value={
+            User {
+              "firstName": "User",
+              "lastName": "One",
+              "title": "Mr",
+              "toString": [Function],
+            }
+          }
+        >
+          <li
+            role="presentation"
+          >
+            <button
+              aria-selected={null}
+              className="pf-c-select__menu-item"
+              id="Mr: User One-0"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="option"
+              type="button"
+            >
+              Mr: User One
+            </button>
+          </li>
+        </SelectOption>
+        <SelectOption
+          className=""
+          id="Mrs: New User-1"
+          index={1}
+          isChecked={false}
+          isDisabled={false}
+          isFocused={false}
+          isPlaceholder={false}
+          isSelected={false}
+          key=".$1"
+          keyHandler={[Function]}
+          onClick={[Function]}
+          sendRef={[Function]}
+          value={
+            User {
+              "firstName": "New",
+              "lastName": "User",
+              "title": "Mrs",
+              "toString": [Function],
+            }
+          }
+        >
+          <li
+            role="presentation"
+          >
+            <button
+              aria-selected={null}
+              className="pf-c-select__menu-item"
+              id="Mrs: New User-1"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="option"
+              type="button"
+            >
+              Mrs: New User
+            </button>
+          </li>
+        </SelectOption>
+        <SelectOption
+          className=""
+          id="Ms: Test Three-2"
+          index={2}
+          isChecked={false}
+          isDisabled={false}
+          isFocused={false}
+          isPlaceholder={false}
+          isSelected={false}
+          key=".$2"
+          keyHandler={[Function]}
+          onClick={[Function]}
+          sendRef={[Function]}
+          value={
+            User {
+              "firstName": "Test",
+              "lastName": "Three",
+              "title": "Ms",
+              "toString": [Function],
+            }
+          }
+        >
+          <li
+            role="presentation"
+          >
+            <button
+              aria-selected={null}
+              className="pf-c-select__menu-item"
+              id="Ms: Test Three-2"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="option"
+              type="button"
+            >
+              Ms: Test Three
+            </button>
+          </li>
+        </SelectOption>
+      </ul>
+    </SelectMenu>
+  </div>
+</Select>
+`;
+
 exports[`typeahead multi select renders closed successfully 1`] = `
 <Select
   aria-label=""
@@ -3688,10 +4368,10 @@ exports[`typeahead multi select renders closed successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-16"
+      ariaLabelledBy=" pf-toggle-id-18"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-16"
+      id="pf-toggle-id-18"
       isActive={false}
       isExpanded={false}
       isFocused={false}
@@ -3727,9 +4407,9 @@ exports[`typeahead multi select renders closed successfully 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-                aria-labelledby=" pf-toggle-id-16"
+                aria-labelledby=" pf-toggle-id-18"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-16"
+                id="pf-toggle-id-18"
               >
                 <svg
                   aria-hidden="true"
@@ -3779,9 +4459,9 @@ exports[`typeahead multi select renders closed successfully 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           aria-label="Options menu"
-          aria-labelledby=" pf-toggle-id-16"
+          aria-labelledby=" pf-toggle-id-18"
           className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-16"
+          id="pf-toggle-id-18"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -3850,10 +4530,10 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-17"
+      ariaLabelledBy=" pf-toggle-id-19"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-17"
+      id="pf-toggle-id-19"
       isActive={false}
       isExpanded={true}
       isFocused={false}
@@ -3889,9 +4569,9 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-                aria-labelledby=" pf-toggle-id-17"
+                aria-labelledby=" pf-toggle-id-19"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-17"
+                id="pf-toggle-id-19"
               >
                 <svg
                   aria-hidden="true"
@@ -3996,9 +4676,9 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-          aria-labelledby=" pf-toggle-id-17"
+          aria-labelledby=" pf-toggle-id-19"
           className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-17"
+          id="pf-toggle-id-19"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -4215,10 +4895,10 @@ exports[`typeahead multi select renders selected successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-18"
+      ariaLabelledBy=" pf-toggle-id-20"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-18"
+      id="pf-toggle-id-20"
       isActive={false}
       isExpanded={true}
       isFocused={false}
@@ -4323,9 +5003,9 @@ exports[`typeahead multi select renders selected successfully 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-                aria-labelledby=" pf-toggle-id-18"
+                aria-labelledby=" pf-toggle-id-20"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-18"
+                id="pf-toggle-id-20"
               >
                 <svg
                   aria-hidden="true"
@@ -4640,9 +5320,9 @@ exports[`typeahead multi select renders selected successfully 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-          aria-labelledby=" pf-toggle-id-18"
+          aria-labelledby=" pf-toggle-id-20"
           className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-18"
+          id="pf-toggle-id-20"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -4917,10 +5597,10 @@ exports[`typeahead multi select test onChange 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-20"
+      ariaLabelledBy=" pf-toggle-id-22"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-20"
+      id="pf-toggle-id-22"
       isActive={false}
       isExpanded={true}
       isFocused={false}
@@ -4955,9 +5635,9 @@ exports[`typeahead multi select test onChange 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-                aria-labelledby=" pf-toggle-id-20"
+                aria-labelledby=" pf-toggle-id-22"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-20"
+                id="pf-toggle-id-22"
               >
                 <svg
                   aria-hidden="true"
@@ -5026,9 +5706,9 @@ exports[`typeahead multi select test onChange 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-          aria-labelledby=" pf-toggle-id-20"
+          aria-labelledby=" pf-toggle-id-22"
           className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-20"
+          id="pf-toggle-id-22"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -5147,10 +5827,10 @@ exports[`typeahead select renders closed successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-11"
+      ariaLabelledBy=" pf-toggle-id-13"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-11"
+      id="pf-toggle-id-13"
       isActive={false}
       isExpanded={false}
       isFocused={false}
@@ -5185,9 +5865,9 @@ exports[`typeahead select renders closed successfully 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-                aria-labelledby=" pf-toggle-id-11"
+                aria-labelledby=" pf-toggle-id-13"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-11"
+                id="pf-toggle-id-13"
               >
                 <svg
                   aria-hidden="true"
@@ -5237,9 +5917,9 @@ exports[`typeahead select renders closed successfully 1`] = `
           aria-expanded={false}
           aria-haspopup="listbox"
           aria-label="Options menu"
-          aria-labelledby=" pf-toggle-id-11"
+          aria-labelledby=" pf-toggle-id-13"
           className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-11"
+          id="pf-toggle-id-13"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -5308,10 +5988,10 @@ exports[`typeahead select renders expanded successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-12"
+      ariaLabelledBy=" pf-toggle-id-14"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-12"
+      id="pf-toggle-id-14"
       isActive={false}
       isExpanded={true}
       isFocused={false}
@@ -5346,9 +6026,9 @@ exports[`typeahead select renders expanded successfully 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-                aria-labelledby=" pf-toggle-id-12"
+                aria-labelledby=" pf-toggle-id-14"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-12"
+                id="pf-toggle-id-14"
               >
                 <svg
                   aria-hidden="true"
@@ -5453,9 +6133,9 @@ exports[`typeahead select renders expanded successfully 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-          aria-labelledby=" pf-toggle-id-12"
+          aria-labelledby=" pf-toggle-id-14"
           className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-12"
+          id="pf-toggle-id-14"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -5667,10 +6347,10 @@ exports[`typeahead select renders selected successfully 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-13"
+      ariaLabelledBy=" pf-toggle-id-15"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-13"
+      id="pf-toggle-id-15"
       isActive={false}
       isExpanded={true}
       isFocused={false}
@@ -5724,9 +6404,9 @@ exports[`typeahead select renders selected successfully 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-                aria-labelledby=" pf-toggle-id-13"
+                aria-labelledby=" pf-toggle-id-15"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-13"
+                id="pf-toggle-id-15"
               >
                 <svg
                   aria-hidden="true"
@@ -5881,9 +6561,9 @@ exports[`typeahead select renders selected successfully 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-          aria-labelledby=" pf-toggle-id-13"
+          aria-labelledby=" pf-toggle-id-15"
           className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-13"
+          id="pf-toggle-id-15"
           onClick={[Function]}
         >
           <CaretDownIcon
@@ -6124,10 +6804,10 @@ exports[`typeahead select test onChange 1`] = `
   >
     <SelectToggle
       ariaLabelToggle="Options menu"
-      ariaLabelledBy=" pf-toggle-id-15"
+      ariaLabelledBy=" pf-toggle-id-17"
       className=""
       handleTypeaheadKeys={[Function]}
-      id="pf-toggle-id-15"
+      id="pf-toggle-id-17"
       isActive={false}
       isExpanded={true}
       isFocused={false}
@@ -6162,9 +6842,9 @@ exports[`typeahead select test onChange 1`] = `
                 aria-expanded="true"
                 aria-haspopup="listbox"
                 aria-label="Options menu"
-                aria-labelledby=" pf-toggle-id-15"
+                aria-labelledby=" pf-toggle-id-17"
                 class="pf-c-button pf-c-select__toggle-button"
-                id="pf-toggle-id-15"
+                id="pf-toggle-id-17"
               >
                 <svg
                   aria-hidden="true"
@@ -6233,9 +6913,9 @@ exports[`typeahead select test onChange 1`] = `
           aria-expanded={true}
           aria-haspopup="listbox"
           aria-label="Options menu"
-          aria-labelledby=" pf-toggle-id-15"
+          aria-labelledby=" pf-toggle-id-17"
           className="pf-c-button pf-c-select__toggle-button"
-          id="pf-toggle-id-15"
+          id="pf-toggle-id-17"
           onClick={[Function]}
         >
           <CaretDownIcon

--- a/packages/patternfly-4/react-core/src/components/Select/__snapshots__/SelectOption.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Select/__snapshots__/SelectOption.test.tsx.snap
@@ -64,6 +64,69 @@ exports[`select options is selected renders selected successfully 1`] = `
 </ContextConsumer>
 `;
 
+exports[`select options renders with custom display and custom user object successfully 1`] = `
+<SelectOption
+  className=""
+  index={0}
+  isChecked={false}
+  isDisabled={false}
+  isFocused={false}
+  isPlaceholder={false}
+  isSelected={false}
+  keyHandler={[Function]}
+  onClick={[Function]}
+  sendRef={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          <button
+            class="pf-c-select__menu-item"
+            role="option"
+            type="button"
+          >
+            <div>
+              test display
+            </div>
+          </button>,
+          0,
+        ],
+      ],
+      "results": Array [
+        Object {
+          "isThrow": false,
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  value={
+    User {
+      "firstName": "Test",
+      "lastName": "User",
+      "title": "Mr.",
+      "toString": [Function],
+    }
+  }
+>
+  <li
+    role="presentation"
+  >
+    <button
+      aria-selected={null}
+      className="pf-c-select__menu-item"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="option"
+      type="button"
+    >
+      <div>
+        test display
+      </div>
+    </button>
+  </li>
+</SelectOption>
+`;
+
 exports[`select options renders with custom display successfully 1`] = `
 <SelectOption
   className=""
@@ -115,6 +178,65 @@ exports[`select options renders with custom display successfully 1`] = `
       <div>
         test display
       </div>
+    </button>
+  </li>
+</SelectOption>
+`;
+
+exports[`select options renders with custom user object successfully 1`] = `
+<SelectOption
+  className=""
+  index={0}
+  isChecked={false}
+  isDisabled={false}
+  isFocused={false}
+  isPlaceholder={false}
+  isSelected={false}
+  keyHandler={[Function]}
+  onClick={[Function]}
+  sendRef={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          <button
+            class="pf-c-select__menu-item"
+            role="option"
+            type="button"
+          >
+            Mr.: Test User
+          </button>,
+          0,
+        ],
+      ],
+      "results": Array [
+        Object {
+          "isThrow": false,
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  value={
+    User {
+      "firstName": "Test",
+      "lastName": "User",
+      "title": "Mr.",
+      "toString": [Function],
+    }
+  }
+>
+  <li
+    role="presentation"
+  >
+    <button
+      aria-selected={null}
+      className="pf-c-select__menu-item"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="option"
+      type="button"
+    >
+      Mr.: Test User
     </button>
   </li>
 </SelectOption>

--- a/packages/patternfly-4/react-core/src/components/Select/selectConstants.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/selectConstants.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
+import { SelectOptionObject } from './SelectOption';
 
 export interface SelectContextInterface {
   onSelect: (
     event: React.MouseEvent<any, MouseEvent> | React.ChangeEvent<HTMLInputElement>,
-    value: string,
+    value: string | SelectOptionObject,
     isPlaceholder?: boolean
   ) => void;
   onClose: () => void;

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/common/State.ts
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/common/State.ts
@@ -1,0 +1,15 @@
+import {SelectOptionObject} from '@patternfly/react-core';
+
+export class State implements SelectOptionObject {
+    name: string;
+    abbreviation: string;
+    capital: string;
+    founded: number;
+    constructor(name: string, abbreviation: string, capital: string, founded: number) {
+      this.name = name;
+      this.abbreviation = abbreviation;
+      this.capital = capital;
+      this.founded = founded;
+    }
+    toString = () => `${this.name} (${this.abbreviation}) - Founded: ${this.founded}`;
+  }

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
@@ -63,7 +63,7 @@ export class SelectDemo extends Component<SelectDemoState> {
     { value: 'Florida', disabled: false },
     { value: 'New Jersey', disabled: false },
     { value: 'New Mexico', disabled: false },
-    { value: 'New York', disabled: false },
+    { value: { statename: 'New York', abreviation: 'NY', something: 'else', toString: () => 'New York' }, disabled: false },
     { value: 'North Carolina', disabled: false }
   ];
 
@@ -116,18 +116,18 @@ export class SelectDemo extends Component<SelectDemoState> {
         singleSelected: selection,
         singleIsExpanded: false
       });
-      console.log('selected:', selection);
+      console.log('selected:', selection.toString());
     }
   };
 
-  customSingleOnSelect = (event: any, selection: string, isPlaceholder: boolean) => {
+  customSingleOnSelect = (event: any, selection: string | object, isPlaceholder: boolean) => {
     if (isPlaceholder) this.clearSelection();
     else {
       this.setState({
         customSingleSelected: selection,
         customSingleIsExpanded: false
       });
-      console.log('selected:', selection);
+      console.log('selected:', selection.toString());
     }
   };
 
@@ -146,18 +146,18 @@ export class SelectDemo extends Component<SelectDemoState> {
     }
   };
 
-  typeaheadOnSelect = (event: any, selection: string, isPlaceholder: boolean) => {
+  typeaheadOnSelect = (event: any, selection: string | object, isPlaceholder: boolean) => {
     if (isPlaceholder) this.clearSelection();
     else {
       this.setState({
         typeaheadSelected: selection,
         typeaheadIsExpanded: false
       });
-      console.log('selected:', selection);
+      console.log('selected:', selection.toString());
     }
   };
 
-  typeaheadMultiOnSelect = (event: any, selection: string) => {
+  typeaheadMultiOnSelect = (event: any, selection: string | object) => {
     const { typeaheadMultiSelected } = this.state;
     if (typeaheadMultiSelected.includes(selection)) {
       this.setState(
@@ -404,7 +404,7 @@ export class SelectDemo extends Component<SelectDemoState> {
           >
             {this.typeaheadOptions.map((option, index) => (
               <SelectOption isDisabled={option.disabled} key={index} value={option.value}>
-                <div>div-{option.value}<span>-test_span</span><CartArrowDownIcon /></div>
+                <div>div-{option.value.toString()}<span>-test_span</span><CartArrowDownIcon /></div>
               </SelectOption>
             ))}
           </Select>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
@@ -1,6 +1,7 @@
 import { Select, SelectOption, SelectVariant, Stack, StackItem, Title } from '@patternfly/react-core';
 import React, { Component } from 'react';
 import { CartArrowDownIcon } from '@patternfly/react-icons';
+import { State } from '../../../common/State';
 
 export interface SelectDemoState {
   singleIsExpanded: boolean,
@@ -439,7 +440,7 @@ export class SelectDemo extends Component<SelectDemoState> {
         >
           {this.typeaheadOptions.map((option, index) => (
             <SelectOption isDisabled={option.disabled} key={index} value={option.value}>
-              <div>div-{option.value}<span>-test_span</span><CartArrowDownIcon /></div>
+              <div>div-{option.value.toString()}<span>-test_span</span><CartArrowDownIcon /></div>
             </SelectOption>
           ))}
         </Select>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
@@ -1,4 +1,4 @@
-import { Select, SelectOption, SelectVariant, Stack, StackItem, Title } from '@patternfly/react-core';
+import { Select, SelectOption, SelectVariant, Stack, StackItem, Title, SelectOptionObject } from '@patternfly/react-core';
 import React, { Component } from 'react';
 import { CartArrowDownIcon } from '@patternfly/react-icons';
 import { State } from '../../../common/State';
@@ -53,19 +53,29 @@ export class SelectDemo extends Component<SelectDemoState> {
 
   checkboxOptions = [
     <SelectOption key={0} value="Active" />,
-    <SelectOption key={1} value="Cancelled" />,
+    <SelectOption key={1} value={{numericValue: 0, toString: () => 'Cancelled'} as SelectOptionObject} />,
     <SelectOption key={2} value="Paused" />,
     <SelectOption key={3} value="Warning" />,
     <SelectOption key={4} value="Restarted" />
   ];
 
   typeaheadOptions = [
-    { value: 'Alabama', disabled: false },
+    
+    { value: new State('Alabama', 'AL', 'Montgomery', 1846)},
     { value: 'Florida', disabled: false },
     { value: 'New Jersey', disabled: false },
-    { value: 'New Mexico', disabled: false },
-    { value: { statename: 'New York', abreviation: 'NY', something: 'else', toString: () => 'New York' }, disabled: false },
-    { value: 'North Carolina', disabled: false }
+    { value: new State('New Mexico', 'NM', 'Santa Fe', 1912), disabled: false },
+    { value: new State('New York', 'NY', 'Albany', 1788), disabled: false },
+    { value: new State('North Carolina', 'NC', 'Raleigh', 1789), disabled:false}
+  ];
+
+  customSelectValueOptions = [
+    <SelectOption key={6} value={ new State('Alabama', 'AL', 'Montgomery', 1846)} />,
+    <SelectOption key={7} value={ new State('Florida', 'FL', 'Tailahassee', 1845)} />,
+    <SelectOption key={8} value={ new State('New Jersey', 'NJ', 'Trenton', 1787)} />,
+    <SelectOption key={9} value={ new State('New Mexico', 'NM', 'Santa Fe', 1912)} />,
+    <SelectOption key={10} value={ new State('New York', 'NY', 'Albany', 1788)} />,
+    <SelectOption key={11} value={ new State('North Carolina', 'NC', 'Raleigh', 1789)} />
   ];
 
   singleOnToggle = (singleIsExpanded: boolean) => {


### PR DESCRIPTION
This enhancement allows a user to now pass in a user defined object to store additional data besides just the string value to a select option.  The object must have a toString function that is
responsible for returning the the localized string.

fix #2045

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
