### PR TITLE
Chart themeColor doc incorrect

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
@@ -329,7 +329,7 @@ export interface ChartProps extends VictoryChartProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/ChartArea.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/ChartArea.tsx
@@ -322,7 +322,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -340,7 +340,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/ChartBar.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/ChartBar.tsx
@@ -352,7 +352,7 @@ export interface ChartBarProps extends VictoryBarProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -422,7 +422,7 @@ export interface ChartBulletProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeErrorMeasure.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeErrorMeasure.tsx
@@ -116,7 +116,7 @@ export interface ChartBulletComparativeErrorMeasureProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeMeasure.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeMeasure.tsx
@@ -118,7 +118,7 @@ export interface ChartBulletComparativeMeasureProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeWarningMeasure.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeWarningMeasure.tsx
@@ -116,7 +116,7 @@ export interface ChartBulletComparativeWarningMeasureProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
@@ -77,7 +77,7 @@ export interface ChartBulletGroupTitleProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletPrimaryDotMeasure.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletPrimaryDotMeasure.tsx
@@ -113,7 +113,7 @@ export interface ChartBulletPrimaryDotMeasureProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletPrimarySegmentedMeasure.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletPrimarySegmentedMeasure.tsx
@@ -135,7 +135,7 @@ export interface ChartBulletPrimarySegmentedMeasureProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletQualitativeRange.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletQualitativeRange.tsx
@@ -122,7 +122,7 @@ export interface ChartBulletQualitativeRangeProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletTitle.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletTitle.tsx
@@ -113,7 +113,7 @@ export interface ChartBulletTitleProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartContainer/ChartContainer.tsx
@@ -61,7 +61,7 @@ export interface ChartContainerProps extends VictoryContainerProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -417,7 +417,7 @@ export interface ChartDonutProps extends ChartPieProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -372,7 +372,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -460,7 +460,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -354,7 +354,7 @@ export interface ChartGroupProps extends VictoryGroupProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -232,7 +232,7 @@ export interface ChartLegendProps extends VictoryLegendProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegendWrapper.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegendWrapper.tsx
@@ -113,7 +113,7 @@ export interface ChartLegendWrapperProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/ChartLine.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/ChartLine.tsx
@@ -322,7 +322,7 @@ export interface ChartLineProps extends VictoryLineProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -385,7 +385,7 @@ export interface ChartPieProps extends VictoryPieProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartScatter/ChartScatter.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartScatter/ChartScatter.tsx
@@ -339,7 +339,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -296,7 +296,7 @@ export interface ChartStackProps extends VictoryStackProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
@@ -144,7 +144,7 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *

--- a/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
@@ -77,7 +77,7 @@ export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps
    */
   theme?: ChartThemeDefinition;
   /**
-   * Specifies the theme color. Valid values are 'blue', 'green', 'grey' (recomended), 'multi', etc.
+   * Specifies the theme color. Valid values are 'blue', 'green', 'multi', etc.
    *
    * Note: Not compatible with theme prop
    *


### PR DESCRIPTION
The chart `themeColor` prop documentation incorrectly recommends the wrong color.

Fixes https://github.com/patternfly/patternfly-react/issues/2793
