### PR TITLE
refactor(Modal): Simplify disabling of FocusTrap

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/patternfly-4/react-core/src/components/Modal/ModalContent.tsx
@@ -15,7 +15,6 @@ import { ModalBoxHeader } from './ModalBoxHeader';
 import { ModalBoxCloseButton } from './ModalBoxCloseButton';
 import { ModalBox } from './ModalBox';
 import { ModalBoxFooter } from './ModalBoxFooter';
-import { Bullseye } from '../../layouts/Bullseye';
 
 export interface ModalContentProps {
   /** Content rendered inside the Modal. */
@@ -102,16 +101,9 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   );
   return (
     <Backdrop>
-      {disableFocusTrap ? (
-        <Bullseye>
-          {modalBox}
-        </Bullseye>
-      ) 
-      : (
-        <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }} className={css(styles.bullseye)}>
-          {modalBox}
-        </FocusTrap>
-      )}
+      <FocusTrap active={!disableFocusTrap} focusTrapOptions={{ clickOutsideDeactivates: true }} className={css(styles.bullseye)}>
+        {modalBox}
+      </FocusTrap>
     </Backdrop>
   );
 };


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: This removes complexity and uses FocusTrapReact's `active` prop instead of switching to Bullseye component

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: #2966

<!-- feel free to add additional comments -->
