### PR TITLE
fix(Wizard): adds default function to onClose prop

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/patternfly-4/react-core/src/components/Wizard/Wizard.tsx
@@ -122,7 +122,7 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
     width: null as string,
     height: null as string,
     footer: null as React.ReactNode,
-    onClose: () => undefined as () => void
+    onClose: () => undefined as any
   };
   private container: HTMLDivElement;
   private titleId: string;

--- a/packages/patternfly-4/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/patternfly-4/react-core/src/components/Wizard/Wizard.tsx
@@ -122,7 +122,7 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
     width: null as string,
     height: null as string,
     footer: null as React.ReactNode,
-    onClose: () => undefined
+    onClose: () => undefined as () => void
   };
   private container: HTMLDivElement;
   private titleId: string;

--- a/packages/patternfly-4/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/patternfly-4/react-core/src/components/Wizard/Wizard.tsx
@@ -121,7 +121,8 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
     onGoToStep: null as WizardStepFunctionType,
     width: null as string,
     height: null as string,
-    footer: null as React.ReactNode
+    footer: null as React.ReactNode,
+    onClose: () => undefined
   };
   private container: HTMLDivElement;
   private titleId: string;

--- a/packages/patternfly-4/react-core/src/components/Wizard/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Wizard/__snapshots__/Wizard.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Wizard should match snapshot 1`] = `
                 "goToStepById": [Function],
                 "goToStepByName": [Function],
                 "onBack": [Function],
-                "onClose": undefined,
+                "onClose": [Function],
                 "onNext": [Function],
               }
             }
@@ -46,6 +46,7 @@ exports[`Wizard should match snapshot 1`] = `
                 ariaLabelCloseButton="Close"
                 description="Description here"
                 descriptionId="pf-wizard-description-0"
+                onClose={[Function]}
                 title="Wizard title"
                 titleId="pf-wizard-title-0"
               />
@@ -127,6 +128,7 @@ exports[`Wizard should match snapshot 1`] = `
                   isValid={true}
                   nextButtonText="Next"
                   onBack={[Function]}
+                  onClose={[Function]}
                   onNext={[Function]}
                 />
               </Unknown>


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: This adds a default function to `onClose` so that it no longer crashes the component if left out

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: fixes #2831

<!-- feel free to add additional comments -->

cc @suomiy 	