### PR TITLE
fix(switch): backward compatibility in case labelOff is not set

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Switch/Switch.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Switch/Switch.test.tsx
@@ -28,6 +28,18 @@ test('switch is not checked', () => {
   expect(view).toMatchSnapshot();
 });
 
+test('switch with only label is checked', () => {
+  const check = true;
+  const view = mount(<Switch id="switch-is-checked" label={check ? "On" : "Off"} isChecked={check} />);
+  expect(view).toMatchSnapshot();
+});
+
+test('switch with only label is not checked', () => {
+  const check = false;
+  const view = mount(<Switch id="switch-is-not-checked" label={check ? "On" : "Off"} isChecked={check} />);
+  expect(view).toMatchSnapshot();
+});
+
 test('no label switch is checked', () => {
   const view = mount(<Switch id="no-label-switch-is-checked" isChecked />);
   expect(view).toMatchSnapshot();

--- a/packages/patternfly-4/react-core/src/components/Switch/Switch.tsx
+++ b/packages/patternfly-4/react-core/src/components/Switch/Switch.tsx
@@ -70,7 +70,25 @@ class Switch extends React.Component<SwitchProps & InjectedOuiaProps> {
           aria-labelledby={isAriaLabelledBy ? `${this.id}-on`: null}
           {...props}
         />
-        {label !== '' || labelOff !== '' ? (
+        {label !== '' ? (
+          <React.Fragment>
+            <span className={css(styles.switchToggle)} />
+            <span
+              className={css(styles.switchLabel, styles.modifiers.on)}
+              id={isAriaLabelledBy ? `${this.id}-on` : null}
+              aria-hidden="true"
+            >
+              {label}
+            </span>
+            <span
+              className={css(styles.switchLabel, styles.modifiers.off)}
+              id={isAriaLabelledBy ? `${this.id}-off` : null}
+              aria-hidden="true"
+            >
+              {labelOff || label}
+            </span>
+          </React.Fragment>
+        ) : label !== '' && labelOff !== '' ? (
           <React.Fragment>
             <span className={css(styles.switchToggle)} />
             <span

--- a/packages/patternfly-4/react-core/src/components/Switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Switch/__snapshots__/Switch.test.tsx.snap
@@ -475,3 +475,143 @@ exports[`switch is not checked and disabled 1`] = `
   </ComponentWithOuia>
 </Component>
 `;
+
+exports[`switch with only label is checked 1`] = `
+<Component
+  id="switch-is-checked"
+  isChecked={true}
+  label="On"
+>
+  <ComponentWithOuia
+    component={[Function]}
+    componentProps={
+      Object {
+        "id": "switch-is-checked",
+        "isChecked": true,
+        "label": "On",
+      }
+    }
+    consumerContext={null}
+  >
+    <Switch
+      aria-label=""
+      className=""
+      id="switch-is-checked"
+      isChecked={true}
+      isDisabled={false}
+      label="On"
+      labelOff=""
+      onChange={[Function]}
+      ouiaContext={
+        Object {
+          "isOuia": false,
+          "ouiaId": null,
+        }
+      }
+    >
+      <label
+        className="pf-c-switch"
+        htmlFor="switch-is-checked"
+      >
+        <input
+          aria-label=""
+          aria-labelledby="switch-is-checked-on"
+          className="pf-c-switch__input"
+          defaultChecked={true}
+          disabled={false}
+          id="switch-is-checked"
+          onChange={[Function]}
+          type="checkbox"
+        />
+        <span
+          className="pf-c-switch__toggle"
+        />
+        <span
+          aria-hidden="true"
+          className="pf-c-switch__label pf-m-on"
+          id="switch-is-checked-on"
+        >
+          On
+        </span>
+        <span
+          aria-hidden="true"
+          className="pf-c-switch__label pf-m-off"
+          id="switch-is-checked-off"
+        >
+          On
+        </span>
+      </label>
+    </Switch>
+  </ComponentWithOuia>
+</Component>
+`;
+
+exports[`switch with only label is not checked 1`] = `
+<Component
+  id="switch-is-not-checked"
+  isChecked={false}
+  label="Off"
+>
+  <ComponentWithOuia
+    component={[Function]}
+    componentProps={
+      Object {
+        "id": "switch-is-not-checked",
+        "isChecked": false,
+        "label": "Off",
+      }
+    }
+    consumerContext={null}
+  >
+    <Switch
+      aria-label=""
+      className=""
+      id="switch-is-not-checked"
+      isChecked={false}
+      isDisabled={false}
+      label="Off"
+      labelOff=""
+      onChange={[Function]}
+      ouiaContext={
+        Object {
+          "isOuia": false,
+          "ouiaId": null,
+        }
+      }
+    >
+      <label
+        className="pf-c-switch"
+        htmlFor="switch-is-not-checked"
+      >
+        <input
+          aria-label=""
+          aria-labelledby="switch-is-not-checked-on"
+          className="pf-c-switch__input"
+          defaultChecked={false}
+          disabled={false}
+          id="switch-is-not-checked"
+          onChange={[Function]}
+          type="checkbox"
+        />
+        <span
+          className="pf-c-switch__toggle"
+        />
+        <span
+          aria-hidden="true"
+          className="pf-c-switch__label pf-m-on"
+          id="switch-is-not-checked-on"
+        >
+          Off
+        </span>
+        <span
+          aria-hidden="true"
+          className="pf-c-switch__label pf-m-off"
+          id="switch-is-not-checked-off"
+        >
+          Off
+        </span>
+      </label>
+    </Switch>
+  </ComponentWithOuia>
+</Component>
+`;


### PR DESCRIPTION
**What**:

Add a check if `label` is set but not `labelOff` - in that case display `label` on both labels.
if both `label` and `labelOff` are set display in the new format
Otherwise - display switch without labels.

Added tests to verify that if `labelOff` not given the label is shown.

fixes #2814 

//cc @SpyTec 