### PR TITLE
Docs: target the container with more specificity

### DIFF
--- a/packages/patternfly-4/react-docs/src/styles/workspace.css
+++ b/packages/patternfly-4/react-docs/src/styles/workspace.css
@@ -2,6 +2,6 @@
   height: 100%;
 }
 
-#___gatsby > div {
+#___gatsby > div[role="group"] {
   height: 100%;
 }


### PR DESCRIPTION
Previous selector was also targeting the div appended by the [2nd Popover example](https://patternfly-react.surge.sh/patternfly-4/components/popover/)