### PR TITLE
fix(switch): use defaultChecked instead of checked

### DIFF
--- a/packages/patternfly-4/react-core/src/components/DataList/DataListCheck.tsx
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListCheck.tsx
@@ -37,7 +37,7 @@ export const DataListCheck: React.FunctionComponent<DataListCheckProps> = ({
         onChange={(event) => onChange(event.currentTarget.checked, event)}
         aria-invalid={!isValid}
         disabled={isDisabled}
-        checked={isChecked || checked}
+        defaultChecked={isChecked || checked}
       />
     </div>
   </div>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
@@ -47,7 +47,7 @@ export class DropdownToggleCheckbox extends React.Component<DropdownToggleCheckb
           onChange={this.handleChange}
           aria-invalid={!isValid}
           disabled={isDisabled}
-          checked={isChecked || checked}
+          defaultChecked={isChecked || checked}
         />
       </label>
     );

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggleCheckbox.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggleCheckbox.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`controlled 1`] = `
   <input
     aria-invalid={false}
     aria-label="check"
-    checked={true}
+    defaultChecked={true}
     disabled={false}
     id="check"
     onChange={[Function]}
@@ -25,7 +25,7 @@ exports[`isDisabled 1`] = `
   <input
     aria-invalid={false}
     aria-label="check"
-    checked={null}
+    defaultChecked={null}
     disabled={true}
     id="check"
     onChange={[Function]}
@@ -43,7 +43,7 @@ exports[`passing HTML attribute 1`] = `
     aria-invalid={false}
     aria-label="check"
     aria-labelledby="labelId"
-    checked={true}
+    defaultChecked={true}
     disabled={false}
     id="check"
     label="label"
@@ -61,7 +61,7 @@ exports[`passing class 1`] = `
   <input
     aria-invalid={false}
     aria-label="check"
-    checked={true}
+    defaultChecked={true}
     disabled={false}
     id="check"
     label="label"
@@ -79,7 +79,7 @@ exports[`uncontrolled 1`] = `
   <input
     aria-invalid={false}
     aria-label="check"
-    checked={null}
+    defaultChecked={null}
     disabled={false}
     id="check"
     onChange={[Function]}

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.tsx
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.tsx
@@ -67,7 +67,7 @@ export class Radio extends React.Component<RadioProps> {
           onChange={this.handleChange}
           aria-invalid={!isValid}
           disabled={isDisabled}
-          checked={checked || isChecked}
+          defaultChecked={checked || isChecked}
           {...!isChecked && { defaultChecked }}
           {...!label && { 'aria-label': ariaLabel }}
         />

--- a/packages/patternfly-4/react-core/src/components/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Radio/__snapshots__/Radio.test.tsx.snap
@@ -7,8 +7,8 @@ exports[`Radio check component controlled 1`] = `
   <input
     aria-invalid={false}
     aria-label="check"
-    checked={true}
     className="pf-c-radio__input"
+    defaultChecked={true}
     disabled={false}
     id="check"
     name="check"
@@ -41,8 +41,8 @@ exports[`Radio check component label is function 1`] = `
 >
   <input
     aria-invalid={false}
-    checked={true}
     className="pf-c-radio__input"
+    defaultChecked={true}
     disabled={false}
     id="check"
     name="check"
@@ -66,8 +66,8 @@ exports[`Radio check component label is node 1`] = `
 >
   <input
     aria-invalid={false}
-    checked={true}
     className="pf-c-radio__input"
+    defaultChecked={true}
     disabled={false}
     id="check"
     name="check"
@@ -91,8 +91,8 @@ exports[`Radio check component label is string 1`] = `
 >
   <input
     aria-invalid={false}
-    checked={true}
     className="pf-c-radio__input"
+    defaultChecked={true}
     disabled={false}
     id="check"
     name="check"
@@ -115,8 +115,8 @@ exports[`Radio check component passing HTML attribute 1`] = `
   <input
     aria-invalid={false}
     aria-labelledby="labelId"
