### PR TITLE
feat(ExpandCollapse): Add onToggle callback 

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.js
@@ -24,7 +24,11 @@ class ExpandCollapse extends React.Component {
   }
 
   onClick = () => {
-    this.setState(prevState => ({ expanded: !prevState.expanded }));
+    if (this.props.onToggle) {
+      this.props.onToggle();
+    } else {
+      this.setState(prevState => ({ expanded: !prevState.expanded }));
+    }
   };
 
   render() {
@@ -62,7 +66,9 @@ ExpandCollapse.propTypes = {
   /** Flag to show a separation border line */
   bordered: PropTypes.bool,
   /** Flag to control expansion state */
-  expanded: PropTypes.bool // eslint-disable-line react/no-unused-prop-types
+  expanded: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
+  /** Callback function to control externally stored expansion state */
+  onToggle: PropTypes.func
 };
 
 ExpandCollapse.defaultProps = {
@@ -71,7 +77,8 @@ ExpandCollapse.defaultProps = {
   textExpanded: 'Hide Advanced Options',
   align: ALIGN_LEFT,
   bordered: true,
-  expanded: false
+  expanded: false,
+  onToggle: undefined
 };
 
 ExpandCollapse.ALIGN_LEFT = ALIGN_LEFT;

--- a/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ExpandCollapse/ExpandCollapse.test.js
@@ -107,3 +107,15 @@ test('ExpandCollapse with explicit override prop', () => {
   expect(view.find('span.fa-angle-down')).toHaveLength(1);
   expect(view.find('.btn-link').text()).toEqual('Hide Advanced Options');
 });
+
+test('ExpandCollapse with explicit onToggle callback', () => {
+  const callback = jest.fn();
+  const view = mount(
+    <ExpandCollapse onToggle={callback}>
+      <div id="content">My text</div>
+    </ExpandCollapse>
+  );
+  const button = view.find('.btn-link');
+  button.simulate('click');
+  expect(callback).toBeCalled();
+});


### PR DESCRIPTION
So that state of the component can be controlled externally

This is to bring feature parity with PF4. Also this makes it possible to keep the UI consistent if
the children of ExpandCollapse trigger a rerender of the component containing the ExpandCollapse.

Fix #2610

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Add onToggle callback for ExpandCollapse so that the expanded state can be controlled externally.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: #2610

<!-- feel free to add additional comments -->
