### PR TITLE
First pass at updating the examples for the patternfly/react-table library

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -13,6 +13,7 @@ import {
   TableHeader,
   TableBody,
   sortable,
+  SortHelpers,
   SortByDirection,
   headerCol,
   TableVariant,
@@ -22,13 +23,16 @@ import {
   textCenter,
   wrappable,
   classNames,
-  Visibility
+  Visibility,
+  useSortableRows,
+  useSelectableRows
 } from '@patternfly/react-table';
-
 import {
   CodeBranchIcon,
   CodeIcon,
-  CubeIcon
+  CubeIcon,
+  CheckIcon,
+  TimesIcon
 } from '@patternfly/react-icons';
 
 import DemoSortableTable from './demo/DemoSortableTable';
@@ -241,11 +245,11 @@ function SortableTable () {
   }; 
 
   const cells = [
-    { title: 'Repositories', transforms: [sortable(SortHelpers.strings)] },
-    { title: 'Branches', transforms: [sortable(SortHelpers.numbers)] },
-    { title: 'Pull requests', transforms: [sortable(SortHelpers.numbers)] },
-    { title: 'Workspaces', transforms: [sortable(SortHelpers.numbers)] },
-    { title: 'Last Commit', transforms: [sortable(sortLastCommit)] }
+    { title: 'Repositories', transforms: [sortable] },
+    { title: 'Branches', transforms: [sortable.numbers] },
+    { title: 'Pull requests', transforms: [sortable.numbers] },
+    { title: 'Workspaces', transforms: [sortable.numbers] },
+    { title: 'Last Commit', transforms: [sortable.custom(sortLastCommit)] }
   ];
 
   const [sortedRows, onSort, sortBy] = useSortableRows(rows);
@@ -268,7 +272,6 @@ import {
   TableHeader,
   TableBody,
   headerCol,
-  sortable,
   useSelectableRows
 } from '@patternfly/react-table';
 
@@ -307,6 +310,7 @@ import {
   TableHeader,
   TableBody,
   headerCol,
+  sortable,
   useSelectableRows
 } from '@patternfly/react-table';
 
@@ -318,11 +322,11 @@ function SortableAndSelectableTable () {
   ];
   
   const cells = [
-    { title: 'Repositories', transforms: [sortable(SortHelpers.strings)], cellTransforms: [headerCol()] },
-    { title: 'Branches', transforms: [sortable(SortHelpers.numbers)] },
-    { title: 'Pull requests', transforms: [sortable(SortHelpers.numbers)] },
-    { title: 'Workspaces', transforms: [sortable(SortHelpers.numbers)] },
-    { title: 'Last Commit', transforms: [sortable(SortHelpers.numbers)] }
+    { title: 'Repositories', transforms: [sortable], cellTransforms: [headerCol()] },
+    { title: 'Branches', transforms: [sortable.numbers] },
+    { title: 'Pull requests', transforms: [sortable.numbers] },
+    { title: 'Workspaces', transforms: [sortable.numbers] },
+    { title: 'Last Commit', transforms: [sortable.numbers] }
   ];
   
   const [sortedRows, onSort, sortBy] = useSortableRows(rows, cells);
@@ -404,7 +408,7 @@ class SimpleActionsTable extends React.Component {
   render() {
     const { columns, rows, actions } = this.state;
     return (
-      <Table caption="Actions Table" actions={actions} cells={columns} rows={rows}>
+      <Table caption="Simple Actions Table" actions={actions} cells={columns} rows={rows}>
         <TableHeader />
         <TableBody />
       </Table>

--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -41,70 +41,175 @@ import {
   Table,
   TableHeader,
   TableBody,
-  sortable,
-  SortByDirection,
-  headerCol,
-  TableVariant,
-  expandable,
+  textCenter,
+} from '@patternfly/react-table';
+
+function SimpleTable() {
+  const cells = [
+    'Repositories',
+    'Branches',
+    'Pull requests',
+    'Workspaces',
+    'Last Commit'
+  ];
+  const rows = [
+    ['Foo', 2, 0, 6, 1533635470],
+    ['Bar', 1, 11, 2, 1564566670],
+    ['Baz', 6, 4, 99, 1565167870],    
+  ];
+
+  return (
+    <Table caption="Simple Table" cells={cells} rows={rows}>
+      <TableHeader />
+      <TableBody />
+    </Table>
+  );
+}
+```
+
+## Cell/row options
+
+```js
+import React from 'react';
+import {
+  Table,
+  TableHeader,
+  TableBody,
   cellWidth,
   textCenter,
 } from '@patternfly/react-table';
 
-class SimpleTable extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      columns: [
-        { title: 'Repositories' },
-        'Branches',
-        { title: 'Pull requests' },
-        'Workspaces',
-        {
-          title: 'Last Commit',
-          transforms: [textCenter],
-          cellTransforms: [textCenter]
-        }
-      ],
-      rows: [
-        {
-          cells: ['one', 'two', 'three', 'four', 'five']
-        },
-        {
-          cells: [
-            {
-              title: <div>one - 2</div>,
-              props: { title: 'hover title', colSpan: 3 }
-            },
-            'four - 2',
-            'five - 2'
-          ]
-        },
-        {
-          cells: [
-            'one - 3',
-            'two - 3',
-            'three - 3',
-            'four - 3',
-            {
-              title: 'five - 3 (not centered)',
-              props: { textCenter: false }
-            }
-          ]
-        }
-      ]
+function SimpleCustomTable() {
+  const cells = [
+    // Equivalent to just passing the string
+    { title: 'Repositories' }, 
+    'Branches',
+    { title: 'Pull requests' },
+    'Workspaces',
+    // Will run the `transform` functions on the header, and the 
+    // `cellTransforms` on the cells. Transformers are used to inject
+    // extra props to the the cell component. In this case we use the
+    // builtin `textCenter` transformer to instruct the cell to apply
+    // the required stylings to center the cell content.
+    {
+      title: 'Last Commit',
+      transforms: [textCenter],
+      cellTransforms: [textCenter]
+    }
+  ];
+  const rows = [
+    ['Foo', 2, 0, 6, 1533635470],
+    [
+      // Cell content can also be defined as a JSX element.
+      // Extra props can be passed to the cell (the `td` element).
+      {
+        title: <div>Bar 👾</div>,
+        props: { title: 'hover title', colSpan: 3 }
+      },
+      2,
+      {
+        title: <div>1564566670</div>
+      }
+    ],
+    [
+      'Baz', 
+      6, 
+      4, 
+      99,
+      // In this example, we disable the default cellTransform for this specific cell, setting the `textCenter` prop to `false`.
+      {
+        title: '1565167870 (not centered)',
+        props: { textCenter: false }
+      }
+    ]
+  ];
+
+  return (
+    <Table caption="Cell/rows options" cells={cells} rows={rows}>
+      <TableHeader />
+      <TableBody />
+    </Table>
+  );
+}
+```
+
+## Cell formatters
+
+```js
+import React from 'react';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  textCenter
+} from '@patternfly/react-table';
+import {
+  CheckIcon,
+  TimesIcon
+} from '@patternfly/react-icons';
+
+function CellFormatters() {
+  const rows = [
+    ['Foo', 1533635470, 1],
+    ['Bar', 1564566670, 0],
+    ['Baz', 1565167870, 1],    
+  ];
+
+  // A component that displays a CI build status.
+  // *Heads-up* - this component definition should *not* stay inside
+  // the main component function in a real world application; it's
+  // done this way in this example as a work-around against the 
+  // limitation of one component per example of the documentation
+  // system in use.
+  const CIStatusIcon = ({ passing }) => {
+    const styles = {
+      color: passing 
+        ? 'var(--pf-global--success-color--200)' 
+        : 'var(--pf-global--danger-color--100)'
     };
-  }
-
-  render() {
-    const { columns, rows } = this.state;
-
+    const icon = passing ? <CheckIcon /> : <TimesIcon />;
+    const text = passing ? 'Passing' : 'Failing';
     return (
-      <Table caption="Simple Table" cells={columns} rows={rows}>
-        <TableHeader />
-        <TableBody />
-      </Table>
+      <div style={styles}>
+        {icon} {text}
+      </div>
     );
+  };
+
+  // Last commit comes as a unix timestamp (in seconds). We specify
+  // a formatter that convert it to something readable by humans.
+  const lastCommitTimestampToLocalHuman = (value, extraProps) => {
+    return new Date(value * 1000).toLocaleString();
   }
+
+  // CI Status comes as a boolean value. We specify a formatter that
+  // passes the value to the `CIStatusIcon` we wrote.
+  const statusToIcon = (value, extraProps) => {
+    return <CIStatusIcon passing={value} />;
+  }
+
+  const cells = [
+    'Repositories',
+    {
+      title: 'Last Commit',
+      cellFormatters: [lastCommitTimestampToLocalHuman]
+    },
+    {
+      title: 'CI Status',
+      cellFormatters: [statusToIcon],
+      // We apply some transforms to both the header and the cell, to make
+      // it centered. 
+      transforms: [textCenter],
+      cellTransforms: [textCenter]
+    }
+  ];
+
+  return (
+    <Table caption="Cell formatters" cells={cells} rows={rows}>
+      <TableHeader />
+      <TableBody />
+    </Table>
+  );
 }
 ```
 
@@ -117,51 +222,43 @@ import {
   TableHeader,
   TableBody,
   sortable,
-  SortByDirection,
-  headerCol,
-  TableVariant,
-  expandable,
-  cellWidth
 } from '@patternfly/react-table';
 
-class SortableTable extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      columns: [
-        { title: 'Repositories', transforms: [sortable] },
-        'Branches',
-        { title: 'Pull requests', transforms: [sortable] },
-        'Workspaces',
-        'Last Commit'
-      ],
-      rows: [['one', 'two', 'a', 'four', 'five'], ['a', 'two', 'k', 'four', 'five'], ['p', 'two', 'b', 'four', 'five']],
-      sortBy: {}
-    };
-    this.onSort = this.onSort.bind(this);
-  }
+function SortableTable () {
+  const rows = [
+    ['Foo', 2, 0, 6, 1533635470],
+    ['Bar', 1, 11, 2, 1564566670],
+    ['Baz', 6, 4, 99, 1565167870],
+  ];
 
-  onSort(_event, index, direction) {
-    const sortedRows = this.state.rows.sort((a, b) => (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0));
-    this.setState({
-      sortBy: {
-        index,
-        direction
-      },
-      rows: direction === SortByDirection.asc ? sortedRows : sortedRows.reverse()
+  const cells = [
+    { title: 'Repositories', transforms: [sortable] },
+    { title: 'Branches', transforms: [sortable] },
+    { title: 'Pull requests', transforms: [sortable] },
+    { title: 'Workspaces', transforms: [sortable] },
+    { title: 'Last Commit', transforms: [sortable] }
+  ];
+
+  const [sortBy, setSortBy] = React.useState({});
+  const onSort = (_event, index, direction) => {
+    setSortBy({
+      index,
+      direction
     });
-  }
+  };
 
-  render() {
-    const { columns, rows, sortBy } = this.state;
+  const sortedRows = !sortBy.direction ? rows : rows.sort(
+    (a, b) => (a[sortBy.index] < b[sortBy.index] ? -1 : a[sortBy.index] > b[sortBy.index] ? 1 : 0) 
+    * 
+    (sortBy.direction === 'desc' ? -1 : 1)
+  );
 
-    return (
-      <Table caption="Sortable Table" sortBy={sortBy} onSort={this.onSort} cells={columns} rows={rows}>
-        <TableHeader />
-        <TableBody />
-      </Table>
-    );
-  }
+  return (
+    <Table caption="Sortable Table" sortBy={sortBy} onSort={onSort} cells={cells} rows={rows}>
+      <TableHeader />
+      <TableBody />
+    </Table>
+  );
 }
 ```
 
@@ -173,66 +270,90 @@ import {
   Table,
   TableHeader,
   TableBody,
-  sortable,
-  SortByDirection,
   headerCol,
-  TableVariant,
-  expandable,
-  cellWidth
+  sortable,
+  useSelectableRows
 } from '@patternfly/react-table';
 
-class SelectableTable extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      columns: [
-        { title: 'Repositories', cellTransforms: [headerCol()] },
-        'Branches',
-        { title: 'Pull requests' },
-        'Workspaces',
-        'Last Commit'
-      ],
-      rows: [
-        {
-          cells: ['one', 'two', 'a', 'four', 'five']
-        },
-        {
-          cells: ['a', 'two', 'k', 'four', 'five']
-        },
-        {
-          cells: ['p', 'two', 'b', 'four', 'five']
-        }
-      ]
-    };
-    this.onSelect = this.onSelect.bind(this);
-  }
+function SelectableTable () {
+  const rows = [
+    ['Foo', 2, 0, 6, 1533635470],
+    ['Bar', 1, 11, 2, 1564566670],
+    ['Baz', 6, 4, 99, 1565167870],
+  ];
+  
+  const cells = [
+    { title: 'Repositories', cellTransforms: [headerCol()] },
+    'Branches',
+    'Pull requests',
+    'Workspaces',
+    'Last Commit',
+  ];
+  
+  const [selectedRows, onSelect] = useSelectableRows(rows);
 
-  onSelect(event, isSelected, rowId) {
-    let rows;
-    if (rowId === -1) {
-      rows = this.state.rows.map(oneRow => {
-        oneRow.selected = isSelected;
-        return oneRow;
-      });
-    } else {
-      rows = [...this.state.rows];
-      rows[rowId].selected = isSelected;
-    }
-    this.setState({
-      rows
+  return (
+    <Table caption="Selectable Table" onSelect={onSelect} cells={cells} rows={selectedRows}>
+      <TableHeader />
+      <TableBody />
+    </Table>
+  );
+}
+```
+
+## Sortable and selectable table
+
+```js
+import React from 'react';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  headerCol,
+  useSelectableRows
+} from '@patternfly/react-table';
+
+function SortableAndSelectableTable () {
+  const rows = [
+    ['Foo', 2, 0, 6, 1533635470],
+    ['Bar', 1, 11, 2, 1564566670],
+    ['Baz', 6, 4, 99, 1565167870],
+  ];
+  
+  const cells = [
+    { title: 'Repositories', transforms: [sortable], cellTransforms: [headerCol()] },
+    { title: 'Branches', transforms: [sortable] },
+    { title: 'Pull requests', transforms: [sortable] },
+    { title: 'Workspaces', transforms: [sortable] },
+    { title: 'Last Commit', transforms: [sortable] }
+  ];
+  
+  const [sortBy, setSortBy] = React.useState({});
+  const onSort = (_event, index, direction) => {
+    setSortBy({
+      index,
+      direction
     });
-  }
+  };
 
-  render() {
-    const { columns, rows } = this.state;
+  const sortedRows = !sortBy.direction ? rows : rows.sort(
+    (a, b) => (a[sortBy.index] < b[sortBy.index] ? -1 : a[sortBy.index] > b[sortBy.index] ? 1 : 0) 
+    * 
+    (sortBy.direction === 'desc' ? -1 : 1)
+  );
 
-    return (
-      <Table caption="Selectable Table" onSelect={this.onSelect} cells={columns} rows={rows}>
-        <TableHeader />
-        <TableBody />
-      </Table>
-    );
-  }
+  // we need to specify the getRowKey callback to use unique ids to identify the
+  // selected rows. We use the repository name in this example.  
+  const [sortedAndSelectedRows, onSelect] = useSelectableRows(sortedRows,  {
+    getRowKey: (rowData, rowIndex) => rowData[0]
+  });
+
+  return (
+    <Table caption="Sortable And Selectable Table" onSort={onSort} onSelect={onSelect} cells={cells} rows={sortedAndSelectedRows}>
+      <TableHeader />
+      <TableBody />
+    </Table>
+  );
 }
 ```
 

--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -222,39 +222,36 @@ import {
   TableHeader,
   TableBody,
   sortable,
+  SortHelpers,
+  useSortableRows
 } from '@patternfly/react-table';
 
 function SortableTable () {
   const rows = [
     ['Foo', 2, 0, 6, 1533635470],
-    ['Bar', 1, 11, 2, 1564566670],
+    ['Bar', 1, 11, 2, { title: <div>⏰ 1564566670</div>, value: 1564566670 }],
     ['Baz', 6, 4, 99, 1565167870],
+    ['Qux', undefined, 4, undefined, 1565167870],
   ];
+  
+  const sortLastCommit = (a, b, aObj, bObj) => {
+    a = aObj.value || a;
+    b = bObj.value || b;
+    return SortHelpers.numbers(a, b); 
+  }; 
 
   const cells = [
-    { title: 'Repositories', transforms: [sortable] },
-    { title: 'Branches', transforms: [sortable] },
-    { title: 'Pull requests', transforms: [sortable] },
-    { title: 'Workspaces', transforms: [sortable] },
-    { title: 'Last Commit', transforms: [sortable] }
+    { title: 'Repositories', transforms: [sortable(SortHelpers.strings)] },
+    { title: 'Branches', transforms: [sortable(SortHelpers.numbers)] },
+    { title: 'Pull requests', transforms: [sortable(SortHelpers.numbers)] },
+    { title: 'Workspaces', transforms: [sortable(SortHelpers.numbers)] },
+    { title: 'Last Commit', transforms: [sortable(sortLastCommit)] }
   ];
 
-  const [sortBy, setSortBy] = React.useState({});
-  const onSort = (_event, index, direction) => {
-    setSortBy({
-      index,
-      direction
-    });
-  };
-
-  const sortedRows = !sortBy.direction ? rows : rows.sort(
-    (a, b) => (a[sortBy.index] < b[sortBy.index] ? -1 : a[sortBy.index] > b[sortBy.index] ? 1 : 0) 
-    * 
-    (sortBy.direction === 'desc' ? -1 : 1)
-  );
+  const [sortedRows, onSort, sortBy] = useSortableRows(rows);
 
   return (
-    <Table caption="Sortable Table" sortBy={sortBy} onSort={onSort} cells={cells} rows={rows}>
+    <Table caption="Sortable Table" sortBy={sortBy} onSort={onSort} cells={cells} rows={sortedRows}>
       <TableHeader />
       <TableBody />
     </Table>
@@ -321,26 +318,14 @@ function SortableAndSelectableTable () {
   ];
   
   const cells = [
-    { title: 'Repositories', transforms: [sortable], cellTransforms: [headerCol()] },
-    { title: 'Branches', transforms: [sortable] },
-    { title: 'Pull requests', transforms: [sortable] },
-    { title: 'Workspaces', transforms: [sortable] },
-    { title: 'Last Commit', transforms: [sortable] }
+    { title: 'Repositories', transforms: [sortable(SortHelpers.strings)], cellTransforms: [headerCol()] },
+    { title: 'Branches', transforms: [sortable(SortHelpers.numbers)] },
+    { title: 'Pull requests', transforms: [sortable(SortHelpers.numbers)] },
+    { title: 'Workspaces', transforms: [sortable(SortHelpers.numbers)] },
+    { title: 'Last Commit', transforms: [sortable(SortHelpers.numbers)] }
   ];
   
-  const [sortBy, setSortBy] = React.useState({});
-  const onSort = (_event, index, direction) => {
-    setSortBy({
-      index,
-      direction
-    });
-  };
-
-  const sortedRows = !sortBy.direction ? rows : rows.sort(
-    (a, b) => (a[sortBy.index] < b[sortBy.index] ? -1 : a[sortBy.index] > b[sortBy.index] ? 1 : 0) 
-    * 
-    (sortBy.direction === 'desc' ? -1 : 1)
-  );
+  const [sortedRows, onSort, sortBy] = useSortableRows(rows, cells);
 
   // we need to specify the getRowKey callback to use unique ids to identify the
   // selected rows. We use the repository name in this example.  
@@ -349,7 +334,7 @@ function SortableAndSelectableTable () {
   });
 
   return (
-    <Table caption="Sortable And Selectable Table" onSort={onSort} onSelect={onSelect} cells={cells} rows={sortedAndSelectedRows}>
+    <Table caption="Sortable And Selectable Table" onSort={onSort} sortBy={sortBy} onSelect={onSelect} cells={cells} rows={sortedAndSelectedRows}>
       <TableHeader />
       <TableBody />
     </Table>

--- a/packages/patternfly-4/react-table/src/components/Table/Table.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.tsx
@@ -8,7 +8,7 @@ import { BodyCell } from './BodyCell';
 import { HeaderCell } from './HeaderCell';
 import { RowWrapper } from './RowWrapper';
 import { BodyWrapper } from './BodyWrapper';
-import { calculateColumns } from './utils/headerUtils';
+import { calculateColumns } from './utils';
 import { formatterValueType, ColumnType, RowType, RowKeyType, ColumnsType } from './base';
 
 export enum TableGridBreakpoint {
@@ -23,8 +23,8 @@ export enum TableGridBreakpoint {
 export enum TableVariant {
   compact = 'compact'
 }
-
-export type OnSort = (event: React.MouseEvent, columnIndex: number, sortByDirection: SortByDirection, extraData: IExtraColumnData) => void;
+export type OnSortCallback = (aValue: any, bValue: any, aObject: IRow | string, bObject: IRow | string) => number;
+export type OnSort = (event: React.MouseEvent, columnIndex: number, sortByDirection: SortByDirection, extraData: IExtraColumnData, sortCallback: OnSortCallback) => void;
 export type OnCollapse = (event: React.MouseEvent, rowIndex: number, isOpen: boolean, rowData: IRowData, extraData: IExtraData) => void;
 export type OnExpand = (event: React.MouseEvent, rowIndex: number, colIndex: number, isOpen: boolean, rowData: IRowData, extraData: IExtraData) => void;
 export type OnSelect = (event: React.MouseEvent, isSelected: boolean, rowIndex: number, rowData: IRowData, extraData: IExtraData) => void;
@@ -45,6 +45,7 @@ export interface IColumn {
   extraParams: {
     sortBy?: ISortBy;
     onSort?: OnSort;
+    sortCallback?: OnSortCallback;
     onCollapse?: OnCollapse;
     onExpand?: OnExpand;
     onSelect?: OnSelect;
@@ -54,6 +55,7 @@ export interface IColumn {
     dropdownPosition?: DropdownPosition;
     dropdownDirection?: DropdownDirection;
     allRowsSelected?: boolean;
+    firstUserColumnIndex?: number;
   };
 }
 
@@ -106,6 +108,8 @@ export interface IDecorator extends React.HTMLProps<HTMLElement> {
   children?: React.ReactNode;
 }
 
+export type ICells = (ICell | string)[];
+
 export interface ICell {
   title?: string;
   transforms?: ((...args: any) => any)[];
@@ -123,6 +127,8 @@ export interface IRowCell {
   title?: React.ReactNode;
   props?: any;
 }
+
+export type IRows = (((string | number | IRowCell)[]) | IRow)[];
 
 export interface IRow extends RowType {
   cells?: (React.ReactNode | IRowCell)[];
@@ -161,8 +167,8 @@ export interface TableProps {
   contentId?: string;
   dropdownPosition?: 'right' | 'left';
   dropdownDirection?: 'up' | 'down';
-  rows: (IRow | string[])[];
-  cells: (ICell | string)[];
+  rows: IRows;
+  cells: ICells;
   bodyWrapper?: Function;
   rowWrapper?: Function;
   role?: string;

--- a/packages/patternfly-4/react-table/src/components/Table/hooks/index.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useSelectableRows';

--- a/packages/patternfly-4/react-table/src/components/Table/hooks/index.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useSelectableRows';
+export * from './useSortableRows';

--- a/packages/patternfly-4/react-table/src/components/Table/hooks/useSelectableRows.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/hooks/useSelectableRows.ts
@@ -1,0 +1,83 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { IRows, ISelectableArray, OnSelectCallback } from '../Table';
+
+const defaultOptions = {
+  getRowKey: (rowData, rowIndex) => rowIndex
+};
+
+/**
+ * Returns the onSelect callback required by the Table component to allow for
+ * selecting rows, and the updated `rows` with the right internal flags to tell
+ * the Table component which rows are selected and which are not.
+ *
+ * @example
+ * const [selectedRows, selectedRows] = useSelectableRows(rows);
+ *
+ * @param rows
+ * @param getRowKey - optional, a function to return an unique key for a row. By
+ * default the row's index is used. For the table to be also sortable while being
+ * selectable, a key that uniquely identify the row among its siblings is required.
+ */
+export function useSelectableRows(rows: IRows, { getRowKey } = defaultOptions) {
+  // Selected rows's keys will be saved in the component's state
+  const [selectedKeys, setSelectedKeys] = useState<ReturnType<typeof getRowKey>>([]);
+
+  // When selecting/deselecting all lines, or when transitioning from an all rows
+  // selected state, we need to compute the new keys based on the full list of keys
+  // available in the original rows array.
+  // Since that array can be composed of many entries, we cache the value so we don't
+  // pay the cost of the map when the user is not changing the original data.
+  const allKeys = useMemo(() => rows.map((r, idx) => getRowKey(r, idx)), [rows, getRowKey]);
+
+  // Since the Table component will not re-render rows if unchanged (because of the
+  // BodyRow:shouldComponentUpdate method), we need to have a reference to an alway
+  // up to date value of the selected keys in the callback we pass to the selectable
+  // cell. This way we can ensure that that callback will not run against stale state
+  // data.
+  const latestSelectedKeys = useRef<typeof selectedKeys>(selectedKeys);
+
+  // The callback that should be passed to the Table's onSelect property.
+  // It will update the list of selected keys based on the user action.
+  // Note that the user could be interacting with the select/deselect all button
+  // in the header: that case is identified by the rowIndex value passed as -1
+  // by the Table component.
+  const onSelect = useCallback<OnSelectCallback>(
+    (event, isSelected, rowIndex, rowData, extraData) => {
+      const latestIndexes = latestSelectedKeys.current;
+      let updatedIndexes = selectedKeys;
+      // A rowIndex -1 indicates that the user clicked on the select all checkbox.
+      if (rowIndex === -1) {
+        updatedIndexes = isSelected ? allKeys : [];
+      } else {
+        // A specific row has been selected/deselected
+        const rowKey = getRowKey(rowData, rowIndex);
+        updatedIndexes = isSelected
+          ? Array.from(new Set([...latestIndexes, rowKey]))
+          : latestIndexes.filter(index => index !== rowKey);
+      }
+      // Here we make sure that other onSelect callbacks will work against the latest
+      // set of selected keys.
+      latestSelectedKeys.current = updatedIndexes;
+      // We still have to save the selected keys in the state, to trigger a re-render
+      // of the component so that selected rows will actually be displayed as
+      // selected.
+      setSelectedKeys(updatedIndexes);
+    },
+    [setSelectedKeys, latestSelectedKeys, allKeys, getRowKey]
+  );
+
+  const selectedRows = rows.map((row, index) => {
+    const isRowSelected = selectedKeys.includes(getRowKey(row, index));
+    if (Array.isArray(row)) {
+      const updatedRow = [...row] as typeof row;
+      updatedRow.selected = isRowSelected;
+      return updatedRow;
+    }
+
+    const updatedRow = { ...row };
+    updatedRow.selected = isRowSelected;
+    return updatedRow;
+  });
+
+  return [selectedRows, onSelect];
+}

--- a/packages/patternfly-4/react-table/src/components/Table/hooks/useSelectableRows.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/hooks/useSelectableRows.ts
@@ -1,8 +1,8 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { IRows, ISelectableArray, OnSelectCallback } from '../Table';
+import { IRowData, IRows, OnSelect } from '../Table';
 
 const defaultOptions = {
-  getRowKey: (rowData, rowIndex) => rowIndex
+  getRowKey: (rowData: IRowData, rowIndex: number) => rowIndex
 };
 
 /**
@@ -20,7 +20,7 @@ const defaultOptions = {
  */
 export function useSelectableRows(rows: IRows, { getRowKey } = defaultOptions) {
   // Selected rows's keys will be saved in the component's state
-  const [selectedKeys, setSelectedKeys] = useState<ReturnType<typeof getRowKey>>([]);
+  const [selectedKeys, setSelectedKeys] = useState<ReturnType<typeof getRowKey>[]>([]);
 
   // When selecting/deselecting all lines, or when transitioning from an all rows
   // selected state, we need to compute the new keys based on the full list of keys
@@ -41,7 +41,7 @@ export function useSelectableRows(rows: IRows, { getRowKey } = defaultOptions) {
   // Note that the user could be interacting with the select/deselect all button
   // in the header: that case is identified by the rowIndex value passed as -1
   // by the Table component.
-  const onSelect = useCallback<OnSelectCallback>(
+  const onSelect = useCallback<OnSelect>(
     (event, isSelected, rowIndex, rowData, extraData) => {
       const latestIndexes = latestSelectedKeys.current;
       let updatedIndexes = selectedKeys;
@@ -70,13 +70,14 @@ export function useSelectableRows(rows: IRows, { getRowKey } = defaultOptions) {
     const isRowSelected = selectedKeys.includes(getRowKey(row, index));
     if (Array.isArray(row)) {
       const updatedRow = [...row] as typeof row;
+      // cast required to work with primitive types
+      (updatedRow as any).selected = isRowSelected;
+      return updatedRow;
+    } else {
+      const updatedRow = {...row};
       updatedRow.selected = isRowSelected;
       return updatedRow;
     }
-
-    const updatedRow = { ...row };
-    updatedRow.selected = isRowSelected;
-    return updatedRow;
   });
 
   return [selectedRows, onSelect];

--- a/packages/patternfly-4/react-table/src/components/Table/hooks/useSortableRows.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/hooks/useSortableRows.ts
@@ -1,0 +1,50 @@
+import { useMemo, useState } from 'react';
+import { IExtraColumnData, IRows, OnSort, OnSortCallback, OnSortDirection } from '../Table';
+
+export const SortHelpers = {
+  numbers(a: number, b: number) {
+    if (a < b) {
+      return -1;
+    } else if (a > b) {
+      return 1;
+    }
+    return 0;
+  },
+
+  booleans(a: boolean, b: boolean) {
+    const toNumber = (v: boolean) => (v ? 1 : 0);
+    return SortHelpers.numbers(toNumber(a), toNumber(b));
+  },
+
+  strings(a: string, b: string) {
+    return a.localeCompare(b);
+  }
+};
+
+export function useSortableRows(rows: IRows) {
+  const [sortBy, setSortBy] = useState<
+    | { index: number; direction: OnSortDirection; columnData: IExtraColumnData; sortCallback: OnSortCallback }
+    | undefined
+  >();
+
+  const onSort: OnSort = (_event, index, direction, columnData, sortCallback) => {
+    setSortBy({
+      index,
+      direction,
+      columnData,
+      sortCallback
+    });
+  };
+
+  const sortCb = (rowA, rowB) => {
+    const [a, b] =
+      sortBy.direction === 'desc' ? [rowA[sortBy.index], rowB[sortBy.index]] : [rowB[sortBy.index], rowA[sortBy.index]];
+    const aValue = typeof a === 'object' && a.title ? a.title : a;
+    const bValue = typeof b === 'object' && b.title ? b.title : b;
+    return sortBy.sortCallback(aValue, bValue, a, b);
+  };
+
+  const sortedRows = useMemo(() => (!sortBy ? rows : rows.sort(sortCb)), [sortBy, rows, sortCb]);
+
+  return [sortedRows, onSort, sortBy];
+}

--- a/packages/patternfly-4/react-table/src/components/Table/hooks/useSortableRows.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/hooks/useSortableRows.ts
@@ -1,29 +1,9 @@
 import { useMemo, useState } from 'react';
-import { IExtraColumnData, IRows, OnSort, OnSortCallback, OnSortDirection } from '../Table';
-
-export const SortHelpers = {
-  numbers(a: number, b: number) {
-    if (a < b) {
-      return -1;
-    } else if (a > b) {
-      return 1;
-    }
-    return 0;
-  },
-
-  booleans(a: boolean, b: boolean) {
-    const toNumber = (v: boolean) => (v ? 1 : 0);
-    return SortHelpers.numbers(toNumber(a), toNumber(b));
-  },
-
-  strings(a: string, b: string) {
-    return a.localeCompare(b);
-  }
-};
+import { IExtraColumnData, IRows, OnSort, OnSortCallback, SortByDirection } from '../Table';
 
 export function useSortableRows(rows: IRows) {
   const [sortBy, setSortBy] = useState<
-    | { index: number; direction: OnSortDirection; columnData: IExtraColumnData; sortCallback: OnSortCallback }
+    | { index: number; direction: SortByDirection; columnData: IExtraColumnData; sortCallback: OnSortCallback }
     | undefined
   >();
 
@@ -36,7 +16,7 @@ export function useSortableRows(rows: IRows) {
     });
   };
 
-  const sortCb = (rowA, rowB) => {
+  const sortCb = (rowA: any, rowB: any) => {
     const [a, b] =
       sortBy.direction === 'desc' ? [rowA[sortBy.index], rowB[sortBy.index]] : [rowB[sortBy.index], rowA[sortBy.index]];
     const aValue = typeof a === 'object' && a.title ? a.title : a;

--- a/packages/patternfly-4/react-table/src/components/Table/index.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/index.ts
@@ -11,3 +11,4 @@ export * from './RowWrapper';
 export * from './SelectColumn';
 export * from './SortColumn';
 export * from './utils';
+export * from './hooks';

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/sortable.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/sortable.tsx
@@ -7,15 +7,20 @@ import { SortColumn } from '../../SortColumn';
 
 export const sortable = (label: IFormatterValueType, { columnIndex, column, property }: IExtra) => {
   const {
-    extraParams: { sortBy, onSort }
+    extraParams: { sortBy, onSort, firstUserColumnIndex }
   } = column;
+
+  // correct the column index based on the presence of extra columns added on the
+  // left of the user provided ones
+  const correctedColumnIndex = columnIndex - firstUserColumnIndex;
+
   const extraData = {
-    columnIndex,
+    columnIndex: correctedColumnIndex,
     column,
     property
   };
 
-  const isSortedBy = sortBy && columnIndex === sortBy.index;
+  const isSortedBy = sortBy && correctedColumnIndex === sortBy.index;
   function sortClicked(event: React.MouseEvent) {
     let reversedDirection;
     if (!isSortedBy) {
@@ -24,7 +29,7 @@ export const sortable = (label: IFormatterValueType, { columnIndex, column, prop
       reversedDirection = sortBy.direction === SortByDirection.asc ? SortByDirection.desc : SortByDirection.asc;
     }
     // tslint:disable-next-line:no-unused-expression
-    onSort && onSort(event, columnIndex, reversedDirection, extraData);
+    onSort && onSort(event, correctedColumnIndex, reversedDirection, extraData);
   }
 
   return {

--- a/packages/patternfly-4/react-table/src/components/Table/utils/transformers.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/transformers.tsx
@@ -1,5 +1,5 @@
 export { selectable } from './decorators/selectable';
-export { sortable } from './decorators/sortable';
+export { sortable, SortHelpers } from './decorators/sortable';
 export { cellActions } from './decorators/cellActions';
 export { cellWidth } from './decorators/cellWidth';
 export { wrappable } from './decorators/wrappable';


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: 

I have personally struggled with patternfly/react-table's examples for a number of reasons:
* examples are provided as class-based components. This is ok, but some of us moved to function components (with hooks. Given that that seems to be the direction the React community is following, I think it makes sense to update the examples to the new style.
* heavy and confusing use of `setState`. I think `setState` in an example should be used only if the example requires it. But more importantly, for a developer that's still learning React it teaches a bad lesson. The React way should be to derive the state required for the rendering as much as possible, and avoid storing multiple copies of the same data using the state.
* arrays and objects are mutated in place. This is a bad practice in general, but with hooks it's also a pitfall since all hooks perform a shallow comparison between objects, which doesn't catch object mutations.

So I took a stab at updating the examples (well, some of them for the moment) to address the above points.

Finally, when updating the selectable rows example I got bit really hard by something that looked like a bug in the library but ended up being the right behavior. Using an immutable data structure and keeping track of the selected rows by storing the id in some state, this is what was happening: 

1. initial render

| Select  | Name | Notes |
| ------------- | ------------- | ------------- |
| [ ]  | Foo  |  |
| [ ]  | Bar  |  |
| [ ]  | Baz  |  |

2. we select the Bar line

| Select  | Name | Notes |
| ------------- | ------------- | ------------- |
| [ ]  | Foo  | this row will not be re-rendered |
| [x]  | Bar  | this row will be re-rendered because it's been selected |
| [ ]  | Baz  | this row will not be re-rendered |

3. we select the Baz line. We expect Bar to stay select, but it gets deselected.

| Select  | Name | Notes |
| ------------- | ------------- | ------------- |
| [ ]  | Foo  | this row will not be re-rendered |
| [ ]  | Bar  | this row will be re-rendered but with an unchecked state, because that was its state when Baz was rendered the first time |
| [x]  | Baz  | this row will be re-rendered because it's been selected |

This was happening because the Foo's and Baz's `onSelect` callback was not being updated because the `BodyRow:shouldComponentUpdate` function _correctly_ detected that nothing changed in the data, and skipped the render.
The solution was simple, the `onSelect` callback had to make use of `useRef` to track the latest snapshot of the selected rows. 

I then realized that the logic for the selectable table wasn't trivial, especially for a developer new in the React ways, and also we were exposing _a lot_ of logic to the end-user that I think we could abstract away. So I moved all the logic to a reusable hook called `useSelectableRows` that does all the above for the user, asking only for the rows and, optionally, a function to retrieve the row's key.

The example is now super short and I think we can save other devs some good amount of time because of this little hook.

I plan to do apply the same treatment to the remaining examples, but I'll probably not be able to do so for a few weeks. In the meantime, I'd like to collect your feedback about these changes. Are you all ok with it? Something that can be improved or changed?

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: kinda related #2358

<!-- feel free to add additional comments -->