-    checked={true}
     className="pf-c-radio__input"
+    defaultChecked={true}
     disabled={false}
     id="check"
     name="check"
@@ -138,8 +138,8 @@ exports[`Radio check component passing class 1`] = `
 >
   <input
     aria-invalid={false}
-    checked={true}
     className="pf-c-radio__input"
+    defaultChecked={true}
     disabled={false}
     id="check"
     name="check"

--- a/packages/patternfly-4/react-core/src/components/Select/CheckboxSelectOption.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/CheckboxSelectOption.tsx
@@ -87,7 +87,7 @@ export class CheckboxSelectOption extends React.Component<CheckboxSelectOptionPr
                 }
               }}
               ref={this.ref}
-              checked={isChecked || false}
+              defaultChecked={isChecked || false}
               disabled={isDisabled}
             />
             <span className={css(checkStyles.checkLabel, isDisabled && styles.modifiers.disabled)}>{children || value}</span>

--- a/packages/patternfly-4/react-core/src/components/Select/SelectOption.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/SelectOption.tsx
@@ -148,7 +148,7 @@ export class SelectOption extends React.Component<SelectOptionProps> {
                     }
                   }}
                   ref={this.ref}
-                  checked={isChecked || false}
+                  defaultChecked={isChecked || false}
                   disabled={isDisabled}
                 />
                 <span className={css(checkStyles.checkLabel, isDisabled && styles.modifiers.disabled)}>{children || value.toString()}</span>

--- a/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -365,8 +365,8 @@ exports[`checkbox select renders checkbox select groups successfully - old class
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Mr"
                             onChange={[Function]}
