### PR TITLE
fix(Topology): Fix paddings for topology control bar buttons

### DIFF
--- a/packages/patternfly-4/react-topology/src/components/TopologyControlBar/__snapshots__/TopologyControlBar.test.tsx.snap
+++ b/packages/patternfly-4/react-topology/src/components/TopologyControlBar/__snapshots__/TopologyControlBar.test.tsx.snap
@@ -3,8 +3,6 @@
 exports[`TopologyControlBar should accept button options correctly 1`] = `
 .pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
   display: block;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
   margin-right: 0.25rem;
   margin-top: 0.25rem;
   background-color: #ffffff;
@@ -25,8 +23,6 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
 }
 .pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
   display: block;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
   margin-right: 0.25rem;
   margin-top: 0.25rem;
   background-color: #ffffff;
@@ -47,8 +43,6 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
 }
 .pf-c-button.pf-m-tertiary.pf-topology-control-bar__button.pf-m-disabled {
   display: block;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
   margin-right: 0.25rem;
   margin-top: 0.25rem;
   background-color: #ffffff;
@@ -609,8 +603,6 @@ exports[`TopologyControlBar should accept button options correctly 1`] = `
 exports[`TopologyControlBar should display the default controls correctly 1`] = `
 .pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
   display: block;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
   margin-right: 0.25rem;
   margin-top: 0.25rem;
   background-color: #ffffff;
@@ -631,8 +623,6 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
 }
 .pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
   display: block;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
   margin-right: 0.25rem;
   margin-top: 0.25rem;
   background-color: #ffffff;
@@ -653,8 +643,6 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
 }
 .pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
   display: block;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
   margin-right: 0.25rem;
   margin-top: 0.25rem;
   background-color: #ffffff;
@@ -675,8 +663,6 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
 }
 .pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
   display: block;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
   margin-right: 0.25rem;
   margin-top: 0.25rem;
   background-color: #ffffff;
@@ -697,8 +683,6 @@ exports[`TopologyControlBar should display the default controls correctly 1`] = 
 }
 .pf-c-button.pf-m-tertiary.pf-topology-control-bar__button {
   display: block;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
   margin-right: 0.25rem;
   margin-top: 0.25rem;
   background-color: #ffffff;

--- a/packages/patternfly-4/react-topology/src/components/TopologyControlBar/css/topology-controlbar-css.ts
+++ b/packages/patternfly-4/react-topology/src/components/TopologyControlBar/css/topology-controlbar-css.ts
@@ -7,8 +7,6 @@ export const topologyControlbarCss = StyleSheet.parse(`
     left: var(--pf-global--spacer--xl);
     
     &__button.pf-c-button.pf-m-tertiary {
-      padding-left: var(--pf-global--spacer--sm);
-      padding-right: var(--pf-global--spacer--sm);
       margin-right: var(--pf-global--spacer--xs);
       margin-top: var(--pf-global--spacer--xs);
       background-color: var(--pf-global--BackgroundColor--100);


### PR DESCRIPTION
**What**:
Remove css settings that override the paddings for the topology control bar buttons

**Additional issues**:
Fixes #2627 

cc @christianvogt @mceledonia 
