### PR TITLE
fix(VncConsole): Change prop name in VncActions and added needed prop to VncConsole

### DIFF
--- a/packages/patternfly-3/react-console/src/VncConsole/VncActions.js
+++ b/packages/patternfly-3/react-console/src/VncConsole/VncActions.js
@@ -12,7 +12,7 @@ const VncActions = ({
   textDisconnect,
   onCtrlAltDel,
   onDisconnect,
-  insertToolbarTo
+  portalToolbarTo
 }) => {
   const toolbar = (
     <div>
@@ -27,11 +27,11 @@ const VncActions = ({
     </div>
   );
 
-  if (!insertToolbarTo) {
+  if (!portalToolbarTo) {
     return toolbar;
   }
   return (
-    document.getElementById(insertToolbarTo) && ReactDOM.createPortal(toolbar, document.getElementById(insertToolbarTo))
+    document.getElementById(portalToolbarTo) && ReactDOM.createPortal(toolbar, document.getElementById(portalToolbarTo))
   );
 };
 
@@ -43,7 +43,7 @@ VncActions.propTypes = {
   textSendShortcut: PropTypes.string,
   textDisconnect: PropTypes.string,
 
-  insertToolbarTo: PropTypes.string // id of element where VncAction should be inserted
+  portalToolbarTo: PropTypes.string // id of element where VncAction should be inserted
 };
 
 VncActions.defaultProps = {
@@ -53,7 +53,7 @@ VncActions.defaultProps = {
   textSendShortcut: 'Send Key',
   textDisconnect: 'Disconnect',
 
-  insertToolbarTo: ''
+  portalToolbarTo: ''
 };
 
 export default VncActions;

--- a/packages/patternfly-3/react-console/src/VncConsole/VncConsole.js
+++ b/packages/patternfly-3/react-console/src/VncConsole/VncConsole.js
@@ -120,7 +120,8 @@ class VncConsole extends React.Component {
       textSendShortcut,
       textCtrlAltDel,
       textDisconnect,
-      portalToolbarTo
+      portalToolbarTo,
+      consoleContainerId
     } = this.props;
 
     let status = null;
@@ -148,7 +149,7 @@ class VncConsole extends React.Component {
 
     if (!this.novncStaticComponent) {
       // create just once
-      this.novncStaticComponent = <div ref={this.setNovncElem} />;
+      this.novncStaticComponent = <div id={consoleContainerId} ref={this.setNovncElem} />;
     }
 
     return (
@@ -191,6 +192,7 @@ VncConsole.propTypes = {
   repeaterID: PropTypes.string,
   vncLogging: PropTypes.string /** log-level for noVNC */,
   portalToolbarTo: PropTypes.string,
+  consoleContainerId: PropTypes.string,
 
   topClassName: PropTypes.string /** Enable customization */,
 
@@ -222,6 +224,7 @@ VncConsole.defaultProps = {
   repeaterID: '',
   vncLogging: 'warn',
   portalToolbarTo: '',
+  consoleContainerId: undefined,
 
   topClassName: '',
 


### PR DESCRIPTION
There was incosistent between `portalToolbarTo` prop name and same prop in VncActions.

@priley86 could you, please, take a quick look?
