### PR TITLE
fix(dropdown): extract DropdownWithContext

### DIFF
--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/ApplicationLauncher.tsx
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/ApplicationLauncher.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/AppLauncher/app-launcher';
 import { ThIcon } from '@patternfly/react-icons';
 import { DropdownDirection, DropdownPosition, DropdownToggle, DropdownContext } from '../Dropdown';
-import { DropdownWithContext } from '../Dropdown/Dropdown';
+import { DropdownWithContext } from '../Dropdown/DropdownWithContext';
 
 export interface ApplicationLauncherProps extends React.HTMLProps<HTMLDivElement> {
     /** Additional element css classes */

--- a/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/Dropdown.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Dropdown/dropdown';
-import { css } from '@patternfly/react-styles';
-import { DropdownMenu } from './DropdownMenu';
 import { DropdownPosition, DropdownDirection, DropdownContext } from './dropdownConstants';
+import { DropdownWithContext } from './DropdownWithContext';
 
 export interface DropdownProps extends React.HTMLProps<HTMLDivElement> {
   /** Anything which can be rendered in a dropdown */
@@ -25,112 +24,6 @@ export interface DropdownProps extends React.HTMLProps<HTMLDivElement> {
   toggle: React.ReactElement<any>;
   /** Function callback called when user selects item */
   onSelect?(event: React.SyntheticEvent<HTMLDivElement>): void;
-}
-
-export class DropdownWithContext extends React.Component<DropdownProps> {
-  openedOnEnter = false;
-  baseComponentRef = React.createRef<any>();
-
-  // seed for the aria-labelledby ID
-  static currentId = 0;
-
-  static defaultProps = {
-    className: '',
-    dropdownItems: [] as any[],
-    isOpen: false,
-    isPlain: false,
-    isGrouped: false,
-    position: DropdownPosition.left,
-    direction: DropdownDirection.down,
-    onSelect: Function.prototype
-  };
-
-  constructor(props: DropdownProps) {
-    super(props);
-    if (props.dropdownItems && props.dropdownItems.length > 0 && props.children) {
-      throw new Error(
-        'Children and dropdownItems props have been provided. Only the dropdownItems prop items will be rendered '
-      );
-    }
-  }
-
-  onEnter = () => {
-    this.openedOnEnter = true;
-  }
-
-  componentDidUpdate() {
-    if (!this.props.isOpen) { this.openedOnEnter = false; }
-  }
-
-  render() {
-    const {
-      children,
-      className,
-      direction,
-      dropdownItems,
-      isOpen,
-      isPlain,
-      isGrouped,
-      onSelect,
-      position,
-      toggle,
-      ...props
-    } = this.props;
-    const id = toggle.props.id || `pf-toggle-id-${DropdownWithContext.currentId++}`;
-    let component: string;
-    let renderedContent: React.ReactNode[];
-    let ariaHasPopup = false;
-    if (dropdownItems && dropdownItems.length > 0) {
-      component = 'ul';
-      renderedContent = dropdownItems;
-      ariaHasPopup = true;
-    } else {
-      component = 'div';
-      renderedContent = React.Children.toArray(children);
-    }
-    return (
-      <DropdownContext.Consumer>
-        {({ baseClass, baseComponent, id: contextId }) => {
-          const BaseComponent = baseComponent as any;
-          return (
-            <BaseComponent
-              {...props}
-              className={css(
-                baseClass,
-                direction === DropdownDirection.up && styles.modifiers.top,
-                isOpen && styles.modifiers.expanded,
-                className
-              )}
-              ref={this.baseComponentRef}
-            >
-              {React.Children.map(toggle, (oneToggle) =>
-                React.cloneElement(oneToggle, {
-                  parentRef: this.baseComponentRef,
-                  isOpen,
-                  id,
-                  isPlain,
-                  ariaHasPopup,
-                  onEnter: this.onEnter
-                })
-              )}
-              {isOpen && (
-                <DropdownMenu
-                  component={component}
-                  isOpen={isOpen}
-                  position={position}
-                  aria-labelledby={contextId ? `${contextId}-toggle` : id}
-                  openedOnEnter={this.openedOnEnter}
-                  isGrouped={isGrouped}
-                >
-                  {renderedContent}
-                </DropdownMenu>
-              )}
-            </BaseComponent>
-          );
-        }}
-      </DropdownContext.Consumer>
-    );
-  }
 }
 
 export const Dropdown: React.FunctionComponent<DropdownProps> = ({

--- a/packages/patternfly-4/react-core/src/components/Dropdown/DropdownWithContext.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/DropdownWithContext.tsx
@@ -1,0 +1,112 @@
+import * as React from 'react';
+import styles from '@patternfly/react-styles/css/components/Dropdown/dropdown';
+import { css } from '@patternfly/react-styles';
+import { DropdownMenu } from './DropdownMenu';
+import { DropdownProps } from './Dropdown';
+import { DropdownPosition, DropdownDirection, DropdownContext } from './dropdownConstants';
+
+export class DropdownWithContext extends React.Component<DropdownProps> {
+  openedOnEnter = false;
+  baseComponentRef = React.createRef<any>();
+
+  // seed for the aria-labelledby ID
+  static currentId = 0;
+
+  static defaultProps = {
+    className: '',
+    dropdownItems: [] as any[],
+    isOpen: false,
+    isPlain: false,
+    isGrouped: false,
+    position: DropdownPosition.left,
+    direction: DropdownDirection.down,
+    onSelect: Function.prototype
+  };
+
+  constructor(props: DropdownProps) {
+    super(props);
+    if (props.dropdownItems && props.dropdownItems.length > 0 && props.children) {
+      throw new Error(
+        'Children and dropdownItems props have been provided. Only the dropdownItems prop items will be rendered '
+      );
+    }
+  }
+
+  onEnter = () => {
+    this.openedOnEnter = true;
+  }
+
+  componentDidUpdate() {
+    if (!this.props.isOpen) { this.openedOnEnter = false; }
+  }
+
+  render() {
+    const {
+      children,
+      className,
+      direction,
+      dropdownItems,
+      isOpen,
+      isPlain,
+      isGrouped,
+      onSelect,
+      position,
+      toggle,
+      ...props
+    } = this.props;
+    const id = toggle.props.id || `pf-toggle-id-${DropdownWithContext.currentId++}`;
+    let component: string;
+    let renderedContent: React.ReactNode[];
+    let ariaHasPopup = false;
+    if (dropdownItems && dropdownItems.length > 0) {
+      component = 'ul';
+      renderedContent = dropdownItems;
+      ariaHasPopup = true;
+    } else {
+      component = 'div';
+      renderedContent = React.Children.toArray(children);
+    }
+    return (
+      <DropdownContext.Consumer>
+        {({ baseClass, baseComponent, id: contextId }) => {
+          const BaseComponent = baseComponent as any;
+          return (
+            <BaseComponent
+              {...props}
+              className={css(
+                baseClass,
+                direction === DropdownDirection.up && styles.modifiers.top,
+                isOpen && styles.modifiers.expanded,
+                className
+              )}
+              ref={this.baseComponentRef}
+            >
+              {React.Children.map(toggle, (oneToggle) =>
+                React.cloneElement(oneToggle, {
+                  parentRef: this.baseComponentRef,
+                  isOpen,
+                  id,
+                  isPlain,
+                  ariaHasPopup,
+                  onEnter: this.onEnter
+                })
+              )}
+              {isOpen && (
+                <DropdownMenu
+                  component={component}
+                  isOpen={isOpen}
+                  position={position}
+                  aria-labelledby={contextId ? `${contextId}-toggle` : id}
+                  openedOnEnter={this.openedOnEnter}
+                  isGrouped={isGrouped}
+                >
+                  {renderedContent}
+                </DropdownMenu>
+              )}
+            </BaseComponent>
+          );
+        }}
+      </DropdownContext.Consumer>
+    );
+  }
+}

--- a/packages/patternfly-4/react-core/src/components/OptionsMenu/OptionsMenu.tsx
+++ b/packages/patternfly-4/react-core/src/components/OptionsMenu/OptionsMenu.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/OptionsMenu/options-menu';
 import { css } from '@patternfly/react-styles';
 import { DropdownContext } from '../Dropdown';
-import { DropdownWithContext } from '../Dropdown/Dropdown';
+import { DropdownWithContext } from '../Dropdown/DropdownWithContext';
 
 export enum OptionsMenuPosition {
   right = 'right',


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Fixes #2871

React Docgen can't handle grabbing the props for 2 exports from the same file. Solution: extract `DropdownWithContext` to a separate file.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
