### PR TITLE
fix(Dropdown): pass event object through onSelect

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -123,7 +123,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
                       onClick: (event: React.MouseEvent) => {
                         if (!isDisabled) {
                           onClick(event);
-                          onSelect();
+                          onSelect(event);
                         }
                       }
                     });
@@ -139,7 +139,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
                       onClick={(event: MouseEvent) => {
                         if (!isDisabled) {
                           onClick(event);
-                          onSelect();
+                          onSelect(event);
                         }
                       }}
                     >


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: fixes missing event passthrough on internal onSelect callback

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Fixes issue**: #2658 
<!-- feel free to add additional comments -->
