### PR TITLE
fix(radio): group radio inputs in docs (axe-core)

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.md
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.md
@@ -8,6 +8,7 @@ propComponents: ['Radio']
 import { Radio } from '@patternfly/react-core';
 
 ## Controlled radio
+
 ```js
 import React from 'react';
 import { Radio } from '@patternfly/react-core';
@@ -16,12 +17,12 @@ class ControlledRadio extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: '4'
+      check1: false,
     };
 
     this.handleChange = (_, event) => {
       const { value } = event.currentTarget;
-      this.setState({ value });
+      this.setState({ [value]: true });
     };
   }
 
@@ -29,20 +30,11 @@ class ControlledRadio extends React.Component {
     return (
       <React.Fragment>
         <Radio
-          value="3"
-          isChecked={this.state.value === '3'}
-          name="pf-version"
+          isChecked={this.state.check1}
+          name="radio-1"
           onChange={this.handleChange}
-          label="Controlled radio 1"
-          id="radio-1"
-        />{' '}
-        <Radio
-          value="4"
-          isChecked={this.state.value === '4'}
-          name="pf-version"
-          onChange={this.handleChange}
-          label="Controlled radio 2"
-          id="radio-2"
+          label="Controlled radio"
+          id="radio-controlled"
         />
       </React.Fragment>
     );
@@ -51,27 +43,54 @@ class ControlledRadio extends React.Component {
 ```
 
 ## Uncontrolled radio
+
 ```js
 import React from 'react';
 import { Radio } from '@patternfly/react-core';
 
 UncontrolledRadio = () => (
   <React.Fragment>
-    <Radio label="Uncontrolled radio example" id="radio-4" name="radio-4" />
-    <Radio label="Uncontrolled radio example" id="radio-5" name="radio-4" />
+    <Radio label="Uncontrolled radio example" id="radio-uncontrolled" name="radio-2" />
+  </React.Fragment>
+);
+```
+
+## Reversed radio
+
+```js
+import React from 'react';
+import { Radio } from '@patternfly/react-core';
+
+ReversedRadio = () => (
+  <React.Fragment>
+    <Radio isLabelBeforeButton label="Reversed radio example" id="radio-reversed" name="radio-3" />
+  </React.Fragment>
+);
+```
+
+## Label wraps input radio
+
+```js
+import React from 'react';
+import { Radio } from '@patternfly/react-core';
+
+LabelWrapsInputRadio = () => (
+  <React.Fragment>
+    <Radio isLabelWrapped label="Label wraps input example" id="radio-label-wraps-input" name="radio-4" />
   </React.Fragment>
 );
 ```
 
 ## Disabled radio
+
 ```js
 import React from 'react';
 import { Radio } from '@patternfly/react-core';
 
 DisabledRadio = () => (
   <React.Fragment>
-    <Radio label="Disabled checked radio example" defaultChecked isDisabled name="group-1" id="radio-disabled" />{' '}
-    <Radio id="radio-disabled-2" label="Disabled radio example" isDisabled name="group-2" />
+    <Radio id="radio-disabled" label="Disabled radio example" isDisabled name="radio-5" />
+    <Radio id="radio-disabled-checked" defaultChecked label="Disabled and checked radio example" isDisabled name="radio-6" />
   </React.Fragment>
 );
 ```

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.test.tsx
@@ -22,6 +22,16 @@ describe('Radio check component', () => {
     expect(view).toMatchSnapshot();
   });
 
