### PR TITLE
fix(Tab icon): Change tab title prop to allow custom components

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Tabs/Tab.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tab.test.tsx
@@ -11,6 +11,15 @@ test('should render tab', () => {
   expect(view).toMatchSnapshot();
 });
 
+test('should render tab with node', () => {
+  const view = shallow(
+    <Tab eventKey={0} title={<span>Tab item 1</span>}>
+      Tab 1 section
+    </Tab>
+  );
+  expect(view).toMatchSnapshot();
+});
+
 test('should render active tab', () => {
   const view = shallow(
     <Tab eventKey={0} title="Tab item 1">

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tab.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { Omit } from '../../helpers/typeUtils';
 
-export interface TabProps extends React.HTMLProps<HTMLAnchorElement | HTMLButtonElement> {
+export interface TabProps extends Omit<React.HTMLProps<HTMLAnchorElement | HTMLButtonElement>, 'title'> {
   /** content rendered inside the Tab content area. */
   children?: React.ReactNode; 
   /** additional classes added to the Tab */
@@ -8,7 +9,7 @@ export interface TabProps extends React.HTMLProps<HTMLAnchorElement | HTMLButton
   /** URL associated with the Tab. A Tab with an href will render as an <a> instead of a <button>. A Tab inside a <Tabs variant="nav"> should have an href. */
   href?: string; 
   /** Tab title */
-  title: string; 
+  title: React.ReactNode; 
   /** uniquely identifies the tab */
   eventKey: number | string; 
   /** child id for case in which a TabContent section is defined outside of a Tabs component */

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tabs.md
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tabs.md
@@ -8,6 +8,7 @@ typescript: true
 ## Simple tabs
 
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
+import { UserFriendsIcon, DatabaseIcon } from '@patternfly/react-icons';
 
 Use primary sections
 
@@ -422,6 +423,41 @@ class SeparateTabContent extends React.Component {
           </TabContent>
         </div>
       </React.Fragment>
+    );
+  }
+}
+```
+
+## Icon in tab title
+```js
+import React from 'react';
+import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
+import { UserFriendsIcon, DatabaseIcon } from '@patternfly/react-icons';
+
+class SimpleTabs extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeTabKey: 0
+    };
+    // Toggle currently active tab
+    this.handleTabClick = (event, tabIndex) => {
+      this.setState({
+        activeTabKey: tabIndex
+      });
+    };
+  }
+
+  render() {
+    return (
+      <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
+        <Tab eventKey={0} title={<span><UserFriendsIcon />Tab item 1</span>}>
+          Tab 1 section
+        </Tab>
+        <Tab eventKey={1} title={<span><DatabaseIcon />Tab item 2</span>}>
+          Tab 2 section
+        </Tab>
+      </Tabs>
     );
   }
 }

--- a/packages/patternfly-4/react-core/src/components/Tabs/__snapshots__/Tab.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Tabs/__snapshots__/Tab.test.tsx.snap
@@ -19,3 +19,17 @@ exports[`should render tab 1`] = `
   Tab 1 section
 </TabContainer>
 `;
+
+exports[`should render tab with node 1`] = `
+<TabContainer
+  eventKey={0}
+  forwardRef={null}
+  title={
+    <span>
+      Tab item 1
+    </span>
+  }
+>
+  Tab 1 section
+</TabContainer>
+`;


### PR DESCRIPTION
Fixes: #2536

**What**:
Allow consumers to pass whatever component they choose in tab title to allow icons and such be part of tab.
