### PR TITLE
feat(AsyncTypeAheadSelect): pass reference to inner component

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/TypeAheadSelect/AsyncTypeAheadSelect.js
+++ b/packages/patternfly-3/patternfly-react/src/components/TypeAheadSelect/AsyncTypeAheadSelect.js
@@ -18,25 +18,31 @@ class AsyncTypeAheadSelect extends React.Component {
     Promise.resolve(this.props.onSearch(query)).then(options => this.onSearchEnd(options));
   };
 
-  render = () => (
-    <AsyncTypeahead
-      {...this.props}
-      onSearch={this.handleSearch}
-      options={this.state.options}
-      isLoading={this.state.isLoading}
-    />
-  );
+  render() {
+    const { innerRef, ...props } = this.props;
+    return (
+      <AsyncTypeahead
+        {...props}
+        ref={innerRef}
+        onSearch={this.handleSearch}
+        options={this.state.options}
+        isLoading={this.state.isLoading}
+      />
+    );
+  }
 }
 
 AsyncTypeAheadSelect.propTypes = {
   onSearch: PropTypes.func.isRequired,
   options: PropTypes.array,
-  isLoading: PropTypes.bool
+  isLoading: PropTypes.bool,
+  innerRef: PropTypes.any
 };
 
 AsyncTypeAheadSelect.defaultProps = {
   options: [],
-  isLoading: false
+  isLoading: false,
+  innerRef: null
 };
 
-export default AsyncTypeAheadSelect;
+export default React.forwardRef((props, ref) => <AsyncTypeAheadSelect {...props} innerRef={ref} />);

--- a/packages/patternfly-3/patternfly-react/src/components/TypeAheadSelect/AsyncTypeAheadSelect.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/TypeAheadSelect/AsyncTypeAheadSelect.test.js
@@ -3,6 +3,8 @@ import { shallow } from 'enzyme';
 import AsyncTypeAheadSelect from './AsyncTypeAheadSelect';
 
 test('AsyncTypeAheadSelect is working !!', () => {
+  let typeaheadRef;
+
   const optionsArray = ['One', 'Two', 'Three'];
   const timeout = 500;
   const handleSearch = () => {
@@ -11,19 +13,25 @@ test('AsyncTypeAheadSelect is working !!', () => {
   const component = shallow(
     <AsyncTypeAheadSelect
       useCache
+      ref={r => {
+        typeaheadRef = r;
+      }}
       labelKey="login"
       minLength={0}
       placeholder="Search someone who have forked Patternfly-react.."
       onSearch={handleSearch}
       renderMenuItemChildren={option => <span>option</span>}
     />
-  );
+  ).dive();
 
   expect(component).toMatchSnapshot();
   component.instance().handleSearch();
+  expect(typeaheadRef).toBeUndefined();
+
   setTimeout(() => {
     component.update();
     expect(component.state().options).toEqual(optionsArray);
     expect(component.state().isLoading).toEqual(false);
+    expect(typeaheadRef.getInstance()).toBeDefined();
   }, timeout + 1000);
 });


### PR DESCRIPTION


<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Allows the use of react-bootstrap-typeahead's API

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Refer to issue**: #1481

<!-- feel free to add additional comments -->
