### PR TITLE
fix(react-virtualized): use the same semantic version of react-virtualized globally

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/package.json
+++ b/packages/patternfly-3/patternfly-react-extensions/package.json
@@ -42,7 +42,7 @@
     "react-click-outside": "^3.0.1",
     "react-diff-view": "^1.8.1",
     "react-ellipsis-with-tooltip": "^1.0.8",
-    "react-virtualized": "9.x",
+    "react-virtualized": "^9.21.1",
     "unidiff": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/patternfly-3/patternfly-react/package.json
+++ b/packages/patternfly-3/patternfly-react/package.json
@@ -77,7 +77,6 @@
     "clean-css-cli": "^4.2.1",
     "react-axe": "^3.0.2",
     "react-diff-view": "^1.8.1",
-    "react-virtualized": "9.x",
     "rimraf": "^2.6.2",
     "shx": "^0.3.2"
   }

--- a/packages/patternfly-4/react-virtualized-extension/package.json
+++ b/packages/patternfly-4/react-virtualized-extension/package.json
@@ -36,7 +36,7 @@
     "exenv": "^1.2.2",
     "linear-layout-vector": "0.0.1",
     "react-lifecycles-compat": "^3.0.4",
-    "react-virtualized": "9.21.1"
+    "react-virtualized": "^9.21.1"
   },
   "peerDependencies": {
     "@patternfly/react-table": "^2.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16976,9 +16976,10 @@ react-treebeard@^2.1.0:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react-virtualized@9.21.1, react-virtualized@9.x:
+react-virtualized@^9.21.1:
   version "9.21.1"
   resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.21.1.tgz#4dbbf8f0a1420e2de3abf28fbb77120815277b3a"
+  integrity sha512-E53vFjRRMCyUTEKuDLuGH1ld/9TFzjf/fFW816PE4HFXWZorESbSTYtiZz1oAjra0MminaUU1EnvUxoGuEFFPA==
   dependencies:
     babel-runtime "^6.26.0"
     clsx "^1.0.1"


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
This should prevent multiple versions of `react-virtualized` being installed if using both `@patternfly/react-virtualized-extension` and `patternfly-react-extensions`, and also ensure treeshaking can occur.

fixes #2642 

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
