### PR TITLE
feat(tab): support JSX elements in Tab title

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tab.tsx
@@ -1,23 +1,24 @@
 import * as React from 'react';
+import { Omit } from '../../helpers/typeUtils';
 
-export interface TabProps extends React.HTMLProps<HTMLAnchorElement | HTMLButtonElement> {
+export interface TabProps extends Omit<React.HTMLProps<HTMLAnchorElement | HTMLButtonElement>, 'title'> {
   /** content rendered inside the Tab content area. */
-  children?: React.ReactNode;
+  children?: React.ReactNode; 
   /** additional classes added to the Tab */
-  className?: string;
+  className?: string; 
   /** URL associated with the Tab. A Tab with an href will render as an <a> instead of a <button>. A Tab inside a <Tabs variant="nav"> should have an href. */
-  href?: string;
+  href?: string; 
   /** Tab title */
-  title: string;
+  title: React.ReactNode;
   /** uniquely identifies the tab */
-  eventKey: number | string;
+  eventKey: number | string; 
   /** child id for case in which a TabContent section is defined outside of a Tabs component */
-  tabContentId?: string | number;
+  tabContentId?: string | number; 
   /** child reference for case in which a TabContent section is defined outside of a Tabs component */
   tabContentRef?: React.RefObject<any>;
 }
 
-const Tab0: React.FC<TabProps> = ({
+const Tab0: React.FunctionComponent<TabProps> = ({
   children,
   eventKey,
   className = '',
@@ -33,7 +34,7 @@ const Tab0: React.FC<TabProps> = ({
       {children}
     </Component>
   );
-};
+}
 
 interface ForwardedRefProps extends TabProps {
   forwardRef?: React.Ref<any>;

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tabs.md
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tabs.md
@@ -8,14 +8,14 @@ typescript: true
 ## Simple tabs
 
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
-import { AddressBookIcon } from '@patternfly/react-icons`';
+import { AddressBookIcon } from '@patternfly/react-icons';
 
 Use primary sections
 
 ```js
 import React from 'react';
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
-import { AddressBookIcon } from '@patternfly/react-icons`';
+import { AddressBookIcon } from '@patternfly/react-icons';
 
 class SimpleTabs extends React.Component {
   constructor(props) {

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tabs.md
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tabs.md
@@ -8,12 +8,14 @@ typescript: true
 ## Simple tabs
 
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
+import { AddressBookIcon } from '@patternfly/react-icons`';
 
 Use primary sections
 
 ```js
 import React from 'react';
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
+import { AddressBookIcon } from '@patternfly/react-icons`';
 
 class SimpleTabs extends React.Component {
   constructor(props) {
@@ -41,6 +43,16 @@ class SimpleTabs extends React.Component {
         <Tab eventKey={2} title="Tab item 3">
           Tab 3 section
         </Tab>
+        <Tab
+          eventKey={3}
+          title={
+            <>
+              Tab item 4 <AddressBookIcon />
+            </>
+          }
+        >
+          Tab 4 section
+        </Tab>
       </Tabs>
     );
   }
@@ -48,6 +60,7 @@ class SimpleTabs extends React.Component {
 ```
 
 ## Scroll buttons primary tabs
+
 ```js
 import React from 'react';
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
@@ -113,6 +126,7 @@ class ScrollButtonsPrimaryTabs extends React.Component {
 ```
 
 ## Secondary buttons tabs
+
 ```js
 import React from 'react';
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
@@ -167,6 +181,7 @@ class SecondaryTabs extends React.Component {
 ```
 
 ## Scroll buttons secondary tabs
+
 ```js
 import React from 'react';
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
@@ -232,6 +247,7 @@ class ScrollButtonsSecondaryTabs extends React.Component {
 ```
 
 ## Filled buttons tabs
+
 ```js
 import React from 'react';
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
@@ -269,6 +285,7 @@ class FilledTabs extends React.Component {
 ```
 
 ## Secondary tabs using the nav element
+
 ```js
 import React from 'react';
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
@@ -336,6 +353,7 @@ class SecondaryTabsNavVariant extends React.Component {
 ```
 
 ## Tabs using the nav element
+
 ```js
 import React from 'react';
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
@@ -379,6 +397,7 @@ class TabsNavVariant extends React.Component {
 ```
 
 ## Separate tab content
+
 ```js
 import React from 'react';
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tabs.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tabs.test.tsx
@@ -15,6 +15,17 @@ test('should render simple tabs', () => {
       <Tab id="tab3" eventKey={2} title="Tab item 3">
         Tab 3 section
       </Tab>
+      <Tab
+        id="tab4"
+        eventKey={3}
+        title={
+          <b>
+            Tab item <i>4</i>
+          </b>
+        }
+      >
+        Tab 4 section
+      </Tab>
     </Tabs>
   );
   expect(view).toMatchSnapshot();

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tabs.tsx
@@ -70,7 +70,11 @@ class Tabs extends React.Component<TabsProps & InjectedOuiaProps, TabsState> {
     variant: TabsVariant.div
   };
 
-  handleTabClick(event: React.MouseEvent<HTMLElement, MouseEvent>, eventKey: number, tabContentRef: React.RefObject<any>) {
+  handleTabClick(
+    event: React.MouseEvent<HTMLElement, MouseEvent>,
+    eventKey: number,
+    tabContentRef: React.RefObject<any>
+  ) {
     this.props.onSelect(event, eventKey);
     // process any tab content sections outside of the component
     if (tabContentRef) {
@@ -212,46 +216,46 @@ class Tabs extends React.Component<TabsProps & InjectedOuiaProps, TabsState> {
           }}
           {...props}
         >
-            <button
-              className={css(styles.tabsScrollButton, isSecondary && buttonStyles.modifiers.secondary)}
-              aria-label={leftScrollAriaLabel}
-              onClick={this.scrollLeft}
-            >
-              <AngleLeftIcon />
-            </button>
+          <button
+            className={css(styles.tabsScrollButton, isSecondary && buttonStyles.modifiers.secondary)}
+            aria-label={leftScrollAriaLabel}
+            onClick={this.scrollLeft}
+          >
+            <AngleLeftIcon />
+          </button>
           <ul className={css(styles.tabsList)} ref={this.tabList} onScroll={this.handleScrollButtons}>
-            {React.Children.map(children, (child: any, index) => (
-              <li
-                key={index}
-                className={css(
-                  styles.tabsItem,
-                  child.props.eventKey === activeKey && styles.modifiers.current,
-                  className
-                )}
-              >
-                <Tab
-                  className={css(styles.tabsButton)}
-                  onClick={(event: any) => this.handleTabClick(event, child.props.eventKey, child.props.tabContentRef)}
-                  id={`pf-tab-${child.props.eventKey}-${child.props.id || uniqueId}`}
-                  aria-controls={
-                    child.props.tabContentId
-                      ? `${child.props.tabContentId}`
-                      : `pf-tab-section-${child.props.eventKey}-${child.props.id || uniqueId}`
-                  }
-                  {...child.props}
+            {React.Children.map(children, (child: any, index) => {
+              const { title, eventKey, tabContentRef, id: childId, tabContentId, ...rest } = child.props;
+              return (
+                <li
+                  key={index}
+                  className={css(styles.tabsItem, eventKey === activeKey && styles.modifiers.current, className)}
                 >
-                  {child.props.title}
-                </Tab>
-              </li>
-            ))}
+                  <Tab
+                    className={css(styles.tabsButton)}
+                    onClick={(event: any) => this.handleTabClick(event, eventKey, tabContentRef)}
+                    id={`pf-tab-${eventKey}-${childId || uniqueId}`}
+                    aria-controls={
+                      tabContentId ? `${tabContentId}` : `pf-tab-section-${eventKey}-${childId || uniqueId}`
+                    }
+                    tabContentId={tabContentId}
+                    tabContentRef={tabContentRef}
+                    eventKey={eventKey}
+                    {...rest}
+                  >
+                    {title}
+                  </Tab>
+                </li>
+              );
+            })}
           </ul>
-            <button
-              className={css(styles.tabsScrollButton, isSecondary && buttonStyles.modifiers.secondary)}
-              aria-label={rightScrollAriaLabel}
-              onClick={this.scrollRight}
-            >
-              <AngleRightIcon />
-            </button>
+          <button
+            className={css(styles.tabsScrollButton, isSecondary && buttonStyles.modifiers.secondary)}
+            aria-label={rightScrollAriaLabel}
+            onClick={this.scrollRight}
+          >
+            <AngleRightIcon />
+          </button>
         </Component>
         {React.Children.map(children, (child: any, index) =>
           !child.props.children ? null : (

--- a/packages/patternfly-4/react-core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -103,31 +103,28 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
               aria-controls="pf-tab-section-0-tab1"
               className="pf-c-tabs__button"
               eventKey={0}
-              id="tab1"
+              id="pf-tab-0-tab1"
               onClick={[Function]}
-              title="Tab item 1"
             >
               <TabContainer
                 aria-controls="pf-tab-section-0-tab1"
                 className="pf-c-tabs__button"
                 eventKey={0}
                 forwardRef={null}
-                id="tab1"
+                id="pf-tab-0-tab1"
                 onClick={[Function]}
-                title="Tab item 1"
               >
                 <Tab0
                   aria-controls="pf-tab-section-0-tab1"
                   className="pf-c-tabs__button"
                   eventKey={0}
-                  id="tab1"
+                  id="pf-tab-0-tab1"
                   onClick={[Function]}
-                  title="Tab item 1"
                 >
                   <button
                     aria-controls="pf-tab-section-0-tab1"
                     className="pf-c-tabs__button"
-                    id="tab1"
+                    id="pf-tab-0-tab1"
                     onClick={[Function]}
                   >
                     Tab item 1
@@ -144,31 +141,28 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
               aria-controls="pf-tab-section-1-tab2"
               className="pf-c-tabs__button"
               eventKey={1}
-              id="tab2"
+              id="pf-tab-1-tab2"
               onClick={[Function]}
-              title="Tab item 2"
             >
               <TabContainer
                 aria-controls="pf-tab-section-1-tab2"
                 className="pf-c-tabs__button"
                 eventKey={1}
                 forwardRef={null}
-                id="tab2"
+                id="pf-tab-1-tab2"
                 onClick={[Function]}
-                title="Tab item 2"
               >
                 <Tab0
                   aria-controls="pf-tab-section-1-tab2"
                   className="pf-c-tabs__button"
                   eventKey={1}
-                  id="tab2"
+                  id="pf-tab-1-tab2"
                   onClick={[Function]}
-                  title="Tab item 2"
                 >
                   <button
                     aria-controls="pf-tab-section-1-tab2"
                     className="pf-c-tabs__button"
-                    id="tab2"
+                    id="pf-tab-1-tab2"
                     onClick={[Function]}
                   >
                     Tab item 2
@@ -185,31 +179,28 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
               aria-controls="pf-tab-section-2-tab3"
               className="pf-c-tabs__button"
               eventKey={2}
-              id="tab3"
+              id="pf-tab-2-tab3"
               onClick={[Function]}
-              title="Tab item 3"
             >
               <TabContainer
                 aria-controls="pf-tab-section-2-tab3"
                 className="pf-c-tabs__button"
                 eventKey={2}
                 forwardRef={null}
-                id="tab3"
+                id="pf-tab-2-tab3"
                 onClick={[Function]}
-                title="Tab item 3"
               >
                 <Tab0
                   aria-controls="pf-tab-section-2-tab3"
                   className="pf-c-tabs__button"
                   eventKey={2}
-                  id="tab3"
+                  id="pf-tab-2-tab3"
                   onClick={[Function]}
-                  title="Tab item 3"
                 >
                   <button
                     aria-controls="pf-tab-section-2-tab3"
                     className="pf-c-tabs__button"
-                    id="tab3"
+                    id="pf-tab-2-tab3"
                     onClick={[Function]}
                   >
                     Tab item 3
@@ -480,31 +471,28 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
               aria-controls="pf-tab-section-0-tab1"
               className="pf-c-tabs__button"
               eventKey={0}
-              id="tab1"
+              id="pf-tab-0-tab1"
               onClick={[Function]}
-              title="Tab item 1"
             >
               <TabContainer
                 aria-controls="pf-tab-section-0-tab1"
                 className="pf-c-tabs__button"
                 eventKey={0}
                 forwardRef={null}
-                id="tab1"
+                id="pf-tab-0-tab1"
                 onClick={[Function]}
-                title="Tab item 1"
               >
                 <Tab0
                   aria-controls="pf-tab-section-0-tab1"
                   className="pf-c-tabs__button"
                   eventKey={0}
-                  id="tab1"
+                  id="pf-tab-0-tab1"
                   onClick={[Function]}
-                  title="Tab item 1"
                 >
                   <button
                     aria-controls="pf-tab-section-0-tab1"
                     className="pf-c-tabs__button"
-                    id="tab1"
+                    id="pf-tab-0-tab1"
                     onClick={[Function]}
                   >
                     Tab item 1
@@ -521,31 +509,28 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
               aria-controls="pf-tab-section-1-tab2"
               className="pf-c-tabs__button"
               eventKey={1}
-              id="tab2"
+              id="pf-tab-1-tab2"
               onClick={[Function]}
-              title="Tab item 2"
             >
               <TabContainer
                 aria-controls="pf-tab-section-1-tab2"
                 className="pf-c-tabs__button"
                 eventKey={1}
                 forwardRef={null}
-                id="tab2"
+                id="pf-tab-1-tab2"
                 onClick={[Function]}
-                title="Tab item 2"
               >
                 <Tab0
                   aria-controls="pf-tab-section-1-tab2"
                   className="pf-c-tabs__button"
                   eventKey={1}
-                  id="tab2"
+                  id="pf-tab-1-tab2"
                   onClick={[Function]}
-                  title="Tab item 2"
                 >
                   <button
                     aria-controls="pf-tab-section-1-tab2"
                     className="pf-c-tabs__button"
-                    id="tab2"
+                    id="pf-tab-1-tab2"
                     onClick={[Function]}
                   >
                     Tab item 2
@@ -562,31 +547,28 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
               aria-controls="pf-tab-section-2-tab3"
               className="pf-c-tabs__button"
               eventKey={2}
-              id="tab3"
+              id="pf-tab-2-tab3"
               onClick={[Function]}
-              title="Tab item 3"
             >
               <TabContainer
                 aria-controls="pf-tab-section-2-tab3"
                 className="pf-c-tabs__button"
                 eventKey={2}
                 forwardRef={null}
-                id="tab3"
+                id="pf-tab-2-tab3"
                 onClick={[Function]}
-                title="Tab item 3"
               >
                 <Tab0
                   aria-controls="pf-tab-section-2-tab3"
                   className="pf-c-tabs__button"
                   eventKey={2}
-                  id="tab3"
+                  id="pf-tab-2-tab3"
                   onClick={[Function]}
-                  title="Tab item 3"
                 >
                   <button
                     aria-controls="pf-tab-section-2-tab3"
                     className="pf-c-tabs__button"
-                    id="tab3"
+                    id="pf-tab-2-tab3"
                     onClick={[Function]}
                   >
                     Tab item 3
@@ -857,31 +839,28 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
               aria-controls="pf-tab-section-0-tab1"
               className="pf-c-tabs__button"
               eventKey={0}
-              id="tab1"
+              id="pf-tab-0-tab1"
               onClick={[Function]}
-              title="Tab item 1"
             >
               <TabContainer
                 aria-controls="pf-tab-section-0-tab1"
                 className="pf-c-tabs__button"
                 eventKey={0}
                 forwardRef={null}
-                id="tab1"
+                id="pf-tab-0-tab1"
                 onClick={[Function]}
-                title="Tab item 1"
               >
                 <Tab0
                   aria-controls="pf-tab-section-0-tab1"
                   className="pf-c-tabs__button"
                   eventKey={0}
-                  id="tab1"
+                  id="pf-tab-0-tab1"
                   onClick={[Function]}
-                  title="Tab item 1"
                 >
                   <button
                     aria-controls="pf-tab-section-0-tab1"
                     className="pf-c-tabs__button"
-                    id="tab1"
+                    id="pf-tab-0-tab1"
                     onClick={[Function]}
                   >
                     Tab item 1
@@ -898,31 +877,28 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
               aria-controls="pf-tab-section-1-tab2"
               className="pf-c-tabs__button"
               eventKey={1}
-              id="tab2"
+              id="pf-tab-1-tab2"
               onClick={[Function]}
-              title="Tab item 2"
             >
               <TabContainer
                 aria-controls="pf-tab-section-1-tab2"
                 className="pf-c-tabs__button"
                 eventKey={1}
                 forwardRef={null}
-                id="tab2"
+                id="pf-tab-1-tab2"
                 onClick={[Function]}
-                title="Tab item 2"
               >
                 <Tab0
                   aria-controls="pf-tab-section-1-tab2"
                   className="pf-c-tabs__button"
                   eventKey={1}
-                  id="tab2"
+                  id="pf-tab-1-tab2"
                   onClick={[Function]}
-                  title="Tab item 2"
                 >
                   <button
                     aria-controls="pf-tab-section-1-tab2"
                     className="pf-c-tabs__button"
-                    id="tab2"
+                    id="pf-tab-1-tab2"
                     onClick={[Function]}
                   >
                     Tab item 2
@@ -939,31 +915,28 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
               aria-controls="pf-tab-section-2-tab3"
               className="pf-c-tabs__button"
               eventKey={2}
-              id="tab3"
+              id="pf-tab-2-tab3"
               onClick={[Function]}
-              title="Tab item 3"
             >
               <TabContainer
                 aria-controls="pf-tab-section-2-tab3"
                 className="pf-c-tabs__button"
                 eventKey={2}
                 forwardRef={null}
-                id="tab3"
+                id="pf-tab-2-tab3"
                 onClick={[Function]}
-                title="Tab item 3"
               >
                 <Tab0
                   aria-controls="pf-tab-section-2-tab3"
                   className="pf-c-tabs__button"
                   eventKey={2}
-                  id="tab3"
+                  id="pf-tab-2-tab3"
                   onClick={[Function]}
-                  title="Tab item 3"
                 >
                   <button
                     aria-controls="pf-tab-section-2-tab3"
                     className="pf-c-tabs__button"
-                    id="tab3"
+                    id="pf-tab-2-tab3"
                     onClick={[Function]}
                   >
                     Tab item 3
@@ -1166,7 +1139,7 @@ Array [
           aria-controls="pf-tab-section-0-tab1"
           class="pf-c-tabs__button"
           href="#/items/1"
-          id="tab1"
+          id="pf-tab-0-tab1"
         >
           Tab item 1
         </a>
@@ -1178,7 +1151,7 @@ Array [
           aria-controls="pf-tab-section-1-tab2"
           class="pf-c-tabs__button"
           href="#/items/2"
-          id="tab2"
+          id="pf-tab-1-tab2"
         >
           Tab item 2
         </a>
@@ -1190,7 +1163,7 @@ Array [
           aria-controls="pf-tab-section-2-tab3"
           class="pf-c-tabs__button"
           href="#/items/3"
-          id="tab3"
+          id="pf-tab-2-tab3"
         >
           Tab item 3
         </a>
@@ -1281,7 +1254,7 @@ Array [
         <button
           aria-controls="pf-tab-section-0-tab1"
           class="pf-c-tabs__button"
-          id="tab1"
+          id="pf-tab-0-tab1"
         >
           Tab item 1
         </button>
@@ -1292,7 +1265,7 @@ Array [
         <button
           aria-controls="pf-tab-section-1-tab2"
           class="pf-c-tabs__button"
-          id="tab2"
+          id="pf-tab-1-tab2"
         >
           Tab item 2
         </button>
@@ -1303,7 +1276,7 @@ Array [
         <button
           aria-controls="pf-tab-section-2-tab3"
           class="pf-c-tabs__button"
-          id="tab3"
+          id="pf-tab-2-tab3"
         >
           Tab item 3
         </button>
@@ -1405,7 +1378,7 @@ Array [
         <button
           aria-controls="pf-tab-section-1-tab2"
           class="pf-c-tabs__button"
-          id="tab2"
+          id="pf-tab-1-tab2"
         >
           Tab item 2
         </button>
@@ -1416,7 +1389,7 @@ Array [
         <button
           aria-controls="pf-tab-section-2-tab3"
           class="pf-c-tabs__button"
-          id="tab3"
+          id="pf-tab-2-tab3"
         >
           Tab item 3
         </button>
@@ -1480,7 +1453,7 @@ Array [
           <button
             aria-controls="pf-tab-section-10-secondary tab1"
             class="pf-c-tabs__button"
-            id="secondary tab1"
+            id="pf-tab-10-secondary tab1"
           >
             Secondary Tab 1
           </button>
@@ -1491,7 +1464,7 @@ Array [
           <button
             aria-controls="pf-tab-section-11-secondary tab2"
             class="pf-c-tabs__button"
-            id="secondary tab2"
+            id="pf-tab-11-secondary tab2"
           >
             Secondary Tab 2
           </button>
@@ -1502,7 +1475,7 @@ Array [
           <button
             aria-controls="pf-tab-section-12-secondary tab3"
             class="pf-c-tabs__button"
-            id="secondary tab3"
+            id="pf-tab-12-secondary tab3"
           >
             Secondary Tab 3
           </button>
@@ -1615,7 +1588,7 @@ Array [
         <button
           aria-controls="pf-tab-section-0-tab1"
           class="pf-c-tabs__button"
-          id="tab1"
+          id="pf-tab-0-tab1"
         >
           Tab item 1
         </button>
@@ -1626,7 +1599,7 @@ Array [
         <button
           aria-controls="pf-tab-section-1-tab2"
           class="pf-c-tabs__button"
-          id="tab2"
+          id="pf-tab-1-tab2"
         >
           Tab item 2
         </button>
@@ -1637,9 +1610,25 @@ Array [
         <button
           aria-controls="pf-tab-section-2-tab3"
           class="pf-c-tabs__button"
-          id="tab3"
+          id="pf-tab-2-tab3"
         >
           Tab item 3
+        </button>
+      </li>
+      <li
+        class="pf-c-tabs__item"
+      >
+        <button
+          aria-controls="pf-tab-section-3-tab4"
+          class="pf-c-tabs__button"
+          id="pf-tab-3-tab4"
+        >
+          <b>
+            Tab item 
+            <i>
+              4
+            </i>
+          </b>
         </button>
       </li>
     </ul>
@@ -1692,6 +1681,16 @@ Array [
   >
     Tab 3 section
   </section>,
+  <section
+    aria-labelledby="pf-tab-3-tab4"
+    class="pf-c-tab-content"
+    hidden=""
+    id="pf-tab-section-3-tab4"
+    role="tabpanel"
+    tabindex="0"
+  >
+    Tab 4 section
+  </section>,
 ]
 `;
 
@@ -1728,7 +1727,7 @@ Array [
         <button
           aria-controls="pf-tab-section-one-tab1"
           class="pf-c-tabs__button"
-          id="tab1"
+          id="pf-tab-one-tab1"
         >
           Tab item 1
         </button>
@@ -1739,7 +1738,7 @@ Array [
         <button
           aria-controls="pf-tab-section-two-tab2"
           class="pf-c-tabs__button"
-          id="tab2"
+          id="pf-tab-two-tab2"
         >
           Tab item 2
         </button>
@@ -1750,7 +1749,7 @@ Array [
         <button
           aria-controls="pf-tab-section-three-tab3"
           class="pf-c-tabs__button"
-          id="tab3"
+          id="pf-tab-three-tab3"
         >
           Tab item 3
         </button>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsDemo.tsx
@@ -34,7 +34,7 @@ export class TabDemo extends Component {
         <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
           <Tab id="demoTab1" eventKey={0} title="Tab item 1" tabContentId="demoTab1Section" tabContentRef={this.contentRef1} />
           <Tab id="demoTab2" eventKey={1} title="Tab item 2" tabContentId="demoTab2Section" tabContentRef={this.contentRef2} />
-          <Tab id="demoTab3" eventKey={2} title="Tab item 3" tabContentId="demoTab3Section" tabContentRef={this.contentRef3} />
+          <Tab id="demoTab3" eventKey={2} title={<i>Tab item 3</i>} tabContentId="demoTab3Section" tabContentRef={this.contentRef3} />
         </Tabs>
         <div>
           <TabContent eventKey={0} id="demoTab1Section" ref={this.contentRef1} aria-label="Tab item 1" onAuxClick={(event) => console.log(event)}>


### PR DESCRIPTION
**What**:

closes #2623 

In general Tab supported JSX elements the problem is that the `title` props type was set to string. In addition, `Tab` didn't use the `title` prop at all, which was confusing, because it was passed as a child in the `Tabs` component. So what I did was removing `title` from props. 

//cc @xeviknal 