### PR TITLE
feat(Table): add new visibleOn and hiddenOn breakpoint

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -713,12 +713,12 @@ class HiddenVisibleBreakpointTable extends React.Component {
       columns: [
         {
           title: 'Repositories',
-          columnTransforms: [classNames(Visibility.hidden, Visibility.visibleOnMd, Visibility.hiddenOnLg)]
+          columnTransforms: [classNames(Visibility.hidden, Visibility.visibleOnMd, Visibility.hiddenOnLg, Visibility.visibleOn2Xl)]
         },
         'Branches',
         {
           title: 'Pull requests',
-          columnTransforms: [classNames(Visibility.hiddenOnMd, Visibility.visibleOnLg)]
+          columnTransforms: [classNames(Visibility.hiddenOnMd, Visibility.visibleOnLg, Visibility.hiddenOn2Xl)]
         },
         'Workspaces',
         {

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/classNames.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/classNames.ts
@@ -7,10 +7,12 @@ export const Visibility = pickProperties(styles.modifiers, [
   'hiddenOnMd',
   'hiddenOnLg',
   'hiddenOnXl',
+  'hiddenOn2Xl',
   'visibleOnSm',
   'visibleOnMd',
   'visibleOnLg',
-  'visibleOnXl'
+  'visibleOnXl',
+  'visibleOn2Xl'
 ]);
 
 // tslint:disable-next-line:no-shadowed-variable


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Adds the new 2xl breakpoint to visibleOn and hiddenOn classes.
<!-- Are there any upstream issues or separate issues you need to reference? -->

**Refer to issue**: #2436

<!-- feel free to add additional comments -->

@priley86 Is there a good way to add tests for this? I'm unfamiliar with table and unsure how it uses the Visibility object.