@@ -395,8 +395,8 @@ exports[`checkbox select renders checkbox select groups successfully - old class
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Mrs"
                             onChange={[Function]}
@@ -425,8 +425,8 @@ exports[`checkbox select renders checkbox select groups successfully - old class
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Ms"
                             onChange={[Function]}
@@ -455,8 +455,8 @@ exports[`checkbox select renders checkbox select groups successfully - old class
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Other"
                             onChange={[Function]}
@@ -507,8 +507,8 @@ exports[`checkbox select renders checkbox select groups successfully - old class
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Mr"
                             onChange={[Function]}
@@ -537,8 +537,8 @@ exports[`checkbox select renders checkbox select groups successfully - old class
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Mrs"
                             onChange={[Function]}
@@ -567,8 +567,8 @@ exports[`checkbox select renders checkbox select groups successfully - old class
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Ms"
                             onChange={[Function]}
@@ -597,8 +597,8 @@ exports[`checkbox select renders checkbox select groups successfully - old class
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Other"
                             onChange={[Function]}
@@ -992,8 +992,8 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Mr"
                             onChange={[Function]}
@@ -1025,8 +1025,8 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Mrs"
                             onChange={[Function]}
@@ -1058,8 +1058,8 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Ms"
                             onChange={[Function]}
@@ -1091,8 +1091,8 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Other"
                             onChange={[Function]}
@@ -1146,8 +1146,8 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Mr"
                             onChange={[Function]}
@@ -1179,8 +1179,8 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Mrs"
                             onChange={[Function]}
@@ -1212,8 +1212,8 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Ms"
                             onChange={[Function]}
@@ -1245,8 +1245,8 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
                           onKeyDown={[Function]}
                         >
                           <input
-                            checked={false}
                             className="pf-c-check__input"
+                            defaultChecked={false}
                             disabled={false}
                             id="Other"
                             onChange={[Function]}
@@ -1822,8 +1822,8 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
                       onKeyDown={[Function]}
                     >
                       <input
-                        checked={false}
                         className="pf-c-check__input"
+                        defaultChecked={false}
                         disabled={false}
                         id="Mr"
                         onChange={[Function]}
@@ -1852,8 +1852,8 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
                       onKeyDown={[Function]}
                     >
                       <input
-                        checked={false}
                         className="pf-c-check__input"
+                        defaultChecked={false}
                         disabled={false}
                         id="Mrs"
                         onChange={[Function]}
@@ -1882,8 +1882,8 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
                       onKeyDown={[Function]}
                     >
                       <input
-                        checked={false}
                         className="pf-c-check__input"
+                        defaultChecked={false}
                         disabled={false}
                         id="Ms"
                         onChange={[Function]}
@@ -1912,8 +1912,8 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
                       onKeyDown={[Function]}
                     >
                       <input
-                        checked={false}
                         className="pf-c-check__input"
+                        defaultChecked={false}
                         disabled={false}
                         id="Other"
                         onChange={[Function]}
@@ -2208,8 +2208,8 @@ exports[`checkbox select renders expanded successfully 1`] = `
                       onKeyDown={[Function]}
                     >
                       <input
-                        checked={false}
                         className="pf-c-check__input"
+                        defaultChecked={false}
                         disabled={false}
                         id="Mr"
                         onChange={[Function]}
@@ -2241,8 +2241,8 @@ exports[`checkbox select renders expanded successfully 1`] = `
                       onKeyDown={[Function]}
                     >
                       <input
-                        checked={false}
                         className="pf-c-check__input"
+                        defaultChecked={false}
                         disabled={false}
                         id="Mrs"
                         onChange={[Function]}
@@ -2274,8 +2274,8 @@ exports[`checkbox select renders expanded successfully 1`] = `
                       onKeyDown={[Function]}
                     >
                       <input
-                        checked={false}
                         className="pf-c-check__input"
+                        defaultChecked={false}
                         disabled={false}
                         id="Ms"
                         onChange={[Function]}
@@ -2307,8 +2307,8 @@ exports[`checkbox select renders expanded successfully 1`] = `
                       onKeyDown={[Function]}
                     >
                       <input
-                        checked={false}
                         className="pf-c-check__input"
+                        defaultChecked={false}
                         disabled={false}
                         id="Other"
                         onChange={[Function]}
@@ -2596,8 +2596,8 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
                       onKeyDown={[Function]}
                     >
                       <input
-                        checked={false}
                         className="pf-c-check__input"
+                        defaultChecked={false}
                         disabled={false}
                         id="Mr: User One"
                         onChange={[Function]}
@@ -2636,8 +2636,8 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
                       onKeyDown={[Function]}
                     >
                       <input
-                        checked={false}
                         className="pf-c-check__input"
+                        defaultChecked={false}
                         disabled={false}
                         id="Mrs: New User"
                         onChange={[Function]}
@@ -2676,8 +2676,8 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
                       onKeyDown={[Function]}
                     >
                       <input
-                        checked={false}
                         className="pf-c-check__input"
+                        defaultChecked={false}
                         disabled={false}
                         id="Ms: Test Three"
                         onChange={[Function]}

--- a/packages/patternfly-4/react-core/src/components/Switch/Switch.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Switch/Switch.test.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import { Switch } from './Switch';
 
 const props = {
-  onChange: jest.fn((checked) => console.log('impl', checked)),
+  onChange: jest.fn(),
   isChecked: false
 };
 

--- a/packages/patternfly-4/react-core/src/components/Switch/Switch.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Switch/Switch.test.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import * as React from 'react';
 import { mount } from 'enzyme';
 import { Switch } from './Switch';
 
 const props = {
-  onChange: jest.fn(),
-  checked: false
+  onChange: jest.fn((checked) => console.log('impl', checked)),
+  isChecked: false
 };
 
 test('switch label for attribute equals input id attribute', () => {
@@ -50,6 +50,8 @@ test('switch is not checked and disabled', () => {
 
 test('switch passes value and event to onChange handler', () => {
   const view = mount(<Switch id="onChange-switch" {...props} />);
-  view.find('input').simulate('change', { target: { checked: true } });
-  expect(view.find('input').prop('checked')).toBe(true);
+  const input = view.find('input');
+  expect(input.prop('defaultChecked')).toBe(false);
+  input.simulate('change', { target: { checked: true } });
+  expect(props.onChange.mock.calls[0][0]).toBe(true);
 });

--- a/packages/patternfly-4/react-core/src/components/Switch/Switch.tsx
+++ b/packages/patternfly-4/react-core/src/components/Switch/Switch.tsx
@@ -61,14 +61,14 @@ class Switch extends React.Component<SwitchProps & InjectedOuiaProps> {
         }}
       >
         <input
-          {...props}
           id={this.id}
           className={css(styles.switchInput)}
           type="checkbox"
-          onChange={(event) => onChange(event.currentTarget.checked, event)}
-          checked={isChecked}
+          onChange={(event) => onChange(event.target.checked, event)}
+          defaultChecked={isChecked}
           disabled={isDisabled}
-          aria-labelledby={isAriaLabelledBy ? `${this.id}-on` : null}
+          aria-labelledby={isAriaLabelledBy ? `${this.id}-on`: null}
+          {...props}
         />
         {label !== '' || labelOff !== '' ? (
           <React.Fragment>

--- a/packages/patternfly-4/react-core/src/components/Switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Switch/__snapshots__/Switch.test.tsx.snap
@@ -38,8 +38,8 @@ exports[`no label switch is checked 1`] = `
         <input
           aria-label=""
           aria-labelledby="no-label-switch-is-checked-on"
-          checked={true}
           className="pf-c-switch__input"
+          defaultChecked={true}
           disabled={false}
           id="no-label-switch-is-checked"
           onChange={[Function]}
@@ -120,8 +120,8 @@ exports[`no label switch is not checked 1`] = `
         <input
           aria-label=""
           aria-labelledby="no-label-switch-is-not-checked-on"
-          checked={false}
           className="pf-c-switch__input"
+          defaultChecked={false}
           disabled={false}
           id="no-label-switch-is-not-checked"
           onChange={[Function]}
@@ -206,8 +206,8 @@ exports[`switch is checked 1`] = `
         <input
           aria-label=""
           aria-labelledby="switch-is-checked-on"
-          checked={true}
           className="pf-c-switch__input"
+          defaultChecked={true}
           disabled={false}
           id="switch-is-checked"
           onChange={[Function]}
@@ -276,8 +276,8 @@ exports[`switch is checked and disabled 1`] = `
         <input
           aria-label=""
           aria-labelledby="switch-is-checked-and-disabled-on"
-          checked={true}
           className="pf-c-switch__input"
+          defaultChecked={true}
           disabled={true}
           id="switch-is-checked-and-disabled"
           onChange={[Function]}
@@ -362,8 +362,8 @@ exports[`switch is not checked 1`] = `
         <input
           aria-label=""
           aria-labelledby="switch-is-not-checked-on"
-          checked={false}
           className="pf-c-switch__input"
+          defaultChecked={false}
           disabled={false}
           id="switch-is-not-checked"
           onChange={[Function]}
@@ -432,8 +432,8 @@ exports[`switch is not checked and disabled 1`] = `
         <input
           aria-label=""
           aria-labelledby="switch-is-not-checked-and-disabled-on"
-          checked={false}
           className="pf-c-switch__input"
+          defaultChecked={false}
           disabled={true}
           id="switch-is-not-checked-and-disabled"
           onChange={[Function]}


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Fixes #2669 and actually changes the `<input>`'s `checked` prop in the DOM for our Switch. This is a somewhat tricky React bug, but the solution is to use `defaultChecked` instead of `checked`. Setting `checked={true}` or `checked={false}` has no effect in the DOM outside of the first render, which is semantically incorrect.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
