### PR TITLE
fix(ActionGroup): Remove unneeded Action import

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Form/ActionGroup.tsx
+++ b/packages/patternfly-4/react-core/src/components/Form/ActionGroup.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Form/form';
 import { css } from '@patternfly/react-styles';
 import { FormContext } from './FormContext';
-import { Action } from 'history';
 
 export interface ActionGroupProps extends React.HTMLProps<HTMLDivElement> {
   /** Anything that can be rendered as ActionGroup content. */


### PR DESCRIPTION
Removed "import { Action } from 'history'" since it's not being used.

Fixes #2745.