### PR TITLE
feat(Table): add empty state demo

### DIFF
--- a/packages/patternfly-4/react-core/src/layouts/Bullseye/examples/Bullseye.md
+++ b/packages/patternfly-4/react-core/src/layouts/Bullseye/examples/Bullseye.md
@@ -14,7 +14,7 @@ import './bullseye.scss';
 import React from 'react';
 import { Bullseye } from '@patternfly/react-core';
 
-<Bullseye>
+<Bullseye className="layout-example">
   <div>Bullseye ◎ layout</div>
 </Bullseye>
 ```

--- a/packages/patternfly-4/react-core/src/layouts/Bullseye/examples/bullseye.scss
+++ b/packages/patternfly-4/react-core/src/layouts/Bullseye/examples/bullseye.scss
@@ -1,11 +1,11 @@
 .ws-preview {
-  & .pf-l-bullseye {
+  & .layout-example {
     padding: 1rem;
     border-width: 2px;
     border-style: dashed;
   }
 
-  & .pf-l-bullseye > div {
+  & .layout-example  > div {
     padding: 1rem;
     border-width: 2px;
     border-style: dashed;

--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -108,6 +108,98 @@ class SimpleTable extends React.Component {
 }
 ```
 
+## Table with empty state
+
+```js
+import React from 'react';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  sortable,
+  SortByDirection,
+  headerCol,
+  TableVariant,
+  expandable,
+  cellWidth,
+  textCenter,
+} from '@patternfly/react-table';
+import {
+  Bullseye,
+  Title,
+  Button,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateSecondaryActions
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+
+class EmptyTable extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      columns: [
+        { title: 'Repositories' },
+        'Branches',
+        { title: 'Pull requests' },
+        'Workspaces',
+        {
+          title: 'Last Commit',
+          transforms: [textCenter],
+          cellTransforms: [textCenter]
+        }
+      ],
+      rows: []
+    };
+  }
+
+  renderEmptyState() {
+    return (<EmptyState variant={EmptyStateVariant.full}>
+      <EmptyStateIcon icon={CubesIcon} />
+      <Title headingLevel="h5" size="lg">
+        Empty State
+      </Title>
+      <EmptyStateBody>
+        This represents an the empty state pattern in Patternfly 4. Hopefully it's simple enough to use but flexible
+        enough to meet a variety of needs.
+      </EmptyStateBody>
+      <Button variant="primary">Primary Action</Button>
+      <EmptyStateSecondaryActions>
+        <Button variant="link">Multiple</Button>
+        <Button variant="link">Action Buttons</Button>
+        <Button variant="link">Can</Button>
+        <Button variant="link">Go here</Button>
+        <Button variant="link">In the secondary</Button>
+        <Button variant="link">Action area</Button>
+      </EmptyStateSecondaryActions>
+    </EmptyState>);
+  };
+
+  render() {
+    const { columns, rows } = this.state;
+
+    return (
+      <Table caption="Empty Table" cells={columns} rows={rows}>
+        <TableHeader />
+        {rows.length > 0 && <TableBody /> || (
+          <tbody>
+            <tr>
+              <td colspan={5}>
+                <Bullseye>
+                  {this.renderEmptyState()}
+                </Bullseye>
+              </td>
+            </tr>
+          </tbody>
+        )}
+      </Table>
+    );
+  }
+}
+```
+
 ## Sortable table
 
 ```js


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: adds an example showing a table using the empty state component for cases with no rows.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Refer to issue**: #1433

<!-- feel free to add additional comments -->