+  test('isLabelBeforeButton', () => {
+    const view = shallow(<Radio id="check" isLabelBeforeButton label="Radio label" aria-label="check" name="check" />);
+    expect(view).toMatchSnapshot();
+  });
+
+  test('isLabelWrapped', () => {
+    const view = shallow(<Radio id="check" isLabelWrapped label="Radio label" aria-label="check" name="check" />);
+    expect(view).toMatchSnapshot();
+  });
+
   test('label is string', () => {
     const view = shallow(<Radio label="Label" id="check" isChecked aria-label="check" name="check" />);
     expect(view).toMatchSnapshot();

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.tsx
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.tsx
@@ -9,6 +9,10 @@ export interface RadioProps
   className?: string;
   /** Id of the radio. */
   id: string;
+  /** Flag to show if the radio label is wrapped on small screen. */
+  isLabelWrapped?: boolean;
+  /** Flag to show if the radio label is shown before the radio button. */
+  isLabelBeforeButton?: boolean;
   /** Flag to show if the radio is checked. */
   isChecked?: boolean;
   /** Flag to show if the radio is disabled. */
@@ -51,6 +55,8 @@ export class Radio extends React.Component<RadioProps> {
       checked,
       className,
       defaultChecked,
+      isLabelWrapped,
+      isLabelBeforeButton,
       isChecked,
       isDisabled,
       isValid,
@@ -58,28 +64,48 @@ export class Radio extends React.Component<RadioProps> {
       onChange,
       ...props
     } = this.props;
-    return (
-      <div className={css(styles.radio, className)}>
-        <input
-          {...props}
-          className={css(styles.radioInput)}
-          type="radio"
-          onChange={this.handleChange}
-          aria-invalid={!isValid}
-          disabled={isDisabled}
-          defaultChecked={checked || isChecked}
-          {...(!isChecked && { defaultChecked })}
-          {...(!label && { 'aria-label': ariaLabel })}
-        />
-        {label && (
-          <label
-            className={css(styles.radioLabel, getModifier(styles, isDisabled && ('disabled' as any)))}
-            htmlFor={props.id}
-          >
-            {label}
-          </label>
-        )}
-      </div>
+
+    const inputRendered = (
+      <input
+        {...props}
+        className={css(styles.radioInput)}
+        type="radio"
+        onChange={this.handleChange}
+        aria-invalid={!isValid}
+        disabled={isDisabled}
+        defaultChecked={checked || isChecked}
+        {...(!isChecked && { defaultChecked })}
+        {...(!label && { 'aria-label': ariaLabel })}
+      />
+    );
+    const labelRendered = !label ? null : isLabelWrapped ? (
+      <span className={css(styles.radioLabel, getModifier(styles, isDisabled && ('disabled' as any)))}>{label}</span>
+    ) : (
+      <label
+        className={css(styles.radioLabel, getModifier(styles, isDisabled && ('disabled' as any)))}
+        htmlFor={props.id}
+      >
+        {label}
+      </label>
+    );
+    const childrenRendered = isLabelBeforeButton ? (
+      <>
+        {labelRendered}
+        {inputRendered}
+      </>
+    ) : (
+      <>
+        {inputRendered}
+        {labelRendered}
+      </>
+    );
+
+    return isLabelWrapped ? (
+      <label className={css(styles.radio, className)} htmlFor={props.id}>
+        {childrenRendered}
+      </label>
+    ) : (
+      <div className={css(styles.radio, className)}>{childrenRendered}</div>
     );
   }
 }

--- a/packages/patternfly-4/react-core/src/components/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Radio/__snapshots__/Radio.test.tsx.snap
@@ -35,6 +35,50 @@ exports[`Radio check component isDisabled 1`] = `
 </div>
 `;
 
+exports[`Radio check component isLabelBeforeButton 1`] = `
+<div
+  className="pf-c-radio"
+>
+  <label
+    className="pf-c-radio__label"
+    htmlFor="check"
+  >
+    Radio label
+  </label>
+  <input
+    aria-invalid={false}
+    className="pf-c-radio__input"
+    disabled={false}
+    id="check"
+    name="check"
+    onChange={[Function]}
+    type="radio"
+  />
+</div>
+`;
+
+exports[`Radio check component isLabelWrapped 1`] = `
+<label
+  className="pf-c-radio"
+  htmlFor="check"
+>
+  <input
+    aria-invalid={false}
+    className="pf-c-radio__input"
+    disabled={false}
+    id="check"
+    name="check"
+    onChange={[Function]}
+    type="radio"
+  />
+  <span
+    className="pf-c-radio__label"
+  >
+    Radio label
+  </span>
+</label>
+`;
+
 exports[`Radio check component label is function 1`] = `
 <div
   className="pf-c-radio"


### PR DESCRIPTION
**What**:

closes #2568 

Radio inputs that have the same name should be grouped. One way to group them is inside a div with `role="group"` and `aria-label` to describe this group.

//cc @christiemolloy 