### PR TITLE
fix(FormGroup): Add className to element if not inline

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Form/FormGroup.tsx
+++ b/packages/patternfly-4/react-core/src/components/Form/FormGroup.tsx
@@ -40,7 +40,7 @@ export const FormGroup: React.FunctionComponent<FormGroupProps> = ({
 }: FormGroupProps) => (
   <FormContext.Consumer>
     {({ isHorizontal }: { isHorizontal: boolean }) => (
-      <div {...props} className={css(styles.formGroup, isInline ? getModifier(styles, 'inline', className) : '')}>
+      <div {...props} className={css(styles.formGroup, isInline ? getModifier(styles, 'inline', className) : className)}>
         {label && (
           <label className={css(styles.formLabel)} htmlFor={fieldId}>
             <span className={css(styles.formLabelText)}>


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: This fixes a regression from the conversion to TypeScript. The `className` prop is now correctly added to the root element

Regressed line: https://github.com/patternfly/patternfly-react/pull/1933/files#diff-f425f61f010b4c0b3170c953c332aba4L56

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: fixes #2855 

<!-- feel free to add additional comments -->

cc @keithjgrant 