### PR TITLE
feat(Split button): Allow texts in split button

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.md
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.md
@@ -594,6 +594,73 @@ class SplitButtonDropdown extends React.Component {
 }
 ```
 
+## Split button (with text)
+
+```js
+import React from 'react';
+import { Dropdown, DropdownToggle, DropdownToggleCheckbox, DropdownItem, DropdownSeparator, DropdownPosition, DropdownDirection, KebabToggle } from '@patternfly/react-core';
+import { ThIcon } from '@patternfly/react-icons';
+
+class SplitButtonDropdown extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false
+    };
+    this.onToggle = isOpen => {
+      this.setState({
+        isOpen
+      });
+    };
+    this.onSelect = event => {
+      this.setState({
+        isOpen: !this.state.isOpen
+      });
+    };
+  }
+
+  render() {
+    const { isOpen } = this.state;
+    const dropdownItems = [
+      <DropdownItem key="link">Link</DropdownItem>,
+      <DropdownItem key="action" component="button">
+        Action
+      </DropdownItem>,
+      <DropdownItem key="disabled link" isDisabled>
+        Disabled Link
+      </DropdownItem>,
+      <DropdownItem key="disabled action" isDisabled component="button">
+        Disabled Action
+      </DropdownItem>,
+      <DropdownSeparator key="separator" />,
+      <DropdownItem key="separated link">Separated Link</DropdownItem>,
+      <DropdownItem key="separated action" component="button">
+        Separated Action
+      </DropdownItem>
+    ];
+    return (
+      <Dropdown
+        onSelect={this.onSelect}
+        toggle={(
+          <DropdownToggle
+            splitButtonItems={[
+              <DropdownToggleCheckbox
+                id="example-checkbox-2"
+                key="split-checkbox"
+                aria-label="Select all"
+              >10 selected</DropdownToggleCheckbox>
+            ]}
+            onToggle={this.onToggle}
+          />
+        )}
+        isOpen={isOpen}
+        dropdownItems={dropdownItems}
+      />
+    );
+  }
+}
+```
+
 ## Split button (disabled)
 
 ```js

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.test.tsx
@@ -17,6 +17,11 @@ test('uncontrolled', () => {
   expect(view).toMatchSnapshot();
 });
 
+test('with text', () => {
+  const view = shallow(<DropdownToggleCheckbox id="check" isDisabled aria-label="check">Some text</DropdownToggleCheckbox>);
+  expect(view).toMatchSnapshot();
+});
+
 test('isDisabled', () => {
   const view = shallow(<DropdownToggleCheckbox id="check" isDisabled aria-label="check" />);
   expect(view).toMatchSnapshot();

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
@@ -16,6 +16,8 @@ export interface DropdownToggleCheckboxProps extends Omit<React.HTMLProps<HTMLIn
   checked?: boolean | null;
   /** A callback for when the checkbox selection changes */
   onChange?(checked: boolean, event: React.FormEvent<HTMLInputElement>): void;
+  /** */
+  children?: React.ReactNode;
   /** Id of the checkbox */
   id: string;
   /** Aria-label of the checkbox */
@@ -38,7 +40,14 @@ export class DropdownToggleCheckbox extends React.Component<DropdownToggleCheckb
   }
 
   render() {
-    const { className, onChange, isValid, isDisabled, isChecked, checked, ...props } = this.props;
+    const { className, onChange, isValid, isDisabled, isChecked, checked, children, ...props } = this.props;
+    const text = children && <span
+      className={css(styles.dropdownToggleText, className)}
+      aria-hidden="true"
+      id={`${props.id}-text`}
+    >
+      {children}
+    </span>;
     return (
       <label className={css(styles.dropdownToggleCheck, className)} htmlFor={props.id}>
         <input
@@ -49,6 +58,7 @@ export class DropdownToggleCheckbox extends React.Component<DropdownToggleCheckb
           disabled={isDisabled}
           defaultChecked={isChecked || checked}
         />
+        {text}
       </label>
     );
   }

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
@@ -16,7 +16,7 @@ export interface DropdownToggleCheckboxProps extends Omit<React.HTMLProps<HTMLIn
   checked?: boolean | null;
   /** A callback for when the checkbox selection changes */
   onChange?(checked: boolean, event: React.FormEvent<HTMLInputElement>): void;
-  /** */
+  /** Element to be rendered inside the <span> */
   children?: React.ReactNode;
   /** Id of the checkbox */
   id: string;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggleCheckbox.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggleCheckbox.test.tsx.snap
@@ -87,3 +87,27 @@ exports[`uncontrolled 1`] = `
   />
 </label>
 `;
+
+exports[`with text 1`] = `
+<label
+  className="pf-c-dropdown__toggle-check"
+  htmlFor="check"
+>
+  <input
+    aria-invalid={false}
+    aria-label="check"
+    defaultChecked={null}
+    disabled={true}
+    id="check"
+    onChange={[Function]}
+    type="checkbox"
+  />
+  <span
+    aria-hidden="true"
+    className="pf-c-dropdown__toggle-text"
+    id="check-text"
+  >
+    Some text
+  </span>
+</label>
+`;


### PR DESCRIPTION
Fixes: #2758

**What**:
Allows passing children to split button in order to allow passing number of selected to this component.

**Additional issues**:

<!-- feel free to add additional comments -->
