### PR TITLE
fix(select): disable focus trap on checkbox select with no children

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Select/SelectMenu.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/SelectMenu.tsx
@@ -136,7 +136,7 @@ export class SelectMenu extends React.Component<SelectMenuProps> {
                 {this.extendChildren()}
               </ul>
             )}
-            {variant === SelectVariant.checkbox && (
+            {variant === SelectVariant.checkbox && React.Children.count(children) > 0 && (
               <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
                 <div className={css(styles.selectMenu, className)}>
                   <form noValidate className={css(formStyles.form)}>
@@ -144,6 +144,13 @@ export class SelectMenu extends React.Component<SelectMenuProps> {
                   </form>
                 </div>
               </FocusTrap>
+            )}
+            {variant === SelectVariant.checkbox && React.Children.count(children) === 0 && (
+              <div className={css(styles.selectMenu, className)}>
+                <form noValidate className={css(formStyles.form)}>
+                  <div className={css(formStyles.formGroup)}/>
+                </form>
+              </div>
             )}
           </React.Fragment>
         )}


### PR DESCRIPTION
**What**:

It seems like Focus Trap throws exception if no children to ref. In order to avoid this error, render the component with no Focus Trap when no children is passed.

closes #2618 

//cc @SpyTec 