### PR TITLE
fix(Dropdown split button): Add 3rd state to split button

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.md
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.md
@@ -661,6 +661,79 @@ class SplitButtonDropdown extends React.Component {
 }
 ```
 
+## Split button (3rd state)
+
+```js
+import React from 'react';
+import { Dropdown, DropdownToggle, DropdownToggleCheckbox, DropdownItem, DropdownSeparator, DropdownPosition, DropdownDirection, KebabToggle } from '@patternfly/react-core';
+import { ThIcon } from '@patternfly/react-icons';
+class SplitButtonDropdown extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false,
+      isChecked: null
+    };
+    this.onToggle = isOpen => {
+      this.setState({
+        isOpen
+      });
+    };
+    this.onSelect = event => {
+      this.setState({
+        isOpen: !this.state.isOpen
+      });
+    };
+    this.onChange = (isChecked) => {
+      this.setState({
+        isChecked
+      })
+    }
+  }
+  render() {
+    const { isOpen, isChecked } = this.state;
+    const dropdownItems = [
+      <DropdownItem key="link">Link</DropdownItem>,
+      <DropdownItem key="action" component="button">
+        Action
+      </DropdownItem>,
+      <DropdownItem key="disabled link" isDisabled>
+        Disabled Link
+      </DropdownItem>,
+      <DropdownItem key="disabled action" isDisabled component="button">
+        Disabled Action
+      </DropdownItem>,
+      <DropdownSeparator key="separator" />,
+      <DropdownItem key="separated link">Separated Link</DropdownItem>,
+      <DropdownItem key="separated action" component="button">
+        Separated Action
+      </DropdownItem>
+    ];
+    return (
+      <Dropdown
+        onSelect={this.onSelect}
+        toggle={(
+          <DropdownToggle
+            splitButtonItems={[
+              <DropdownToggleCheckbox
+                id="example-checkbox-3rd-state"
+                key="split-checkbox"
+                aria-label="Select all"
+                onChange={(checked) => this.onChange(checked)}
+                isChecked={isChecked}
+              />
+            ]}
+            onToggle={this.onToggle}
+          />
+        )}
+        isOpen={isOpen}
+        dropdownItems={dropdownItems}
+      />
+    );
+  }
+}
+```
+
 ## Split button (disabled)
 
 ```js

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { DropdownToggleCheckbox } from './DropdownToggleCheckbox';
 
 const props = {
@@ -44,4 +44,15 @@ test('passing HTML attribute', () => {
     <DropdownToggleCheckbox label="label" aria-labelledby="labelId" id="check" isChecked aria-label="check" />
   );
   expect(view).toMatchSnapshot();
+});
+
+test('checkbox passes value and event to onChange handler', () => {
+  const newValue = true;
+  const event = {
+    target: { checked: newValue }
+  };
+  const view = mount(<DropdownToggleCheckbox id="check" {...props} aria-label="check" />);
+  view.find('input').simulate('change', event);
+  expect(props.onChange.mock.calls[0][0]).toBe(newValue);
+  expect(props.onChange.mock.calls[0][1]).toMatchObject(event);
 });

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.test.tsx
@@ -27,6 +27,11 @@ test('isDisabled', () => {
   expect(view).toMatchSnapshot();
 });
 
