### PR TITLE
feat(PF4 - Drawer): Update drawer to expose all parts

### DIFF
--- a/packages/patternfly-4/react-core/src/experimental/components/Drawer/Drawer.md
+++ b/packages/patternfly-4/react-core/src/experimental/components/Drawer/Drawer.md
@@ -2,11 +2,11 @@
 title: 'Drawer'
 cssPrefix: 'pf-c-drawer'
 typescript: true
-propComponents: ['Drawer', 'DrawerPanelContent']
+propComponents: ['Drawer', 'DrawerPanelContent', 'DrawerContent']
 section: 'experimental'
 ---
 
-import { Drawer, DrawerPanelContent } from '@patternfly/react-core/dist/esm/experimental';
+import { Drawer, DrawerPanelContent, DrawerContent } from '@patternfly/react-core/dist/esm/experimental';
 import { Alert } from '@patternfly/react-core';
 
 <Alert variant="danger" title="Warning">
@@ -19,7 +19,7 @@ import { Alert } from '@patternfly/react-core';
 
 ```js
 import React {ReactFragment} from 'react';
-import { Drawer, DrawerPanelContent } from '@patternfly/react-core/dist/esm/experimental';
+import { Drawer, DrawerPanelContent, DrawerContent } from '@patternfly/react-core/dist/esm/experimental';
 import { Button } from '@patternfly/react-core';
 
 class SimpleDrawer extends React.Component {
@@ -40,13 +40,15 @@ class SimpleDrawer extends React.Component {
 
   render() {
     const { isExpanded } = this.state;
-    const panelContent = (<DrawerPanelContent> drawer-panel </DrawerPanelContent>);
 
     const drawerContent = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.";
 
     return (<React.Fragment>
             <Button onClick={this.onClick}>Toggle Drawer</Button>
-            <Drawer isExpanded={isExpanded} panelContent={panelContent}>{drawerContent}</Drawer>
+            <Drawer isExpanded={isExpanded}>
+              <DrawerContent>{drawerContent}</DrawerContent>
+              <DrawerPanelContent> drawer-panel </DrawerPanelContent>
+            </Drawer>
         </React.Fragment>);
   }
 }
@@ -57,7 +59,7 @@ class SimpleDrawer extends React.Component {
 
 ```js
 import React {ReactFragment} from 'react';
