### PR TITLE
fix(HorizontalNavMenuItem): Allow HorizontalNavMenuItem's title to be a node

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/HorizontalNavMenuItem.js
+++ b/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/HorizontalNavMenuItem.js
@@ -35,7 +35,7 @@ const HorizontalNavMenuItem = props => {
 HorizontalNavMenuItem.propTypes = {
   children: PropTypes.node,
   onItemClick: PropTypes.object,
-  title: PropTypes.string,
+  title: PropTypes.node,
   active: PropTypes.bool,
   dropdown: PropTypes.bool,
   submenu: PropTypes.bool,


### PR DESCRIPTION
 Allow HorizontalNavMenuItem's title to be a node rather than just a string.

Needed by: https://github.com/ManageIQ/react-ui-components/pull/115 and https://github.com/ManageIQ/manageiq-ui-classic/pull/5997

Ping @karelhala 