### PR TITLE
fix(Chart Themes): Fix missing fill and stroke colors for area and line charts

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -315,7 +315,7 @@ exports[`Chart 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -2615,7 +2615,7 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -2912,7 +2912,7 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -3073,7 +3073,7 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -3370,7 +3370,7 @@ exports[`Chart 2`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -5670,7 +5670,7 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -5967,7 +5967,7 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -6128,7 +6128,7 @@ exports[`renders axis and component children 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -6425,7 +6425,7 @@ exports[`renders axis and component children 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -8730,7 +8730,7 @@ exports[`renders axis and component children 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -9027,7 +9027,7 @@ exports[`renders axis and component children 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -349,7 +349,7 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -543,7 +543,7 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -840,7 +840,7 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -1058,7 +1058,7 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -1355,7 +1355,7 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`ChartAxis 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -349,7 +349,7 @@ exports[`ChartAxis 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -558,7 +558,7 @@ exports[`ChartAxis 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -855,7 +855,7 @@ exports[`ChartAxis 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -1030,7 +1030,7 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -1327,7 +1327,7 @@ exports[`renders component data 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -3635,7 +3635,7 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -3932,7 +3932,7 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -364,7 +364,7 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -573,7 +573,7 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -870,7 +870,7 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -1030,7 +1030,7 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -1327,7 +1327,7 @@ exports[`renders component data 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -3635,7 +3635,7 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -3932,7 +3932,7 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -321,7 +321,7 @@ exports[`Chart 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -498,7 +498,7 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -795,7 +795,7 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -970,7 +970,7 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -1267,7 +1267,7 @@ exports[`Chart 2`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -1444,7 +1444,7 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -1741,7 +1741,7 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -1916,7 +1916,7 @@ exports[`renders container via ChartLegend 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -2213,7 +2213,7 @@ exports[`renders container via ChartLegend 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -2391,7 +2391,7 @@ exports[`renders container via ChartLegend 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -2688,7 +2688,7 @@ exports[`renders container via ChartLegend 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#151515",
+              "fill": "#06c",
               "fillOpacity": 0.4,
               "stroke": "transparent",
               "strokeWidth": 2,
@@ -325,7 +325,7 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#151515",
+              "stroke": "#06c",
               "strokeWidth": 2,
             },
             "labels": Object {
@@ -498,7 +498,7 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#151515",
+              "fill": "#06c",
               "fillOpacity": 0.4,
               "stroke": "transparent",
               "strokeWidth": 2,
@@ -795,7 +795,7 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#151515",
+              "stroke": "#06c",
               "strokeWidth": 2,
             },
             "labels": Object {
@@ -984,7 +984,7 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#151515",
+              "fill": "#06c",
               "fillOpacity": 0.4,
               "stroke": "transparent",
               "strokeWidth": 2,
@@ -1281,7 +1281,7 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#151515",
+              "stroke": "#06c",
               "strokeWidth": 2,
             },
             "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#151515",
+              "fill": "#06c",
               "fillOpacity": 0.4,
               "stroke": "transparent",
               "strokeWidth": 2,
@@ -333,7 +333,7 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#151515",
+              "stroke": "#06c",
               "strokeWidth": 2,
             },
             "labels": Object {
@@ -514,7 +514,7 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#151515",
+              "fill": "#06c",
               "fillOpacity": 0.4,
               "stroke": "transparent",
               "strokeWidth": 2,
@@ -811,7 +811,7 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#151515",
+              "stroke": "#06c",
               "strokeWidth": 2,
             },
             "labels": Object {
@@ -1004,7 +1004,7 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#151515",
+              "fill": "#06c",
               "fillOpacity": 0.4,
               "stroke": "transparent",
               "strokeWidth": 2,
@@ -1301,7 +1301,7 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#151515",
+              "stroke": "#06c",
               "strokeWidth": 2,
             },
             "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#151515",
+              "fill": "#06c",
               "fillOpacity": 0.4,
               "stroke": "transparent",
               "strokeWidth": 2,
@@ -331,7 +331,7 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#151515",
+              "stroke": "#06c",
               "strokeWidth": 2,
             },
             "labels": Object {
@@ -508,7 +508,7 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#151515",
+              "fill": "#06c",
               "fillOpacity": 0.4,
               "stroke": "transparent",
               "strokeWidth": 2,
@@ -804,7 +804,7 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#151515",
+              "stroke": "#06c",
               "strokeWidth": 2,
             },
             "labels": Object {
@@ -981,7 +981,7 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#151515",
+              "fill": "#06c",
               "fillOpacity": 0.4,
               "stroke": "transparent",
               "strokeWidth": 2,
@@ -1277,7 +1277,7 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#151515",
+              "stroke": "#06c",
               "strokeWidth": 2,
             },
             "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`ChartGroup 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -315,7 +315,7 @@ exports[`ChartGroup 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -474,7 +474,7 @@ exports[`ChartGroup 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -771,7 +771,7 @@ exports[`ChartGroup 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -931,7 +931,7 @@ exports[`ChartGroup 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -1228,7 +1228,7 @@ exports[`ChartGroup 2`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -1387,7 +1387,7 @@ exports[`ChartGroup 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -1684,7 +1684,7 @@ exports[`ChartGroup 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -1844,7 +1844,7 @@ exports[`renders container children 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -2141,7 +2141,7 @@ exports[`renders container children 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -2301,7 +2301,7 @@ exports[`renders container children 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -2598,7 +2598,7 @@ exports[`renders container children 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -321,7 +321,7 @@ exports[`Chart 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -498,7 +498,7 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -795,7 +795,7 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -970,7 +970,7 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -1267,7 +1267,7 @@ exports[`Chart 2`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -1444,7 +1444,7 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -1741,7 +1741,7 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -1916,7 +1916,7 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -2213,7 +2213,7 @@ exports[`renders component data 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -2391,7 +2391,7 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -2688,7 +2688,7 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -348,7 +348,7 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -541,7 +541,7 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -838,7 +838,7 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -998,7 +998,7 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -1295,7 +1295,7 @@ exports[`renders component data 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -3600,7 +3600,7 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -3897,7 +3897,7 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`Chart 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#151515",
+                  "fill": "#06c",
                   "fillOpacity": 0.4,
                   "stroke": "transparent",
                   "strokeWidth": 2,
@@ -358,7 +358,7 @@ exports[`Chart 1`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#151515",
+                  "stroke": "#06c",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
@@ -521,7 +521,7 @@ exports[`Chart 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#151515",
+              "fill": "#06c",
               "fillOpacity": 0.4,
               "stroke": "transparent",
               "strokeWidth": 2,
@@ -818,7 +818,7 @@ exports[`Chart 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#151515",
+              "stroke": "#06c",
               "strokeWidth": 2,
             },
             "labels": Object {
@@ -1023,7 +1023,7 @@ exports[`Chart 2`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#151515",
+                  "fill": "#06c",
                   "fillOpacity": 0.4,
                   "stroke": "transparent",
                   "strokeWidth": 2,
@@ -1320,7 +1320,7 @@ exports[`Chart 2`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#151515",
+                  "stroke": "#06c",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
@@ -1483,7 +1483,7 @@ exports[`Chart 2`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#151515",
+              "fill": "#06c",
               "fillOpacity": 0.4,
               "stroke": "transparent",
               "strokeWidth": 2,
@@ -1780,7 +1780,7 @@ exports[`Chart 2`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#151515",
+              "stroke": "#06c",
               "strokeWidth": 2,
             },
             "labels": Object {
@@ -1977,7 +1977,7 @@ exports[`renders component data 1`] = `
               "padding": 50,
               "style": Object {
                 "data": Object {
-                  "fill": "#151515",
+                  "fill": "#06c",
                   "fillOpacity": 0.4,
                   "stroke": "transparent",
                   "strokeWidth": 2,
@@ -2274,7 +2274,7 @@ exports[`renders component data 1`] = `
                 "data": Object {
                   "fill": "transparent",
                   "opacity": 1,
-                  "stroke": "#151515",
+                  "stroke": "#06c",
                   "strokeWidth": 2,
                 },
                 "labels": Object {
@@ -2437,7 +2437,7 @@ exports[`renders component data 1`] = `
           "padding": 50,
           "style": Object {
             "data": Object {
-              "fill": "#151515",
+              "fill": "#06c",
               "fillOpacity": 0.4,
               "stroke": "transparent",
               "strokeWidth": 2,
@@ -2734,7 +2734,7 @@ exports[`renders component data 1`] = `
             "data": Object {
               "fill": "transparent",
               "opacity": 1,
-              "stroke": "#151515",
+              "stroke": "#06c",
               "strokeWidth": 2,
             },
             "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Chart 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -321,7 +321,7 @@ exports[`Chart 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -498,7 +498,7 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -795,7 +795,7 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -970,7 +970,7 @@ exports[`Chart 2`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -1267,7 +1267,7 @@ exports[`Chart 2`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -1444,7 +1444,7 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -1741,7 +1741,7 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -1916,7 +1916,7 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -2213,7 +2213,7 @@ exports[`renders component data 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -2394,7 +2394,7 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -2691,7 +2691,7 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`Chart 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -324,7 +324,7 @@ exports[`Chart 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -493,7 +493,7 @@ exports[`Chart 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -790,7 +790,7 @@ exports[`Chart 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -950,7 +950,7 @@ exports[`renders component data 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -1247,7 +1247,7 @@ exports[`renders component data 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -3555,7 +3555,7 @@ exports[`renders component data 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -3852,7 +3852,7 @@ exports[`renders component data 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/color-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/color-theme.ts
@@ -10,7 +10,12 @@ export const ColorTheme = (props: ColorThemeInterface) => {
 
   return {
     area: {
-      colorScale: COLOR_SCALE
+      colorScale: COLOR_SCALE,
+      style: {
+        data: {
+          fill: COLOR_SCALE[0]
+        }
+      }
     },
     axis: {
       colorScale: COLOR_SCALE
@@ -42,7 +47,12 @@ export const ColorTheme = (props: ColorThemeInterface) => {
       colorScale: COLOR_SCALE
     },
     line: {
-      colorScale: COLOR_SCALE
+      colorScale: COLOR_SCALE,
+      style: {
+        data: {
+          stroke: COLOR_SCALE[0]
+        }
+      }
     },
     pie: {
       colorScale: COLOR_SCALE

--- a/packages/patternfly-4/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`ChartTooltip 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -331,7 +331,7 @@ exports[`ChartTooltip 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -507,7 +507,7 @@ exports[`ChartTooltip 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -804,7 +804,7 @@ exports[`ChartTooltip 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -992,7 +992,7 @@ exports[`allows tooltip via container component 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -1289,7 +1289,7 @@ exports[`allows tooltip via container component 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -1450,7 +1450,7 @@ exports[`allows tooltip via container component 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -1747,7 +1747,7 @@ exports[`allows tooltip via container component 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`ChartVoronoiContainer 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -340,7 +340,7 @@ exports[`ChartVoronoiContainer 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -526,7 +526,7 @@ exports[`ChartVoronoiContainer 2`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -823,7 +823,7 @@ exports[`ChartVoronoiContainer 2`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {
@@ -1011,7 +1011,7 @@ exports[`renders container via ChartGroup 1`] = `
             "padding": 50,
             "style": Object {
               "data": Object {
-                "fill": "#151515",
+                "fill": "#06c",
                 "fillOpacity": 0.4,
                 "stroke": "transparent",
                 "strokeWidth": 2,
@@ -1308,7 +1308,7 @@ exports[`renders container via ChartGroup 1`] = `
               "data": Object {
                 "fill": "transparent",
                 "opacity": 1,
-                "stroke": "#151515",
+                "stroke": "#06c",
                 "strokeWidth": 2,
               },
               "labels": Object {
@@ -1469,7 +1469,7 @@ exports[`renders container via ChartGroup 1`] = `
         "padding": 50,
         "style": Object {
           "data": Object {
-            "fill": "#151515",
+            "fill": "#06c",
             "fillOpacity": 0.4,
             "stroke": "transparent",
             "strokeWidth": 2,
@@ -1766,7 +1766,7 @@ exports[`renders container via ChartGroup 1`] = `
           "data": Object {
             "fill": "transparent",
             "opacity": 1,
-            "stroke": "#151515",
+            "stroke": "#06c",
             "strokeWidth": 2,
           },
           "labels": Object {

--- a/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -2313,6 +2313,7 @@ exports[`select custom select filter filters properly 1`] = `
   className=""
   isExpanded={true}
   isGrouped={false}
+  isPlain={false}
   onClear={[Function]}
   onFilter={[Function]}
   onSelect={[MockFunction]}


### PR DESCRIPTION
fix #2624

**What**:
- Set `area.style.data.fill` to first color scale value in `colorTheme` function.
- Set `line.style.data.stroke` to first color scale value in `colorTheme` function