+test('3rd state', () => {
+  const view = shallow(<DropdownToggleCheckbox id="check" isChecked={null} aria-label="check" />);
+  expect(view).toMatchSnapshot();
+});
+
 test('passing class', () => {
   const view = shallow(
     <DropdownToggleCheckbox label="label" className="class-123" id="check" isChecked aria-label="check" />
@@ -39,14 +44,4 @@ test('passing HTML attribute', () => {
     <DropdownToggleCheckbox label="label" aria-labelledby="labelId" id="check" isChecked aria-label="check" />
   );
   expect(view).toMatchSnapshot();
-});
-
-test('checkbox passes value and event to onChange handler', () => {
-  const newValue = true;
-  const event = {
-    currentTarget: { checked: newValue }
-  };
-  const view = shallow(<DropdownToggleCheckbox id="check" {...props} aria-label="check" />);
-  view.find('input').simulate('change', event);
-  expect(props.onChange).toBeCalledWith(newValue, event);
 });

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Dropdown/dropdown';
 import { css } from '@patternfly/react-styles';
+import { Checkbox } from '../Checkbox';
 import { Omit } from '../../helpers/typeUtils';
 
-export interface DropdownToggleCheckboxProps extends Omit<React.HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled' | 'checked'> {
+export interface DropdownToggleCheckboxProps
+  extends Omit<React.HTMLProps<HTMLInputElement>, 'type' | 'onChange' | 'disabled' | 'checked'> {
   /** Additional classes added to the DropdownToggleCheckbox */
   className?: string;
   /** Flag to show if the checkbox selection is valid or invalid */
@@ -30,17 +32,16 @@ export class DropdownToggleCheckbox extends React.Component<DropdownToggleCheckb
     className: '',
     isValid: true,
     isDisabled: false,
-    isChecked: null as boolean | null,
-    checked: null as boolean | null,
     onChange: () => undefined as any
   };
 
-  handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    this.props.onChange(event.currentTarget.checked, event);
+  calculateChecked = () => {
+    const { isChecked, checked } = this.props;
+    return isChecked !== undefined ? isChecked : checked;
   }
 
   render() {
-    const { className, onChange, isValid, isDisabled, isChecked, checked, children, ...props } = this.props;
+    const { className, onChange, isValid, isDisabled, isChecked, ref, checked, children, ...props } = this.props;
     const text = children && <span
       className={css(styles.dropdownToggleText, className)}
       aria-hidden="true"
@@ -50,13 +51,13 @@ export class DropdownToggleCheckbox extends React.Component<DropdownToggleCheckb
     </span>;
     return (
       <label className={css(styles.dropdownToggleCheck, className)} htmlFor={props.id}>
-        <input
+        <Checkbox
           {...props}
-          type="checkbox"
-          onChange={this.handleChange}
+          {...(this.calculateChecked() !== undefined) && { onChange }}
+          ref={ref as any}
           aria-invalid={!isValid}
-          disabled={isDisabled}
-          defaultChecked={isChecked || checked}
+          isDisabled={isDisabled}
+          isChecked={this.calculateChecked()}
         />
         {text}
       </label>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
@@ -35,6 +35,10 @@ export class DropdownToggleCheckbox extends React.Component<DropdownToggleCheckb
     onChange: () => undefined as any
   };
 
+  handleChange = (checked: boolean, event: React.FormEvent<HTMLInputElement>) => {
+    this.props.onChange((event.target as HTMLInputElement).checked, event);
+  }
+
   calculateChecked = () => {
     const { isChecked, checked } = this.props;
     return isChecked !== undefined ? isChecked : checked;
@@ -53,7 +57,7 @@ export class DropdownToggleCheckbox extends React.Component<DropdownToggleCheckb
       <label className={css(styles.dropdownToggleCheck, className)} htmlFor={props.id}>
         <Checkbox
           {...props}
-          {...(this.calculateChecked() !== undefined) && { onChange }}
+          {...(this.calculateChecked() !== undefined) && { onChange: this.handleChange }}
           ref={ref as any}
           aria-invalid={!isValid}
           isDisabled={isDisabled}

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggleCheckbox.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggleCheckbox.test.tsx.snap
@@ -1,18 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`3rd state 1`] = `
+<label
+  className="pf-c-dropdown__toggle-check"
+  htmlFor="check"
+>
+  <Checkbox
+    aria-invalid={false}
+    aria-label="check"
+    className=""
+    id="check"
+    isChecked={null}
+    isDisabled={false}
+    isValid={true}
+    onChange={[Function]}
+  />
+</label>
+`;
+
 exports[`controlled 1`] = `
 <label
   className="pf-c-dropdown__toggle-check"
   htmlFor="check"
 >
-  <input
+  <Checkbox
     aria-invalid={false}
     aria-label="check"
     defaultChecked={true}
     disabled={false}
     id="check"
+    isChecked={true}
+    isDisabled={false}
+    isValid={true}
     onChange={[Function]}
-    type="checkbox"
   />
 </label>
 `;
@@ -22,14 +42,16 @@ exports[`isDisabled 1`] = `
   className="pf-c-dropdown__toggle-check"
   htmlFor="check"
 >
-  <input
+  <Checkbox
     aria-invalid={false}
     aria-label="check"
     defaultChecked={null}
     disabled={true}
     id="check"
+    isChecked={false}
+    isDisabled={true}
+    isValid={true}
     onChange={[Function]}
-    type="checkbox"
   />
 </label>
 `;
@@ -39,16 +61,18 @@ exports[`passing HTML attribute 1`] = `
   className="pf-c-dropdown__toggle-check"
   htmlFor="check"
 >
-  <input
+  <Checkbox
     aria-invalid={false}
     aria-label="check"
     aria-labelledby="labelId"
     defaultChecked={true}
     disabled={false}
     id="check"
+    isChecked={true}
+    isDisabled={false}
+    isValid={true}
     label="label"
     onChange={[Function]}
-    type="checkbox"
   />
 </label>
 `;
@@ -58,15 +82,17 @@ exports[`passing class 1`] = `
   className="pf-c-dropdown__toggle-check class-123"
   htmlFor="check"
 >
-  <input
+  <Checkbox
     aria-invalid={false}
     aria-label="check"
     defaultChecked={true}
     disabled={false}
     id="check"
+    isChecked={true}
+    isDisabled={false}
+    isValid={true}
     label="label"
     onChange={[Function]}
-    type="checkbox"
   />
 </label>
 `;
@@ -76,14 +102,16 @@ exports[`uncontrolled 1`] = `
   className="pf-c-dropdown__toggle-check"
   htmlFor="check"
 >
-  <input
+  <Checkbox
     aria-invalid={false}
     aria-label="check"
     defaultChecked={null}
     disabled={false}
     id="check"
+    isChecked={false}
+    isDisabled={false}
+    isValid={true}
     onChange={[Function]}
-    type="checkbox"
   />
 </label>
 `;

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggleCheckbox.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/DropdownToggleCheckbox.test.tsx.snap
@@ -26,8 +26,7 @@ exports[`controlled 1`] = `
   <Checkbox
     aria-invalid={false}
     aria-label="check"
-    defaultChecked={true}
-    disabled={false}
+    className=""
     id="check"
     isChecked={true}
     isDisabled={false}
@@ -45,8 +44,7 @@ exports[`isDisabled 1`] = `
   <Checkbox
     aria-invalid={false}
     aria-label="check"
-    defaultChecked={null}
-    disabled={true}
+    className=""
     id="check"
     isChecked={false}
     isDisabled={true}
@@ -65,8 +63,7 @@ exports[`passing HTML attribute 1`] = `
     aria-invalid={false}
     aria-label="check"
     aria-labelledby="labelId"
-    defaultChecked={true}
-    disabled={false}
+    className=""
     id="check"
     isChecked={true}
     isDisabled={false}
@@ -85,8 +82,7 @@ exports[`passing class 1`] = `
   <Checkbox
     aria-invalid={false}
     aria-label="check"
-    defaultChecked={true}
-    disabled={false}
+    className=""
     id="check"
     isChecked={true}
     isDisabled={false}
@@ -105,8 +101,7 @@ exports[`uncontrolled 1`] = `
   <Checkbox
     aria-invalid={false}
     aria-label="check"
-    defaultChecked={null}
-    disabled={false}
+    className=""
     id="check"
     isChecked={false}
     isDisabled={false}
@@ -121,14 +116,15 @@ exports[`with text 1`] = `
   className="pf-c-dropdown__toggle-check"
   htmlFor="check"
 >
-  <input
+  <Checkbox
     aria-invalid={false}
     aria-label="check"
-    defaultChecked={null}
-    disabled={true}
+    className=""
     id="check"
+    isChecked={false}
+    isDisabled={true}
+    isValid={true}
     onChange={[Function]}
-    type="checkbox"
   />
   <span
     aria-hidden="true"


### PR DESCRIPTION
Fixes: #2841

**What**:
In order to allow 3rd state in checkbox of split button we have to use `Checkbox` component.

**Additional issues**:

<!-- feel free to add additional comments -->
