### PR TITLE
feat(chart-stack): add monthly example

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -302,8 +302,8 @@ class ResponsiveStack extends React.Component {
       <div ref={this.containerRef}>
         <div>
           <Chart
-            ariaDesc="Average number of pets"
-            ariaTitle="Stack chart example"
+            ariaDesc="Stack Chart with monthly metric data"
+            ariaTitle="Monthly Stack Chart"
             domainPadding={{ x: [30, 25] }}
             legendData={[{ name: 'Sockets' }, { name: 'Cores' }, { name: 'Nodes' }]}
             legendPosition="bottom"
@@ -316,7 +316,7 @@ class ResponsiveStack extends React.Component {
             }}
             width={width}
           >
-            <ChartAxis tickValues = {this.getTickValues()} />
+            <ChartAxis tickValues = {this.getTickValues()} fixLabelOverlap />
             <ChartAxis dependentAxis showGrid />
             <ChartStack domainPadding={{x: [10, 2]}}>
               { this.renderChartBars() }

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -277,10 +277,10 @@ class ResponsiveStack extends React.Component {
         />,
       ];
     }
-    this.getTickValues = () => {
+    this.getTickValues = (offset = 2) => {
       let tickValues = [];
       for(let i = 1; i < 32; i++){
-        if (i % 5 == 0){
+        if (i % offset == 0){
           tickValues.push(`Aug. ${i}`);
         }
       }

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -210,3 +210,121 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
   </div>
 </div>
 ```
+
+## Monthly vertical stack with bottom aligned legend and responsive container
+```js
+import React from 'react';
+import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
+
+class ResponsiveStack extends React.Component {
+  constructor(props) {
+    super(props);
+    this.containerRef = React.createRef();
+    this.state = {
+      width: 0
+    };
+    this.handleResize = () => {
+      this.setState({ width: this.containerRef.current.clientWidth });
+    };
+    this.renderChartBars = () => {
+      let bars = [];
+      for(let i = 1; i < 32; i++){
+        bars.push({ x: `Aug. ${i}`, y: Math.floor(Math.random() * 6) + 1 });
+      };
+
+      let socketBars = bars.map(tick => {
+        return {
+          x: tick.x,
+          y: tick.y,
+          name: 'Sockets',
+          label: `${tick.x} Sockets: ${tick.y}`
+        };
+      });
+
+      let coresBars = bars.map(tick => {
+        return {
+          x: tick.x,
+          y: tick.y,
+          name: 'Cores',
+          label: `${tick.x} Cores: ${tick.y}`
+        };
+      });
+
+      let nodesBars = bars.map(tick => {
+        return {
+          x: tick.x,
+          y: tick.y,
+          name: 'Nodes',
+          label: `${tick.x} Nodes: ${tick.y}`
+        };
+      });
+
+      return [
+        <ChartBar 
+          data={socketBars} 
+          labelComponent={<ChartTooltip />}
+        />,
+        <ChartBar 
+          data={coresBars} 
+          labelComponent={<ChartTooltip />}
+        />,
+        <ChartBar 
+          data={nodesBars} 
+          labelComponent={<ChartTooltip />}
+        />,
+      ];
+    }
+    this.getTickValues = () => {
+      let tickValues = [];
+      for(let i = 1; i < 32; i++){
+        if (i % 5 == 0){
+          tickValues.push(`Aug. ${i}`);
+        }
+      }
+      return tickValues;
+    }
+  }
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({ width: this.containerRef.current.clientWidth });
+      window.addEventListener('resize', this.handleResize);
+    });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  render(){
+    const { width } = this.state;
+    return (
+      <div ref={this.containerRef}>
+        <div>
+          <Chart
+            ariaDesc="Average number of pets"
+            ariaTitle="Stack chart example"
+            domainPadding={{ x: [30, 25] }}
+            legendData={[{ name: 'Sockets' }, { name: 'Cores' }, { name: 'Nodes' }]}
+            legendPosition="bottom"
+            height={275}
+            padding={{
+              bottom: 75, // Adjusted to accomodate legend
+              left: 50,
+              right: 50, 
+              top: 50
+            }}
+            width={width}
+          >
+            <ChartAxis tickValues = {this.getTickValues()} />
+            <ChartAxis dependentAxis showGrid />
+            <ChartStack domainPadding={{x: [10, 2]}}>
+              { this.renderChartBars() }
+            </ChartStack>
+          </Chart>
+        </div>
+      </div>
+    )
+  }
+}
+```

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -224,15 +224,18 @@ class ResponsiveStack extends React.Component {
       width: 0
     };
     this.handleResize = () => {
-      this.setState({ width: this.containerRef.current.clientWidth });
+      if(this.containerRef.current && this.containerRef.current.clientWidth){
+        this.setState({ width: this.containerRef.current.clientWidth });
+      }
     };
-    this.renderChartBars = () => {
-      let bars = [];
-      for(let i = 1; i < 32; i++){
-        bars.push({ x: `Aug. ${i}`, y: Math.floor(Math.random() * 6) + 1 });
-      };
 
-      let socketBars = bars.map(tick => {
+    this.bars = [];
+    for(let i = 1; i < 32; i++){
+      this.bars.push({ x: `Aug. ${i}`, y: Math.floor(Math.random() * 6) + 1 });
+    };
+
+    this.renderChartBars = () => {
+      let socketBars = this.bars.map(tick => {
         return {
           x: tick.x,
           y: tick.y,
@@ -241,7 +244,7 @@ class ResponsiveStack extends React.Component {
         };
       });
 
-      let coresBars = bars.map(tick => {
+      let coresBars = this.bars.map(tick => {
         return {
           x: tick.x,
           y: tick.y,
@@ -250,7 +253,7 @@ class ResponsiveStack extends React.Component {
         };
       });
 
-      let nodesBars = bars.map(tick => {
+      let nodesBars = this.bars.map(tick => {
         return {
           x: tick.x,
           y: tick.y,
@@ -286,10 +289,8 @@ class ResponsiveStack extends React.Component {
   }
 
   componentDidMount() {
-    setTimeout(() => {
-      this.setState({ width: this.containerRef.current.clientWidth });
-      window.addEventListener('resize', this.handleResize);
-    });
+    this.handleResize();
+    window.addEventListener('resize', this.handleResize);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
Refactors downstream monthly stack chart view in Subscriptions based on current discussions. This needs more review and iteration, but we'd like to tackle this problem in PatternFly!

Note: will need to test whatever solution we come up w/ here downstream before merge...

Current screenshots...

https://patternfly-react-pr-2625.surge.sh/patternfly-4/charts/chartstack/

Desktop:
<img width="1050" alt="Screen Shot 2019-08-01 at 10 27 03 AM" src="https://user-images.githubusercontent.com/4237045/62301628-f6a17e80-b446-11e9-9dde-1100da65ee72.png">

Tablet:
<img width="738" alt="Screen Shot 2019-08-01 at 10 27 54 AM" src="https://user-images.githubusercontent.com/4237045/62301757-294b7700-b447-11e9-905b-ec1c04922616.png">

Mobile:
<img width="481" alt="Screen Shot 2019-08-01 at 10 28 11 AM" src="https://user-images.githubusercontent.com/4237045/62301774-32d4df00-b447-11e9-8108-a5ac384dcb3d.png">


<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
