### PR TITLE
chore(dropdown): exclude checked from props, fix duplicate key error

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.md
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.md
@@ -523,7 +523,7 @@ class SplitButtonDropdown extends React.Component {
             splitButtonItems={[
               <DropdownToggleCheckbox
                 id="example-checkbox-1"
-                key="checkbox"
+                key="split-checkbox"
                 aria-label="Select all"
               />
             ]}
@@ -590,7 +590,7 @@ class SplitButtonDisabledDropdown extends React.Component {
             splitButtonItems={[
               <DropdownToggleCheckbox
                 id="example-checkbox-1"
-                key="checkbox"
+                key="disabled-checkbox"
                 aria-label="Select all"
                 isDisabled
               />

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
@@ -3,7 +3,7 @@ import styles from '@patternfly/react-styles/css/components/Dropdown/dropdown';
 import { css } from '@patternfly/react-styles';
 import { Omit } from '../../helpers/typeUtils';
 
-export interface DropdownToggleCheckboxProps extends Omit<React.HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled'> { 
+export interface DropdownToggleCheckboxProps extends Omit<React.HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled' | 'checked'> {
   /** Additional classes added to the DropdownToggleCheckbox */
   className?: string;
   /** Flag to show if the checkbox selection is valid or invalid */
@@ -23,7 +23,7 @@ export interface DropdownToggleCheckboxProps extends Omit<React.HTMLProps<HTMLIn
 }
 
 export class DropdownToggleCheckbox extends React.Component<DropdownToggleCheckboxProps> {
-  
+
   static defaultProps = {
     className: '',
     isValid: true,


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: This PR clears a couple of errors in dropdown. I suppose we could simply not allow `null` as a value for the union type for checked, but I didn't want to change the behavior so I excluded it from the `HTMLInputElement` props we're extending.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: https://github.com/patternfly/patternfly-react/issues/2691

<!-- feel free to add additional comments -->
Fixes these errors

<img width="1540" alt="Screen Shot 2019-08-13 at 9 05 03 AM" src="https://user-images.githubusercontent.com/5942899/62945239-60f1e180-bdac-11e9-9567-07e9521295cd.png">

<img width="1126" alt="Screen Shot 2019-08-12 at 5 35 56 PM" src="https://user-images.githubusercontent.com/5942899/62945329-8a127200-bdac-11e9-904d-310e0ec175fe.png">