-import { Drawer, DrawerPanelContent } from '@patternfly/react-core/dist/esm/experimental';
+import { Drawer, DrawerPanelContent, DrawerContent } from '@patternfly/react-core/dist/esm/experimental';
 import { Button } from '@patternfly/react-core';
 
 class SimpleDrawerInlineContent extends React.Component {
@@ -78,13 +80,15 @@ class SimpleDrawerInlineContent extends React.Component {
 
   render() {
     const { isExpanded } = this.state;
-    const panelContent = (<DrawerPanelContent> drawer-panel </DrawerPanelContent>);
 
     const drawerContent = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.";
 
     return (<React.Fragment>
             <Button onClick={this.onClick}>Toggle Drawer</Button>
-            <Drawer isExpanded={isExpanded} isInline panelContent={panelContent}>{drawerContent}</Drawer>
+            <Drawer isExpanded={isExpanded} isInline>
+              <DrawerContent>{drawerContent}</DrawerContent>
+              <DrawerPanelContent> drawer-panel </DrawerPanelContent>
+            </Drawer>
         </React.Fragment>);
   }
 }

--- a/packages/patternfly-4/react-core/src/experimental/components/Drawer/Drawer.test.tsx
+++ b/packages/patternfly-4/react-core/src/experimental/components/Drawer/Drawer.test.tsx
@@ -1,4 +1,4 @@
-import { Drawer, DrawerPanelContent } from './';
+import { Drawer, DrawerPanelContent, DrawerContent } from './';
 import React from 'react';
 import { shallow } from 'enzyme';
 
@@ -8,14 +8,14 @@ Object.values([
   { isExpanded: true, isInline: true },
   { isExpanded: false, isInline: true }
 ]).forEach(({ isExpanded, isInline }) => {
-  const panelContent = <DrawerPanelContent> drawer-panel </DrawerPanelContent>;
 
   const drawerContent =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
   test(`Drawer isExpanded = ${isExpanded} and isInline = ${isInline}`, () => {
     const view = shallow(
-      <Drawer isExpanded={isExpanded} isInline={isInline} panelContent={panelContent}>
-        {drawerContent}
+      <Drawer isExpanded={isExpanded} isInline={isInline}>
+        <DrawerContent>{drawerContent}</DrawerContent>
+        <DrawerPanelContent> drawer-panel </DrawerPanelContent>
       </Drawer>
     );
     expect(view).toMatchSnapshot();

--- a/packages/patternfly-4/react-core/src/experimental/components/Drawer/Drawer.test.tsx
+++ b/packages/patternfly-4/react-core/src/experimental/components/Drawer/Drawer.test.tsx
@@ -1,6 +1,6 @@
 import { Drawer, DrawerPanelContent, DrawerContent } from './';
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 Object.values([
   { isExpanded: true, isInline: false },
@@ -12,7 +12,7 @@ Object.values([
   const drawerContent =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.';
   test(`Drawer isExpanded = ${isExpanded} and isInline = ${isInline}`, () => {
-    const view = shallow(
+    const view = mount(
       <Drawer isExpanded={isExpanded} isInline={isInline}>
         <DrawerContent>{drawerContent}</DrawerContent>
         <DrawerPanelContent> drawer-panel </DrawerPanelContent>

--- a/packages/patternfly-4/react-core/src/experimental/components/Drawer/Drawer.tsx
+++ b/packages/patternfly-4/react-core/src/experimental/components/Drawer/Drawer.tsx
@@ -11,8 +11,6 @@ export interface DrawerProps extends React.HTMLProps<HTMLDivElement> {
   isExpanded?: boolean;
   /** Indicates if the content element and panel element are displayed side by side. */
   isInline?: boolean;
-  /** Content rendered in the drawer */
-  panelContent?: React.ReactNode;
 }
 
 export const Drawer: React.SFC<DrawerProps> = ({
@@ -20,15 +18,12 @@ export const Drawer: React.SFC<DrawerProps> = ({
   children,
   isExpanded = false,
   isInline = false,
-  panelContent,
   ...props
 }: DrawerProps) => (
   <div {...props} className={css(styles.drawer,
     isExpanded && styles.modifiers.expanded,
     isInline && styles.modifiers.inline,
     className)}>
-     <div className={css(
-       styles.drawerContent)}> { children } </div>
-     { panelContent }
+     { children }
   </div>
 );

--- a/packages/patternfly-4/react-core/src/experimental/components/Drawer/DrawerContent.tsx
+++ b/packages/patternfly-4/react-core/src/experimental/components/Drawer/DrawerContent.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/Drawer/drawer';
+import { css } from '@patternfly/react-styles';
+
+export interface DrawerContentProps extends React.HTMLProps<HTMLDivElement> {
+  /** Additional classes added to the Drawer. */
+  className?: string;
+  /** Content to rendered in the drawer */
+  children?: React.ReactNode;
+}
+
+export const DrawerContent: React.SFC<DrawerContentProps> = ({
+  className = '',
+  children,
+  ...props
+}: DrawerContentProps) => (
+  <div className={css(styles.drawerContent)} {...props}>
+    {children}
+  </div>
+);

--- a/packages/patternfly-4/react-core/src/experimental/components/Drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/experimental/components/Drawer/__snapshots__/Drawer.test.tsx.snap
@@ -4,13 +4,9 @@ exports[`Drawer isExpanded = false and isInline = false 1`] = `
 <div
   className="pf-c-drawer"
 >
-  <div
-    className="pf-c-drawer__content"
-  >
-     
+  <Component>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
-     
-  </div>
+  </Component>
   <Component>
      drawer-panel 
   </Component>
@@ -21,13 +17,9 @@ exports[`Drawer isExpanded = false and isInline = true 1`] = `
 <div
   className="pf-c-drawer pf-m-inline"
 >
-  <div
-    className="pf-c-drawer__content"
-  >
-     
+  <Component>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
-     
-  </div>
+  </Component>
   <Component>
      drawer-panel 
   </Component>
@@ -38,13 +30,9 @@ exports[`Drawer isExpanded = true and isInline = false 1`] = `
 <div
   className="pf-c-drawer pf-m-expanded"
 >
-  <div
-    className="pf-c-drawer__content"
-  >
-     
+  <Component>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
-     
-  </div>
+  </Component>
   <Component>
      drawer-panel 
   </Component>
@@ -55,13 +43,9 @@ exports[`Drawer isExpanded = true and isInline = true 1`] = `
 <div
   className="pf-c-drawer pf-m-expanded pf-m-inline"
 >
-  <div
-    className="pf-c-drawer__content"
-  >
-     
+  <Component>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
-     
-  </div>
+  </Component>
   <Component>
      drawer-panel 
   </Component>

--- a/packages/patternfly-4/react-core/src/experimental/components/Drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/experimental/components/Drawer/__snapshots__/Drawer.test.tsx.snap
@@ -1,53 +1,121 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Drawer isExpanded = false and isInline = false 1`] = `
-<div
-  className="pf-c-drawer"
+<Component
+  isExpanded={false}
+  isInline={false}
 >
-  <Component>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
-  </Component>
-  <Component>
-     drawer-panel 
-  </Component>
-</div>
+  <div
+    className="pf-c-drawer"
+  >
+    <Component>
+      <div
+        className="pf-c-drawer__content"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
+      </div>
+    </Component>
+    <Component>
+      <aside
+        className="pf-c-drawer__panel"
+      >
+        <div
+          className="pf-c-drawer__panel-body"
+        >
+           drawer-panel 
+        </div>
+      </aside>
+    </Component>
+  </div>
+</Component>
 `;
 
 exports[`Drawer isExpanded = false and isInline = true 1`] = `
-<div
-  className="pf-c-drawer pf-m-inline"
+<Component
+  isExpanded={false}
+  isInline={true}
 >
-  <Component>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
-  </Component>
-  <Component>
-     drawer-panel 
-  </Component>
-</div>
+  <div
+    className="pf-c-drawer pf-m-inline"
+  >
+    <Component>
+      <div
+        className="pf-c-drawer__content"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
+      </div>
+    </Component>
+    <Component>
+      <aside
+        className="pf-c-drawer__panel"
+      >
+        <div
+          className="pf-c-drawer__panel-body"
+        >
+           drawer-panel 
+        </div>
+      </aside>
+    </Component>
+  </div>
+</Component>
 `;
 
 exports[`Drawer isExpanded = true and isInline = false 1`] = `
-<div
-  className="pf-c-drawer pf-m-expanded"
+<Component
+  isExpanded={true}
+  isInline={false}
 >
-  <Component>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
-  </Component>
-  <Component>
-     drawer-panel 
-  </Component>
-</div>
+  <div
+    className="pf-c-drawer pf-m-expanded"
+  >
+    <Component>
+      <div
+        className="pf-c-drawer__content"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
+      </div>
+    </Component>
+    <Component>
+      <aside
+        className="pf-c-drawer__panel"
+      >
+        <div
+          className="pf-c-drawer__panel-body"
+        >
+           drawer-panel 
+        </div>
+      </aside>
+    </Component>
+  </div>
+</Component>
 `;
 
 exports[`Drawer isExpanded = true and isInline = true 1`] = `
-<div
-  className="pf-c-drawer pf-m-expanded pf-m-inline"
+<Component
+  isExpanded={true}
+  isInline={true}
 >
-  <Component>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
-  </Component>
-  <Component>
-     drawer-panel 
-  </Component>
-</div>
+  <div
+    className="pf-c-drawer pf-m-expanded pf-m-inline"
+  >
+    <Component>
+      <div
+        className="pf-c-drawer__content"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pretium est a porttitor vehicula. Quisque vel commodo urna. Morbi mattis rutrum ante, id vehicula ex accumsan ut. Morbi viverra, eros vel porttitor facilisis, eros purus aliquet erat,nec lobortis felis elit pulvinar sem. Vivamus vulputate, risus eget commodo eleifend, eros nibh porta quam, vitae lacinia leo libero at magna. Maecenas aliquam sagittis orci, et posuere nisi ultrices sit amet. Aliquam ex odio, malesuada sed posuere quis, pellentesque at mauris. Phasellus venenatis massa ex, eget pulvinar libero auctor pretium. Aliquam erat volutpat. Duis euismod justo in quam ullamcorper, in commodo massa vulputate.
+      </div>
+    </Component>
+    <Component>
+      <aside
+        className="pf-c-drawer__panel"
+      >
+        <div
+          className="pf-c-drawer__panel-body"
+        >
+           drawer-panel 
+        </div>
+      </aside>
+    </Component>
+  </div>
+</Component>
 `;

--- a/packages/patternfly-4/react-core/src/experimental/components/Drawer/index.ts
+++ b/packages/patternfly-4/react-core/src/experimental/components/Drawer/index.ts
@@ -1,2 +1,3 @@
 export * from './Drawer';
 export * from './DrawerPanelContent';
+export * from './DrawerContent';


### PR DESCRIPTION
**What**:

Thank you @dlabaj for experimental Drawer component! Usage is nice and straight forward, what do you think about exposing DrawerContent as well? This way users can add the `DrawerPanelContent` when they want to, for instance when data in it should be loaded from server so they want to show it only when user clicks on some element to show it. Also special classes and attributes can be aplied to Content so for instance if app has some special attributes to track where user is located they can do that easilly with this.

It's essentially the same, except that content is not part of Drawer itself, but special component and Panel is not sent trough prop but as child.
