### PR TITLE
fix(Modal): FocusTrap works with showClose being false

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Modal/Modal.tsx
+++ b/packages/patternfly-4/react-core/src/components/Modal/Modal.tsx
@@ -37,7 +37,7 @@ export interface ModalProps extends React.HTMLProps<HTMLDivElement> {
   isLarge?: boolean;
   /** Creates a small version of the Modal */
   isSmall?: boolean;
-  /** Flag to disable focus trap if no focusable elements are available */
+  /** Flag to disable focus trap */
   disableFocusTrap?: boolean;
 }
 

--- a/packages/patternfly-4/react-core/src/components/Modal/Modal.tsx
+++ b/packages/patternfly-4/react-core/src/components/Modal/Modal.tsx
@@ -37,6 +37,8 @@ export interface ModalProps extends React.HTMLProps<HTMLDivElement> {
   isLarge?: boolean;
   /** Creates a small version of the Modal */
   isSmall?: boolean;
+  /** Flag to disable focus trap if no focusable elements are available */
+  disableFocusTrap?: boolean;
 }
 
 interface ModalState {

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
@@ -15,6 +15,7 @@ import { ModalBoxHeader } from './ModalBoxHeader';
 import { ModalBoxCloseButton } from './ModalBoxCloseButton';
 import { ModalBox } from './ModalBox';
 import { ModalBoxFooter } from './ModalBoxFooter';
+import { Bullseye } from '../../layouts/Bullseye';
 
 export interface ModalContentProps {
   /** Content rendered inside the Modal. */
@@ -79,7 +80,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
     <ModalBoxFooter>{footer}</ModalBoxFooter> :
     actions.length > 0 && <ModalBoxFooter>{actions}</ModalBoxFooter>;
   const boxStyle = width === -1 ? {} : { width };
-  let modalBox = (
+  const modalBox = (
     <ModalBox
           style={boxStyle}
           className={className}
@@ -97,23 +98,18 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
     </ModalBox>
   );
   // Only add FocusTrap if close button exists to prevent errors
-  if (showClose) {
-    modalBox = (
-      <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }} className={css(styles.bullseye)}>
-        {modalBox}
-      </FocusTrap>
-    );
-  }
-  else {
-    modalBox = (
-      <div className={css(styles.bullseye)}>
-        {modalBox}
-      </div>
-    );
-  }
   return (
     <Backdrop>
-      {modalBox}
+      {showClose ? (
+        <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }} className={css(styles.bullseye)}>
+          {modalBox}
+        </FocusTrap>
+      ) 
+      : (
+        <Bullseye>
+          {modalBox}
+        </Bullseye>
+      )}
     </Backdrop>
   );
 };

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
@@ -48,7 +48,7 @@ export interface ModalContentProps {
   ariaDescribedById?: string;
   /** Id of the ModalBoxBody */
   id: string;
-  /** Flag to disable focus trap if no focusable elements are available */
+  /** Flag to disable focus trap */
   disableFocusTrap?: boolean;
 }
 
@@ -85,13 +85,13 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   const boxStyle = width === -1 ? {} : { width };
   const modalBox = (
     <ModalBox
-          style={boxStyle}
-          className={className}
-          isLarge={isLarge}
-          isSmall={isSmall}
-          title={title}
-          id={ariaDescribedById || id}
-        >
+      style={boxStyle}
+      className={className}
+      isLarge={isLarge}
+      isSmall={isSmall}
+      title={title}
+      id={ariaDescribedById || id}
+    >
       {showClose && <ModalBoxCloseButton onClose={onClose} />}
       {modalBoxHeader}
       <ModalBoxBody {...props} id={id}>
@@ -100,7 +100,6 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
       {modalBoxFooter}
     </ModalBox>
   );
-  // Only add FocusTrap if close button exists to prevent errors
   return (
     <Backdrop>
       {disableFocusTrap ? (

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
@@ -48,6 +48,8 @@ export interface ModalContentProps {
   ariaDescribedById?: string;
   /** Id of the ModalBoxBody */
   id: string;
+  /** Flag to show the close button in the header area of the modal */
+  disableFocusTrap?: boolean;
 }
 
 export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
@@ -66,8 +68,9 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   width = -1,
   ariaDescribedById = '',
   id = '',
+  disableFocusTrap = false,
   ...props
-}) => {
+}: ModalContentProps) => {
   if (!isOpen) {
     return null;
   }
@@ -100,15 +103,15 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   // Only add FocusTrap if close button exists to prevent errors
   return (
     <Backdrop>
-      {showClose ? (
-        <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }} className={css(styles.bullseye)}>
-          {modalBox}
-        </FocusTrap>
-      ) 
-      : (
+      {disableFocusTrap ? (
         <Bullseye>
           {modalBox}
         </Bullseye>
+      ) 
+      : (
+        <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }} className={css(styles.bullseye)}>
+          {modalBox}
+        </FocusTrap>
       )}
     </Backdrop>
   );

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
@@ -102,7 +102,14 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
       <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }} className={css(styles.bullseye)}>
         {modalBox}
       </FocusTrap>
-    )
+    );
+  }
+  else {
+    modalBox = (
+      <div className={css(styles.bullseye)}>
+        {modalBox}
+      </div>
+    );
   }
   return (
     <Backdrop>

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
@@ -48,7 +48,7 @@ export interface ModalContentProps {
   ariaDescribedById?: string;
   /** Id of the ModalBoxBody */
   id: string;
-  /** Flag to show the close button in the header area of the modal */
+  /** Flag to disable focus trap if no focusable elements are available */
   disableFocusTrap?: boolean;
 }
 

--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
@@ -79,11 +79,8 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
     <ModalBoxFooter>{footer}</ModalBoxFooter> :
     actions.length > 0 && <ModalBoxFooter>{actions}</ModalBoxFooter>;
   const boxStyle = width === -1 ? {} : { width };
-
-  return (
-    <Backdrop>
-      <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }} className={css(styles.bullseye)}>
-        <ModalBox
+  let modalBox = (
+    <ModalBox
           style={boxStyle}
           className={className}
           isLarge={isLarge}
@@ -91,14 +88,25 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
           title={title}
           id={ariaDescribedById || id}
         >
-          {showClose && <ModalBoxCloseButton onClose={onClose} />}
-          {modalBoxHeader}
-          <ModalBoxBody {...props} id={id}>
-            {children}
-          </ModalBoxBody>
-          {modalBoxFooter}
-        </ModalBox>
+      {showClose && <ModalBoxCloseButton onClose={onClose} />}
+      {modalBoxHeader}
+      <ModalBoxBody {...props} id={id}>
+        {children}
+      </ModalBoxBody>
+      {modalBoxFooter}
+    </ModalBox>
+  );
+  // Only add FocusTrap if close button exists to prevent errors
+  if (showClose) {
+    modalBox = (
+      <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }} className={css(styles.bullseye)}>
+        {modalBox}
       </FocusTrap>
+    )
+  }
+  return (
+    <Backdrop>
+      {modalBox}
     </Backdrop>
   );
 };


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Fixes FocusTrap breaking on Modal if `showClose` prop is false.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: Fixes #2757

<!-- feel free to add additional comments -->

I have not been able to test this out as I cannot build PatternFly at the moment. 