### PR TITLE
Update Victory to 30.0.0

### DIFF
--- a/packages/patternfly-4/react-charts/package.json
+++ b/packages/patternfly-4/react-charts/package.json
@@ -29,7 +29,14 @@
   },
   "homepage": "https://github.com/patternfly/patternfly-react#readme",
   "dependencies": {
-    "@patternfly/react-styles": "^3.5.23"
+    "hoist-non-react-statics": "^3.3.0",
+    "lodash": "^4.17.11",
+    "victory": "^33.0.5",
+    "victory-core": "^33.0.1",
+    "victory-legend": "^33.0.1",
+    "@patternfly/patternfly": "2.31.7",
+    "@patternfly/react-styles": "^3.5.23",
+    "@patternfly/react-tokens": "^2.6.27"
   },
   "peerDependencies": {
     "prop-types": "^15.6.1",
@@ -45,15 +52,6 @@
     "clean": "rimraf dist",
     "develop": "yarn build:babel:esm --skip-initial-build --watch --verbose --source-maps"
   },
-  "optionalDependencies": {
-    "@types/lodash": "^4.14.132",
-    "@types/victory": "^31.0.18",
-    "hoist-non-react-statics": "^3.3.0",
-    "lodash": "^4.17.11",
-    "victory": "^32.2.3",
-    "victory-core": "^32.2.3",
-    "victory-legend": "^32.2.3"
-  },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
@@ -63,9 +61,8 @@
     "@babel/plugin-transform-typescript": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
-    "@patternfly/patternfly": "2.31.7",
-    "@patternfly/react-icons": "^3.14.3",
-    "@patternfly/react-tokens": "^2.6.27",
+    "@types/lodash": "^4.14.132",
+    "@types/victory": "^31.0.21",
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-plugin-typescript-to-proptypes": "^0.17.1",
     "css": "^2.2.3",

--- a/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
@@ -23,16 +23,12 @@ import {
   ChartLegendWrapper
 } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
-import { getLabelTextSize, getPaddingForSide, getTheme } from '../ChartUtils';
+import { getClassName, getLabelTextSize, getPaddingForSide, getTheme } from '../ChartUtils';
 
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
  */
 export interface ChartProps extends VictoryChartProps {
-  /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-chart/
-   */
-  ' '?: any;
   /**
    * Specifies the zoom capability of the container component. A value of true allows the chart to
    * zoom in and out. Zoom events are controlled by scrolling. When zoomed in, panning events are
@@ -124,7 +120,7 @@ export interface ChartProps extends VictoryChartProps {
    * The mutation function will be called with the calculated props for the individual selected
    * element (i.e. a single bar), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
-   * @examples
+   * @example
    * events={[
    *   {
    *     target: "data",
@@ -152,7 +148,7 @@ export interface ChartProps extends VictoryChartProps {
    */
   events?: EventPropTypeInterface<string, StringOrNumberOrCallback>[];
   /**
-   * ChartLegend uses the standard externalEventMutations prop.
+   * Chart uses the standard externalEventMutations prop.
    */
   externalEventMutations?: any[];
   /**
@@ -167,9 +163,8 @@ export interface ChartProps extends VictoryChartProps {
    *
    * Because Victory renders responsive containers, the width and height props do not determine the width and
    * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Typically, the parent container is set to the same width in order to maintain the aspect ratio.
+   * pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set
+   * to the same width in order to maintain the aspect ratio.
    */
   height?: number;
   /**
@@ -214,6 +209,9 @@ export interface ChartProps extends VictoryChartProps {
   legendOrientation?: 'horizontal' | 'vertical';
   /**
    * The legend position relation to the chart. Valid values are 'bottom', 'bottom-left', and 'right'
+   *
+   * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
+   * cases, the legend may not be visible until enough padding is applied.
    */
   legendPosition?: 'bottom' | 'bottom-left' | 'right';
   /**
@@ -350,9 +348,8 @@ export interface ChartProps extends VictoryChartProps {
    *
    * Because Victory renders responsive containers, the width and height props do not determine the width and
    * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Typically, the parent container is set to the same width in order to maintain the aspect ratio.
+   * pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set
+   * to the same width in order to maintain the aspect ratio.
    */
   width?: number;
 }
@@ -362,7 +359,6 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
   ariaDesc,
   ariaTitle,
   children,
-  containerComponent = allowZoom ? <VictoryZoomContainer /> : <ChartContainer />,
   legendComponent = <ChartLegend/>,
   legendData,
   legendPosition = ChartCommonStyles.legend.position as ChartLegendPosition,
@@ -373,6 +369,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
 
   // destructure last
   theme = getTheme(themeColor, themeVariant),
+  containerComponent = allowZoom ? <VictoryZoomContainer /> : <ChartContainer />,
   legendOrientation = theme.legend.orientation as ChartLegendOrientation,
   height = theme.chart.height,
   width = theme.chart.width,
@@ -385,16 +382,12 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     top: getPaddingForSide('top', padding, theme.chart.padding),
   };
 
-  const chartSize = {
-    height: Math.abs(height - (defaultPadding.bottom + defaultPadding.top)),
-    width: Math.abs(width - (defaultPadding.left + defaultPadding.right))
-  };
-
   const container = React.cloneElement(containerComponent, {
     desc: ariaDesc,
     title: ariaTitle,
     theme,
-    ...containerComponent.props
+    ...containerComponent.props,
+    className: getClassName({className: containerComponent.props.className}) // Override VictoryContainer class name
   });
 
   const legend = React.cloneElement(legendComponent, {
@@ -410,7 +403,7 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
       return null;
     }
     let dx = 0;
-    let dy = defaultPadding.top;
+    let dy = 0;
     let xAxisLabelHeight = 0;
     let legendTitleHeight = legend.props.title ? 10 : 0;
 
@@ -423,25 +416,22 @@ export const Chart: React.FunctionComponent<ChartProps> = ({
     });
 
     if (legendPosition === ChartLegendPosition.bottom) {
-      dy += ChartCommonStyles.legend.margin + xAxisLabelHeight + legendTitleHeight;
+      dy += xAxisLabelHeight + legendTitleHeight;
     } else if (legendPosition === ChartLegendPosition.bottomLeft) {
-      dy += ChartCommonStyles.legend.margin + xAxisLabelHeight + legendTitleHeight;
-      dx += defaultPadding.left - 10;
-    } else if (legendPosition === ChartLegendPosition.right) {
-      dx += defaultPadding.left;
+      dy += xAxisLabelHeight + legendTitleHeight;
+      dx = -10;
     }
     return (
       <ChartLegendWrapper
-        chartHeight={chartSize.height}
-        chartType="pie"
-        chartWidth={chartSize.width}
+        chartType="chart"
         dx={dx}
         dy={dy}
+        height={height}
         orientation={legendOrientation}
+        padding={defaultPadding}
         position={legendPosition}
-        svgHeight={height}
-        svgWidth={width}
         theme={theme}
+        width={width}
       >
         {legend}
       </ChartLegendWrapper>

--- a/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
+++ b/packages/patternfly-4/react-charts/src/components/Chart/Chart.tsx
@@ -25,6 +25,7 @@ import {
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
 import { getClassName, getLabelTextSize, getPaddingForSide, getTheme } from '../ChartUtils';
 
+
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
  */

--- a/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/Chart/__snapshots__/Chart.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Chart 1`] = `
 <VictoryChart
   containerComponent={
     <Unknown
+      className="pf-c-chart"
       theme={
         Object {
           "area": Object {
@@ -461,6 +462,8 @@ exports[`Chart 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -486,6 +489,8 @@ exports[`Chart 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -969,6 +974,8 @@ exports[`Chart 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -986,6 +993,8 @@ exports[`Chart 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -1010,6 +1019,8 @@ exports[`Chart 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -1493,6 +1504,8 @@ exports[`Chart 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -1514,6 +1527,8 @@ exports[`Chart 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -1529,12 +1544,16 @@ exports[`Chart 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -1551,6 +1570,8 @@ exports[`Chart 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2036,6 +2057,8 @@ exports[`Chart 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -2053,6 +2076,8 @@ exports[`Chart 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -2068,12 +2093,16 @@ exports[`Chart 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2089,6 +2118,8 @@ exports[`Chart 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2574,6 +2605,8 @@ exports[`Chart 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -3057,6 +3090,7 @@ exports[`Chart 2`] = `
 <VictoryChart
   containerComponent={
     <Unknown
+      className="pf-c-chart"
       theme={
         Object {
           "area": Object {
@@ -3514,6 +3548,8 @@ exports[`Chart 2`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -3539,6 +3575,8 @@ exports[`Chart 2`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -4022,6 +4060,8 @@ exports[`Chart 2`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -4039,6 +4079,8 @@ exports[`Chart 2`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -4063,6 +4105,8 @@ exports[`Chart 2`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -4546,6 +4590,8 @@ exports[`Chart 2`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -4567,6 +4613,8 @@ exports[`Chart 2`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -4582,12 +4630,16 @@ exports[`Chart 2`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -4604,6 +4656,8 @@ exports[`Chart 2`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -5089,6 +5143,8 @@ exports[`Chart 2`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -5106,6 +5162,8 @@ exports[`Chart 2`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -5121,12 +5179,16 @@ exports[`Chart 2`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -5142,6 +5204,8 @@ exports[`Chart 2`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -5627,6 +5691,8 @@ exports[`Chart 2`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -6110,6 +6176,7 @@ exports[`renders axis and component children 1`] = `
 <VictoryChart
   containerComponent={
     <Unknown
+      className="pf-c-chart"
       theme={
         Object {
           "area": Object {
@@ -6567,6 +6634,8 @@ exports[`renders axis and component children 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -6592,6 +6661,8 @@ exports[`renders axis and component children 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -7075,6 +7146,8 @@ exports[`renders axis and component children 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -7092,6 +7165,8 @@ exports[`renders axis and component children 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -7116,6 +7191,8 @@ exports[`renders axis and component children 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -7599,6 +7676,8 @@ exports[`renders axis and component children 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -7620,6 +7699,8 @@ exports[`renders axis and component children 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -7635,12 +7716,16 @@ exports[`renders axis and component children 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -7657,6 +7742,8 @@ exports[`renders axis and component children 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -8142,6 +8229,8 @@ exports[`renders axis and component children 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -8159,6 +8248,8 @@ exports[`renders axis and component children 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -8174,12 +8265,16 @@ exports[`renders axis and component children 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -8195,6 +8290,8 @@ exports[`renders axis and component children 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -8680,6 +8777,8 @@ exports[`renders axis and component children 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/ChartArea.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/ChartArea.tsx
@@ -16,6 +16,7 @@ import {
   VictoryArea,
   VictoryAreaProps
 } from 'victory';
+import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
 
@@ -29,13 +30,12 @@ export enum ChartAreaSortOrder {
  */
 export interface ChartAreaProps extends VictoryAreaProps {
   /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-area/
-   */
-  ' '?: any;
-  /**
+   * type: boolean || object
+   *
    * The animate prop specifies props for VictoryAnimation to use.
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
+   *
    * @example
    * {duration: 500, onExit: () => {}, onEnter: {duration: 500, before: () => ({y: 0})})}
    */
@@ -186,7 +186,7 @@ export interface ChartAreaProps extends VictoryAreaProps {
    * like data={[{x: 1, y: 1, label: "first"}]}.
    * @example ["spring", "summer", "fall", "winter"], (datum) => datum.title
    */
-  labels?: string[] | ((data: any) => string);
+  labels?: string[] | number[] | Function;
   /**
    * The maxDomain prop defines a maximum domain value for a chart. This prop is useful in situations where the maximum
    * domain of a chart is static, while the minimum value depends on data or other variable information. If the domain
@@ -376,9 +376,12 @@ export interface ChartAreaProps extends VictoryAreaProps {
 export const ChartArea: React.FunctionComponent<ChartAreaProps> = ({
   themeColor,
   themeVariant,
-  theme = getTheme(themeColor, themeVariant), // destructure last
+
+  // destructure last
+  theme = getTheme(themeColor, themeVariant),
+  containerComponent = <ChartContainer theme={theme} />,
   ...rest
-}: ChartAreaProps) => <VictoryArea theme={theme} {...rest} />;
+}: ChartAreaProps) => <VictoryArea containerComponent={containerComponent} theme={theme} {...rest} />;
 
 // Note: VictoryArea.role must be hoisted
 hoistNonReactStatics(ChartArea, VictoryArea);

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/__snapshots__/ChartArea.test.tsx.snap
@@ -3,17 +3,464 @@
 exports[`ChartArea 1`] = `
 <VictoryArea
   containerComponent={
-    <VictoryContainer
-      className="VictoryContainer"
-      portalComponent={<Portal />}
-      portalZIndex={99}
-      responsive={true}
+    <Unknown
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
     />
   }
   dataComponent={
     <Area
       groupComponent={<g />}
       pathComponent={<Path />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   groupComponent={
@@ -493,17 +940,464 @@ exports[`ChartArea 1`] = `
 exports[`ChartArea 2`] = `
 <VictoryArea
   containerComponent={
-    <VictoryContainer
-      className="VictoryContainer"
-      portalComponent={<Portal />}
-      portalZIndex={99}
-      responsive={true}
+    <Unknown
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
     />
   }
   dataComponent={
     <Area
       groupComponent={<g />}
       pathComponent={<Path />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   groupComponent={
@@ -983,11 +1877,456 @@ exports[`ChartArea 2`] = `
 exports[`renders component data 1`] = `
 <VictoryArea
   containerComponent={
-    <VictoryContainer
-      className="VictoryContainer"
-      portalComponent={<Portal />}
-      portalZIndex={99}
-      responsive={true}
+    <Unknown
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
     />
   }
   data={
@@ -1018,6 +2357,8 @@ exports[`renders component data 1`] = `
     <Area
       groupComponent={<g />}
       pathComponent={<Path />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   groupComponent={

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -2,24 +2,40 @@
 title: 'Area'
 section: 'charts'
 typescript: true
-propComponents: ['Chart', 'ChartArea', 'ChartGroup', 'ChartVoronoiContainer']
+propComponents: ['Chart', 'ChartAreaProps', 'ChartAxis', 'ChartGroup', 'ChartLegend', 'ChartVoronoiContainer']
 ---
 
-import { Chart, ChartArea, ChartAxis, ChartGroup, ChartLabel, ChartVoronoiContainer } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '@patternfly/react-charts';
+import '@patternfly/patternfly/patternfly-charts.css';
 import './chart-area.scss';
+
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+## Tutorial
+
+PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, 
+along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React 
+based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+In this tutorial, we will build an area chart together - starting with a simple chart, adding multiple datasets, 
+tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart 
+components together to build a consistent user experience.
+
+[Start course](https://katacoda.com/patternfly/courses/charts/module-area)
 
 ## Simple area chart with right aligned legend
 ```js
 import React from 'react';
 import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '@patternfly/react-charts';
+// import '@patternfly/patternfly/patternfly-charts.css'; // For mixed blend mode
 
 <div>
   <div className="area-chart-legend-right">
     <Chart
       ariaDesc="Average number of pets"
       ariaTitle="Area chart example"
-      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
-      legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
+      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+      legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
       legendOrientation="vertical"
       legendPosition="right"
       height={200}
@@ -27,7 +43,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '
       padding={{
         bottom: 50,
         left: 50,
-        right: 200, // Adjusted to accomodate legend
+        right: 200, // Adjusted to accommodate legend
         top: 50
       }}
       width={800}
@@ -37,30 +53,30 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '
       <ChartGroup>
         <ChartArea
           data={[
-            { name: 'Cats', x: 1, y: 3 },
-            { name: 'Cats', x: 2, y: 4 },
-            { name: 'Cats', x: 3, y: 8 },
-            { name: 'Cats', x: 4, y: 6 }
+            { name: 'Cats', x: '2015', y: 3 },
+            { name: 'Cats', x: '2016', y: 4 },
+            { name: 'Cats', x: '2017', y: 8 },
+            { name: 'Cats', x: '2018', y: 6 }
           ]}
           interpolation="basis"
         />
         <ChartArea
           data={[
-            { name: 'Birds', x: 1, y: 2 },
-            { name: 'Birds', x: 2, y: 3 },
-            { name: 'Birds', x: 3, y: 4 },
-            { name: 'Birds', x: 4, y: 5 },
-            { name: 'Birds', x: 5, y: 6 }
+            { name: 'Dogs', x: '2015', y: 2 },
+            { name: 'Dogs', x: '2016', y: 3 },
+            { name: 'Dogs', x: '2017', y: 4 },
+            { name: 'Dogs', x: '2018', y: 5 },
+            { name: 'Dogs', x: '2019', y: 6 }
           ]}
           interpolation="basis"
         />
         <ChartArea
           data={[
-            { name: 'Dogs', x: 1, y: 1 },
-            { name: 'Dogs', x: 2, y: 2 },
-            { name: 'Dogs', x: 3, y: 3 },
-            { name: 'Dogs', x: 4, y: 2 },
-            { name: 'Dogs', x: 5, y: 4 }
+            { name: 'Birds', x: '2015', y: 1 },
+            { name: 'Birds', x: '2016', y: 2 },
+            { name: 'Birds', x: '2017', y: 3 },
+            { name: 'Birds', x: '2018', y: 2 },
+            { name: 'Birds', x: '2019', y: 4 }
           ]}
           interpolation="basis"
         />
@@ -70,22 +86,23 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '
 </div>
 ```
 
-## Cyan area chart with bottom aligned legend
+## Cyan area chart with bottom aligned legend and axis label
 ```js
 import React from 'react';
 import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patternfly/react-charts';
+// import '@patternfly/patternfly/patternfly-charts.css'; // For mixed blend mode
 
 <div>
   <div className="area-chart-legend-bottom">
     <Chart
       ariaDesc="Average number of pets"
       ariaTitle="Area chart example"
-      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
-      legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
+      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+      legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
       legendPosition="bottom"
       height={250}
       padding={{
-        bottom: 100, // Adjusted to accomodate legend
+        bottom: 100, // Adjusted to accommodate legend
         left: 50,
         right: 50,
         top: 50,
@@ -94,35 +111,35 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patte
       themeColor={ChartThemeColor.cyan}
       width={650}
     >
-      <ChartAxis label="Animals"/>
+      <ChartAxis label="Years"/>
       <ChartAxis dependentAxis showGrid/>
       <ChartGroup>
         <ChartArea
           data={[
-            { name: 'Cats', x: 1, y: 3 },
-            { name: 'Cats', x: 2, y: 4 },
-            { name: 'Cats', x: 3, y: 8 },
-            { name: 'Cats', x: 4, y: 6 }
+            { name: 'Cats', x: '2015', y: 3 },
+            { name: 'Cats', x: '2016', y: 4 },
+            { name: 'Cats', x: '2017', y: 8 },
+            { name: 'Cats', x: '2018', y: 6 }
           ]}
           interpolation="basis"
         />
         <ChartArea
           data={[
-            { name: 'Birds', x: 1, y: 2 },
-            { name: 'Birds', x: 2, y: 3 },
-            { name: 'Birds', x: 3, y: 4 },
-            { name: 'Birds', x: 4, y: 5 },
-            { name: 'Birds', x: 5, y: 6 }
+            { name: 'Dogs', x: '2015', y: 2 },
+            { name: 'Dogs', x: '2016', y: 3 },
+            { name: 'Dogs', x: '2017', y: 4 },
+            { name: 'Dogs', x: '2018', y: 5 },
+            { name: 'Dogs', x: '2019', y: 6 }
           ]}
           interpolation="basis"
         />
         <ChartArea
           data={[
-            { name: 'Dogs', x: 1, y: 1 },
-            { name: 'Dogs', x: 2, y: 2 },
-            { name: 'Dogs', x: 3, y: 3 },
-            { name: 'Dogs', x: 4, y: 2 },
-            { name: 'Dogs', x: 5, y: 4 }
+            { name: 'Birds', x: '2015', y: 1 },
+            { name: 'Birds', x: '2016', y: 2 },
+            { name: 'Birds', x: '2017', y: 3 },
+            { name: 'Birds', x: '2018', y: 2 },
+            { name: 'Birds', x: '2019', y: 4 }
           ]}
           interpolation="basis"
         />
@@ -136,6 +153,7 @@ import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patte
 ```js
 import React from 'react';
 import { Chart, ChartArea, ChartAxis, ChartGroup, ChartThemeColor } from '@patternfly/react-charts';
+// import '@patternfly/patternfly/patternfly-charts.css'; // For mixed blend mode
 
 class MultiColorChart extends React.Component {
   constructor(props) {
@@ -169,12 +187,12 @@ class MultiColorChart extends React.Component {
           <Chart
             ariaDesc="Average number of pets"
             ariaTitle="Area chart example"
-            containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
-            legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
+            containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+            legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
             legendPosition="bottom-left"
             height={225}
             padding={{
-              bottom: 75, // Adjusted to accomodate legend
+              bottom: 75, // Adjusted to accommodate legend
               left: 50,
               right: 50,
               top: 50,
@@ -188,30 +206,30 @@ class MultiColorChart extends React.Component {
             <ChartGroup>
               <ChartArea
                 data={[
-                  { name: 'Cats', x: 1, y: 3 },
-                  { name: 'Cats', x: 2, y: 4 },
-                  { name: 'Cats', x: 3, y: 8 },
-                  { name: 'Cats', x: 4, y: 6 }
-                ]}
-                interpolation="basis"
-              />
-             <ChartArea
-               data={[
-                  { name: 'Birds', x: 1, y: 2 },
-                  { name: 'Birds', x: 2, y: 3 },
-                  { name: 'Birds', x: 3, y: 4 },
-                  { name: 'Birds', x: 4, y: 5 },
-                  { name: 'Birds', x: 5, y: 6 }
+                  { name: 'Cats', x: '2015', y: 3 },
+                  { name: 'Cats', x: '2016', y: 4 },
+                  { name: 'Cats', x: '2017', y: 8 },
+                  { name: 'Cats', x: '2018', y: 6 }
                 ]}
                 interpolation="basis"
               />
               <ChartArea
                 data={[
-                  { name: 'Dogs', x: 1, y: 1 },
-                  { name: 'Dogs', x: 2, y: 2 },
-                  { name: 'Dogs', x: 3, y: 3 },
-                  { name: 'Dogs', x: 4, y: 2 },
-                  { name: 'Dogs', x: 5, y: 4 }
+                  { name: 'Dogs', x: '2015', y: 2 },
+                  { name: 'Dogs', x: '2016', y: 3 },
+                  { name: 'Dogs', x: '2017', y: 4 },
+                  { name: 'Dogs', x: '2018', y: 5 },
+                  { name: 'Dogs', x: '2019', y: 6 }
+                ]}
+                interpolation="basis"
+              />
+              <ChartArea
+                data={[
+                  { name: 'Birds', x: '2015', y: 1 },
+                  { name: 'Birds', x: '2016', y: 2 },
+                  { name: 'Birds', x: '2017', y: 3 },
+                  { name: 'Birds', x: '2018', y: 2 },
+                  { name: 'Birds', x: '2019', y: 4 }
                 ]}
                 interpolation="basis"
               />
@@ -223,3 +241,19 @@ class MultiColorChart extends React.Component {
   }
 }
 ```
+
+## Tips
+
+- For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+- `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `Chart` props, see <a href="https://formidable.com/open-source/victory/docs/victory-chart" target="_blank">VictoryChart</a>
+ - For `ChartArea` props, see <a href="https://formidable.com/open-source/victory/docs/victory-area" target="_blank">VictoryArea</a>
+ - For `ChartAxis` props, see <a href="https://formidable.com/open-source/victory/docs/victory-axis" target="_blank">VictoryAxis</a>
+ - For `ChartGroup` props, see <a href="https://formidable.com/open-source/victory/docs/victory-group" target="_blank">VictoryGroup</a>
+ - For `ChartLegend` props, see <a href="https://formidable.com/open-source/victory/docs/victory-legend" target="_blank">VictoryLegend</a>
+ - For `ChartVoronoiContainer` props, see <a href="https://formidable.com/open-source/victory/docs/victory-voronoi-container" target="_blank">VictoryVoronoiContainer</a>

--- a/packages/patternfly-4/react-charts/src/components/ChartAxis/ChartAxis.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartAxis/ChartAxis.tsx
@@ -19,10 +19,6 @@ import { getAxisTheme, getTheme } from '../ChartUtils';
  */
 export interface ChartAxisProps extends VictoryAxisProps {
   /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-axis/
-   */
-  ' '?: any;
-  /**
    * The animate prop specifies props for VictoryAnimation to use.
    * The animate prop should also be used to specify enter and exit
    * transition configurations with the `onExit` and `onEnter` namespaces respectively.
@@ -83,7 +79,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * The domain prop describes the range of values your axis will include. This prop should be
    * given as a array of the minimum and maximum expected values for your axis.
    * If this value is not given it will be calculated based on the scale or tickValues.
-   * @examples [-1, 1]
+   * @example [-1, 1]
    */
   domain?: DomainPropType;
   /**
@@ -108,7 +104,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    * function will be called with the calculated props for the individual selected
    * element (i.e. a single tick), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
-   * @examples
+   * @example
    * events={[
    *   {
    *     target: "grid",
@@ -134,7 +130,7 @@ export interface ChartAxisProps extends VictoryAxisProps {
    */
   events?: EventPropTypeInterface<'axis' | 'axisLabel' | 'grid' | 'ticks' | 'tickLabels' | 'parent', number | string>[];
   /**
-   * ChartLegend uses the standard externalEventMutations prop.
+   * ChartAxis uses the standard externalEventMutations prop.
    */
   externalEventMutations?: any[];
   /**

--- a/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartAxis/__snapshots__/ChartAxis.test.tsx.snap
@@ -5,6 +5,8 @@ exports[`ChartAxis 1`] = `
   axisComponent={
     <LineSegment
       lineComponent={<Line />}
+      role="presentation"
+      shapeRendering="auto"
       type="axis"
     />
   }
@@ -29,6 +31,8 @@ exports[`ChartAxis 1`] = `
   gridComponent={
     <LineSegment
       lineComponent={<Line />}
+      role="presentation"
+      shapeRendering="auto"
       type="grid"
     />
   }
@@ -490,6 +494,8 @@ exports[`ChartAxis 1`] = `
   tickComponent={
     <LineSegment
       lineComponent={<Line />}
+      role="presentation"
+      shapeRendering="auto"
       type="tick"
     />
   }
@@ -510,6 +516,8 @@ exports[`ChartAxis 2`] = `
   axisComponent={
     <LineSegment
       lineComponent={<Line />}
+      role="presentation"
+      shapeRendering="auto"
       type="axis"
     />
   }
@@ -534,6 +542,8 @@ exports[`ChartAxis 2`] = `
   gridComponent={
     <LineSegment
       lineComponent={<Line />}
+      role="presentation"
+      shapeRendering="auto"
       type="grid"
     />
   }
@@ -995,6 +1005,8 @@ exports[`ChartAxis 2`] = `
   tickComponent={
     <LineSegment
       lineComponent={<Line />}
+      role="presentation"
+      shapeRendering="auto"
       type="tick"
     />
   }
@@ -1014,6 +1026,7 @@ exports[`renders component data 1`] = `
 <VictoryChart
   containerComponent={
     <Unknown
+      className="pf-c-chart"
       theme={
         Object {
           "area": Object {
@@ -1471,6 +1484,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -1496,6 +1511,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -1979,6 +1996,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -1996,6 +2015,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -2020,6 +2041,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2503,6 +2526,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -2524,6 +2549,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -2539,12 +2566,16 @@ exports[`renders component data 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2561,6 +2592,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3046,6 +3079,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -3063,6 +3098,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -3078,12 +3115,16 @@ exports[`renders component data 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3099,6 +3140,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3584,6 +3627,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/ChartBar.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/ChartBar.tsx
@@ -15,8 +15,9 @@ import {
   StringOrNumberOrCallback,
   VictoryStyleInterface,
   VictoryBar,
-  VictoryBarProps
+  VictoryBarProps,
 } from 'victory';
+import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
 
@@ -24,10 +25,6 @@ import { getTheme } from '../ChartUtils';
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
  */
 export interface ChartBarProps extends VictoryBarProps {
-  /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-bar/
-   */
-  ' '?: any;
   /**
    * The alignment prop specifies how bars should be aligned relative to their data points.
    * This prop may be given as “start”, “middle” or “end”. When this prop is not specified,
@@ -406,9 +403,12 @@ export interface ChartBarProps extends VictoryBarProps {
 export const ChartBar: React.FunctionComponent<ChartBarProps> = ({
   themeColor,
   themeVariant,
-  theme = getTheme(themeColor, themeVariant), // destructure last
+
+    // destructure last
+  theme = getTheme(themeColor, themeVariant),
+  containerComponent = <ChartContainer theme={theme} />,
   ...rest
-}: ChartBarProps) => <VictoryBar theme={theme} {...rest} />;
+}: ChartBarProps) => <VictoryBar containerComponent={containerComponent} theme={theme} {...rest} />;
 
 // Note: VictoryBar.getDomain & VictoryBar.role must be hoisted
 hoistNonReactStatics(ChartBar, VictoryBar);

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/__snapshots__/ChartBar.test.tsx.snap
@@ -3,11 +3,456 @@
 exports[`ChartBar 1`] = `
 <VictoryBar
   containerComponent={
-    <VictoryContainer
-      className="VictoryContainer"
-      portalComponent={<Portal />}
-      portalZIndex={99}
-      responsive={true}
+    <Unknown
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
     />
   }
   data={
@@ -34,6 +479,8 @@ exports[`ChartBar 1`] = `
     <Bar
       defaultBarWidth={8}
       pathComponent={<Path />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   groupComponent={
@@ -508,11 +955,456 @@ exports[`ChartBar 1`] = `
 exports[`ChartBar 2`] = `
 <VictoryBar
   containerComponent={
-    <VictoryContainer
-      className="VictoryContainer"
-      portalComponent={<Portal />}
-      portalZIndex={99}
-      responsive={true}
+    <Unknown
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
     />
   }
   data={
@@ -539,6 +1431,8 @@ exports[`ChartBar 2`] = `
     <Bar
       defaultBarWidth={8}
       pathComponent={<Path />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   groupComponent={
@@ -1014,6 +1908,7 @@ exports[`renders component data 1`] = `
 <VictoryChart
   containerComponent={
     <Unknown
+      className="pf-c-chart"
       theme={
         Object {
           "area": Object {
@@ -1471,6 +2366,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -1496,6 +2393,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -1979,6 +2878,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -1996,6 +2897,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -2020,6 +2923,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2503,6 +3408,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -2524,6 +3431,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -2539,12 +3448,16 @@ exports[`renders component data 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2561,6 +3474,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3046,6 +3961,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -3063,6 +3980,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -3078,12 +3997,16 @@ exports[`renders component data 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3099,6 +4022,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3584,6 +4509,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -2,11 +2,25 @@
 title: 'Bar'
 section: 'charts'
 typescript: true
-propComponents: ['Chart', 'ChartBar', 'ChartGroup']
+propComponents: ['Chart', 'ChartAxis', 'ChartBar', 'ChartGroup', 'ChartLegend', 'ChartVoronoiContainer']
 ---
 
-import { Chart, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
 import './chart-bar.scss';
+
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+## Tutorial
+
+PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, 
+along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React 
+based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+In this tutorial, we will build a bar chart together - starting with a simple chart, adding multiple datasets, 
+tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart 
+components together to build a consistent user experience.
+
+[Start course](https://katacoda.com/patternfly/courses/charts/module-bar)
 
 ## Simple bar chart with right aligned legend
 ```js
@@ -18,17 +32,17 @@ import { Chart, ChartBar } from '@patternfly/react-charts';
     <Chart
       ariaDesc="Average number of pets"
       ariaTitle="Bar chart example"
-      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} voronoiDimension="x" />}
+      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
       domain={{y: [0,9]}}
       domainPadding={{ x: [30, 25] }}
-      legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }, { name: 'Mice' }]}
+      legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
       legendOrientation="vertical"
       legendPosition="right"
       height={250}
       padding={{
         bottom: 50,
         left: 50,
-        right: 200, // Adjusted to accomodate legend
+        right: 200, // Adjusted to accommodate legend
         top: 50
       }}
       width={600}
@@ -56,13 +70,13 @@ import { Chart, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiContainer } f
     <Chart
       ariaDesc="Average number of pets"
       ariaTitle="Bar chart example"
-      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} voronoiDimension="x" />}
+      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
       domainPadding={{ x: [30, 25] }}
-      legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }, { name: 'Mice' }]}
+      legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
       legendPosition="bottom"
       height={275}
       padding={{
-        bottom: 75, // Adjusted to accomodate legend
+        bottom: 75, // Adjusted to accommodate legend
         left: 50,
         right: 50,
         top: 50
@@ -83,7 +97,8 @@ import { Chart, ChartBar, ChartGroup, ChartThemeColor, ChartVoronoiContainer } f
 </div>
 ```
 
-## Multi-color (ordered), horizontal bar chart with zoom and bottom-left aligned legend
+## Multi-color (ordered), horizontal bar chart with bottom-left aligned legend
+This demonstrates zoom for both the x and y axis
 ```js
 import React from 'react';
 import { Chart, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-charts';
@@ -95,13 +110,13 @@ import { Chart, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-
       ariaDesc="Average number of pets"
       ariaTitle="Bar chart example"
       domainPadding={{ x: [30, 25] }}
-      legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }, { name: 'Mice' }]}
+      legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
       legendPosition="bottom-left"
       height={400}
       padding={{
-        bottom: 75, // Adjusted to accomodate legend
+        bottom: 75, // Adjusted to accommodate legend
         left: 50,
-        right: 100, // Adjusted to accomodate tooltip
+        right: 100, // Adjusted to accommodate tooltip
         top: 50
       }}
       themeColor={ChartThemeColor.multiOrdered}
@@ -109,7 +124,7 @@ import { Chart, ChartBar, ChartGroup, ChartThemeColor } from '@patternfly/react-
     >
       <ChartAxis />
       <ChartAxis dependentAxis showGrid />
-      <ChartGroup allowZoom={true} offset={11} horizontal>
+      <ChartGroup offset={11} horizontal>
         <ChartBar data={[{ name: 'Cats', x: '2015', y: 1 }, { name: 'Cats', x: '2016', y: 2 }, { name: 'Cats', x: '2017', y: 5 }, { name: 'Cats', x: '2018', y: 3 }]} />
         <ChartBar data={[{ name: 'Dogs', x: '2015', y: 2 }, { name: 'Dogs', x: '2016', y: 1 }, { name: 'Dogs', x: '2017', y: 7 }, { name: 'Dogs', x: '2018', y: 4 }]} />
         <ChartBar data={[{ name: 'Birds', x: '2015', y: 4 }, { name: 'Birds', x: '2016', y: 4 }, { name: 'Birds', x: '2017', y: 9 }, { name: 'Birds', x: '2018', y: 7 }]} />
@@ -130,7 +145,7 @@ import { Chart, ChartBar } from '@patternfly/react-charts';
     <Chart
       ariaDesc="Average number of pets"
       ariaTitle="Bar chart example"
-      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} voronoiDimension="x" />}
+      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
       domain={{y: [0,9]}}
       domainPadding={{ x: [30, 25] }}
       legendData={[{ name: 'Cats' }]}
@@ -140,7 +155,7 @@ import { Chart, ChartBar } from '@patternfly/react-charts';
       padding={{
         bottom: 50,
         left: 50,
-        right: 200, // Adjusted to accomodate legend
+        right: 200, // Adjusted to accommodate legend
         top: 50
       }}
       width={600}
@@ -150,3 +165,19 @@ import { Chart, ChartBar } from '@patternfly/react-charts';
   </div>
 </div>
 ```
+
+## Tips
+
+- For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+- `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `Chart` props, see <a href="https://formidable.com/open-source/victory/docs/victory-chart" target="_blank">VictoryChart</a>
+ - For `ChartAxis` props, see <a href="https://formidable.com/open-source/victory/docs/victory-axis" target="_blank">VictoryAxis</a>
+ - For `ChartBar` props, see <a href="https://formidable.com/open-source/victory/docs/victory-bar" target="_blank">VictoryBar</a>
+ - For `ChartGroup` props, see <a href="https://formidable.com/open-source/victory/docs/victory-group" target="_blank">VictoryGroup</a>
+ - For `ChartLegend` props, see <a href="https://formidable.com/open-source/victory/docs/victory-legend" target="_blank">VictoryLegend</a>
+ - For `ChartVoronoiContainer` props, see <a href="https://formidable.com/open-source/victory/docs/victory-voronoi-container" target="_blank">VictoryVoronoiContainer</a>

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBullet.test.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBullet.test.tsx
@@ -15,7 +15,7 @@ test('renders component data', () => {
       ariaDesc="Storage capacity"
       ariaTitle="Bullet chart example"
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
-      labels={(datum) => `${datum.name}: ${datum.y}`}
+      labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       primarySegmentedMeasureData={[{ name: 'Measure', y: 50 }]}
       qualitativeRangeData={[{ name: 'Range', y: 50 }, { name: 'Range', y: 75 }]}

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeErrorMeasure.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeErrorMeasure.tsx
@@ -10,7 +10,7 @@ import {
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition}  from '../ChartTheme';
 import { getBulletComparativeErrorMeasureTheme } from '../ChartUtils';
-import { ChartBulletComparativeMeasure, getComparativeMeasureData } from './ChartBulletComparativeMeasure';
+import { ChartBulletComparativeMeasure } from './ChartBulletComparativeMeasure';
 
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
@@ -38,6 +38,12 @@ export interface ChartBulletComparativeErrorMeasureProps {
    * the chart, and the number of bars.
    */
   barWidth?: NumberOrCallback;
+  /**
+   * The constrainToVisibleArea prop determines whether to coerce tooltips so that they fit within the visible area of
+   * the chart. When this prop is set to true, tooltip pointers will still point to the correct data point, but the
+   * center of the tooltip will be shifted to fit within the overall width and height of the svg Victory renders.
+   */
+  constrainToVisibleArea?: boolean;
   /**
    * The data prop specifies the data to be plotted. Data should be in the form of an array
    * of data points, or an array of arrays of data points for multiple datasets.
@@ -149,37 +155,11 @@ export interface ChartBulletComparativeErrorMeasureProps {
   y?: DataGetterPropType;
 }
 
-interface ChartBulletComparativeErrorMeasureInterface {
-  data?: any[];
-  invert?: boolean;
-  theme?: ChartThemeDefinition;
-  themeColor?: string;
-  themeVariant?: string;
-  y?: DataGetterPropType;
-}
-
-export const getComparativeErrorMeasureData = ({
-  data,
-  themeColor,
-  themeVariant,
-
-  // destructure last
-  theme = getBulletComparativeErrorMeasureTheme(themeColor, themeVariant),
-  y
-}: ChartBulletComparativeErrorMeasureInterface) => {
-  return getComparativeMeasureData({
-    data,
-    theme,
-    themeColor,
-    themeVariant,
-    y
-  });
-};
-
 export const ChartBulletComparativeErrorMeasure: React.FunctionComponent<ChartBulletComparativeErrorMeasureProps> = ({
   ariaDesc,
   ariaTitle,
   barWidth,
+  constrainToVisibleArea = false,
   data,
   domain,
   horizontal = true,
@@ -203,6 +183,7 @@ export const ChartBulletComparativeErrorMeasure: React.FunctionComponent<ChartBu
       ariaDesc,
       ariaTitle,
       barWidth,
+      constrainToVisibleArea,
       data,
       domain,
       height,

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeWarningMeasure.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeWarningMeasure.tsx
@@ -10,7 +10,7 @@ import {
 import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition}  from '../ChartTheme';
 import { getBulletComparativeWarningMeasureTheme } from '../ChartUtils';
-import { ChartBulletComparativeMeasure, getComparativeMeasureData } from './ChartBulletComparativeMeasure';
+import { ChartBulletComparativeMeasure } from './ChartBulletComparativeMeasure';
 
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
@@ -38,6 +38,12 @@ export interface ChartBulletComparativeWarningMeasureProps {
    * the chart, and the number of bars.
    */
   barWidth?: NumberOrCallback;
+  /**
+   * The constrainToVisibleArea prop determines whether to coerce tooltips so that they fit within the visible area of
+   * the chart. When this prop is set to true, tooltip pointers will still point to the correct data point, but the
+   * center of the tooltip will be shifted to fit within the overall width and height of the svg Victory renders.
+   */
+  constrainToVisibleArea?: boolean;
   /**
    * The data prop specifies the data to be plotted. Data should be in the form of an array
    * of data points, or an array of arrays of data points for multiple datasets.
@@ -149,37 +155,11 @@ export interface ChartBulletComparativeWarningMeasureProps {
   y?: DataGetterPropType;
 }
 
-interface ChartBulletComparativeWarningMeasureInterface {
-  data?: any[];
-  invert?: boolean;
-  theme?: ChartThemeDefinition;
-  themeColor?: string;
-  themeVariant?: string;
-  y?: DataGetterPropType;
-}
-
-export const getComparativeWarningMeasureData = ({
-  data,
-  themeColor,
-  themeVariant,
-
-  // destructure last
-  theme = getBulletComparativeWarningMeasureTheme(themeColor, themeVariant),
-  y
-}: ChartBulletComparativeWarningMeasureInterface) => {
-  return getComparativeMeasureData({
-    data,
-    theme,
-    themeColor,
-    themeVariant,
-    y
-  });
-};
-
 export const ChartBulletComparativeWarningMeasure: React.FunctionComponent<ChartBulletComparativeWarningMeasureProps> = ({
   ariaDesc,
   ariaTitle,
   barWidth,
+  constrainToVisibleArea = false,
   data,
   domain,
   horizontal = true,
@@ -203,6 +183,7 @@ export const ChartBulletComparativeWarningMeasure: React.FunctionComponent<Chart
     ariaDesc,
     ariaTitle,
     barWidth,
+    constrainToVisibleArea,
     data,
     domain,
     height,

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
@@ -7,7 +7,7 @@ import { Line } from 'victory-core';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartBulletStyles, ChartThemeDefinition } from '../ChartTheme';
-import { getBulletGroupTitleTheme, getLabelTextSize, getLabelX, getLabelY, getPaddingForSide } from '../ChartUtils';
+import { getBulletGroupTitleTheme, getLabelTextSize, getBulletLabelX, getBulletLabelY, getPaddingForSide } from '../ChartUtils';
 
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
@@ -171,11 +171,11 @@ export const ChartBulletGroupTitle: React.FunctionComponent<ChartBulletGroupTitl
       text: showBoth ? [title, subTitle] : title,
       textAnchor: 'middle',
       verticalAnchor: 'middle',
-      x: getLabelX({
+      x: getBulletLabelX({
         chartWidth: width,
         labelPosition: 'top'
       }),
-      y: getLabelY({
+      y: getBulletLabelY({
         chartHeight: height,
         dy: defaultPadding.top,
         labelPosition: 'top'

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletTitle.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletTitle.tsx
@@ -7,7 +7,7 @@ import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartLegendPosition } from '../ChartLegend';
 import { ChartBulletStyles, ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
-import { getBulletTheme, getLabelX, getLabelY, getPaddingForSide } from '../ChartUtils';
+import { getBulletTheme, getBulletLabelX, getBulletLabelY, getPaddingForSide } from '../ChartUtils';
 
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
@@ -27,35 +27,6 @@ export interface ChartBulletTitleProps {
    * Note: Overridden by the title prop of containerComponent
    */
   ariaTitle?: string;
-  /**
-   * Specifies the height of the bullet chart. This value should be given as a number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and height props do not determine the width and
-   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, height (the overall SVG height) may need to be larger than bulletHeight (the bullet size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, bulletHeight is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, bulletHeight (not height) may need to be set in order to adjust the bullet
-   * height.
-   */
-  bulletHeight?: number;
-  /**
-   * Specifies the width of the bullet chart. This value should be given as a number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and height props do not determine the width and
-   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, width (the overall SVG width) may need to be larger than bulletWidth (the bullet size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, bulletWidth is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, bulletWidth (not width) may need to be set in order to adjust the bullet width.
-   */
-  bulletWidth?: number;
   /**
    * The capHeight prop defines a text metric for the font being used: the expected height of capital letters.
    * This is necessary because of SVG, which (a) positions the *bottom* of the text at `y`, and (b) has no notion of
@@ -171,10 +142,13 @@ export const ChartBulletTitle: React.FunctionComponent<ChartBulletTitleProps> = 
   theme = getBulletTheme(themeColor, themeVariant),
   height = horizontal ? theme.chart.height : theme.chart.width,
   width = horizontal ? theme.chart.width : theme.chart.height,
-  bulletHeight = horizontal ? theme.chart.height : height,
-  bulletWidth = horizontal ? width : theme.chart.height,
   ...rest
 }: ChartBulletTitleProps) => {
+  const chartSize = {
+    height: horizontal ? theme.chart.height : height,
+    width: horizontal ? width : theme.chart.height
+  };
+
   const defaultPadding = {
     bottom: getPaddingForSide('bottom',  padding, theme.chart.padding),
     left: getPaddingForSide('left', padding, theme.chart.padding),
@@ -191,6 +165,8 @@ export const ChartBulletTitle: React.FunctionComponent<ChartBulletTitleProps> = 
       labelPosition = titlePosition;
     }
 
+    // The x and y calculations below are used to adjust the position of the title, based on padding and scale.
+    // This ensures that when padding is adjusted, the title moves along with the chart's position.
     return React.cloneElement(titleComponent, {
       ...showBoth && { capHeight },
       style: [ChartBulletStyles.label.title, ChartBulletStyles.label.subTitle],
@@ -199,8 +175,8 @@ export const ChartBulletTitle: React.FunctionComponent<ChartBulletTitleProps> = 
       verticalAnchor: labelPosition === 'top-left' ? 'end' : 'middle',
       // Adjust for padding
       x: horizontal
-        ? getLabelX({
-          chartWidth: bulletWidth,
+        ? getBulletLabelX({
+          chartWidth: chartSize.width,
           dx: labelPosition === 'top-left'
             ? defaultPadding.left
             : defaultPadding.left - ChartCommonStyles.label.margin * 1.75,
@@ -210,8 +186,8 @@ export const ChartBulletTitle: React.FunctionComponent<ChartBulletTitleProps> = 
         })
         : defaultPadding.left * .5 + (defaultPadding.right * .5 - (defaultPadding.right - 50)) +
           ChartBulletStyles.qualitativeRangeWidth / 2,
-      y: getLabelY({
-        chartHeight: bulletHeight,
+      y: getBulletLabelY({
+        chartHeight: chartSize.height,
         // Adjust for padding
         dy: labelPosition === 'top-left'
           ? defaultPadding.top * .5 + (defaultPadding.bottom * .5 - (defaultPadding.bottom)) + 58 -

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBullet.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBullet.test.tsx.snap
@@ -38,8 +38,6 @@ exports[`ChartBulletQualitativeRange 1`] = `
     width={450}
   />
   <Component
-    bulletHeight={140}
-    bulletWidth={450}
     height={140}
     horizontal={true}
     legendPosition="bottom"
@@ -490,6 +488,8 @@ exports[`ChartBulletQualitativeRange 1`] = `
     width={450}
   />
   <Component
+    barWidth={30}
+    constrainToVisibleArea={false}
     domain={
       Object {
         "x": Array [
@@ -506,10 +506,18 @@ exports[`ChartBulletQualitativeRange 1`] = `
     horizontal={true}
     invert={false}
     key="pf-qualitative-range-0"
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     standalone={false}
     width={450}
   />
   <Component
+    barWidth={9}
+    constrainToVisibleArea={false}
     domain={
       Object {
         "x": Array [
@@ -525,10 +533,17 @@ exports[`ChartBulletQualitativeRange 1`] = `
     height={140}
     horizontal={true}
     invert={false}
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     standalone={false}
     width={450}
   />
   <Component
+    constrainToVisibleArea={false}
     domain={
       Object {
         "x": Array [
@@ -544,10 +559,19 @@ exports[`ChartBulletQualitativeRange 1`] = `
     height={140}
     horizontal={true}
     invert={false}
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
+    size={6}
     standalone={false}
     width={450}
   />
   <Component
+    barWidth={30}
+    constrainToVisibleArea={false}
     domain={
       Object {
         "x": Array [
@@ -562,10 +586,18 @@ exports[`ChartBulletQualitativeRange 1`] = `
     }
     height={140}
     horizontal={true}
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     standalone={false}
     width={450}
   />
   <Component
+    barWidth={30}
+    constrainToVisibleArea={false}
     domain={
       Object {
         "x": Array [
@@ -580,18 +612,22 @@ exports[`ChartBulletQualitativeRange 1`] = `
     }
     height={140}
     horizontal={true}
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     standalone={false}
     width={450}
   />
   <Component
-    chartHeight={140}
-    chartWidth={350}
+    chartType="bullet"
     dx={0}
     dy={-25}
+    height={140}
     orientation="horizontal"
     position="bottom"
-    svgHeight={140}
-    svgWidth={450}
     theme={
       Object {
         "area": Object {
@@ -1035,6 +1071,7 @@ exports[`ChartBulletQualitativeRange 1`] = `
         },
       }
     }
+    width={450}
   >
     <Component
       data={Array []}
@@ -1526,8 +1563,6 @@ exports[`ChartBulletQualitativeRange 2`] = `
     width={450}
   />
   <Component
-    bulletHeight={140}
-    bulletWidth={450}
     height={140}
     horizontal={true}
     legendPosition="bottom"
@@ -1978,6 +2013,8 @@ exports[`ChartBulletQualitativeRange 2`] = `
     width={450}
   />
   <Component
+    barWidth={30}
+    constrainToVisibleArea={false}
     domain={
       Object {
         "x": Array [
@@ -1994,10 +2031,18 @@ exports[`ChartBulletQualitativeRange 2`] = `
     horizontal={true}
     invert={false}
     key="pf-qualitative-range-1"
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     standalone={false}
     width={450}
   />
   <Component
+    barWidth={9}
+    constrainToVisibleArea={false}
     domain={
       Object {
         "x": Array [
@@ -2013,10 +2058,17 @@ exports[`ChartBulletQualitativeRange 2`] = `
     height={140}
     horizontal={true}
     invert={false}
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     standalone={false}
     width={450}
   />
   <Component
+    constrainToVisibleArea={false}
     domain={
       Object {
         "x": Array [
@@ -2032,10 +2084,19 @@ exports[`ChartBulletQualitativeRange 2`] = `
     height={140}
     horizontal={true}
     invert={false}
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
+    size={6}
     standalone={false}
     width={450}
   />
   <Component
+    barWidth={30}
+    constrainToVisibleArea={false}
     domain={
       Object {
         "x": Array [
@@ -2050,10 +2111,18 @@ exports[`ChartBulletQualitativeRange 2`] = `
     }
     height={140}
     horizontal={true}
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     standalone={false}
     width={450}
   />
   <Component
+    barWidth={30}
+    constrainToVisibleArea={false}
     domain={
       Object {
         "x": Array [
@@ -2068,18 +2137,22 @@ exports[`ChartBulletQualitativeRange 2`] = `
     }
     height={140}
     horizontal={true}
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     standalone={false}
     width={450}
   />
   <Component
-    chartHeight={140}
-    chartWidth={350}
+    chartType="bullet"
     dx={0}
     dy={-25}
+    height={140}
     orientation="horizontal"
     position="bottom"
-    svgHeight={140}
-    svgWidth={450}
     theme={
       Object {
         "area": Object {
@@ -2523,6 +2596,7 @@ exports[`ChartBulletQualitativeRange 2`] = `
         },
       }
     }
+    width={450}
   >
     <Component
       data={Array []}
@@ -3020,8 +3094,6 @@ exports[`renders component data 1`] = `
     width={450}
   />
   <Component
-    bulletHeight={140}
-    bulletWidth={450}
     height={140}
     horizontal={true}
     legendPosition="bottom"
@@ -3472,6 +3544,8 @@ exports[`renders component data 1`] = `
     width={450}
   />
   <Component
+    barWidth={30}
+    constrainToVisibleArea={false}
     data={
       Array [
         Object {
@@ -3500,11 +3574,19 @@ exports[`renders component data 1`] = `
     horizontal={true}
     invert={false}
     key="pf-qualitative-range-2"
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     labels={[Function]}
     standalone={false}
     width={450}
   />
   <Component
+    barWidth={9}
+    constrainToVisibleArea={false}
     data={
       Array [
         Object {
@@ -3528,11 +3610,18 @@ exports[`renders component data 1`] = `
     height={140}
     horizontal={true}
     invert={false}
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     labels={[Function]}
     standalone={false}
     width={450}
   />
   <Component
+    constrainToVisibleArea={false}
     domain={
       Object {
         "x": Array [
@@ -3548,11 +3637,20 @@ exports[`renders component data 1`] = `
     height={140}
     horizontal={true}
     invert={false}
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     labels={[Function]}
+    size={6}
     standalone={false}
     width={450}
   />
   <Component
+    barWidth={30}
+    constrainToVisibleArea={false}
     domain={
       Object {
         "x": Array [
@@ -3567,11 +3665,19 @@ exports[`renders component data 1`] = `
     }
     height={140}
     horizontal={true}
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     labels={[Function]}
     standalone={false}
     width={450}
   />
   <Component
+    barWidth={30}
+    constrainToVisibleArea={false}
     data={
       Array [
         Object {
@@ -3594,19 +3700,23 @@ exports[`renders component data 1`] = `
     }
     height={140}
     horizontal={true}
+    labelComponent={
+      <Unknown
+        height={140}
+        width={450}
+      />
+    }
     labels={[Function]}
     standalone={false}
     width={450}
   />
   <Component
-    chartHeight={140}
-    chartWidth={350}
+    chartType="bullet"
     dx={0}
     dy={-25}
+    height={140}
     orientation="horizontal"
     position="bottom"
-    svgHeight={140}
-    svgWidth={450}
     theme={
       Object {
         "area": Object {
@@ -4050,6 +4160,7 @@ exports[`renders component data 1`] = `
         },
       }
     }
+    width={450}
   >
     <Component
       data={Array []}

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeErrorMeasure.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeErrorMeasure.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`ChartBulletComparativeErrorMeasure 1`] = `
   width={450}
 >
   <Component
+    constrainToVisibleArea={false}
     height={140}
     horizontal={true}
     standalone={false}
@@ -469,6 +470,7 @@ exports[`ChartBulletComparativeErrorMeasure 2`] = `
   width={450}
 >
   <Component
+    constrainToVisibleArea={false}
     height={140}
     horizontal={true}
     standalone={false}
@@ -932,6 +934,7 @@ exports[`renders component data 1`] = `
   width={450}
 >
   <Component
+    constrainToVisibleArea={false}
     data={
       Array [
         Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeMeasure.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeMeasure.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`renders component data 1`] = `
     key="pf-comparative-measure-0"
     labelComponent={
       <Unknown
+        constrainToVisibleArea={false}
         dx={[Function]}
         dy={[Function]}
         orientation="top"

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeWarningMeasure.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeWarningMeasure.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`ChartBulletComparativeZeroMeasure 1`] = `
   width={450}
 >
   <Component
+    constrainToVisibleArea={false}
     height={140}
     horizontal={true}
     standalone={false}
@@ -469,6 +470,7 @@ exports[`ChartBulletComparativeZeroMeasure 2`] = `
   width={450}
 >
   <Component
+    constrainToVisibleArea={false}
     height={140}
     horizontal={true}
     standalone={false}
@@ -932,6 +934,7 @@ exports[`renders component data 1`] = `
   width={450}
 >
   <Component
+    constrainToVisibleArea={false}
     data={
       Array [
         Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletPrimaryDotMeasure.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletPrimaryDotMeasure.test.tsx.snap
@@ -23,12 +23,14 @@ exports[`renders component data 1`] = `
     data={
       Array [
         Object {
-          "_color": "#002f5d",
-          "_index": 2,
+          "_color": "#06c",
+          "_index": 0,
           "_x": 1,
-          "_y": 150,
+          "_y": 50,
+          "_y0": 50,
           "x": 1,
-          "y": 150,
+          "y": 50,
+          "y0": 50,
         },
       ]
     }
@@ -45,8 +47,9 @@ exports[`renders component data 1`] = `
     key="pf-primary-dot-measure-0"
     labelComponent={
       <Unknown
-        dx={[Function]}
-        dy={[Function]}
+        constrainToVisibleArea={false}
+        dx={0}
+        dy={-6}
         orientation="top"
       />
     }
@@ -55,498 +58,7 @@ exports[`renders component data 1`] = `
     style={
       Object {
         "data": Object {
-          "fill": "#002f5d",
-        },
-      }
-    }
-    theme={
-      Object {
-        "area": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "#06c",
-              "fillOpacity": 0.3,
-              "strokeWidth": 2,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
-          },
-          "width": 450,
-        },
-        "axis": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "axis": Object {
-              "fill": "transparent",
-              "stroke": "#d2d2d2",
-              "strokeLinecap": "round",
-              "strokeLinejoin": "round",
-              "strokeWidth": 1,
-            },
-            "axisLabel": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 40,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
-            "grid": Object {
-              "fill": "none",
-              "pointerEvents": "painted",
-              "stroke": "none",
-              "strokeLinecap": "round",
-              "strokeLinejoin": "round",
-            },
-            "tickLabels": Object {
-              "fill": "#4f5255",
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "ticks": Object {
-              "fill": "transparent",
-              "size": 5,
-              "stroke": "#d2d2d2",
-              "strokeLinecap": "round",
-              "strokeLinejoin": "round",
-              "strokeWidth": 1,
-            },
-          },
-          "width": 450,
-        },
-        "bar": Object {
-          "barWidth": 10,
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "#06c",
-              "padding": 8,
-              "stroke": "none",
-              "strokeWidth": 0,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-          },
-          "width": 450,
-        },
-        "boxplot": Object {
-          "boxWidth": 20,
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "max": Object {
-              "padding": 8,
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "maxLabels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "median": Object {
-              "padding": 8,
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "medianLabels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "min": Object {
-              "padding": 8,
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "minLabels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "q1": Object {
-              "fill": "#8a8d90",
-              "padding": 8,
-            },
-            "q1Labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "q3": Object {
-              "fill": "#8a8d90",
-              "padding": 8,
-            },
-            "q3Labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-          },
-          "width": 450,
-        },
-        "candlestick": Object {
-          "candleColors": Object {
-            "negative": "#151515",
-            "positive": "#fff",
-          },
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
-          },
-          "width": 450,
-        },
-        "chart": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "width": 450,
-        },
-        "errorbar": Object {
-          "borderWidth": 8,
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "transparent",
-              "opacity": 1,
-              "stroke": "#151515",
-              "strokeWidth": 2,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
-          },
-          "width": 450,
-        },
-        "group": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 140,
-          "padding": 50,
-          "width": 450,
-        },
-        "legend": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "gutter": 20,
-          "orientation": "horizontal",
-          "style": Object {
-            "data": Object {
-              "type": "square",
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-            },
-            "title": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 2,
-              "stroke": "transparent",
-            },
-          },
-          "titleOrientation": "top",
-        },
-        "line": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "transparent",
-              "opacity": 1,
-              "stroke": "#06c",
-              "strokeWidth": 2,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
-          },
-          "width": 450,
-        },
-        "pie": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 230,
-          "padding": 20,
-          "style": Object {
-            "data": Object {
-              "padding": 8,
-              "stroke": "transparent",
-              "strokeWidth": 1,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 8,
-              "stroke": "transparent",
-            },
-          },
-          "width": 230,
-        },
-        "scatter": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "#151515",
-              "opacity": 1,
-              "stroke": "transparent",
-              "strokeWidth": 0,
-            },
-            "labels": Object {
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 10,
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
-          },
-          "width": 450,
-        },
-        "stack": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "strokeWidth": 1,
-            },
-          },
-          "width": 450,
-        },
-        "tooltip": Object {
-          "cornerRadius": 0,
-          "flyoutStyle": Object {
-            "cornerRadius": 0,
-            "fill": "#151515",
-            "pointerEvents": "none",
-            "stroke": "#151515",
-            "strokeWidth": 0,
-          },
-          "pointerLength": 10,
-          "pointerWidth": 20,
-          "style": Object {
-            "fill": "#ededed",
-            "padding": 16,
-            "pointerEvents": "none",
-          },
-        },
-        "voronoi": Object {
-          "colorScale": Array [
-            "#06c",
-            "#8bc1f7",
-            "#002f5d",
-            "#519de9",
-            "#004b95",
-          ],
-          "height": 300,
-          "padding": 50,
-          "style": Object {
-            "data": Object {
-              "fill": "transparent",
-              "stroke": "transparent",
-              "strokeWidth": 0,
-            },
-            "flyout": Object {
-              "fill": "#151515",
-              "pointerEvents": "none",
-              "stroke": "#151515",
-              "strokeWidth": 1,
-            },
-            "labels": Object {
-              "fill": "#ededed",
-              "fontFamily": "var(--pf-chart-global--FontFamily)",
-              "fontSize": 14,
-              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-              "padding": 8,
-              "pointerEvents": "none",
-              "stroke": "transparent",
-              "textAnchor": "middle",
-            },
-          },
-          "width": 450,
-        },
-      }
-    }
-    width={450}
-  />
-  <Component
-    data={
-      Array [
-        Object {
-          "_color": "#8bc1f7",
-          "_index": 1,
-          "_x": 1,
-          "_y": 85,
-          "x": 1,
-          "y": 85,
-        },
-      ]
-    }
-    domain={
-      Object {
-        "x": Array [
-          0,
-          200,
-        ],
-      }
-    }
-    height={140}
-    horizontal={true}
-    key="pf-primary-dot-measure-1"
-    labelComponent={
-      <Unknown
-        dx={[Function]}
-        dy={[Function]}
-        orientation="top"
-      />
-    }
-    size={6}
-    standalone={false}
-    style={
-      Object {
-        "data": Object {
-          "fill": "#8bc1f7",
+          "fill": "#06c",
         },
       }
     }
@@ -1006,11 +518,507 @@ exports[`renders component data 1`] = `
       Array [
         Object {
           "_color": "#06c",
-          "_index": 0,
+          "_index": 1,
           "_x": 1,
-          "_y": 50,
+          "_y": 85,
+          "_y0": 85,
           "x": 1,
-          "y": 50,
+          "y": 85,
+          "y0": 85,
+        },
+      ]
+    }
+    domain={
+      Object {
+        "x": Array [
+          0,
+          200,
+        ],
+      }
+    }
+    height={140}
+    horizontal={true}
+    key="pf-primary-dot-measure-1"
+    labelComponent={
+      <Unknown
+        constrainToVisibleArea={false}
+        dx={0}
+        dy={-6}
+        orientation="top"
+      />
+    }
+    size={6}
+    standalone={false}
+    style={
+      Object {
+        "data": Object {
+          "fill": "#06c",
+        },
+      }
+    }
+    theme={
+      Object {
+        "area": Object {
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 300,
+          "padding": 50,
+          "style": Object {
+            "data": Object {
+              "fill": "#06c",
+              "fillOpacity": 0.3,
+              "strokeWidth": 2,
+            },
+            "labels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+              "textAnchor": "middle",
+            },
+          },
+          "width": 450,
+        },
+        "axis": Object {
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 300,
+          "padding": 50,
+          "style": Object {
+            "axis": Object {
+              "fill": "transparent",
+              "stroke": "#d2d2d2",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
+            },
+            "axisLabel": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 40,
+              "stroke": "transparent",
+              "textAnchor": "middle",
+            },
+            "grid": Object {
+              "fill": "none",
+              "pointerEvents": "painted",
+              "stroke": "none",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+            },
+            "tickLabels": Object {
+              "fill": "#4f5255",
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+            },
+            "ticks": Object {
+              "fill": "transparent",
+              "size": 5,
+              "stroke": "#d2d2d2",
+              "strokeLinecap": "round",
+              "strokeLinejoin": "round",
+              "strokeWidth": 1,
+            },
+          },
+          "width": 450,
+        },
+        "bar": Object {
+          "barWidth": 10,
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 300,
+          "padding": 50,
+          "style": Object {
+            "data": Object {
+              "fill": "#06c",
+              "padding": 8,
+              "stroke": "none",
+              "strokeWidth": 0,
+            },
+            "labels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+            },
+          },
+          "width": 450,
+        },
+        "boxplot": Object {
+          "boxWidth": 20,
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 300,
+          "padding": 50,
+          "style": Object {
+            "max": Object {
+              "padding": 8,
+              "stroke": "#151515",
+              "strokeWidth": 1,
+            },
+            "maxLabels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+            },
+            "median": Object {
+              "padding": 8,
+              "stroke": "#151515",
+              "strokeWidth": 1,
+            },
+            "medianLabels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+            },
+            "min": Object {
+              "padding": 8,
+              "stroke": "#151515",
+              "strokeWidth": 1,
+            },
+            "minLabels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+            },
+            "q1": Object {
+              "fill": "#8a8d90",
+              "padding": 8,
+            },
+            "q1Labels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+            },
+            "q3": Object {
+              "fill": "#8a8d90",
+              "padding": 8,
+            },
+            "q3Labels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+            },
+          },
+          "width": 450,
+        },
+        "candlestick": Object {
+          "candleColors": Object {
+            "negative": "#151515",
+            "positive": "#fff",
+          },
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 300,
+          "padding": 50,
+          "style": Object {
+            "data": Object {
+              "stroke": "#151515",
+              "strokeWidth": 1,
+            },
+            "labels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+              "textAnchor": "middle",
+            },
+          },
+          "width": 450,
+        },
+        "chart": Object {
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 300,
+          "padding": 50,
+          "width": 450,
+        },
+        "errorbar": Object {
+          "borderWidth": 8,
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 300,
+          "padding": 50,
+          "style": Object {
+            "data": Object {
+              "fill": "transparent",
+              "opacity": 1,
+              "stroke": "#151515",
+              "strokeWidth": 2,
+            },
+            "labels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+              "textAnchor": "middle",
+            },
+          },
+          "width": 450,
+        },
+        "group": Object {
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 140,
+          "padding": 50,
+          "width": 450,
+        },
+        "legend": Object {
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "gutter": 20,
+          "orientation": "horizontal",
+          "style": Object {
+            "data": Object {
+              "type": "square",
+            },
+            "labels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+            },
+            "title": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 2,
+              "stroke": "transparent",
+            },
+          },
+          "titleOrientation": "top",
+        },
+        "line": Object {
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 300,
+          "padding": 50,
+          "style": Object {
+            "data": Object {
+              "fill": "transparent",
+              "opacity": 1,
+              "stroke": "#06c",
+              "strokeWidth": 2,
+            },
+            "labels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+              "textAnchor": "middle",
+            },
+          },
+          "width": 450,
+        },
+        "pie": Object {
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 230,
+          "padding": 20,
+          "style": Object {
+            "data": Object {
+              "padding": 8,
+              "stroke": "transparent",
+              "strokeWidth": 1,
+            },
+            "labels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 8,
+              "stroke": "transparent",
+            },
+          },
+          "width": 230,
+        },
+        "scatter": Object {
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 300,
+          "padding": 50,
+          "style": Object {
+            "data": Object {
+              "fill": "#151515",
+              "opacity": 1,
+              "stroke": "transparent",
+              "strokeWidth": 0,
+            },
+            "labels": Object {
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 10,
+              "stroke": "transparent",
+              "textAnchor": "middle",
+            },
+          },
+          "width": 450,
+        },
+        "stack": Object {
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 300,
+          "padding": 50,
+          "style": Object {
+            "data": Object {
+              "strokeWidth": 1,
+            },
+          },
+          "width": 450,
+        },
+        "tooltip": Object {
+          "cornerRadius": 0,
+          "flyoutStyle": Object {
+            "cornerRadius": 0,
+            "fill": "#151515",
+            "pointerEvents": "none",
+            "stroke": "#151515",
+            "strokeWidth": 0,
+          },
+          "pointerLength": 10,
+          "pointerWidth": 20,
+          "style": Object {
+            "fill": "#ededed",
+            "padding": 16,
+            "pointerEvents": "none",
+          },
+        },
+        "voronoi": Object {
+          "colorScale": Array [
+            "#06c",
+            "#8bc1f7",
+            "#002f5d",
+            "#519de9",
+            "#004b95",
+          ],
+          "height": 300,
+          "padding": 50,
+          "style": Object {
+            "data": Object {
+              "fill": "transparent",
+              "stroke": "transparent",
+              "strokeWidth": 0,
+            },
+            "flyout": Object {
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 1,
+            },
+            "labels": Object {
+              "fill": "#ededed",
+              "fontFamily": "var(--pf-chart-global--FontFamily)",
+              "fontSize": 14,
+              "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+              "padding": 8,
+              "pointerEvents": "none",
+              "stroke": "transparent",
+              "textAnchor": "middle",
+            },
+          },
+          "width": 450,
+        },
+      }
+    }
+    width={450}
+  />
+  <Component
+    data={
+      Array [
+        Object {
+          "_color": "#06c",
+          "_index": 2,
+          "_x": 1,
+          "_y": 150,
+          "_y0": 150,
+          "x": 1,
+          "y": 150,
+          "y0": 150,
         },
       ]
     }
@@ -1027,8 +1035,9 @@ exports[`renders component data 1`] = `
     key="pf-primary-dot-measure-2"
     labelComponent={
       <Unknown
-        dx={[Function]}
-        dy={[Function]}
+        constrainToVisibleArea={false}
+        dx={0}
+        dy={-6}
         orientation="top"
       />
     }

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletPrimarySegmentedMeasure.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletPrimarySegmentedMeasure.test.tsx.snap
@@ -46,6 +46,7 @@ exports[`renders component data 1`] = `
     key="pf-primary-segmented-measure-0"
     labelComponent={
       <Unknown
+        constrainToVisibleArea={false}
         dx={[Function]}
         dy={[Function]}
         orientation="top"
@@ -537,6 +538,7 @@ exports[`renders component data 1`] = `
     key="pf-primary-segmented-measure-1"
     labelComponent={
       <Unknown
+        constrainToVisibleArea={false}
         dx={[Function]}
         dy={[Function]}
         orientation="top"
@@ -1028,6 +1030,7 @@ exports[`renders component data 1`] = `
     key="pf-primary-segmented-measure-2"
     labelComponent={
       <Unknown
+        constrainToVisibleArea={false}
         dx={[Function]}
         dy={[Function]}
         orientation="top"

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletQualitativeRange.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletQualitativeRange.test.tsx.snap
@@ -46,6 +46,7 @@ exports[`renders component data 1`] = `
     key="pf-qualitative-range-0"
     labelComponent={
       <Unknown
+        constrainToVisibleArea={false}
         dx={[Function]}
         dy={[Function]}
         orientation="top"
@@ -537,6 +538,7 @@ exports[`renders component data 1`] = `
     key="pf-qualitative-range-1"
     labelComponent={
       <Unknown
+        constrainToVisibleArea={false}
         dx={[Function]}
         dy={[Function]}
         orientation="top"
@@ -1028,6 +1030,7 @@ exports[`renders component data 1`] = `
     key="pf-qualitative-range-2"
     labelComponent={
       <Unknown
+        constrainToVisibleArea={false}
         dx={[Function]}
         dy={[Function]}
         orientation="top"

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -2,11 +2,25 @@
 title: 'Bullet'
 section: 'charts'
 typescript: true
-propComponents: ['ChartAxis', 'ChartBullet']
+propComponents: ['ChartAxis', 'ChartBullet', 'ChartContainer', 'ChartLegend']
 ---
 
-import { ChartAxis, ChartBullet, ChartContainer, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
+import { ChartAxis, ChartBullet, ChartContainer, ChartThemeColor } from '@patternfly/react-charts';
 import './chart-bullet.scss';
+
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+## Tutorial
+
+PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, 
+along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React 
+based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+In this tutorial, we will build a bar chart together - starting with a simple chart, adding qualitative ranges, 
+primary comparative measures, a comparative warning measure, tooltips, labels, a legend, and concluding by changing the 
+theme color. You'll learn how to use React chart components together to build a consistent user experience.
+
+[Start course](https://katacoda.com/patternfly/courses/charts/module-bullet)
 
 ## Simple bullet chart
 ```js
@@ -19,8 +33,9 @@ import { ChartBullet } from '@patternfly/react-charts';
       ariaDesc="Storage capacity"
       ariaTitle="Bullet chart example"
       comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
+      constrainToVisibleArea
       height={150}
-      labels={datum => `${datum.name}: ${datum.y}`}
+      labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       primarySegmentedMeasureData={[{ name: 'Measure', y: 60 }]}
       qualitativeRangeData={[{ name: 'Range', y: 50 }, { name: 'Range', y: 75 }]}
@@ -42,12 +57,13 @@ import { ChartBullet } from '@patternfly/react-charts';
       ariaTitle="Bullet chart example"
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+      constrainToVisibleArea
       height={200}
-      labels={datum => `${datum.name}: ${datum.y}`}
+      labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
         bottom: 50,
-        left: 150, // Adjusted to accomodate labels
+        left: 150, // Adjusted to accommodate labels
         right: 50,
         top: 50
       }}
@@ -102,8 +118,9 @@ class MultiColorChart extends React.Component {
             ariaTitle="Bullet chart example"
             comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
             comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+            constrainToVisibleArea
             height={250}
-            labels={datum => `${datum.name}: ${datum.y}`}
+            labels={({ datum }) => `${datum.name}: ${datum.y}`}
             legendItemsPerRow={itemsPerRow}
             legendPosition="bottom-left"
             maxDomain={{y: 100}}
@@ -111,7 +128,7 @@ class MultiColorChart extends React.Component {
               bottom: 50,
               left: 50,
               right: 50,
-              top: 100 // Adjusted to accomodate labels
+              top: 100 // Adjusted to accommodate labels
             }}
             primarySegmentedMeasureData={[{ name: 'Measure', y: 25 }, { name: 'Measure', y: 60 }]}
             primarySegmentedMeasureLegendData={[{ name: 'Measure 1' }, { name: 'Measure 2' }]}
@@ -141,12 +158,13 @@ import { ChartBullet } from '@patternfly/react-charts';
       ariaTitle="Bullet chart example"
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+      constrainToVisibleArea
       height={200}
-      labels={datum => `${datum.name}: ${datum.y}`}
+      labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
         bottom: 50,
-        left: 150, // Adjusted to accomodate labels
+        left: 150, // Adjusted to accommodate labels
         right: 50,
         top: 50
       }}
@@ -177,12 +195,13 @@ import { ChartAxis, ChartBullet } from '@patternfly/react-charts';
       comparativeErrorMeasureLegendData={[{ name: 'Error' }]}
       comparativeWarningMeasureData={[{name: 'Warning', y: 80}]}
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+      constrainToVisibleArea
       height={200}
-      labels={datum => `${datum.name}: ${datum.y}`}
+      labels={({ datum }) => `${datum.name}: ${datum.y}`}
       legendItemsPerRow={3}
       padding={{
         bottom: 50,
-        left: 150, // Adjusted to accomodate labels
+        left: 150, // Adjusted to accommodate labels
         right: 50,
         top: 50
       }}
@@ -209,16 +228,17 @@ import { ChartBullet } from '@patternfly/react-charts';
     <ChartBullet
       ariaDesc="Storage capacity"
       ariaTitle="Bullet chart example"
-      comparativeWarningMeasureData={[{name: 'Warning', y: 100}]}
+      comparativeWarningMeasureData={[{name: 'Warning', y: 80}]}
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
-      labels={datum => `${datum.name}: ${datum.y}`}
+      constrainToVisibleArea
+      labels={({ datum }) => `${datum.name}: ${datum.y}`}
       height={200}
       maxDomain={{y: 125}}
       minDomain={{y: 50}}
       padding={{
         bottom: 50,
-        left: 150, // Adjusted to accomodate labels
-        right: 50,
+        left: 150, // Adjusted to accommodate labels
+        right: 75,
         top: 50
       }}
       primarySegmentedMeasureData={[{ name: 'Measure', y: 75 }, { name: 'Measure', y: 135 }]}
@@ -246,13 +266,14 @@ import { ChartBullet } from '@patternfly/react-charts';
       ariaTitle="Bullet chart example"
       comparativeWarningMeasureData={[{name: 'Warning', y: 60}]}
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+      constrainToVisibleArea
       height={200}
-      labels={datum => `${datum.name}: ${datum.y}`}
+      labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 75}}
       minDomain={{y: -25}}
       padding={{
         bottom: 50,
-        left: 150, // Adjusted to accomodate labels
+        left: 150, // Adjusted to accommodate labels
         right: 50,
         top: 65
       }}
@@ -280,17 +301,18 @@ import { ChartBullet } from '@patternfly/react-charts';
       ariaTitle="Bullet chart example"
       comparativeWarningMeasureData={[{name: 'Warning', y: -88}]}
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+      constrainToVisibleArea
       invert
       height={200}
-      labels={datum => `${datum.name}: ${datum.y}`}
+      labels={({ datum }) => `${datum.name}: ${datum.y}`}
       legendPosition="right"
       legendOrientation="vertical"
       maxDomain={{y: 0}}
       minDomain={{y: -100}}
       padding={{
         bottom: 50,
-        left: 150, // Adjusted to accomodate labels
-        right: 150, // Adjusted to accomodate legend
+        left: 150, // Adjusted to accommodate labels
+        right: 150, // Adjusted to accommodate legend
         top: 80
       }}
       primarySegmentedMeasureData={[{ name: 'Measure', y: -60 }, { name: 'Measure', y: -25 }]}
@@ -317,14 +339,15 @@ import { ChartBullet } from '@patternfly/react-charts';
       ariaTitle="Bullet chart example"
       comparativeWarningMeasureData={[{name: 'Warning', y: 60}]}
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+      constrainToVisibleArea
       height={200}
-      labels={datum => `${datum.name}: ${datum.y}`}
+      labels={({ datum }) => `${datum.name}: ${datum.y}`}
       legendItemsPerRow={4}
       maxDomain={{y: 75}}
       minDomain={{y: -25}}
       padding={{
         bottom: 50,
-        left: 150, // Adjusted to accomodate labels
+        left: 150, // Adjusted to accommodate labels
         right: 50,
         top: 65
       }}
@@ -352,12 +375,13 @@ import { ChartBullet } from '@patternfly/react-charts';
       ariaTitle="Bullet chart example"
       comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+      constrainToVisibleArea
       height={500}
       horizontal={false}
-      labels={datum => `${datum.name}: ${datum.y}`}
+      labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
-        bottom: 125, // Adjusted to accomodate legend
+        bottom: 125, // Adjusted to accommodate legend
         left: 400,
         right: 50,
         top: 50
@@ -386,16 +410,17 @@ import { ChartBullet } from '@patternfly/react-charts';
       ariaTitle="Bullet chart example"
       comparativeWarningMeasureData={[{name: 'Warning', y: 100}]}
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+      constrainToVisibleArea
       height={500}
       horizontal={false}
-      labels={datum => `${datum.name}: ${datum.y}`}
+      labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 125}}
       minDomain={{y: 50}}
       padding={{
-        bottom: 125, // Adjusted to accomodate legend
+        bottom: 125, // Adjusted to accommodate legend
         left: 400,
         right: 50,
-        top: 100 // Adjusted to accomodate primary segmented measure tooltip
+        top: 50 // Adjusted to accommodate primary segmented measure tooltip
       }}
       primarySegmentedMeasureData={[{ name: 'Measure', y: 75 }, { name: 'Measure', y: 135 }]}
       primarySegmentedMeasureLegendData={[{ name: 'Measure 1' }, { name: 'Measure 2' }]}
@@ -410,7 +435,7 @@ import { ChartBullet } from '@patternfly/react-charts';
 </div>
 ```
 
-## Custom height bullet chart
+## Custom bullet chart size
 ```js
 import React from 'react';
 import { ChartBullet } from '@patternfly/react-charts';
@@ -420,11 +445,11 @@ import { ChartBullet } from '@patternfly/react-charts';
     <ChartBullet
       ariaDesc="Storage capacity"
       ariaTitle="Bullet chart example"
-      bulletHeight={160}
+      bulletSize={160}
       comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
       comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
       height={200}
-      labels={datum => `${datum.name}: ${datum.y}`}
+      labels={({ datum }) => `${datum.name}: ${datum.y}`}
       maxDomain={{y: 100}}
       padding={{
         bottom: 50,
@@ -459,12 +484,13 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       >
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 78}]}
+        constrainToVisibleArea
         height={500}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 100, // Adjusted to accomodate legend
-          left: 150, // Adjusted to accomodate labels
+          bottom: 100, // Adjusted to accommodate legend
+          left: 150, // Adjusted to accommodate labels
           right: 50,
           top: 75
         }}
@@ -477,12 +503,13 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       />
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
+        constrainToVisibleArea
         height={500}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 100, // Adjusted to accomodate legend
-          left: 150, // Adjusted to accomodate labels
+          bottom: 100, // Adjusted to accommodate legend
+          left: 150, // Adjusted to accommodate labels
           right: 50,
           top: 300
         }}
@@ -495,12 +522,13 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       />
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 98}]}
+        constrainToVisibleArea
         height={500}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 100, // Adjusted to accomodate legend
-          left: 150, // Adjusted to accomodate labels
+          bottom: 100, // Adjusted to accommodate legend
+          left: 150, // Adjusted to accommodate labels
           right: 50,
           top: 525
         }}
@@ -514,12 +542,13 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 78}]}
         comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+        constrainToVisibleArea
         height={500}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 100, // Adjusted to accomodate legend
-          left: 150, // Adjusted to accomodate labels
+          bottom: 100, // Adjusted to accommodate legend
+          left: 150, // Adjusted to accommodate labels
           right: 50,
           top: 750
         }}
@@ -553,12 +582,13 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 78}]}
         comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+        constrainToVisibleArea
         height={600}
         horizontal={false}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 125, // Adjusted to accomodate legend
+          bottom: 125, // Adjusted to accommodate legend
           left: 50,
           right: 50,
           top: 50
@@ -574,12 +604,13 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       />
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
+        constrainToVisibleArea
         height={600}
         horizontal={false}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 125, // Adjusted to accomodate legend
+          bottom: 125, // Adjusted to accommodate legend
           left: 300,
           right: 50,
           top: 50
@@ -593,12 +624,13 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       />
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 98}]}
+        constrainToVisibleArea
         height={600}
         horizontal={false}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 125, // Adjusted to accomodate legend
+          bottom: 125, // Adjusted to accommodate legend
           left: 550,
           right: 50,
           top: 50
@@ -612,12 +644,13 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       />
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 78}]}
+        constrainToVisibleArea
         height={600}
         horizontal={false}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 125, // Adjusted to accomodate legend
+          bottom: 125, // Adjusted to accommodate legend
           left: 800,
           right: 50,
           top: 50
@@ -649,16 +682,17 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       >
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 78}]}
+        constrainToVisibleArea
         groupSubTitle="Measure details"
         groupTitle="Text label"
         height={575}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 100, // Adjusted to accomodate legend
-          left: 150, // Adjusted to accomodate labels
+          bottom: 100, // Adjusted to accommodate legend
+          left: 150, // Adjusted to accommodate labels
           right: 50,
-          top: 275 // Adjusted to accomodate group labels
+          top: 275 // Adjusted to accommodate group labels
         }}
         primarySegmentedMeasureData={[{ name: 'Measure', y: 15 }, { name: 'Measure', y: 50 }]}
         qualitativeRangeData={[{ name: 'Range', y: 40 }, { name: 'Range', y: 65 }]}
@@ -669,14 +703,15 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       />
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
+        constrainToVisibleArea
         height={600}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 100, // Adjusted to accomodate legend
-          left: 150, // Adjusted to accomodate labels
+          bottom: 100, // Adjusted to accommodate legend
+          left: 150, // Adjusted to accommodate labels
           right: 50,
-          top: 500 // Adjusted to accomodate group labels
+          top: 500 // Adjusted to accommodate group labels
         }}
         primarySegmentedMeasureData={[{ name: 'Measure', y: 25 }, { name: 'Measure', y: 60 }]}
         qualitativeRangeData={[{ name: 'Range', y: 50 }, { name: 'Range', y: 75 }]}
@@ -687,14 +722,15 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       />
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 98}]}
+        constrainToVisibleArea
         height={600}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 100, // Adjusted to accomodate legend
-          left: 150, // Adjusted to accomodate labels
+          bottom: 100, // Adjusted to accommodate legend
+          left: 150, // Adjusted to accommodate labels
           right: 50,
-          top: 725 // Adjusted to accomodate group labels
+          top: 725 // Adjusted to accommodate group labels
         }}
         primarySegmentedMeasureData={[{ name: 'Measure', y: 35 }, { name: 'Measure', y: 70 }]}
         qualitativeRangeData={[{ name: 'Range', y: 60 }, { name: 'Range', y: 85 }]}
@@ -706,14 +742,15 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 78}]}
         comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+        constrainToVisibleArea
         height={600}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 100, // Adjusted to accomodate legend
-          left: 150, // Adjusted to accomodate labels
+          bottom: 100, // Adjusted to accommodate legend
+          left: 150, // Adjusted to accommodate labels
           right: 50,
-          top: 950 // Adjusted to accomodate group labels
+          top: 950 // Adjusted to accommodate group labels
         }}
         primarySegmentedMeasureData={[{ name: 'Measure', y: 15 }, { name: 'Measure', y: 50 }]}
         primarySegmentedMeasureLegendData={[{ name: 'Measure 1' }, { name: 'Measure 2' }]}
@@ -745,17 +782,18 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 78}]}
         comparativeWarningMeasureLegendData={[{ name: 'Warning' }]}
+        constrainToVisibleArea
         groupSubTitle="Measure details"
         groupTitle="Text label"
         height={600}
         horizontal={false}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 125, // Adjusted to accomodate legend
+          bottom: 125, // Adjusted to accommodate legend
           left: 50,
           right: 50,
-          top: 150 // Adjusted to accomodate group labels
+          top: 150 // Adjusted to accommodate group labels
         }}
         primarySegmentedMeasureData={[{ name: 'Measure', y: 15 }, { name: 'Measure', y: 50 }]}
         primarySegmentedMeasureLegendData={[{ name: 'Measure 1' }, { name: 'Measure 2' }]}
@@ -768,15 +806,16 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       />
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 88}]}
+        constrainToVisibleArea
         height={600}
         horizontal={false}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 125, // Adjusted to accomodate legend
+          bottom: 125, // Adjusted to accommodate legend
           left: 300,
           right: 50,
-          top: 150 // Adjusted to accomodate group labels
+          top: 150 // Adjusted to accommodate group labels
         }}
         primarySegmentedMeasureData={[{ name: 'Measure', y: 25 }, { name: 'Measure', y: 60 }]}
         qualitativeRangeData={[{ name: 'Range', y: 50 }, { name: 'Range', y: 75 }]}
@@ -787,15 +826,16 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       />
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 98}]}
+        constrainToVisibleArea
         height={600}
         horizontal={false}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 125, // Adjusted to accomodate legend
+          bottom: 125, // Adjusted to accommodate legend
           left: 550,
           right: 50,
-          top: 150 // Adjusted to accomodate group labels
+          top: 150 // Adjusted to accommodate group labels
         }}
         primarySegmentedMeasureData={[{ name: 'Measure', y: 35 }, { name: 'Measure', y: 70 }]}
         qualitativeRangeData={[{ name: 'Range', y: 60 }, { name: 'Range', y: 85 }]}
@@ -806,15 +846,16 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
       />
       <ChartBullet
         comparativeWarningMeasureData={[{name: 'Warning', y: 78}]}
+        constrainToVisibleArea
         height={600}
         horizontal={false}
-        labels={datum => `${datum.name}: ${datum.y}`}
+        labels={({ datum }) => `${datum.name}: ${datum.y}`}
         maxDomain={{y: 100}}
         padding={{
-          bottom: 125, // Adjusted to accomodate legend
+          bottom: 125, // Adjusted to accommodate legend
           left: 800,
           right: 50,
-          top: 150 // Adjusted to accomodate group labels
+          top: 150 // Adjusted to accommodate group labels
         }}
         primarySegmentedMeasureData={[{ name: 'Measure', y: 15 }, { name: 'Measure', y: 50 }]}
         qualitativeRangeData={[{ name: 'Range', y: 40 }, { name: 'Range', y: 65 }]}
@@ -827,3 +868,16 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
   </div>
 </div>
 ```
+
+## Tips
+
+- `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `ChartAxis` props, see <a href="https://formidable.com/open-source/victory/docs/victory-axis" target="_blank">VictoryAxis</a>
+ - For `ChartBullet` props, see <a href="https://formidable.com/open-source/victory/docs/victory-bar" target="_blank">VictoryBar</a>
+ - For `ChartContainer` props, see <a href="https://formidable.com/open-source/victory/docs/victory-container" target="_blank">VictoryContainer</a>
+ - For `ChartLegend` props, see <a href="https://formidable.com/open-source/victory/docs/victory-legend" target="_blank">VictoryLegend</a>

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/utils/chart-bullet-data.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/utils/chart-bullet-data.ts
@@ -1,0 +1,210 @@
+import { DataGetterPropType } from 'victory';
+import { Data } from 'victory-core';
+import { ChartThemeDefinition } from '../../ChartTheme';
+import {
+  getBulletComparativeErrorMeasureTheme,
+  getBulletComparativeMeasureTheme,
+  getBulletComparativeWarningMeasureTheme,
+  getBulletPrimaryDotMeasureTheme,
+  getBulletPrimaryNegativeMeasureTheme,
+  getBulletPrimarySegmentedMeasureTheme,
+  getBulletQualitativeRangeTheme
+} from '../../ChartUtils';
+
+interface ChartBulletDataInterface {
+  data?: any[];
+  invert?: boolean;
+  negativeMeasureTheme?: ChartThemeDefinition;
+  theme?: ChartThemeDefinition;
+  themeColor?: string;
+  themeVariant?: string;
+  y?: DataGetterPropType;
+  y0?: DataGetterPropType;
+}
+
+export const getComparativeErrorMeasureData = ({
+  data,
+  themeColor,
+  themeVariant,
+
+  // destructure last
+  theme = getBulletComparativeErrorMeasureTheme(themeColor, themeVariant),
+  y
+}: ChartBulletDataInterface) => {
+  return getComparativeMeasureData({
+    data,
+    theme,
+    themeColor,
+    themeVariant,
+    y
+  });
+};
+
+export const getComparativeMeasureData = ({
+  data,
+  themeColor,
+  themeVariant,
+
+  // destructure last
+  theme = getBulletComparativeMeasureTheme(themeColor, themeVariant),
+  y
+}: ChartBulletDataInterface) => {
+  const datum: any[] = [];
+
+  Data.formatData(data, {y}, ['y']).forEach(((dataPoint: any, index: number) => {
+    datum.push({
+      ...dataPoint,
+      _index: index // Save to sync legend color
+    });
+  }));
+
+  const computedData = datum.map((dataPoint: any, index: number) => {
+    return {
+      ...dataPoint,
+      x: 1,
+      _x: 1,
+      y0: dataPoint._y,
+      _y0: dataPoint._y,
+      _color: theme.bar.style.data.fill // Save to sync legend color
+    };
+  });
+  return computedData;
+};
+
+export const getComparativeWarningMeasureData = ({
+  data,
+  themeColor,
+  themeVariant,
+
+  // destructure last
+  theme = getBulletComparativeWarningMeasureTheme(themeColor, themeVariant),
+  y
+}: ChartBulletDataInterface) => {
+  return getComparativeMeasureData({
+    data,
+    theme,
+    themeColor,
+    themeVariant,
+    y
+  });
+};
+
+export const getPrimaryDotMeasureData = ({
+  data,
+  invert,
+  themeColor,
+  themeVariant,
+
+  // destructure last
+  theme = getBulletPrimaryDotMeasureTheme(themeColor, themeVariant),
+  y,
+  y0
+}: ChartBulletDataInterface) => {
+  return getComparativeMeasureData({
+    data,
+    invert,
+    theme,
+    themeColor,
+    themeVariant,
+    y,
+    y0
+  });
+};
+
+export const getPrimarySegmentedMeasureData = ({
+  data,
+  invert,
+  themeColor,
+  themeVariant,
+
+  // destructure last
+  theme = getBulletPrimarySegmentedMeasureTheme(themeColor, themeVariant),
+  negativeMeasureTheme = getBulletPrimaryNegativeMeasureTheme(themeColor, themeVariant),
+  y,
+  y0
+}: ChartBulletDataInterface) => {
+  const negativeDatum: any[] = [];
+  const positiveDatum: any[] = [];
+
+  Data.formatData(data, {y, y0}, ['y', 'y0']).forEach(((dataPoint: any, index: number) => {
+    if (dataPoint._y < 0) {
+      negativeDatum.push({
+        ...dataPoint,
+        _index: index // Save to sync legend color
+      });
+    } else {
+      positiveDatum.push({
+        ...dataPoint,
+        _index: index // Save to sync legend color
+      });
+    }
+  }));
+
+  // Instead of relying on colorScale, colors must be added to each measure in ascending order
+  const negativeComputedData = negativeDatum.sort((a: any, b: any) => b._y - a._y).
+    map((dataPoint: any, index: number) => {
+      return {
+        ...dataPoint,
+        x: 1,
+        _x: 1,
+        _color: invert
+          ? theme.group.colorScale[index % theme.group.colorScale.length]
+          : negativeMeasureTheme.group.colorScale[index % theme.group.colorScale.length]
+      };
+      // Sort descending so largest bar is appears behind others
+    }).reverse();
+
+  // Instead of relying on colorScale, colors must be added to each measure in ascending order
+  const positiveComputedData = positiveDatum.sort((a: any, b: any) => a._y - b._y).
+    map((dataPoint: any, index: number) => {
+      return {
+        ...dataPoint,
+        x: 1,
+        _x: 1,
+        _color: invert
+          ? negativeMeasureTheme.group.colorScale[index % theme.group.colorScale.length]
+          : theme.group.colorScale[index % theme.group.colorScale.length]
+      };
+      // Sort descending so largest bar is appears behind others
+    }).reverse();
+
+  return [
+    ...negativeComputedData,
+    ...positiveComputedData
+  ];
+};
+
+export const getQualitativeRangeData = ({
+  data,
+  invert,
+  themeColor,
+  themeVariant,
+
+  // destructure last
+  theme = getBulletQualitativeRangeTheme(themeColor, themeVariant),
+  y,
+  y0
+}: ChartBulletDataInterface) => {
+  const datum: any[] = [];
+
+  Data.formatData(data, {y, y0}, ['y', 'y0']).forEach(((dataPoint: any, index: number) => {
+    datum.push({
+      ...dataPoint,
+      _index: index // Save to sync legend color
+    });
+  }));
+
+  const computedData = datum.sort((a: any, b: any) => invert ? b._y - a._y : a._y - b._y).
+    map((dataPoint: any, index: number) => {
+      return {
+        ...dataPoint,
+        x: 1,
+        _x: 1,
+        // Instead of relying on colorScale, colors must be added to each measure in ascending order
+        _color: theme.group.colorScale[index % theme.group.colorScale.length]
+      };
+      // Sort descending so largest bar is appears behind others
+    }).reverse();
+
+  return computedData;
+};

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/utils/chart-bullet-domain.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/utils/chart-bullet-domain.ts
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { ChartDomain, getDomains } from '../../ChartUtils';
+
+interface ChartBulletDomainInterface {
+  comparativeErrorMeasureComponent?: React.ReactElement<any>;
+  comparativeErrorMeasureData?: any[];
+  comparativeWarningMeasureComponent?: React.ReactElement<any>;
+  comparativeWarningMeasureData?: any[];
+  primaryDotMeasureComponent?: React.ReactElement<any>;
+  primaryDotMeasureData?: any[];
+  primarySegmentedMeasureComponent?: React.ReactElement<any>;
+  primarySegmentedMeasureData?: any[];
+  maxDomain?: any;
+  minDomain?: any;
+  qualitativeRangeComponent?: React.ReactElement<any>;
+  qualitativeRangeData?: any[];
+}
+
+// Returns the bullet chart's min and max domain for comparative / primary measures and qualitative range data
+export const getBulletDomain = ({
+  comparativeErrorMeasureComponent,
+  comparativeErrorMeasureData,
+  comparativeWarningMeasureComponent,
+  comparativeWarningMeasureData,
+  primaryDotMeasureComponent,
+  primaryDotMeasureData,
+  primarySegmentedMeasureComponent,
+  primarySegmentedMeasureData,
+  maxDomain,
+  minDomain,
+  qualitativeRangeComponent,
+  qualitativeRangeData
+}: ChartBulletDomainInterface): ChartDomain => {
+  const domain = getDomains({
+    maxDomain,
+    minDomain,
+    sources: [{
+      component: comparativeErrorMeasureComponent,
+      data: comparativeErrorMeasureData
+    }, {
+      component: comparativeWarningMeasureComponent,
+      data: comparativeWarningMeasureData
+    }, {
+      component: primaryDotMeasureComponent,
+      data: primaryDotMeasureData
+    }, {
+      component: primarySegmentedMeasureComponent,
+      data: primarySegmentedMeasureData
+    }, {
+      component: qualitativeRangeComponent,
+      data: qualitativeRangeData
+    }]
+  });
+  // Note that comparative measures and qualitative range bars are currently given an x-value of 1, while the bar widths
+  // fill the domain. At one point, lines were used to represent comparative warning, comparative error, and zero
+  // measures. Those components had x-values of 0 and 2, which rendered the lines on top of the comparative measure and
+  // qualitative range bars.
+  domain.x = [0, 2];
+  return domain;
+};

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/utils/chart-bullet-size.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/utils/chart-bullet-size.ts
@@ -1,0 +1,161 @@
+import { ChartThemeDefinition } from '../../ChartTheme';
+import { ChartBulletStyles }  from '../../ChartTheme';
+import {
+  getBulletComparativeErrorMeasureTheme,
+  getBulletComparativeMeasureTheme,
+  getBulletComparativeWarningMeasureTheme,
+  getBulletPrimaryDotMeasureTheme,
+  getBulletPrimarySegmentedMeasureTheme,
+  getBulletQualitativeRangeTheme
+} from '../../ChartUtils';
+
+interface ChartBulletScaleInterface {
+  defaultSize: number; // The default chart size from the theme
+  height: number; // The chart height -- not SVG height
+  horizontal?: boolean; // Flag indicating chart is shown horizontally
+  scale?: number; // The scale factor to reduce / increase the bar width
+  value: number; // The bar height or scatter size from the theme
+  width: number; // The chart width -- not SVG width
+}
+
+interface ChartBulletSizeInterface {
+  height: number; // The chart height -- not SVG height
+  horizontal?: boolean; // Flag indicating chart is shown horizontally
+  theme?: ChartThemeDefinition;
+  themeColor?: string;
+  themeVariant?: string;
+  width: number;  // The chart width -- not SVG width
+}
+
+export const getComparativeMeasureErrorWidth = ({
+  height,
+  horizontal,
+  themeColor,
+  themeVariant,
+  width,
+
+  // destructure last
+  theme = getBulletComparativeErrorMeasureTheme(themeColor, themeVariant),
+}: ChartBulletSizeInterface) => scaleBarWidth({
+  defaultSize: theme.bar.height,
+  height,
+  horizontal,
+  value: ChartBulletStyles.comparativeMeasureErrorWidth,
+  width
+});
+
+export const getComparativeMeasureWidth = ({
+  height,
+  horizontal,
+  themeColor,
+  themeVariant,
+  width,
+
+  // destructure last
+  theme = getBulletComparativeMeasureTheme(themeColor, themeVariant),
+}: ChartBulletSizeInterface) => scaleBarWidth({
+  defaultSize: theme.bar.height,
+  height,
+  horizontal,
+  value: ChartBulletStyles.comparativeMeasureWidth,
+  width
+});
+
+export const getComparativeMeasureWarningWidth = ({
+  height,
+  horizontal,
+  themeColor,
+  themeVariant,
+  width,
+
+  // destructure last
+  theme = getBulletComparativeWarningMeasureTheme(themeColor, themeVariant),
+}: ChartBulletSizeInterface) => scaleBarWidth({
+  defaultSize: theme.bar.height,
+  height,
+  horizontal,
+  value: ChartBulletStyles.comparativeMeasureWarningWidth,
+  width
+});
+
+export const getPrimaryDotMeasureSize = ({
+  height,
+  horizontal,
+  themeColor,
+  themeVariant,
+  width,
+
+  // destructure last
+  theme = getBulletPrimaryDotMeasureTheme(themeColor, themeVariant),
+}: ChartBulletSizeInterface) => scaleSize({
+  defaultSize: theme.group.height,
+  height,
+  horizontal,
+  value: ChartBulletStyles.primaryDotMeasureSize,
+  width
+});
+
+export const getPrimarySegmentedMeasureWidth = ({
+  height,
+  horizontal,
+  themeColor,
+  themeVariant,
+  width,
+
+  // destructure last
+  theme = getBulletPrimarySegmentedMeasureTheme(themeColor, themeVariant),
+}: ChartBulletSizeInterface) => scaleBarWidth({
+  defaultSize: theme.group.height,
+  height,
+  horizontal,
+  scale: .3,
+  value: ChartBulletStyles.primarySegmentedMeasureWidth,
+  width
+});
+
+export const getQualitativeRangeBarWidth = ({
+  height,
+  horizontal,
+  themeColor,
+  themeVariant,
+  width,
+
+  // destructure last
+  theme = getBulletQualitativeRangeTheme(themeColor, themeVariant),
+}: ChartBulletSizeInterface) => scaleBarWidth({
+  defaultSize: theme.group.height,
+  height,
+  horizontal,
+  value: ChartBulletStyles.qualitativeRangeWidth,
+  width
+});
+
+const scale = ({
+  defaultSize,
+  height,
+  horizontal = true,
+  scale = 1,
+  value,
+  width
+}: ChartBulletScaleInterface) => horizontal
+  ? height > defaultSize
+    ? value + (height - defaultSize) * scale
+    : value - (defaultSize - height) * scale
+  : width > defaultSize
+    ? value + (width - defaultSize) * scale
+    : value - (defaultSize - width) * scale;
+
+// Scale bar width per the given size properties
+export const scaleBarWidth = (props: ChartBulletScaleInterface) => Math.max(scale(props), 0);
+
+// Scale size per the given size properties
+export const scaleSize = ({
+  value,
+  ...rest
+}: ChartBulletScaleInterface) => Math.round(
+  scale({
+    scale: 1 / value,
+    value,
+    ...rest,
+  })
+);

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/utils/chart-bullet-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/utils/chart-bullet-theme.ts
@@ -1,0 +1,133 @@
+import {
+  getPrimaryDotMeasureData,
+  getComparativeErrorMeasureData,
+  getComparativeWarningMeasureData,
+  getPrimarySegmentedMeasureData,
+  getQualitativeRangeData
+}  from './chart-bullet-data';
+import { ChartThemeDefinition } from '../../ChartTheme';
+import { getBulletTheme } from '../../ChartUtils';
+
+interface ChartBulletThemeInterface {
+  comparativeErrorMeasureData?: any[];
+  comparativeErrorMeasureLegendData?: any[];
+  comparativeWarningMeasureData?: any[];
+  comparativeWarningMeasureLegendData?: any[];
+  invert?: boolean;
+  primaryDotMeasureData?: any[];
+  primaryDotMeasureLegendData?: any[];
+  primarySegmentedMeasureData?: any[];
+  primarySegmentedMeasureLegendData?: any[];
+  qualitativeRangeData?: any[];
+  qualitativeRangeLegendData?: any[];
+  themeColor?: string;
+  themeVariant?: string;
+}
+
+const getLegendColorScale = (computedData: any, legendData: any) => {
+  const colorScale: string[] = [];
+  legendData.forEach((data: any, index: number) => {
+    for (let i = 0; i < computedData.length; i++) {
+      if (index === computedData[i]._index) {
+        colorScale.push(computedData[i]._color);
+      }
+    }
+  });
+  return colorScale;
+};
+
+export const getColorScale = ({
+  comparativeErrorMeasureData,
+  comparativeErrorMeasureLegendData,
+  comparativeWarningMeasureData,
+  comparativeWarningMeasureLegendData,
+  invert,
+  primaryDotMeasureData,
+  primaryDotMeasureLegendData,
+  primarySegmentedMeasureData,
+  primarySegmentedMeasureLegendData,
+  qualitativeRangeData,
+  qualitativeRangeLegendData,
+  themeColor,
+  themeVariant
+}: ChartBulletThemeInterface): any[] => {
+  const colorScale: any[] = [];
+  if (primaryDotMeasureLegendData && primaryDotMeasureLegendData.length) {
+    const computedData = getPrimaryDotMeasureData({
+      data: primaryDotMeasureData,
+      invert
+    });
+    colorScale.push(...getLegendColorScale(computedData, primaryDotMeasureLegendData));
+  }
+  if (primarySegmentedMeasureLegendData && primarySegmentedMeasureLegendData.length) {
+    const computedData = getPrimarySegmentedMeasureData({
+      data: primarySegmentedMeasureData,
+      invert,
+      themeColor,
+      themeVariant
+    });
+    colorScale.push(...getLegendColorScale(computedData, primarySegmentedMeasureLegendData));
+  }
+  if (comparativeWarningMeasureLegendData && comparativeWarningMeasureLegendData.length) {
+    const computedData = getComparativeWarningMeasureData({
+      data: comparativeWarningMeasureData,
+      invert,
+      themeColor,
+      themeVariant
+    });
+    colorScale.push(...getLegendColorScale(computedData, comparativeWarningMeasureLegendData));
+  }
+  if (comparativeErrorMeasureLegendData && comparativeErrorMeasureLegendData.length) {
+    const computedData = getComparativeErrorMeasureData({
+      data: comparativeErrorMeasureData,
+      invert,
+      themeColor,
+      themeVariant
+    });
+    colorScale.push(...getLegendColorScale(computedData, comparativeErrorMeasureLegendData));
+  }
+  if (qualitativeRangeLegendData && qualitativeRangeLegendData.length) {
+    const computedData = getQualitativeRangeData({
+      data: qualitativeRangeData,
+      invert
+    });
+    colorScale.push(...getLegendColorScale(computedData, qualitativeRangeLegendData));
+  }
+  return colorScale;
+};
+
+// Get bullet chart theme with legend color scale
+export const getBulletThemeWithLegendColorScale = ({
+  comparativeErrorMeasureData,
+  comparativeErrorMeasureLegendData,
+  comparativeWarningMeasureData,
+  comparativeWarningMeasureLegendData,
+  invert,
+  primaryDotMeasureData,
+  primaryDotMeasureLegendData,
+  primarySegmentedMeasureData,
+  primarySegmentedMeasureLegendData,
+  qualitativeRangeData,
+  qualitativeRangeLegendData,
+  themeColor,
+  themeVariant
+}: ChartBulletThemeInterface): ChartThemeDefinition => {
+  const colorScale = getColorScale({
+    comparativeErrorMeasureData,
+    comparativeErrorMeasureLegendData,
+    comparativeWarningMeasureData,
+    comparativeWarningMeasureLegendData,
+    invert,
+    primaryDotMeasureData,
+    primaryDotMeasureLegendData,
+    primarySegmentedMeasureData,
+    primarySegmentedMeasureLegendData,
+    qualitativeRangeData,
+    qualitativeRangeLegendData,
+    themeColor,
+    themeVariant});
+
+  const theme = getBulletTheme(themeColor, themeVariant);
+  theme.legend.colorScale = [...colorScale];
+  return theme;
+};

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/utils/index.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/utils/index.ts
@@ -1,0 +1,4 @@
+export * from './chart-bullet-data';
+export * from './chart-bullet-domain';
+export * from './chart-bullet-size';
+export * from './chart-bullet-theme';

--- a/packages/patternfly-4/react-charts/src/components/ChartContainer/ChartContainer.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartContainer/ChartContainer.tsx
@@ -5,7 +5,7 @@ import {
   VictoryContainerProps
 } from 'victory';
 import { ChartThemeDefinition } from '../ChartTheme';
-import { getTheme } from '../ChartUtils';
+import { getClassName, getTheme } from '../ChartUtils';
 
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
@@ -14,9 +14,25 @@ import { getTheme } from '../ChartUtils';
  */
 export interface ChartContainerProps extends VictoryContainerProps {
   /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-container/
+   * The children prop specifies the child or children that will be rendered within the container. This prop should not
+   * be set manually. It will be set by whatever Victory component is rendering the container.
    */
-  ' '?: any;
+  children?: React.ReactNode | React.ReactNode[];
+  /**
+   * The className prop specifies a className that will be applied to the outer-most div rendered by ChartContainer
+   */
+  className?: string;
+  /**
+   * The containerId prop may be used to set a deterministic id for the container. When a containerId is not manually
+   * set, a unique id will be generated. It is usually necessary to set deterministic ids for automated testing.
+   */
+  containerId?: number | string;
+  /**
+   * The containerRef prop may be used to attach a ref to the outermost element rendered by the container.
+   *
+   * @example containerRef={(ref) => { this.chartRef = ref; }}
+   */
+  containerRef?: Function;
   /**
    * The desc prop specifies the description of the chart/SVG to assist with
    * accessibility for screen readers. The more info about the chart provided in
@@ -32,7 +48,7 @@ export interface ChartContainerProps extends VictoryContainerProps {
    * corresponding events as well as scale, style, width, height, and data when
    * applicable. Use the invert method to convert event coordinate information to
    * data. `scale.x.invert(evt.offsetX)`.
-   * @examples {{ onClick: (evt) => alert(`x: ${evt.clientX}, y: ${evt.clientY}`)}}
+   * @example {{ onClick: (evt) => alert(`x: ${evt.clientX}, y: ${evt.clientY}`)}}
    */
   events?: React.DOMAttributes<any>;
   /**
@@ -52,7 +68,7 @@ export interface ChartContainerProps extends VictoryContainerProps {
    * and width props, as they are used to calculate the alignment of
    * components within the container. Styles from the child component will
    * also be passed, if any exist.
-   * @examples {border: 1px solid red}
+   * @example {border: 1px solid red}
    */
   style?: React.CSSProperties;
   /**
@@ -93,11 +109,20 @@ export interface ChartContainerProps extends VictoryContainerProps {
 
 // const ChartContainer = props => <VictoryContainer {...props} />;
 export const ChartContainer: React.FunctionComponent<ChartContainerProps> = ({
+  className,
   themeColor,
   themeVariant,
-  theme = getTheme(themeColor, themeVariant), // destructure last
+
+  // destructure last
+  theme = getTheme(themeColor, themeVariant),
   ...rest
-}: ChartContainerProps) => <VictoryContainer {...theme} {...rest} />;
+}: ChartContainerProps) => {
+  const chartClassName = getClassName({className});
+
+  // Note: theme is valid, but @types/victory is missing a prop type
+  // @ts-ignore
+  return <VictoryContainer className={chartClassName} theme={theme} {...rest} />;
+}
 
 // Note: VictoryContainer.role must be hoisted
 hoistNonReactStatics(ChartContainer, VictoryContainer);

--- a/packages/patternfly-4/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartContainer/__snapshots__/ChartContainer.test.tsx.snap
@@ -2,483 +2,457 @@
 
 exports[`ChartContainer 1`] = `
 <VictoryContainer
-  area={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "#06c",
-          "fillOpacity": 0.3,
-          "strokeWidth": 2,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-      },
-      "width": 450,
-    }
-  }
-  axis={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "axis": Object {
-          "fill": "transparent",
-          "stroke": "#d2d2d2",
-          "strokeLinecap": "round",
-          "strokeLinejoin": "round",
-          "strokeWidth": 1,
-        },
-        "axisLabel": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 40,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-        "grid": Object {
-          "fill": "none",
-          "pointerEvents": "painted",
-          "stroke": "none",
-          "strokeLinecap": "round",
-          "strokeLinejoin": "round",
-        },
-        "tickLabels": Object {
-          "fill": "#4f5255",
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "ticks": Object {
-          "fill": "transparent",
-          "size": 5,
-          "stroke": "#d2d2d2",
-          "strokeLinecap": "round",
-          "strokeLinejoin": "round",
-          "strokeWidth": 1,
-        },
-      },
-      "width": 450,
-    }
-  }
-  bar={
-    Object {
-      "barWidth": 10,
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "#06c",
-          "padding": 8,
-          "stroke": "none",
-          "strokeWidth": 0,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-      },
-      "width": 450,
-    }
-  }
-  boxplot={
-    Object {
-      "boxWidth": 20,
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "max": Object {
-          "padding": 8,
-          "stroke": "#151515",
-          "strokeWidth": 1,
-        },
-        "maxLabels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "median": Object {
-          "padding": 8,
-          "stroke": "#151515",
-          "strokeWidth": 1,
-        },
-        "medianLabels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "min": Object {
-          "padding": 8,
-          "stroke": "#151515",
-          "strokeWidth": 1,
-        },
-        "minLabels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "q1": Object {
-          "fill": "#8a8d90",
-          "padding": 8,
-        },
-        "q1Labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "q3": Object {
-          "fill": "#8a8d90",
-          "padding": 8,
-        },
-        "q3Labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-      },
-      "width": 450,
-    }
-  }
-  candlestick={
-    Object {
-      "candleColors": Object {
-        "negative": "#151515",
-        "positive": "#fff",
-      },
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "stroke": "#151515",
-          "strokeWidth": 1,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-      },
-      "width": 450,
-    }
-  }
-  chart={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "width": 450,
-    }
-  }
-  className="VictoryContainer"
-  errorbar={
-    Object {
-      "borderWidth": 8,
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "transparent",
-          "opacity": 1,
-          "stroke": "#151515",
-          "strokeWidth": 2,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-      },
-      "width": 450,
-    }
-  }
-  group={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "width": 450,
-    }
-  }
-  legend={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "gutter": 20,
-      "orientation": "horizontal",
-      "style": Object {
-        "data": Object {
-          "type": "square",
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "title": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 2,
-          "stroke": "transparent",
-        },
-      },
-      "titleOrientation": "top",
-    }
-  }
-  line={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "transparent",
-          "opacity": 1,
-          "stroke": "#06c",
-          "strokeWidth": 2,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-      },
-      "width": 450,
-    }
-  }
-  pie={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 230,
-      "padding": 20,
-      "style": Object {
-        "data": Object {
-          "padding": 8,
-          "stroke": "transparent",
-          "strokeWidth": 1,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 8,
-          "stroke": "transparent",
-        },
-      },
-      "width": 230,
-    }
-  }
+  className="pf-c-chart"
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
-  scatter={
+  theme={
     Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "#151515",
-          "opacity": 1,
-          "stroke": "transparent",
-          "strokeWidth": 0,
+      "area": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#06c",
+            "fillOpacity": 0.3,
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
         },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
+        "width": 450,
       },
-      "width": 450,
-    }
-  }
-  stack={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "strokeWidth": 1,
+      "axis": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "axis": Object {
+            "fill": "transparent",
+            "stroke": "#d2d2d2",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
+          },
+          "axisLabel": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 40,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+          "grid": Object {
+            "fill": "none",
+            "pointerEvents": "painted",
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+          },
+          "tickLabels": Object {
+            "fill": "#4f5255",
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "ticks": Object {
+            "fill": "transparent",
+            "size": 5,
+            "stroke": "#d2d2d2",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
+          },
         },
+        "width": 450,
       },
-      "width": 450,
-    }
-  }
-  tooltip={
-    Object {
-      "cornerRadius": 0,
-      "flyoutStyle": Object {
+      "bar": Object {
+        "barWidth": 10,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#06c",
+            "padding": 8,
+            "stroke": "none",
+            "strokeWidth": 0,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+        },
+        "width": 450,
+      },
+      "boxplot": Object {
+        "boxWidth": 20,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "max": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "maxLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "median": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "medianLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "min": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "minLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "q1": Object {
+            "fill": "#8a8d90",
+            "padding": 8,
+          },
+          "q1Labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "q3": Object {
+            "fill": "#8a8d90",
+            "padding": 8,
+          },
+          "q3Labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+        },
+        "width": 450,
+      },
+      "candlestick": Object {
+        "candleColors": Object {
+          "negative": "#151515",
+          "positive": "#fff",
+        },
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "chart": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "width": 450,
+      },
+      "errorbar": Object {
+        "borderWidth": 8,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "opacity": 1,
+            "stroke": "#151515",
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "group": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "width": 450,
+      },
+      "legend": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "gutter": 20,
+        "orientation": "horizontal",
+        "style": Object {
+          "data": Object {
+            "type": "square",
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "title": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 2,
+            "stroke": "transparent",
+          },
+        },
+        "titleOrientation": "top",
+      },
+      "line": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "opacity": 1,
+            "stroke": "#06c",
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "pie": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 230,
+        "padding": 20,
+        "style": Object {
+          "data": Object {
+            "padding": 8,
+            "stroke": "transparent",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 8,
+            "stroke": "transparent",
+          },
+        },
+        "width": 230,
+      },
+      "scatter": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#151515",
+            "opacity": 1,
+            "stroke": "transparent",
+            "strokeWidth": 0,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "stack": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "strokeWidth": 1,
+          },
+        },
+        "width": 450,
+      },
+      "tooltip": Object {
         "cornerRadius": 0,
-        "fill": "#151515",
-        "pointerEvents": "none",
-        "stroke": "#151515",
-        "strokeWidth": 0,
-      },
-      "pointerLength": 10,
-      "pointerWidth": 20,
-      "style": Object {
-        "fill": "#ededed",
-        "padding": 16,
-        "pointerEvents": "none",
-      },
-    }
-  }
-  voronoi={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "transparent",
-          "stroke": "transparent",
-          "strokeWidth": 0,
-        },
-        "flyout": Object {
+        "flyoutStyle": Object {
+          "cornerRadius": 0,
           "fill": "#151515",
           "pointerEvents": "none",
           "stroke": "#151515",
-          "strokeWidth": 1,
+          "strokeWidth": 0,
         },
-        "labels": Object {
+        "pointerLength": 10,
+        "pointerWidth": 20,
+        "style": Object {
           "fill": "#ededed",
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 8,
+          "padding": 16,
           "pointerEvents": "none",
-          "stroke": "transparent",
-          "textAnchor": "middle",
         },
       },
-      "width": 450,
+      "voronoi": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "stroke": "transparent",
+            "strokeWidth": 0,
+          },
+          "flyout": Object {
+            "fill": "#151515",
+            "pointerEvents": "none",
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fill": "#ededed",
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 8,
+            "pointerEvents": "none",
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
     }
   }
 />
@@ -486,483 +460,457 @@ exports[`ChartContainer 1`] = `
 
 exports[`ChartContainer 2`] = `
 <VictoryContainer
-  area={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "#06c",
-          "fillOpacity": 0.3,
-          "strokeWidth": 2,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-      },
-      "width": 450,
-    }
-  }
-  axis={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "axis": Object {
-          "fill": "transparent",
-          "stroke": "#d2d2d2",
-          "strokeLinecap": "round",
-          "strokeLinejoin": "round",
-          "strokeWidth": 1,
-        },
-        "axisLabel": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 40,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-        "grid": Object {
-          "fill": "none",
-          "pointerEvents": "painted",
-          "stroke": "none",
-          "strokeLinecap": "round",
-          "strokeLinejoin": "round",
-        },
-        "tickLabels": Object {
-          "fill": "#4f5255",
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "ticks": Object {
-          "fill": "transparent",
-          "size": 5,
-          "stroke": "#d2d2d2",
-          "strokeLinecap": "round",
-          "strokeLinejoin": "round",
-          "strokeWidth": 1,
-        },
-      },
-      "width": 450,
-    }
-  }
-  bar={
-    Object {
-      "barWidth": 10,
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "#06c",
-          "padding": 8,
-          "stroke": "none",
-          "strokeWidth": 0,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-      },
-      "width": 450,
-    }
-  }
-  boxplot={
-    Object {
-      "boxWidth": 20,
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "max": Object {
-          "padding": 8,
-          "stroke": "#151515",
-          "strokeWidth": 1,
-        },
-        "maxLabels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "median": Object {
-          "padding": 8,
-          "stroke": "#151515",
-          "strokeWidth": 1,
-        },
-        "medianLabels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "min": Object {
-          "padding": 8,
-          "stroke": "#151515",
-          "strokeWidth": 1,
-        },
-        "minLabels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "q1": Object {
-          "fill": "#8a8d90",
-          "padding": 8,
-        },
-        "q1Labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "q3": Object {
-          "fill": "#8a8d90",
-          "padding": 8,
-        },
-        "q3Labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-      },
-      "width": 450,
-    }
-  }
-  candlestick={
-    Object {
-      "candleColors": Object {
-        "negative": "#151515",
-        "positive": "#fff",
-      },
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "stroke": "#151515",
-          "strokeWidth": 1,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-      },
-      "width": 450,
-    }
-  }
-  chart={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "width": 450,
-    }
-  }
-  className="VictoryContainer"
-  errorbar={
-    Object {
-      "borderWidth": 8,
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "transparent",
-          "opacity": 1,
-          "stroke": "#151515",
-          "strokeWidth": 2,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-      },
-      "width": 450,
-    }
-  }
-  group={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "width": 450,
-    }
-  }
-  legend={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "gutter": 20,
-      "orientation": "horizontal",
-      "style": Object {
-        "data": Object {
-          "type": "square",
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "title": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 2,
-          "stroke": "transparent",
-        },
-      },
-      "titleOrientation": "top",
-    }
-  }
-  line={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "transparent",
-          "opacity": 1,
-          "stroke": "#06c",
-          "strokeWidth": 2,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-      },
-      "width": 450,
-    }
-  }
-  pie={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 230,
-      "padding": 20,
-      "style": Object {
-        "data": Object {
-          "padding": 8,
-          "stroke": "transparent",
-          "strokeWidth": 1,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 8,
-          "stroke": "transparent",
-        },
-      },
-      "width": 230,
-    }
-  }
+  className="pf-c-chart"
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
-  scatter={
+  theme={
     Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "#151515",
-          "opacity": 1,
-          "stroke": "transparent",
-          "strokeWidth": 0,
+      "area": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#06c",
+            "fillOpacity": 0.3,
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
         },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
+        "width": 450,
       },
-      "width": 450,
-    }
-  }
-  stack={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "strokeWidth": 1,
+      "axis": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "axis": Object {
+            "fill": "transparent",
+            "stroke": "#d2d2d2",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
+          },
+          "axisLabel": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 40,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+          "grid": Object {
+            "fill": "none",
+            "pointerEvents": "painted",
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+          },
+          "tickLabels": Object {
+            "fill": "#4f5255",
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "ticks": Object {
+            "fill": "transparent",
+            "size": 5,
+            "stroke": "#d2d2d2",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
+          },
         },
+        "width": 450,
       },
-      "width": 450,
-    }
-  }
-  tooltip={
-    Object {
-      "cornerRadius": 0,
-      "flyoutStyle": Object {
+      "bar": Object {
+        "barWidth": 10,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#06c",
+            "padding": 8,
+            "stroke": "none",
+            "strokeWidth": 0,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+        },
+        "width": 450,
+      },
+      "boxplot": Object {
+        "boxWidth": 20,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "max": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "maxLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "median": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "medianLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "min": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "minLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "q1": Object {
+            "fill": "#8a8d90",
+            "padding": 8,
+          },
+          "q1Labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "q3": Object {
+            "fill": "#8a8d90",
+            "padding": 8,
+          },
+          "q3Labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+        },
+        "width": 450,
+      },
+      "candlestick": Object {
+        "candleColors": Object {
+          "negative": "#151515",
+          "positive": "#fff",
+        },
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "chart": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "width": 450,
+      },
+      "errorbar": Object {
+        "borderWidth": 8,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "opacity": 1,
+            "stroke": "#151515",
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "group": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "width": 450,
+      },
+      "legend": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "gutter": 20,
+        "orientation": "horizontal",
+        "style": Object {
+          "data": Object {
+            "type": "square",
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "title": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 2,
+            "stroke": "transparent",
+          },
+        },
+        "titleOrientation": "top",
+      },
+      "line": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "opacity": 1,
+            "stroke": "#06c",
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "pie": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 230,
+        "padding": 20,
+        "style": Object {
+          "data": Object {
+            "padding": 8,
+            "stroke": "transparent",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 8,
+            "stroke": "transparent",
+          },
+        },
+        "width": 230,
+      },
+      "scatter": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#151515",
+            "opacity": 1,
+            "stroke": "transparent",
+            "strokeWidth": 0,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "stack": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "strokeWidth": 1,
+          },
+        },
+        "width": 450,
+      },
+      "tooltip": Object {
         "cornerRadius": 0,
-        "fill": "#151515",
-        "pointerEvents": "none",
-        "stroke": "#151515",
-        "strokeWidth": 0,
-      },
-      "pointerLength": 10,
-      "pointerWidth": 20,
-      "style": Object {
-        "fill": "#ededed",
-        "padding": 16,
-        "pointerEvents": "none",
-      },
-    }
-  }
-  voronoi={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "transparent",
-          "stroke": "transparent",
-          "strokeWidth": 0,
-        },
-        "flyout": Object {
+        "flyoutStyle": Object {
+          "cornerRadius": 0,
           "fill": "#151515",
           "pointerEvents": "none",
           "stroke": "#151515",
-          "strokeWidth": 1,
+          "strokeWidth": 0,
         },
-        "labels": Object {
+        "pointerLength": 10,
+        "pointerWidth": 20,
+        "style": Object {
           "fill": "#ededed",
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 8,
+          "padding": 16,
           "pointerEvents": "none",
-          "stroke": "transparent",
-          "textAnchor": "middle",
         },
       },
-      "width": 450,
+      "voronoi": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "stroke": "transparent",
+            "strokeWidth": 0,
+          },
+          "flyout": Object {
+            "fill": "#151515",
+            "pointerEvents": "none",
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fill": "#ededed",
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 8,
+            "pointerEvents": "none",
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
     }
   }
 />
@@ -970,483 +918,457 @@ exports[`ChartContainer 2`] = `
 
 exports[`renders container via ChartLegend 1`] = `
 <VictoryContainer
-  area={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "#06c",
-          "fillOpacity": 0.3,
-          "strokeWidth": 2,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-      },
-      "width": 450,
-    }
-  }
-  axis={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "axis": Object {
-          "fill": "transparent",
-          "stroke": "#d2d2d2",
-          "strokeLinecap": "round",
-          "strokeLinejoin": "round",
-          "strokeWidth": 1,
-        },
-        "axisLabel": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 40,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-        "grid": Object {
-          "fill": "none",
-          "pointerEvents": "painted",
-          "stroke": "none",
-          "strokeLinecap": "round",
-          "strokeLinejoin": "round",
-        },
-        "tickLabels": Object {
-          "fill": "#4f5255",
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "ticks": Object {
-          "fill": "transparent",
-          "size": 5,
-          "stroke": "#d2d2d2",
-          "strokeLinecap": "round",
-          "strokeLinejoin": "round",
-          "strokeWidth": 1,
-        },
-      },
-      "width": 450,
-    }
-  }
-  bar={
-    Object {
-      "barWidth": 10,
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "#06c",
-          "padding": 8,
-          "stroke": "none",
-          "strokeWidth": 0,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-      },
-      "width": 450,
-    }
-  }
-  boxplot={
-    Object {
-      "boxWidth": 20,
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "max": Object {
-          "padding": 8,
-          "stroke": "#151515",
-          "strokeWidth": 1,
-        },
-        "maxLabels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "median": Object {
-          "padding": 8,
-          "stroke": "#151515",
-          "strokeWidth": 1,
-        },
-        "medianLabels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "min": Object {
-          "padding": 8,
-          "stroke": "#151515",
-          "strokeWidth": 1,
-        },
-        "minLabels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "q1": Object {
-          "fill": "#8a8d90",
-          "padding": 8,
-        },
-        "q1Labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "q3": Object {
-          "fill": "#8a8d90",
-          "padding": 8,
-        },
-        "q3Labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-      },
-      "width": 450,
-    }
-  }
-  candlestick={
-    Object {
-      "candleColors": Object {
-        "negative": "#151515",
-        "positive": "#fff",
-      },
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "stroke": "#151515",
-          "strokeWidth": 1,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-      },
-      "width": 450,
-    }
-  }
-  chart={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "width": 450,
-    }
-  }
-  className="VictoryContainer"
-  errorbar={
-    Object {
-      "borderWidth": 8,
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "transparent",
-          "opacity": 1,
-          "stroke": "#151515",
-          "strokeWidth": 2,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-      },
-      "width": 450,
-    }
-  }
-  group={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "width": 450,
-    }
-  }
-  legend={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "gutter": 20,
-      "orientation": "horizontal",
-      "style": Object {
-        "data": Object {
-          "type": "square",
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-        },
-        "title": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 2,
-          "stroke": "transparent",
-        },
-      },
-      "titleOrientation": "top",
-    }
-  }
-  line={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "transparent",
-          "opacity": 1,
-          "stroke": "#06c",
-          "strokeWidth": 2,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
-      },
-      "width": 450,
-    }
-  }
-  pie={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 230,
-      "padding": 20,
-      "style": Object {
-        "data": Object {
-          "padding": 8,
-          "stroke": "transparent",
-          "strokeWidth": 1,
-        },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 8,
-          "stroke": "transparent",
-        },
-      },
-      "width": 230,
-    }
-  }
+  className="pf-c-chart"
   portalComponent={<Portal />}
   portalZIndex={99}
   responsive={true}
-  scatter={
+  theme={
     Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "#151515",
-          "opacity": 1,
-          "stroke": "transparent",
-          "strokeWidth": 0,
+      "area": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#06c",
+            "fillOpacity": 0.3,
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
         },
-        "labels": Object {
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 10,
-          "stroke": "transparent",
-          "textAnchor": "middle",
-        },
+        "width": 450,
       },
-      "width": 450,
-    }
-  }
-  stack={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "strokeWidth": 1,
+      "axis": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "axis": Object {
+            "fill": "transparent",
+            "stroke": "#d2d2d2",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
+          },
+          "axisLabel": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 40,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+          "grid": Object {
+            "fill": "none",
+            "pointerEvents": "painted",
+            "stroke": "none",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+          },
+          "tickLabels": Object {
+            "fill": "#4f5255",
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "ticks": Object {
+            "fill": "transparent",
+            "size": 5,
+            "stroke": "#d2d2d2",
+            "strokeLinecap": "round",
+            "strokeLinejoin": "round",
+            "strokeWidth": 1,
+          },
         },
+        "width": 450,
       },
-      "width": 450,
-    }
-  }
-  tooltip={
-    Object {
-      "cornerRadius": 0,
-      "flyoutStyle": Object {
+      "bar": Object {
+        "barWidth": 10,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#06c",
+            "padding": 8,
+            "stroke": "none",
+            "strokeWidth": 0,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+        },
+        "width": 450,
+      },
+      "boxplot": Object {
+        "boxWidth": 20,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "max": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "maxLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "median": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "medianLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "min": Object {
+            "padding": 8,
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "minLabels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "q1": Object {
+            "fill": "#8a8d90",
+            "padding": 8,
+          },
+          "q1Labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "q3": Object {
+            "fill": "#8a8d90",
+            "padding": 8,
+          },
+          "q3Labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+        },
+        "width": 450,
+      },
+      "candlestick": Object {
+        "candleColors": Object {
+          "negative": "#151515",
+          "positive": "#fff",
+        },
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "chart": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "width": 450,
+      },
+      "errorbar": Object {
+        "borderWidth": 8,
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "opacity": 1,
+            "stroke": "#151515",
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "group": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "width": 450,
+      },
+      "legend": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "gutter": 20,
+        "orientation": "horizontal",
+        "style": Object {
+          "data": Object {
+            "type": "square",
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+          },
+          "title": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 2,
+            "stroke": "transparent",
+          },
+        },
+        "titleOrientation": "top",
+      },
+      "line": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "opacity": 1,
+            "stroke": "#06c",
+            "strokeWidth": 2,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "pie": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 230,
+        "padding": 20,
+        "style": Object {
+          "data": Object {
+            "padding": 8,
+            "stroke": "transparent",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 8,
+            "stroke": "transparent",
+          },
+        },
+        "width": 230,
+      },
+      "scatter": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "#151515",
+            "opacity": 1,
+            "stroke": "transparent",
+            "strokeWidth": 0,
+          },
+          "labels": Object {
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 10,
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
+      "stack": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "strokeWidth": 1,
+          },
+        },
+        "width": 450,
+      },
+      "tooltip": Object {
         "cornerRadius": 0,
-        "fill": "#151515",
-        "pointerEvents": "none",
-        "stroke": "#151515",
-        "strokeWidth": 0,
-      },
-      "pointerLength": 10,
-      "pointerWidth": 20,
-      "style": Object {
-        "fill": "#ededed",
-        "padding": 16,
-        "pointerEvents": "none",
-      },
-    }
-  }
-  voronoi={
-    Object {
-      "colorScale": Array [
-        "#06c",
-        "#8bc1f7",
-        "#002f5d",
-        "#519de9",
-        "#004b95",
-      ],
-      "height": 300,
-      "padding": 50,
-      "style": Object {
-        "data": Object {
-          "fill": "transparent",
-          "stroke": "transparent",
-          "strokeWidth": 0,
-        },
-        "flyout": Object {
+        "flyoutStyle": Object {
+          "cornerRadius": 0,
           "fill": "#151515",
           "pointerEvents": "none",
           "stroke": "#151515",
-          "strokeWidth": 1,
+          "strokeWidth": 0,
         },
-        "labels": Object {
+        "pointerLength": 10,
+        "pointerWidth": 20,
+        "style": Object {
           "fill": "#ededed",
-          "fontFamily": "var(--pf-chart-global--FontFamily)",
-          "fontSize": 14,
-          "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-          "padding": 8,
+          "padding": 16,
           "pointerEvents": "none",
-          "stroke": "transparent",
-          "textAnchor": "middle",
         },
       },
-      "width": 450,
+      "voronoi": Object {
+        "colorScale": Array [
+          "#06c",
+          "#8bc1f7",
+          "#002f5d",
+          "#519de9",
+          "#004b95",
+        ],
+        "height": 300,
+        "padding": 50,
+        "style": Object {
+          "data": Object {
+            "fill": "transparent",
+            "stroke": "transparent",
+            "strokeWidth": 0,
+          },
+          "flyout": Object {
+            "fill": "#151515",
+            "pointerEvents": "none",
+            "stroke": "#151515",
+            "strokeWidth": 1,
+          },
+          "labels": Object {
+            "fill": "#ededed",
+            "fontFamily": "var(--pf-chart-global--FontFamily)",
+            "fontSize": 14,
+            "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+            "padding": 8,
+            "pointerEvents": "none",
+            "stroke": "transparent",
+            "textAnchor": "middle",
+          },
+        },
+        "width": 450,
+      },
     }
   }
 >

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
@@ -1,19 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChartDonut 1`] = `
-<Component
-  height={230}
-  width={230}
->
+<Fragment>
   <Component
     height={230}
-    innerRadius={98}
-    legendPosition="right"
-    pieDx={0}
-    pieDy={0}
-    pieHeight={230}
-    pieWidth={230}
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -465,24 +455,474 @@ exports[`ChartDonut 1`] = `
       }
     }
     width={230}
-  />
-</Component>
+  >
+    <Component
+      allowTooltip={true}
+      height={230}
+      innerRadius={86}
+      legendPosition="right"
+      radius={95}
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`ChartDonut 2`] = `
-<Component
-  height={230}
-  width={230}
->
+<Fragment>
   <Component
     height={230}
-    innerRadius={98}
-    legendPosition="right"
-    pieDx={0}
-    pieDy={0}
-    pieHeight={230}
-    pieWidth={230}
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -934,40 +1374,474 @@ exports[`ChartDonut 2`] = `
       }
     }
     width={230}
-  />
-</Component>
+  >
+    <Component
+      allowTooltip={true}
+      height={230}
+      innerRadius={86}
+      legendPosition="right"
+      radius={95}
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`renders component data 1`] = `
-<Component
-  height={200}
-  width={200}
->
+<Fragment>
   <Component
-    data={
-      Array [
-        Object {
-          "x": "Cats",
-          "y": 35,
-        },
-        Object {
-          "x": "Dogs",
-          "y": 55,
-        },
-        Object {
-          "x": "Birds",
-          "y": 10,
-        },
-      ]
-    }
     height={200}
-    innerRadius={83}
-    legendPosition="right"
-    pieDx={0}
-    pieDy={0}
-    pieHeight={200}
-    pieWidth={200}
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -1419,6 +2293,482 @@ exports[`renders component data 1`] = `
       }
     }
     width={200}
-  />
-</Component>
+  >
+    <Component
+      allowTooltip={true}
+      data={
+        Array [
+          Object {
+            "x": "Cats",
+            "y": 35,
+          },
+          Object {
+            "x": "Dogs",
+            "y": 55,
+          },
+          Object {
+            "x": "Birds",
+            "y": 10,
+          },
+        ]
+      }
+      height={200}
+      innerRadius={71}
+      legendPosition="right"
+      radius={80}
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={200}
+    />
+  </Component>
+</Fragment>
 `;

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -2,11 +2,25 @@
 title: 'Donut'
 section: 'charts'
 typescript: true
-propComponents: ['ChartDonut']
+propComponents: ['ChartDonut', 'ChartLegend']
 ---
 
 import { ChartDonut, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
 import './chart-donut.scss';
+
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+## Tutorial
+
+PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, 
+along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React 
+based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+In this tutorial, we will build a bar chart together - starting with a simple chart, adding thresholds, tooltips,  
+a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build 
+a consistent user experience.
+
+[Start course](https://katacoda.com/patternfly/courses/charts/module-pie)
 
 ## Simple donut chart
 ```js
@@ -18,8 +32,9 @@ import { ChartDonut } from '@patternfly/react-charts';
     <ChartDonut
       ariaDesc="Average number of pets"
       ariaTitle="Donut chart example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-      labels={datum => `${datum.x}: ${datum.y}%`}
+      labels={({ datum }) => `${datum.x}: ${datum.y}%`}
       subTitle="Pets"
       title="100"
     />
@@ -37,11 +52,18 @@ import { ChartDonut } from '@patternfly/react-charts';
     <ChartDonut
       ariaDesc="Average number of pets"
       ariaTitle="Donut chart example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-      labels={datum => `${datum.x}: ${datum.y}%`}
+      labels={({ datum }) => `${datum.x}: ${datum.y}%`}
       legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
       legendOrientation="vertical"
       legendPosition="right"
+      padding={{
+        bottom: 20,
+        left: 20,
+        right: 140, // Adjusted to accommodate legend
+        top: 20
+      }}
       subTitle="Pets"
       title="100"
       width={350}
@@ -60,11 +82,18 @@ import { ChartDonut, ChartThemeColor, ChartThemeVariant } from '@patternfly/reac
     <ChartDonut
       ariaDesc="Average number of pets"
       ariaTitle="Donut chart example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-      labels={datum => `${datum.x}: ${datum.y}%`}
+      labels={({ datum }) => `${datum.x}: ${datum.y}%`}
       legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
       legendOrientation="vertical"
       legendPosition="right"
+      padding={{
+        bottom: 20,
+        left: 20,
+        right: 140, // Adjusted to accommodate legend
+        top: 20
+      }}
       subTitle="Pets"
       title="100"
       themeColor={ChartThemeColor.multiOrdered}
@@ -85,14 +114,20 @@ import { ChartDonut } from '@patternfly/react-charts';
     <ChartDonut
       ariaDesc="Average number of pets"
       ariaTitle="Donut chart example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-      donutHeight={230}
       donutOrientation="top"
       height={275}
-      labels={datum => `${datum.x}: ${datum.y}%`}
+      labels={({ datum }) => `${datum.x}: ${datum.y}%`}
       legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
       legendPosition="bottom"
       legendWidth={225}
+      padding={{
+        bottom: 65, // Adjusted to accommodate legend
+        left: 20,
+        right: 20,
+        top: 20
+      }}
       subTitle="Pets"
       title="100"
       width={300}
@@ -111,9 +146,10 @@ import { ChartDonut } from '@patternfly/react-charts';
     <ChartDonut
       ariaDesc="Average number of pets"
       ariaTitle="Donut chart example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
       height={150}
-      labels={datum => `${datum.x}: ${datum.y}%`}
+      labels={({ datum }) => `${datum.x}: ${datum.y}%`}
       subTitle="Pets"
       title="100"
       width={150}
@@ -132,12 +168,19 @@ import { ChartDonut } from '@patternfly/react-charts';
     <ChartDonut
       ariaDesc="Average number of pets"
       ariaTitle="Donut chart example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
       height={150}
-      labels={datum => `${datum.x}: ${datum.y}%`}
+      labels={({ datum }) => `${datum.x}: ${datum.y}%`}
       legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
       legendOrientation="vertical"
       legendPosition="right"
+      padding={{
+        bottom: 20,
+        left: 20,
+        right: 145, // Adjusted to accommodate legend
+        top: 20
+      }}
       subTitle="Pets"
       title="100"
       width={275}
@@ -156,13 +199,19 @@ import { ChartDonut } from '@patternfly/react-charts';
     <ChartDonut
       ariaDesc="Average number of pets"
       ariaTitle="Donut chart example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-      donutHeight={150}
-      height={175}
-      labels={datum => `${datum.x}: ${datum.y}%`}
+      height={165}
+      labels={({ datum }) => `${datum.x}: ${datum.y}%`}
       legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
       legendOrientation="vertical"
       legendPosition="right"
+      padding={{
+        bottom: 25, // Adjusted to accommodate subTitle
+        left: 20,
+        right: 145, // Adjusted to accommodate legend
+        top: 20
+      }}
       subTitle="Pets"
       subTitlePosition="bottom"
       title="100"
@@ -182,12 +231,18 @@ import { ChartDonut } from '@patternfly/react-charts';
     <ChartDonut
       ariaDesc="Average number of pets"
       ariaTitle="Donut chart example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-      donutHeight={150}
       height={200}
-      labels={datum => `${datum.x}: ${datum.y}%`}
+      labels={({ datum }) => `${datum.x}: ${datum.y}%`}
       legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
       legendPosition="bottom"
+      padding={{
+        bottom: 70, // Adjusted to accommodate legend
+        left: 20,
+        right: 50, // Adjusted to accommodate subTitle
+        top: 20
+      }}
       subTitle="Pets"
       subTitlePosition="right"
       title="100"
@@ -196,3 +251,15 @@ import { ChartDonut } from '@patternfly/react-charts';
   </div>
 </div>
 ```
+
+## Tips
+
+- For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+- `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `ChartDonut` props, see <a href="https://formidable.com/open-source/victory/docs/victory-pie" target="_blank">VictoryPie</a>
+ - For `ChartLegend` props, see <a href="https://formidable.com/open-source/victory/docs/victory-legend" target="_blank">VictoryLegend</a>

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/chart-donut.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/chart-donut.scss
@@ -26,7 +26,7 @@
     }
 
     .donut-chart-legend-right-subtitle-bottom-sm {
-      height: 175px;
+      height: 165px;
       width: 275px;
     }
 

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -10,12 +10,12 @@ import {
   VictoryPie,
   VictoryStyleInterface
 } from 'victory';
-import { Data } from 'victory-core';
+import { Data, Helpers } from 'victory-core';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { ChartContainer } from '../ChartContainer';
 import { ChartDonut, ChartDonutProps } from '../ChartDonut';
 import { ChartCommonStyles, ChartDonutStyles, ChartThemeDefinition } from '../ChartTheme';
-import { getChartOrigin, getDonutThresholdDynamicTheme, getDonutThresholdStaticTheme } from '../ChartUtils';
+import { getDonutThresholdDynamicTheme, getDonutThresholdStaticTheme, getPaddingForSide } from '../ChartUtils';
 
 export enum ChartDonutThresholdDonutOrientation {
   left = 'left',
@@ -55,9 +55,11 @@ export enum ChartDonutThresholdSubTitlePosition {
  */
 export interface ChartDonutThresholdProps extends ChartDonutProps {
   /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-pie/
+   * Specifies the tooltip capability of the container component. A value of true allows the chart to add a
+   * ChartTooltip component to the labelComponent property. This is a shortcut to display tooltips when the labels
+   * property is also provided.
    */
-  ' '?: any;
+  allowTooltip?: boolean;
   /**
    * The animate prop specifies props for VictoryAnimation to use.
    * The animate prop should also be used to specify enter and exit
@@ -100,6 +102,12 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * data object
    */
   colorScale?: ColorScalePropType;
+  /**
+   * The constrainToVisibleArea prop determines whether to coerce tooltips so that they fit within the visible area of
+   * the chart. When this prop is set to true, tooltip pointers will still point to the correct data point, but the
+   * center of the tooltip will be shifted to fit within the overall width and height of the svg Victory renders.
+   */
+  constrainToVisibleArea?: boolean;
   /**
    * The containerComponent prop takes an entire component which will be used to
    * create a container element for standalone charts.
@@ -155,39 +163,6 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    */
   desc?: string;
   /**
-   * Specifies the height of the donut chart. This value should be given as a number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and height props do not determine the width and
-   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, height (the overall SVG height) may need to be larger than donutHeight (the donut size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, donutHeight is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, donutHeight (not height) may need to be set in order to adjust the donut
-   * height.
-   *
-   * Note: innerRadius may need to be set when using this property.
-   */
-  donutHeight?: number;
-  /**
-   * Specifies the width of the donut chart. This value should be given as a number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and height props do not determine the width and
-   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, width (the overall SVG width) may need to be larger than donutWidth (the donut size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, donutWidth is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, donutWidth (not width) may need to be set in order to adjust the donut width.
-   *
-   * Note: innerRadius may need to be set when using this property.
-   */
-  donutWidth?: number;
-  /**
    * The overall end angle of the pie in degrees. This prop is used in conjunction with
    * startAngle to create a pie that spans only a segment of a circle.
    */
@@ -211,7 +186,7 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * The mutation function will be called with the calculated props for the individual selected
    * element (i.e. a single bar), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
-   * @examples
+   * @example
    * events={[
    *   {
    *     target: "data",
@@ -253,15 +228,8 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    *
    * Because Victory renders responsive containers, the width and height props do not determine the width and
    * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, height (the overall SVG height) may need to be larger than donutHeight (the donut size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, donutHeight is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, donutHeight (not height) may need to be set in order to adjust the donut height.
-   *
-   * Typically, the parent container is set to the same height in order to maintain the aspect ratio.
+   * pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set
+   * to the same height in order to maintain the aspect ratio.
    */
   height?: number;
   /**
@@ -289,6 +257,9 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
   labels?: string[] | ((data: any) => string);
   /**
    * The legend position relation to the donut chart. Valid values are 'bottom' and 'right'
+   *
+   * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
+   * cases, the legend may not be visible until enough padding is applied.
    */
   legendPosition?: 'bottom' | 'right';
   /**
@@ -310,8 +281,6 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
-   *
-   * Note: innerRadius may need to be set when using this property.
    */
   padding?: PaddingProps;
   /**
@@ -396,15 +365,8 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
    *
    * Because Victory renders responsive containers, the width and height props do not determine the width and
    * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, width (the overall SVG width) may need to be larger than donutWidth (the donut size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, donutWidth is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, donutWidth (not width) may need to be set in order to adjust the donut width.
-   *
-   * Typically, the parent container is set to the same width in order to maintain the aspect ratio.
+   * pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set
+   * to the same width in order to maintain the aspect ratio.
    */
   width?: number;
   /**
@@ -432,13 +394,17 @@ export interface ChartDonutThresholdProps extends ChartDonutProps {
 }
 
 export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdProps> = ({
+  allowTooltip = true,
   ariaDesc,
   ariaTitle,
   children,
+  constrainToVisibleArea = false,
   data = [],
   invert = false,
   labels = [], // Don't show any tooltip labels by default, let consumer override if needed
   legendPosition = ChartCommonStyles.legend.position as ChartDonutThresholdLegendPosition,
+  padding,
+  radius,
   standalone = true,
   subTitlePosition = ChartDonutStyles.label.subTitlePosition as ChartDonutThresholdSubTitlePosition,
   themeColor,
@@ -448,13 +414,23 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
 
   // destructure last
   theme = getDonutThresholdStaticTheme(themeColor, themeVariant, invert),
+  containerComponent = <ChartContainer theme={theme}/>,
   height = theme.pie.height,
   width = theme.pie.width,
-  donutHeight = Math.min(height, width),
-  donutWidth = Math.min(height, width),
   ...rest
 }: ChartDonutThresholdProps) => {
-  const donutSize = Math.min(donutHeight, donutWidth);
+  const defaultPadding = {
+    bottom: getPaddingForSide('bottom',  padding, theme.pie.padding),
+    left: getPaddingForSide('left', padding, theme.pie.padding),
+    right: getPaddingForSide('right', padding, theme.pie.padding),
+    top: getPaddingForSide('top', padding, theme.pie.padding),
+  };
+  const chartRadius = radius | Helpers.getRadius({
+    height,
+    width,
+    padding: defaultPadding
+  });
+  const chartSize = chartRadius * 2;
 
   // Returns computed data representing pie chart slices
   const getComputedData = () => {
@@ -483,61 +459,6 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
     ];
   };
 
-  // Returns the horizontal shift for the donut utilization chart
-  const getDonutDx = (dynamicTheme: ChartThemeDefinition, legendPosition: string) => {
-    const dynamicWidth = donutSize - (theme.pie.width - dynamicTheme.pie.width);
-    switch (legendPosition) {
-      case 'right':
-        return Math.round((donutSize - dynamicWidth) / 2);
-      default:
-        return 0;
-    }
-  };
-
-  // Returns the vertical shift for the donut utilization chart
-  const getDonutDy = (dynamicTheme: ChartThemeDefinition) => {
-    const dynamicHeight = donutSize - (theme.pie.height - dynamicTheme.pie.height);
-    return Math.round((donutSize - dynamicHeight) / 2);
-  };
-
-  // Returns the horizontal shift for the donut utilization legend
-  const getLegendDx = (dynamicTheme: ChartThemeDefinition, position: string) => {
-    const dynamicWidth = donutSize - (theme.pie.width - dynamicTheme.pie.width);
-    switch (position) {
-      case 'right':
-        return getDonutDx(dynamicTheme, legendPosition) + Math.round((donutSize - dynamicWidth) / 2);
-      default:
-        return 0;
-    }
-  };
-
-  // Returns the vertical shift for the donut utilization legend
-  const getLegendDy = (dynamicTheme: ChartThemeDefinition, position: string) => {
-    const dynamicWidth = donutSize - (theme.pie.width - dynamicTheme.pie.width);
-    switch (position) {
-      case 'bottom':
-        return getDonutDy(dynamicTheme) + Math.round((donutSize - dynamicWidth) / 2);
-      default:
-        return getDonutDy(dynamicTheme);
-    }
-  };
-
-  // Returns the horizontal shift for the donut utilization subtitle
-  const getSubTitleDx = (dynamicTheme: ChartThemeDefinition, position: string) => {
-    const dynamicWidth = donutSize - (theme.pie.width - dynamicTheme.pie.width);
-    switch (position) {
-      case 'right':
-        return getDonutDx(dynamicTheme, legendPosition) + Math.round((donutSize - dynamicWidth) / 2);
-      default:
-        return Math.round((donutSize - dynamicWidth) / 2);
-    }
-  };
-
-  // Returns the vertical shift for the donut utilization subtitle
-  const getSubTitleDy = (dynamicTheme: ChartThemeDefinition, position: string) => {
-    return getLegendDy(dynamicTheme, position);
-  };
-
   // Render dynamic utilization donut cart
   const renderChildren = () =>
     React.Children.toArray(children).map((child) => {
@@ -549,24 +470,17 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
             childProps.themeVariant || themeVariant);
         const legendPos = childProps.legendPosition || legendPosition;
         const subTitlePos = childProps.subTitlePosition || subTitlePosition;
-        const donutSizeDiff = theme.pie.height - dynamicTheme.pie.height; // static - dynamic chart heights
-        const childDountSize = donutSize > donutSizeDiff ? donutSize - donutSizeDiff : 0; // not visible < 50px
         return React.cloneElement(child, {
+          constrainToVisibleArea,
           data: childData,
-          donutDx: getDonutDx(dynamicTheme, legendPos),
-          donutDy: getDonutDy(dynamicTheme),
-          donutHeight: childDountSize,
-          donutWidth: childDountSize,
           endAngle: 360 * (datum[0]._y ? datum[0]._y / 100 : 0),
           height,
           invert,
-          legendDx: getLegendDx(dynamicTheme, legendPos),
-          legendDy: getLegendDy(dynamicTheme, legendPos),
           legendPosition: legendPos,
+          padding: defaultPadding,
+          radius: chartRadius - 14, // Donut utilization radius is threshold radius minus 14px spacing
           showStatic: false,
           standalone: false,
-          subTitleDx: getSubTitleDx(dynamicTheme, subTitlePos),
-          subTitleDy: getSubTitleDy(dynamicTheme, subTitlePos),
           subTitlePosition: subTitlePos,
           theme: dynamicTheme,
           width,
@@ -579,27 +493,33 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   // Static threshold dount chart
   const chart = (
     <ChartDonut
+      allowTooltip={allowTooltip}
+      constrainToVisibleArea={constrainToVisibleArea}
       data={getComputedData()}
-      height={donutSize}
+      height={height}
       labels={labels}
-      origin={getChartOrigin({
-        chartHeight: donutSize,
-        chartWidth: donutSize,
-        legendPosition,
-        svgWidth: width
-      })}
+      padding={defaultPadding}
       standalone={false}
       theme={theme}
-      width={donutSize}
+      width={width}
       {...rest}
     />
   );
 
+  const container = React.cloneElement(containerComponent, {
+    children: [chart, renderChildren()],
+    desc: ariaDesc,
+    height,
+    title: ariaTitle,
+    width,
+    theme,
+    ...containerComponent.props
+  });
+
   return standalone ? (
-    <ChartContainer desc={ariaDesc} height={height} title={ariaTitle} width={width}>
-      {chart}
-      {renderChildren()}
-    </ChartContainer>
+    <React.Fragment>
+      {container}
+    </React.Fragment>
   ) : (
     <React.Fragment>
       {chart}

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -50,9 +50,11 @@ export enum ChartDonutUtilizationSubTitlePosition {
  */
 export interface ChartDonutUtilizationProps extends ChartDonutProps {
   /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-pie/
+   * Specifies the tooltip capability of the container component. A value of true allows the chart to add a
+   * ChartTooltip component to the labelComponent property. This is a shortcut to display tooltips when the labels
+   * property is also provided.
    */
-  ' '?: any;
+  allowTooltip?: boolean;
   /**
    * The animate prop specifies props for VictoryAnimation to use.
    * The animate prop should also be used to specify enter and exit
@@ -98,6 +100,12 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * data object
    */
   colorScale?: ColorScalePropType;
+  /**
+   * The constrainToVisibleArea prop determines whether to coerce tooltips so that they fit within the visible area of
+   * the chart. When this prop is set to true, tooltip pointers will still point to the correct data point, but the
+   * center of the tooltip will be shifted to fit within the overall width and height of the svg Victory renders.
+   */
+  constrainToVisibleArea?: boolean;
   /**
    * The containerComponent prop takes an entire component which will be used to
    * create a container element for standalone charts.
@@ -153,55 +161,6 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   desc?: string;
   /**
-   * Defines a horizontal shift from the x coordinate. It should not be set manually.
-   */
-  donutDx?: number;
-  /**
-   * Defines a vertical shift from the y coordinate. It should not be set manually.
-   */
-  donutDy?: number;
-  /**
-   * Specifies the height of the donut chart. This value should be given as a number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and height props do not determine the width and
-   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, height (the overall SVG height) may need to be larger than donutHeight (the donut size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, donutHeight is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, donutHeight (not height) may need to be set in order to adjust the donut
-   * height.
-   *
-   * Note: innerRadius may need to be set when using this property.
-   */
-  donutHeight?: number;
-  /**
-   * Specifies the width of the donut chart. This value should be given as a number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and height props do not determine the width and
-   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, width (the overall SVG width) may need to be larger than donutWidth (the donut size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, donutWidth is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, donutWidth (not width) may need to be set in order to adjust the donut width.
-   *
-   * Note: innerRadius may need to be set when using this property.
-   */
-  donutWidth?: number;
-  /**
-   * Defines a horizontal shift from the x coordinate for legend and subtitle. It should not be set manually.
-   */
-  dx?: number;
-  /**
-   * Defines a vertical shift from the y coordinate for legend and subtitle. It should not be set manually.
-   */
-  dy?: number;
-  /**
    * The overall end angle of the pie in degrees. This prop is used in conjunction with
    * startAngle to create a pie that spans only a segment of a circle.
    */
@@ -225,7 +184,7 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * The mutation function will be called with the calculated props for the individual selected
    * element (i.e. a single bar), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
-   * @examples
+   * @example
    * events={[
    *   {
    *     target: "data",
@@ -268,15 +227,8 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    *
    * Because Victory renders responsive containers, the width and height props do not determine the width and
    * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, height (the overall SVG height) may need to be larger than donutHeight (the donut size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, donutHeight is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, donutHeight (not height) may need to be set in order to adjust the donut height.
-   *
-   * Typically, the parent container is set to the same width in order to maintain the aspect ratio.
+   * pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set
+   * to the same width in order to maintain the aspect ratio.
    */
   height?: number;
   /**
@@ -330,14 +282,6 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
     };
   }[];
   /**
-   * Defines a horizontal shift from the x coordinate. It should not be set manually.
-   */
-  legendDx?: number;
-  /**
-   * Defines a vertical shift from the y coordinate. It should not be set manually.
-   */
-  legendDy?: number;
-  /**
    * The orientation prop takes a string that defines whether legend data
    * are displayed in a row or column. When orientation is "horizontal",
    * legend items will be displayed in a single row. When orientation is
@@ -349,6 +293,9 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
   legendOrientation?: 'horizontal' | 'vertical';
   /**
    * The legend position relation to the donut chart. Valid values are 'bottom' and 'right'
+   *
+   * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
+   * cases, the legend may not be visible until enough padding is applied.
    */
   legendPosition?: 'bottom' | 'right';
   /**
@@ -384,8 +331,6 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    * the edge of the chart and any rendered child components. This prop can be given
    * as a number or as an object with padding specified for top, bottom, left
    * and right.
-   *
-   * Note: innerRadius may need to be set when using this property.
    */
   padding?: PaddingProps;
   /**
@@ -440,14 +385,6 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    */
   subTitleComponent?: React.ReactElement<any>;
   /**
-   * Defines a horizontal shift from the x coordinate. It should not be set manually.
-   */
-  subTitleDx?: number;
-  /**
-   * Defines a vertical shift from the y coordinate. It should not be set manually.
-   */
-  subTitleDy?: number;
-  /**
    * The orientation of the donut chart in relation to the legend. Valid values are 'bottom', 'center', and 'right'
    */
   subTitlePosition?: 'bottom' | 'center' | 'right';
@@ -491,15 +428,8 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
    *
    * Because Victory renders responsive containers, the width and height props do not determine the width and
    * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, width (the overall SVG width) may need to be larger than donutWidth (the donut size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, donutWidth is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, donutWidth (not width) may need to be set in order to adjust the donut width.
-   *
-   * Typically, the parent container is set to the same width in order to maintain the aspect ratio.
+   * pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set
+   * to the same width in order to maintain the aspect ratio.
    */
   width?: number;
   /**
@@ -527,10 +457,12 @@ export interface ChartDonutUtilizationProps extends ChartDonutProps {
 }
 
 export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizationProps> = ({
+  allowTooltip = true,
   ariaDesc,
   ariaTitle,
   data,
   invert = false,
+  padding,
   showStatic = true,
   standalone = true,
   themeColor,
@@ -541,14 +473,11 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
 
   // destructure last
   theme = getDonutUtilizationTheme(themeColor, themeVariant),
+  containerComponent = <ChartContainer theme={theme}/>,
   height = theme.pie.height,
   width = theme.pie.width,
-  donutHeight = Math.min(height, width),
-  donutWidth = Math.min(height, width),
   ...rest
 }: ChartDonutUtilizationProps) => {
-  const donutSize = Math.min(donutHeight, donutWidth);
-
   // Returns computed data representing pie chart slices
   const getComputedData = () => {
     const datum = getData();
@@ -612,10 +541,10 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
   const chart = (
     <React.Fragment>
       <ChartDonut
+        allowTooltip={allowTooltip}
         data={getComputedData()}
-        donutHeight={donutSize}
-        donutWidth={donutSize}
         height={height}
+        padding={padding}
         standalone={false}
         theme={getThresholdTheme()}
         width={width}
@@ -624,10 +553,20 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
     </React.Fragment>
   );
 
+  const container = React.cloneElement(containerComponent, {
+    children: chart,
+    desc: ariaDesc,
+    height,
+    title: ariaTitle,
+    width,
+    theme,
+    ...containerComponent.props
+  });
+
   return standalone ? (
-    <ChartContainer desc={ariaDesc} height={height} title={ariaTitle} width={width}>
-      {chart}
-    </ChartContainer>
+    <React.Fragment>
+      {container}
+    </React.Fragment>
   ) : (
     <React.Fragment>
       {chart}

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
@@ -1,27 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChartDonutThreshold 1`] = `
-<Component
-  height={230}
-  width={230}
->
+<Fragment>
   <Component
-    data={
-      Array [
-        Object {
-          "y": 0,
-        },
-      ]
-    }
     height={230}
-    labels={Array []}
-    origin={
-      Object {
-        "x": 115,
-        "y": 115,
-      }
-    }
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -473,32 +455,488 @@ exports[`ChartDonutThreshold 1`] = `
       }
     }
     width={230}
-  />
-</Component>
+  >
+    <Component
+      allowTooltip={true}
+      constrainToVisibleArea={false}
+      data={
+        Array [
+          Object {
+            "y": 0,
+          },
+        ]
+      }
+      height={230}
+      labels={Array []}
+      padding={
+        Object {
+          "bottom": 20,
+          "left": 20,
+          "right": 20,
+          "top": 20,
+        }
+      }
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#ededed",
+              "#d2d2d2",
+              "#b8bbbe",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`ChartDonutThreshold 2`] = `
-<Component
-  height={230}
-  width={230}
->
+<Fragment>
   <Component
-    data={
-      Array [
-        Object {
-          "y": 0,
-        },
-      ]
-    }
     height={230}
-    labels={Array []}
-    origin={
-      Object {
-        "x": 115,
-        "y": 115,
-      }
-    }
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -950,44 +1388,488 @@ exports[`ChartDonutThreshold 2`] = `
       }
     }
     width={230}
-  />
-</Component>
+  >
+    <Component
+      allowTooltip={true}
+      constrainToVisibleArea={false}
+      data={
+        Array [
+          Object {
+            "y": 0,
+          },
+        ]
+      }
+      height={230}
+      labels={Array []}
+      padding={
+        Object {
+          "bottom": 20,
+          "left": 20,
+          "right": 20,
+          "top": 20,
+        }
+      }
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#ededed",
+              "#d2d2d2",
+              "#b8bbbe",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`renders component data 1`] = `
-<Component
-  height={200}
-  width={200}
->
+<Fragment>
   <Component
-    data={
-      Array [
-        Object {
-          "x": "Birds",
-          "y": 10,
-        },
-        Object {
-          "x": "Cats",
-          "y": 25,
-        },
-        Object {
-          "x": "Dogs",
-          "y": 20,
-        },
-        Object {
-          "y": 45,
-        },
-      ]
-    }
     height={200}
-    labels={Array []}
-    origin={
-      Object {
-        "x": 100,
-        "y": 100,
-      }
-    }
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -1439,6 +2321,492 @@ exports[`renders component data 1`] = `
       }
     }
     width={200}
-  />
-</Component>
+  >
+    <Component
+      allowTooltip={true}
+      constrainToVisibleArea={false}
+      data={
+        Array [
+          Object {
+            "x": "Birds",
+            "y": 10,
+          },
+          Object {
+            "x": "Cats",
+            "y": 25,
+          },
+          Object {
+            "x": "Dogs",
+            "y": 20,
+          },
+          Object {
+            "y": 45,
+          },
+        ]
+      }
+      height={200}
+      labels={Array []}
+      padding={
+        Object {
+          "bottom": 20,
+          "left": 20,
+          "right": 20,
+          "top": 20,
+        }
+      }
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#ededed",
+              "#d2d2d2",
+              "#b8bbbe",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={200}
+    />
+  </Component>
+</Fragment>
 `;

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
@@ -1,26 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChartDonutUtilization 1`] = `
-<Component
-  height={230}
-  width={230}
->
+<Fragment>
   <Component
-    data={
-      Array [
-        Object {
-          "x": 0,
-          "y": Object {},
-        },
-        Object {
-          "y": 100,
-        },
-      ]
-    }
-    donutHeight={230}
-    donutWidth={230}
     height={230}
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -468,31 +451,478 @@ exports[`ChartDonutUtilization 1`] = `
       }
     }
     width={230}
-  />
-</Component>
+  >
+    <Component
+      allowTooltip={true}
+      data={
+        Array [
+          Object {
+            "x": 0,
+            "y": Object {},
+          },
+          Object {
+            "y": 100,
+          },
+        ]
+      }
+      height={230}
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#ededed",
+              "#d2d2d2",
+              "#b8bbbe",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#ededed",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`ChartDonutUtilization 2`] = `
-<Component
-  height={230}
-  width={230}
->
+<Fragment>
   <Component
-    data={
-      Array [
-        Object {
-          "x": 0,
-          "y": Object {},
-        },
-        Object {
-          "y": 100,
-        },
-      ]
-    }
-    donutHeight={230}
-    donutWidth={230}
     height={230}
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -940,31 +1370,478 @@ exports[`ChartDonutUtilization 2`] = `
       }
     }
     width={230}
-  />
-</Component>
+  >
+    <Component
+      allowTooltip={true}
+      data={
+        Array [
+          Object {
+            "x": 0,
+            "y": Object {},
+          },
+          Object {
+            "y": 100,
+          },
+        ]
+      }
+      height={230}
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#ededed",
+              "#d2d2d2",
+              "#b8bbbe",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#ededed",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`renders component data 1`] = `
-<Component
-  height={200}
-  width={200}
->
+<Fragment>
   <Component
-    data={
-      Array [
-        Object {
-          "x": "Cats",
-          "y": 35,
-        },
-        Object {
-          "y": 65,
-        },
-      ]
-    }
-    donutHeight={200}
-    donutWidth={200}
     height={200}
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -1412,6 +2289,470 @@ exports[`renders component data 1`] = `
       }
     }
     width={200}
-  />
-</Component>
+  >
+    <Component
+      allowTooltip={true}
+      data={
+        Array [
+          Object {
+            "x": "Cats",
+            "y": 35,
+          },
+          Object {
+            "y": 65,
+          },
+        ]
+      }
+      height={200}
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#ededed",
+              "#d2d2d2",
+              "#b8bbbe",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#ededed",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={200}
+    />
+  </Component>
+</Fragment>
 `;

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -2,11 +2,25 @@
 title: 'Donut utilization'
 section: 'charts'
 typescript: true
-propComponents: ['ChartDonutThreshold', 'ChartDonutUtilization']
+propComponents: ['ChartLegend', 'ChartDonutThreshold', 'ChartDonutUtilization']
 ---
 
 import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
 import './chart-donut-utilization.scss';
+
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+## Tutorial
+
+PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, 
+along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React 
+based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+In this tutorial, we will build a bar chart together - starting with a simple chart, adding thresholds, tooltips,
+a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build 
+a consistent user experience.
+
+[Start course](https://katacoda.com/patternfly/courses/charts/module-donut-utilization)
 
 ## Simple donut utilization chart
 ```js
@@ -18,8 +32,9 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     <ChartDonutUtilization
       ariaDesc="Storage capacity"
       ariaTitle="Donut utilization chart example"
+      constrainToVisibleArea={true}
       data={{ x: 'GBps capacity', y: 75 }}
-      labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+      labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
       subTitle="of 100 GBps"
       title="75%"
     />
@@ -64,10 +79,17 @@ class UtilizationChart extends React.Component {
           <ChartDonutUtilization
             ariaDesc="Storage capacity"
             ariaTitle="Donut utilization chart example"
+            constrainToVisibleArea={true}
             data={{ x: 'GBps capacity', y: used }}
-            labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
             legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
             legendOrientation="vertical"
+            padding={{
+              bottom: 20,
+              left: 20,
+              right: 225, // Adjusted to accommodate legend
+              top: 20
+            }}
             subTitle="of 100 GBps"
             title={`${used}%`}
             thresholds={[{ value: 60 }, { value: 90 }]}
@@ -117,11 +139,18 @@ class UtilizationChart extends React.Component {
           <ChartDonutUtilization
             ariaDesc="Storage capacity"
             ariaTitle="Donut utilization chart example"
+            constrainToVisibleArea={true}
             data={{ x: 'GBps capacity', y: used }}
             invert
-            labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
             legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
             legendOrientation="vertical"
+            padding={{
+              bottom: 20,
+              left: 20,
+              right: 225, // Adjusted to accommodate legend
+              top: 20
+            }}
             subTitle="of 100 GBps"
             title={`${used}%`}
             thresholds={[{ value: 60 }, { value: 20 }]}
@@ -171,13 +200,19 @@ class UtilizationChart extends React.Component {
           <ChartDonutUtilization
             ariaDesc="Storage capacity"
             ariaTitle="Donut utilization chart example"
+            constrainToVisibleArea={true}
             data={{ x: 'Storage capacity', y: used }}
-            donutHeight={230}
             height={300}
-            labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
             legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
             legendOrientation="vertical"
             legendPosition="bottom"
+            padding={{
+              bottom: 75, // Adjusted to accommodate legend
+              left: 20,
+              right: 20,
+              top: 20
+            }}
             subTitle="of 100 GBps"
             title={`${used}%`}
             themeColor={ChartThemeColor.green}
@@ -202,12 +237,18 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     <ChartDonutUtilization
       ariaDesc="Storage capacity"
       ariaTitle="Donut utilization chart example"
+      constrainToVisibleArea={true}
       data={{ x: 'Storage capacity', y: 45 }}
-      donutHeight={230}
       height={275}
-      labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+      labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
       legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
       legendPosition="bottom"
+      padding={{
+        bottom: 65, // Adjusted to accommodate legend
+        left: 20,
+        right: 20,
+        top: 20
+      }}
       subTitle="of 100 GBps"
       title="45%"
       thresholds={[{ value: 60 }, { value: 90 }]}
@@ -227,12 +268,13 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     <ChartDonutThreshold
       ariaDesc="Storage capacity"
       ariaTitle="Donut utilization chart with static threshold example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-      labels={datum => datum.x ? datum.x : null}
+      labels={({ datum }) => datum.x ? datum.x : null}
     >
       <ChartDonutUtilization
         data={{ x: 'Storage capacity', y: 45 }}
-        labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+        labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
         subTitle="of 100 GBps"
         title="45%"
       />
@@ -273,13 +315,20 @@ class ThresholdChart extends React.Component {
           <ChartDonutThreshold
             ariaDesc="Storage capacity"
             ariaTitle="Donut utilization chart with static threshold example"
+            constrainToVisibleArea={true}
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-            labels={datum => datum.x ? datum.x : null}
+            labels={({ datum }) => datum.x ? datum.x : null}
+            padding={{
+              bottom: 20,
+              left: 20,
+              right: 290, // Adjusted to accommodate legend
+              top: 20
+            }}
             width={500}
           >
             <ChartDonutUtilization
               data={{ x: 'Storage capacity', y: used }}
-              labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
               legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
               legendOrientation="vertical"
               subTitle="of 100 GBps"
@@ -331,14 +380,21 @@ class ThresholdChart extends React.Component {
           <ChartDonutThreshold
             ariaDesc="Storage capacity"
             ariaTitle="Donut utilization chart with static threshold example"
+            constrainToVisibleArea={true}
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 20%', y: 20 }]}
             invert
-            labels={datum => datum.x ? datum.x : null}
+            labels={({ datum }) => datum.x ? datum.x : null}
+            padding={{
+              bottom: 20,
+              left: 20,
+              right: 290, // Adjusted to accommodate legend
+              top: 20
+            }}
             width={500}
           >
             <ChartDonutUtilization
               data={{ x: 'Storage capacity', y: used }}
-              labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
               legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 20%' }]}
               legendOrientation="vertical"
               subTitle="of 100 GBps"
@@ -385,15 +441,22 @@ class ThresholdChart extends React.Component {
           <ChartDonutThreshold
             ariaDesc="Storage capacity"
             ariaTitle="Donut utilization chart with static threshold example"
+            constrainToVisibleArea={true}
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
             height={350}
-            labels={datum => datum.x ? datum.x : null}
+            labels={({ datum }) => datum.x ? datum.x : null}
             legendPosition="bottom"
+            padding={{
+              bottom: 125, // Adjusted to accommodate legend
+              left: 20,
+              right: 20,
+              top: 20
+            }}
             width={230}
           >
             <ChartDonutUtilization
               data={{ x: 'Storage capacity', y: used }}
-              labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
               legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
               legendOrientation="vertical"
               subTitle="of 100 GBps"
@@ -420,16 +483,22 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     <ChartDonutThreshold
       ariaDesc="Storage capacity"
       ariaTitle="Donut utilization chart with static threshold example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-      donutHeight={230}
       height={275}
-      labels={datum => datum.x ? datum.x : null}
+      labels={({ datum }) => datum.x ? datum.x : null}
       legendPosition="bottom"
+      padding={{
+        bottom: 65, // Adjusted to accommodate legend
+        left: 20,
+        right: 20,
+        top: 20
+      }}
       width={675}
     >
       <ChartDonutUtilization
         data={{ x: 'Storage capacity', y: 45 }}
-        labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+        labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
         legendData={[{ name: `Storage capacity: 45%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
         subTitle="of 100 GBps"
         title="45%"
@@ -438,6 +507,8 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
   </div>
 </div>
 ```
+
+
 
 ## Small donut utilization chart
 ```js
@@ -449,12 +520,13 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     <ChartDonutUtilization
       ariaDesc="Storage capacity"
       ariaTitle="Donut utilization chart example"
+      constrainToVisibleArea={true}
       data={{ x: 'Storage capacity', y: 75 }}
-      height={150}
-      labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+      height={175}
+      labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
       subTitle="of 100 GBps"
       title="75%"
-      width={150}
+      width={175}
     />
   </div>
 </div>
@@ -497,11 +569,18 @@ class UtilizationChart extends React.Component {
           <ChartDonutUtilization
             ariaDesc="Storage capacity"
             ariaTitle="Donut utilization chart example"
+            constrainToVisibleArea={true}
             data={{ x: 'Storage capacity', y: used }}
-            height={150}
-            labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            height={175}
+            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
             legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
             legendOrientation="vertical"
+            padding={{
+              bottom: 20,
+              left: 20,
+              right: 195, // Adjusted to accommodate legend
+              top: 20
+            }}
             subTitle="of 100 GBps"
             title={`${used}%`}
             thresholds={[{ value: 60 }, { value: 90 }]}
@@ -524,12 +603,18 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     <ChartDonutUtilization
       ariaDesc="Storage capacity"
       ariaTitle="Donut utilization chart example"
+      constrainToVisibleArea={true}
       data={{ x: 'Storage capacity', y: 45 }}
-      donutHeight={150}
-      height={175}
-      labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+      height={185}
+      labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
       legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
       legendOrientation="vertical"
+      padding={{
+        bottom: 25, // Adjusted to accommodate subTitle
+        left: 20,
+        right: 195, // Adjusted to accommodate legend
+        top: 20
+      }}
       subTitle="of 100 GBps"
       subTitlePosition="bottom"
       title="45%"
@@ -550,12 +635,18 @@ import { ChartDonutUtilization } from '@patternfly/react-charts';
     <ChartDonutUtilization
       ariaDesc="Storage capacity"
       ariaTitle="Donut utilization chart example"
+      constrainToVisibleArea={true}
       data={{ x: 'Storage capacity', y: 45 }}
-      donutHeight={150}
       height={200}
-      labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+      labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
       legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
       legendPosition="bottom"
+      padding={{
+        bottom: 45, // Adjusted to accommodate legend
+        left: 20,
+        right: 20,
+        top: 20
+      }}
       subTitle="of 100 GBps"
       subTitlePosition="right"
       title="45%"
@@ -576,14 +667,15 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     <ChartDonutThreshold
       ariaDesc="Storage capacity"
       ariaTitle="Donut utilization chart with static threshold example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-      height={175}
-      labels={datum => datum.x ? datum.x : null}
-      width={175}
+      height={185}
+      labels={({ datum }) => datum.x ? datum.x : null}
+      width={185}
     >
       <ChartDonutUtilization
         data={{ x: 'Storage capacity', y: 45 }}
-        labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+        labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
         subTitle="of 100 GBps"
         title="45%"
       />
@@ -624,14 +716,21 @@ class ThresholdChart extends React.Component {
           <ChartDonutThreshold
             ariaDesc="Storage capacity"
             ariaTitle="Donut utilization chart with static threshold example"
+            constrainToVisibleArea={true}
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-            height={175}
-            labels={datum => datum.x ? datum.x : null}
+            height={185}
+            labels={({ datum }) => datum.x ? datum.x : null}
+            padding={{
+              bottom: 20,
+              left: 20,
+              right: 260, // Adjusted to accommodate legend
+              top: 20
+            }}
             width={425}
           >
             <ChartDonutUtilization
               data={{ x: 'Storage capacity', y: used }}
-              labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
               legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
               legendOrientation="vertical"
               subTitle="of 100 GBps"
@@ -656,16 +755,22 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     <ChartDonutThreshold
       ariaDesc="Storage capacity"
       ariaTitle="Donut utilization chart with static threshold example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-      donutHeight={175}
       height={200}
-      labels={datum => datum.x ? datum.x : null}
+      labels={({ datum }) => datum.x ? datum.x : null}
+      padding={{
+        bottom: 30, // Adjusted to accommodate label
+        left: 20,
+        right: 260, // Adjusted to accommodate legend
+        top: 20
+      }}
       subTitlePosition="bottom"
       width={425}
     >
       <ChartDonutUtilization
         data={{ x: 'Storage capacity', y: 45 }}
-        labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+        labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
         legendData={[{ name: `Storage capacity: 45%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at  90%' }]}
         legendOrientation="vertical"
         subTitle="of 100 GBps"
@@ -687,17 +792,23 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     <ChartDonutThreshold
       ariaDesc="Storage capacity"
       ariaTitle="Donut utilization chart with static threshold example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-      donutHeight={175}
       height={225}
-      labels={datum => datum.x ? datum.x : null}
+      labels={({ datum }) => datum.x ? datum.x : null}
       legendPosition="bottom"
+      padding={{
+        bottom: 60, // Adjusted to accommodate legend
+        left: 20,
+        right: 20,
+        top: 20
+      }}
       subTitlePosition="right"
       width={675}
     >
       <ChartDonutUtilization
         data={{ x: 'Storage capacity', y: 45 }}
-        labels={datum => datum.x ? `${datum.x}: ${datum.y}%` : null}
+        labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
         legendData={[{ name: `Storage capacity: 45%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
         subTitle="of 100 GBps"
         title="45%"
@@ -707,3 +818,15 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
   </div>
 </div>
 ```
+
+## Tips
+
+- For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+- `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `ChartLegend` props, see <a href="https://formidable.com/open-source/victory/docs/victory-legend" target="_blank">VictoryLegend</a>
+ - For `ChartDonutThreshold` & `ChartDonutUtilization` props, see <a href="https://formidable.com/open-source/victory/docs/victory-pie" target="_blank">VictoryPie</a>

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/chart-donut-utilization.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/chart-donut-utilization.scss
@@ -6,8 +6,8 @@
     }
 
     .donut-threshold-chart-sm {
-      height: 175px;
-      width: 175px;
+      height: 185px;
+      width: 185px;
     }
 
     .donut-threshold-chart-legend-bottom-horz {
@@ -26,7 +26,7 @@
     }
 
     .donut-threshold-chart-legend-right-sm {
-      height: 175px;
+      height: 185px;
       width: 425px;
     }
 
@@ -46,8 +46,8 @@
     }
 
     .donut-utilization-chart-sm {
-      height: 150px;
-      width: 150px;
+      height: 175px;
+      width: 175px;
     }
 
     .donut-utilization-chart-legend-bottom-horz {
@@ -66,7 +66,7 @@
     }
 
     .donut-utilization-chart-legend-right-sm {
-      height: 150px;
+      height: 175px;
       width: 350px;
     }
 
@@ -76,7 +76,7 @@
     }
 
     .donut-utilization-chart-legend-right-subtitle-bottom-sm {
-      height: 175px;
+      height: 185px;
       width: 350px;
     }
   }

--- a/packages/patternfly-4/react-charts/src/components/ChartGroup/ChartGroup.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartGroup/ChartGroup.tsx
@@ -18,9 +18,9 @@ import {
   VictoryGroupProps,
   VictoryZoomContainer
 } from 'victory';
+import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
-import { getTheme } from '../ChartUtils';
-import {ChartContainer} from '../ChartContainer';
+import { getClassName, getTheme } from '../ChartUtils';
 
 export enum ChartGroupSortOrder {
   ascending = 'ascending',
@@ -31,10 +31,6 @@ export enum ChartGroupSortOrder {
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
  */
 export interface ChartGroupProps extends VictoryGroupProps {
-  /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-group/
-   */
-  ' '?: any;
   /**
    * Specifies the zoom capability of the container component. A value of true allows the chart to
    * zoom in and out. Zoom events are controlled by scrolling. When zoomed in, panning events are
@@ -422,7 +418,8 @@ export const ChartGroup: React.FunctionComponent<ChartGroupProps> = ({
     desc: ariaDesc,
     title: ariaTitle,
     theme,
-    ...containerComponent.props
+    ...containerComponent.props,
+    className: getClassName({className: containerComponent.props.className}) // Override VictoryContainer class name
   });
 
   return (

--- a/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartGroup/__snapshots__/ChartGroup.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`ChartGroup 1`] = `
 <VictoryGroup
   containerComponent={
     <Unknown
+      className="pf-c-chart"
       theme={
         Object {
           "area": Object {
@@ -915,6 +916,7 @@ exports[`ChartGroup 2`] = `
 <VictoryGroup
   containerComponent={
     <Unknown
+      className="pf-c-chart"
       theme={
         Object {
           "area": Object {
@@ -1826,6 +1828,7 @@ exports[`renders container children 1`] = `
 <VictoryGroup
   containerComponent={
     <Unknown
+      className="pf-c-chart"
       theme={
         Object {
           "area": Object {

--- a/packages/patternfly-4/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -27,10 +27,6 @@ type TextAnchorType = 'start' | 'middle' | 'end' | 'inherit';
  */
 export interface ChartLabelProps extends VictoryLabelProps {
   /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-label/
-   */
-  ' '?: any;
-  /**
    * The active prop specifies whether the label is active or not. The active prop is set by defaultEvents in components
    * like ChartTooltip and VictorySelectionContainer. The active prop is used when evaluating functional styles and
    * props.

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegend.tsx
@@ -38,10 +38,6 @@ export enum ChartLegendRowGutter {
  */
 export interface ChartLegendProps extends VictoryLegendProps {
   /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-legend/
-   */
-  ' '?: any;
-  /**
    * The borderComponent prop takes a component instance which will be responsible
    * for rendering a border around the legend. The new element created from the passed
    * borderComponent will be provided with the following properties calculated by

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegendWrapper.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/ChartLegendWrapper.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { PaddingProps } from 'victory';
 import { ChartLegendOrientation, ChartLegendPosition } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
-import { getLegendX, getLegendY, getTheme } from '../ChartUtils';
+import {getLegendX, getLegendY, getPaddingForSide, getTheme} from '../ChartUtils';
 
 export enum ChartLegendConfigChartType {
   chart = 'chart',
@@ -25,36 +26,6 @@ export enum ChartLegendConfigChartType {
  */
 export interface ChartLegendWrapperProps {
   /**
-   * Specifies the height of the chart. This value should be given as a number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and height props do not determine the width and
-   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, height (the overall SVG height) may need to be larger than chartHeight (the chart size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, chartHeight is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, chartHeight (not height) may need to be set in order to adjust the chart
-   * height
-   */
-  chartHeight?: number;
-  /**
-   * Specifies the width of the chart. This value should be given as a number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and width props do not determine the width and
-   * width of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, width (the overall SVG width) may need to be larger than chartHeight (the chart size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, chartHeight is the min. of either width or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, chartHeight (not width) may need to be set in order to adjust the chart
-   * width
-   */
-  chartWidth?: number;
-  /**
    * The type of chart the legend will apply to. Valid types are; 'area', 'bar', 'line', 'pie', and 'stack'
    *
    * Note: This is used to calculate padding defined by the theme
@@ -73,6 +44,15 @@ export interface ChartLegendWrapperProps {
    */
   dy?: number;
   /**
+   * Specifies the height the svg viewBox of the chart container. This value should be given as a
+   * number of pixels.
+   *
+   * Because Victory renders responsive containers, the width and height props do not determine the width and
+   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
+   * pixels will depend on the size of the container the chart is rendered into.
+   */
+  height?: number;
+  /**
    * The orientation prop takes a string that defines whether legend data
    * are displayed in a row or column. When orientation is "horizontal",
    * legend items will be displayed in a single row. When orientation is
@@ -83,27 +63,16 @@ export interface ChartLegendWrapperProps {
    */
   orientation?: 'horizontal' | 'vertical';
   /**
+   * The padding props specifies the amount of padding in number of pixels between
+   * the edge of the chart and any rendered child components. This prop can be given
+   * as a number or as an object with padding specified for top, bottom, left
+   * and right.
+   */
+  padding?: PaddingProps;
+  /**
    * The legend position relation to the donut chart. Valid values are 'bottom', 'bottom-left', and 'right'
    */
   position?: 'bottom' | 'bottom-left' | 'right';
-  /**
-   * Specifies the height the svg viewBox of the chart container. This value should be given as a
-   * number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and height props do not determine the width and
-   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   */
-  svgHeight?: number;
-  /**
-   * Specifies the width of the svg viewBox of the chart container. This value should be given as a
-   * number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and height props do not determine the width and
-   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   */
-  svgWidth?: number;
   /**
    * The theme prop takes a style object with nested data, labels, and parent objects.
    * You can create this object yourself, or you can use a theme provided by
@@ -128,6 +97,15 @@ export interface ChartLegendWrapperProps {
    * @example themeVariant={ChartThemeVariant.light}
    */
   themeVariant?: string;
+  /**
+   * Specifies the width of the svg viewBox of the chart container. This value should be given as a
+   * number of pixels.
+   *
+   * Because Victory renders responsive containers, the width and height props do not determine the width and
+   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
+   * pixels will depend on the size of the container the chart is rendered into.
+   */
+  width?: number;
 }
 
 export const ChartLegendWrapper: React.FunctionComponent<ChartLegendWrapperProps> = ({
@@ -135,6 +113,7 @@ export const ChartLegendWrapper: React.FunctionComponent<ChartLegendWrapperProps
   children,
   dx = 0,
   dy = 0,
+  padding,
   position = ChartCommonStyles.legend.position as ChartLegendPosition,
   themeColor,
   themeVariant,
@@ -142,34 +121,36 @@ export const ChartLegendWrapper: React.FunctionComponent<ChartLegendWrapperProps
   // destructure last
   theme = getTheme(themeColor, themeVariant),
   orientation = theme.legend.orientation as ChartLegendOrientation,
-  svgHeight = theme.chart.height,
-  svgWidth = theme.chart.width,
-  chartHeight = svgHeight,
-  chartWidth = svgWidth
+  height = theme.chart.height,
+  width = theme.chart.width
 }: ChartLegendWrapperProps) => {
   // Render children
   const renderChildren = () =>
     React.Children.toArray(children).map((child: any) => {
       const childProps = child.props ? child.props : {};
       const legendX = getLegendX({
-        chartWidth,
+        chartType,
         dx,
+        height,
         legendData: childProps.data,
         legendOrientation: childProps.legendOrientation ? childProps.legendOrientation : orientation,
         legendPosition: position,
         legendProps: childProps,
+        padding,
         theme,
-        svgWidth
+        width
       });
       const legendY = getLegendY({
-        chartHeight,
         chartType,
         dy,
+        height,
         legendData: childProps.data,
         legendOrientation: childProps.legendOrientation ? childProps.legendOrientation : orientation,
         legendProps: childProps,
         legendPosition: position,
-        theme
+        padding,
+        theme,
+        width
       });
       if (childProps.data) {
         return React.cloneElement(child as React.ReactElement<any>, {

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/__snapshots__/ChartLegend.test.tsx.snap
@@ -5,6 +5,8 @@ exports[`ChartLegend 1`] = `
   borderComponent={
     <Border
       rectComponent={<Rect />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   containerComponent={
@@ -949,6 +951,8 @@ exports[`ChartLegend 2`] = `
   borderComponent={
     <Border
       rectComponent={<Rect />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   containerComponent={
@@ -1893,6 +1897,8 @@ exports[`renders component data 1`] = `
   borderComponent={
     <Border
       rectComponent={<Rect />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   containerComponent={

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/ChartLine.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/ChartLine.tsx
@@ -14,8 +14,9 @@ import {
   StringOrNumberOrCallback,
   VictoryStyleInterface,
   VictoryLine,
-  VictoryLineProps
+  VictoryLineProps,
 } from 'victory';
+import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
 
@@ -28,10 +29,6 @@ export enum ChartLineSortOrder {
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
  */
 export interface ChartLineProps extends VictoryLineProps {
-  /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-line/
-   */
-  ' '?: any;
   /**
    * The animate prop specifies props for VictoryAnimation to use.
    * The animate prop should also be used to specify enter and exit
@@ -117,7 +114,7 @@ export interface ChartLineProps extends VictoryLineProps {
    * The mutation function will be called with the calculated props for the individual selected
    * element (i.e. a line), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
-   * @examples
+   * @example
    * events={[
    *   {
    *     target: "data",
@@ -376,9 +373,12 @@ export interface ChartLineProps extends VictoryLineProps {
 export const ChartLine: React.FunctionComponent<ChartLineProps> = ({
   themeColor,
   themeVariant,
-  theme = getTheme(themeColor, themeVariant), // destructure last
+
+  // destructure last
+  theme = getTheme(themeColor, themeVariant),
+  containerComponent = <ChartContainer theme={theme} />,
   ...rest
-}: ChartLineProps) => <VictoryLine theme={theme} {...rest} />;
+}: ChartLineProps) => <VictoryLine containerComponent={containerComponent} theme={theme} {...rest} />;
 
 // Note: VictoryLine.role must be hoisted
 hoistNonReactStatics(ChartLine, VictoryLine);

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/__snapshots__/ChartLine.test.tsx.snap
@@ -3,16 +3,463 @@
 exports[`ChartLine 1`] = `
 <VictoryLine
   containerComponent={
-    <VictoryContainer
-      className="VictoryContainer"
-      portalComponent={<Portal />}
-      portalZIndex={99}
-      responsive={true}
+    <Unknown
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
     />
   }
   dataComponent={
     <Curve
       pathComponent={<Path />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   groupComponent={
@@ -492,16 +939,463 @@ exports[`ChartLine 1`] = `
 exports[`ChartLine 2`] = `
 <VictoryLine
   containerComponent={
-    <VictoryContainer
-      className="VictoryContainer"
-      portalComponent={<Portal />}
-      portalZIndex={99}
-      responsive={true}
+    <Unknown
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
     />
   }
   dataComponent={
     <Curve
       pathComponent={<Path />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   groupComponent={
@@ -982,6 +1876,7 @@ exports[`renders component data 1`] = `
 <VictoryChart
   containerComponent={
     <Unknown
+      className="pf-c-chart"
       theme={
         Object {
           "area": Object {
@@ -1439,6 +2334,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -1464,6 +2361,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -1947,6 +2846,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -1964,6 +2865,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -1988,6 +2891,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2471,6 +3376,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -2492,6 +3399,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -2507,12 +3416,16 @@ exports[`renders component data 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2529,6 +3442,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3014,6 +3929,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -3031,6 +3948,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -3046,12 +3965,16 @@ exports[`renders component data 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3067,6 +3990,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3552,6 +4477,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -2,32 +2,48 @@
 title: 'Line'
 section: 'charts'
 typescript: true
-propComponents: ['Chart', 'ChartAxis', 'ChartGroup', 'ChartLegend', 'ChartLine']
+propComponents: ['Chart', 'ChartAxis', 'ChartGroup', 'ChartLegend', 'ChartLine', 'ChartVoronoiContainer']
 ---
 
-import { Chart, ChartAxis, ChartGroup, ChartLegend, ChartLine, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartThemeVariant, ChartVoronoiContainer } from '@patternfly/react-charts';
 import { VictoryZoomContainer } from 'victory';
 import './chart-line.scss';
+
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+## Tutorial
+
+PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, 
+along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React 
+based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+In this tutorial, we will build a bar chart together - starting with a simple chart, adding multiple datasets, 
+tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart 
+components together to build a consistent user experience.
+
+[Start course](https://katacoda.com/patternfly/courses/charts/module-line)
 
 ## Simple line chart with right aligned legend
 ```js
 import React from 'react';
-import { Chart, ChartAxis, ChartGroup, ChartLine } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartVoronoiContainer } from '@patternfly/react-charts';
 
 <div>
   <div className="line-chart-legend-right">
     <Chart
       ariaDesc="Average number of pets"
       ariaTitle="Line chart example"
-      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
+      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
       legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
       legendOrientation="vertical"
       legendPosition="right"
       height={250}
+      maxDomain={{y: 10}}
+      minDomain={{y: 0}}
       padding={{
         bottom: 50,
         left: 50,
-        right: 200, // Adjusted to accomodate legend
+        right: 200, // Adjusted to accommodate legend
         top: 50
       }}
       width={600}
@@ -37,18 +53,18 @@ import { Chart, ChartAxis, ChartGroup, ChartLine } from '@patternfly/react-chart
       <ChartGroup>
         <ChartLine
           data={[
-            { name: 'Cats', x: 1, y: 1 },
-            { name: 'Cats', x: 2, y: 2 },
-            { name: 'Cats', x: 3, y: 5 },
-            { name: 'Cats', x: 4, y: 3 }
+            { name: 'Cats', x: '2015', y: 1 },
+            { name: 'Cats', x: '2016', y: 2 },
+            { name: 'Cats', x: '2017', y: 5 },
+            { name: 'Cats', x: '2018', y: 3 }
           ]}
         />
         <ChartLine
           data={[
-            { name: 'Dogs', x: 1, y: 2 },
-            { name: 'Dogs', x: 2, y: 1 },
-            { name: 'Dogs', x: 3, y: 7 },
-            { name: 'Dogs', x: 4, y: 4 }
+            { name: 'Dogs', x: '2015', y: 2 },
+            { name: 'Dogs', x: '2016', y: 1 },
+            { name: 'Dogs', x: '2017', y: 7 },
+            { name: 'Dogs', x: '2018', y: 4 }
           ]}
           style={{
             data: {
@@ -58,18 +74,18 @@ import { Chart, ChartAxis, ChartGroup, ChartLine } from '@patternfly/react-chart
         />
         <ChartLine
           data={[
-            { name: 'Birds', x: 1, y: 3 },
-            { name: 'Birds', x: 2, y: 4 },
-            { name: 'Birds', x: 3, y: 9 },
-            { name: 'Birds', x: 4, y: 5 }
+            { name: 'Birds', x: '2015', y: 3 },
+            { name: 'Birds', x: '2016', y: 4 },
+            { name: 'Birds', x: '2017', y: 9 },
+            { name: 'Birds', x: '2018', y: 5 }
           ]}
         />
         <ChartLine
           data={[
-            { name: 'Mice', x: 1, y: 3 },
-            { name: 'Mice', x: 2, y: 3 },
-            { name: 'Mice', x: 3, y: 8 },
-            { name: 'Mice', x: 4, y: 7 }
+            { name: 'Mice', x: '2015', y: 3 },
+            { name: 'Mice', x: '2016', y: 3 },
+            { name: 'Mice', x: '2017', y: 8 },
+            { name: 'Mice', x: '2018', y: 7 }
           ]}
         />
       </ChartGroup>
@@ -81,19 +97,21 @@ import { Chart, ChartAxis, ChartGroup, ChartLine } from '@patternfly/react-chart
 ## Green line chart with right aligned legend
 ```js
 import React from 'react';
-import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
 
 <div>
   <div className="line-chart-legend-bottom">
     <Chart
       ariaDesc="Average number of pets"
       ariaTitle="Line chart example"
-      containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
+      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
       legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
       legendPosition="bottom"
       height={275}
+      maxDomain={{y: 10}}
+      minDomain={{y: 0}}
       padding={{
-        bottom: 75, // Adjusted to accomodate legend
+        bottom: 75, // Adjusted to accommodate legend
         left: 50,
         right: 50,
         top: 50
@@ -106,18 +124,18 @@ import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor } from '@patte
       <ChartGroup>
         <ChartLine
           data={[
-            { name: 'Cats', x: 1, y: 1 },
-            { name: 'Cats', x: 2, y: 2 },
-            { name: 'Cats', x: 3, y: 5 },
-            { name: 'Cats', x: 4, y: 3 }
+            { name: 'Cats', x: '2015', y: 1 },
+            { name: 'Cats', x: '2016', y: 2 },
+            { name: 'Cats', x: '2017', y: 5 },
+            { name: 'Cats', x: '2018', y: 3 }
           ]}
         />
         <ChartLine
           data={[
-            { name: 'Dogs', x: 1, y: 2 },
-            { name: 'Dogs', x: 2, y: 1 },
-            { name: 'Dogs', x: 3, y: 7 },
-            { name: 'Dogs', x: 4, y: 4 }
+            { name: 'Dogs', x: '2015', y: 2 },
+            { name: 'Dogs', x: '2016', y: 1 },
+            { name: 'Dogs', x: '2017', y: 7 },
+            { name: 'Dogs', x: '2018', y: 4 }
           ]}
           style={{
             data: {
@@ -127,18 +145,18 @@ import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor } from '@patte
         />
         <ChartLine
           data={[
-            { name: 'Birds', x: 1, y: 3 },
-            { name: 'Birds', x: 2, y: 4 },
-            { name: 'Birds', x: 3, y: 9 },
-            { name: 'Birds', x: 4, y: 5 }
+            { name: 'Birds', x: '2015', y: 3 },
+            { name: 'Birds', x: '2016', y: 4 },
+            { name: 'Birds', x: '2017', y: 9 },
+            { name: 'Birds', x: '2018', y: 5 }
           ]}
         />
         <ChartLine
           data={[
-            { name: 'Mice', x: 1, y: 3 },
-            { name: 'Mice', x: 2, y: 3 },
-            { name: 'Mice', x: 3, y: 8 },
-            { name: 'Mice', x: 4, y: 7 }
+            { name: 'Mice', x: '2015', y: 3 },
+            { name: 'Mice', x: '2016', y: 3 },
+            { name: 'Mice', x: '2017', y: 8 },
+            { name: 'Mice', x: '2018', y: 7 }
           ]}
         />
       </ChartGroup>
@@ -147,7 +165,8 @@ import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor } from '@patte
 </div>
 ```
 
-## Multi-color (unorderd) line chart with x-axis zoom, bottom-left aligned legend, and responsive container
+## Multi-color (unorderd) line chart with bottom-left aligned legend and responsive container
+This demonstrates zoom for the x axis only
 ```js
 import React from 'react';
 import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor } from '@patternfly/react-charts';
@@ -189,8 +208,10 @@ class MultiColorChart extends React.Component {
             legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
             legendPosition="bottom-left"
             height={275}
+            maxDomain={{y: 10}}
+            minDomain={{y: 0}}
             padding={{
-              bottom: 75, // Adjusted to accomodate legend
+              bottom: 75, // Adjusted to accommodate legend
               left: 50,
               right: 50,
               top: 50
@@ -203,18 +224,18 @@ class MultiColorChart extends React.Component {
             <ChartGroup>
               <ChartLine
                 data={[
-                  { name: 'Cats', x: 1, y: 1 },
-                  { name: 'Cats', x: 2, y: 2 },
-                  { name: 'Cats', x: 3, y: 5 },
-                  { name: 'Cats', x: 4, y: 3 }
+                  { name: 'Cats', x: '2015', y: 1 },
+                  { name: 'Cats', x: '2016', y: 2 },
+                  { name: 'Cats', x: '2017', y: 5 },
+                  { name: 'Cats', x: '2018', y: 3 }
                 ]}
               />
               <ChartLine
                 data={[
-                  { name: 'Dogs', x: 1, y: 2 },
-                  { name: 'Dogs', x: 2, y: 1 },
-                  { name: 'Dogs', x: 3, y: 7 },
-                  { name: 'Dogs', x: 4, y: 4 }
+                  { name: 'Dogs', x: '2015', y: 2 },
+                  { name: 'Dogs', x: '2016', y: 1 },
+                  { name: 'Dogs', x: '2017', y: 7 },
+                  { name: 'Dogs', x: '2018', y: 4 }
                 ]}
                 style={{
                   data: {
@@ -224,18 +245,18 @@ class MultiColorChart extends React.Component {
               />
               <ChartLine
                 data={[
-                  { name: 'Birds', x: 1, y: 3 },
-                  { name: 'Birds', x: 2, y: 4 },
-                  { name: 'Birds', x: 3, y: 9 },
-                  { name: 'Birds', x: 4, y: 5 }
+                  { name: 'Birds', x: '2015', y: 3 },
+                  { name: 'Birds', x: '2016', y: 4 },
+                  { name: 'Birds', x: '2017', y: 9 },
+                  { name: 'Birds', x: '2018', y: 5 }
                 ]}
               />
               <ChartLine
                 data={[
-                  { name: 'Mice', x: 1, y: 3 },
-                  { name: 'Mice', x: 2, y: 3 },
-                  { name: 'Mice', x: 3, y: 8 },
-                  { name: 'Mice', x: 4, y: 7 }
+                  { name: 'Mice', x: '2015', y: 3 },
+                  { name: 'Mice', x: '2016', y: 3 },
+                  { name: 'Mice', x: '2017', y: 8 },
+                  { name: 'Mice', x: '2018', y: 7 }
                 ]}
               />
             </ChartGroup>
@@ -246,3 +267,20 @@ class MultiColorChart extends React.Component {
   }
 }
 ```
+
+## Tips
+
+- For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+- `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `Chart` props, see <a href="https://formidable.com/open-source/victory/docs/victory-chart" target="_blank">VictoryChart</a>
+ - For `ChartAxis` props, see <a href="https://formidable.com/open-source/victory/docs/victory-axis" target="_blank">VictoryAxis</a>
+ - For `ChartGroup` props, see <a href="https://formidable.com/open-source/victory/docs/victory-group" target="_blank">VictoryGroup</a>
+ - For `ChartLegend` props, see <a href="https://formidable.com/open-source/victory/docs/victory-legend" target="_blank">VictoryLegend</a>
+ - For `ChartLine` props, see <a href="https://formidable.com/open-source/victory/docs/victory-line" target="_blank">Victoryline</a>
+ - For `ChartVoronoiContainer` props, see <a href="https://formidable.com/open-source/victory/docs/victory-voronoi-container" target="_blank">VictoryVoronoiContainer</a>
+ - For `VictoryZoomContainer` props, see <a href="https://formidable.com/open-source/victory/docs/victory-zoom-container" target="_blank">VictoryZoomContainer</a>

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -10,13 +10,14 @@ import {
   StringOrNumberOrCallback,
   VictoryPie,
   VictoryPieProps,
-  VictoryStyleInterface
+  VictoryStyleInterface,
 } from 'victory';
+import { Helpers } from 'victory-core';
 import { ChartContainer } from '../ChartContainer';
 import { ChartLegend, ChartLegendOrientation, ChartLegendWrapper } from '../ChartLegend';
 import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
 import { ChartTooltip } from '../ChartTooltip';
-import { getChartOrigin, getTheme } from '../ChartUtils';
+import { getPaddingForSide, getTheme } from '../ChartUtils';
 
 export enum ChartPieLabelPosition {
   centroid = 'centroid',
@@ -39,9 +40,11 @@ export enum ChartPieSortOrder {
  */
 export interface ChartPieProps extends VictoryPieProps {
   /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-pie/
+   * Specifies the tooltip capability of the container component. A value of true allows the chart to add a
+   * ChartTooltip component to the labelComponent property. This is a shortcut to display tooltips when the labels
+   * property is also provided.
    */
-  ' '?: any;
+  allowTooltip?: boolean;
   /**
    * The animate prop specifies props for VictoryAnimation to use.
    * The animate prop should also be used to specify enter and exit
@@ -80,6 +83,12 @@ export interface ChartPieProps extends VictoryPieProps {
    * data object
    */
   colorScale?: ColorScalePropType;
+  /**
+   * The constrainToVisibleArea prop determines whether to coerce tooltips so that they fit within the visible area of
+   * the chart. When this prop is set to true, tooltip pointers will still point to the correct data point, but the
+   * center of the tooltip will be shifted to fit within the overall width and height of the svg Victory renders.
+   */
+  constrainToVisibleArea?: boolean;
   /**
    * The containerComponent prop takes an entire component which will be used to
    * create a container element for standalone charts.
@@ -144,7 +153,7 @@ export interface ChartPieProps extends VictoryPieProps {
    * The mutation function will be called with the calculated props for the individual selected
    * element (i.e. a single bar), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
-   * @examples
+   * @example
    * events={[
    *   {
    *     target: "data",
@@ -257,14 +266,6 @@ export interface ChartPieProps extends VictoryPieProps {
     };
   }[];
   /**
-   * Defines a horizontal shift from the x coordinate. It should not be set manually.
-   */
-  legendDx?: number;
-  /**
-   * Defines a vertical shift from the y coordinate. It should not be set manually.
-   */
-  legendDy?: number;
-  /**
    * The orientation prop takes a string that defines whether legend data
    * are displayed in a row or column. When orientation is "horizontal",
    * legend items will be displayed in a single row. When orientation is
@@ -276,6 +277,9 @@ export interface ChartPieProps extends VictoryPieProps {
   legendOrientation?: 'horizontal' | 'vertical';
   /**
    * The legend position relation to the pie chart. Valid values are 'bottom' and 'right'
+   *
+   * Note: When adding a legend, padding may need to be adjusted in order to accommodate the extra legend. In some
+   * cases, the legend may not be visible until enough padding is applied.
    */
   legendPosition?: 'bottom' | 'right';
   /**
@@ -299,47 +303,6 @@ export interface ChartPieProps extends VictoryPieProps {
    * and right.
    */
   padding?: PaddingProps;
-  /**
-   * Specifies the height of the pie chart. This value should be given as a number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and height props do not determine the width and
-   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, height (the overall SVG height) may need to be larger than pieHeight (the pie size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, pieHeight is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, pieHeight (not height) may need to be set in order to adjust the pie
-   * height.
-   *
-   * Note: innerRadius may need to be set when using this property.
-   */
-  pieHeight?: number;
-  /**
-   * Defines a horizontal shift from the x coordinate. It should not be set manually.
-   */
-  pieDx?: number;
-  /**
-   * Defines a vertical shift from the y coordinate. It should not be set manually.
-   */
-  pieDy?: number;
-  /**
-   * Specifies the width of the pie chart. This value should be given as a number of pixels.
-   *
-   * Because Victory renders responsive containers, the width and height props do not determine the width and
-   * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, width (the overall SVG width) may need to be larger than pieWidth (the pie size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, pieWidth is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, pieWidth (not width) may need to be set in order to adjust the pie width.
-   *
-   * Note: innerRadius may need to be set when using this property.
-   */
-  pieWidth?: number;
   /**
    * Specifies the radius of the chart. If this property is not provided it is computed
    * from width, height, and padding props
@@ -405,15 +368,8 @@ export interface ChartPieProps extends VictoryPieProps {
    *
    * Because Victory renders responsive containers, the width and height props do not determine the width and
    * height of the chart in number of pixels, but instead define an aspect ratio for the chart. The exact number of
-   * pixels will depend on the size of the container the chart is rendered into.
-   *
-   * Note: When adding a legend, width (the overall SVG width) may need to be larger than pieWidth (the pie size)
-   * in order to accommodate the extra legend.
-   *
-   * By default, pieWidth is the min. of either height or width. This covers most use cases in order to accommodate
-   * legends within the same SVG. However, pieWidth (not width) may need to be set in order to adjust the pie width.
-   *
-   * Typically, the parent container is set to the same width in order to maintain the aspect ratio.
+   * pixels will depend on the size of the container the chart is rendered into. Typically, the parent container is set
+   * to the same width in order to maintain the aspect ratio.
    */
   width?: number;
   /**
@@ -441,46 +397,50 @@ export interface ChartPieProps extends VictoryPieProps {
 }
 
 export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
+  allowTooltip = true,
   ariaDesc,
   ariaTitle,
-  pieDx = 0,
-  pieDy = 0,
+  constrainToVisibleArea = false,
   legendComponent = <ChartLegend/>,
   legendData,
-  legendDx = 0,
-  legendDy = 0,
   legendPosition = ChartCommonStyles.legend.position as ChartPieLegendPosition,
+  padding,
+  radius,
   standalone = true,
   themeColor,
   themeVariant,
 
   // destructure last
   theme = getTheme(themeColor, themeVariant),
-  labelComponent = <ChartTooltip theme={theme} />,
+  containerComponent = <ChartContainer theme={theme} />,
+  labelComponent = allowTooltip ? <ChartTooltip constrainToVisibleArea={constrainToVisibleArea} theme={theme} /> : undefined,
   legendOrientation = theme.legend.orientation as ChartLegendOrientation,
   height = theme.pie.height,
   width = theme.pie.width,
-  pieHeight = Math.min(height, width),
-  pieWidth = Math.min(height, width),
   ...rest
 }: ChartPieProps) => {
-  const pieSize = Math.min(pieHeight, pieWidth);
+  const defaultPadding = {
+    bottom: getPaddingForSide('bottom',  padding, theme.pie.padding),
+    left: getPaddingForSide('left', padding, theme.pie.padding),
+    right: getPaddingForSide('right', padding, theme.pie.padding),
+    top: getPaddingForSide('top', padding, theme.pie.padding),
+  };
+  const chartRadius = radius ? radius : Helpers.getRadius({
+    height,
+    width,
+    padding: defaultPadding
+  });
+  const chartSize = chartRadius * 2;
 
   const chart = (
     <VictoryPie
-      height={pieSize}
+      height={height}
       labelComponent={labelComponent}
-      origin={getChartOrigin({
-        chartHeight: pieSize,
-        chartWidth: pieSize,
-        dx: pieDx,
-        dy: pieDy,
-        legendPosition,
-        svgWidth: width
-      })}
+      padding={padding}
+      radius={chartRadius}
       standalone={false}
       theme={theme}
-      width={pieSize}
+      width={width}
       {...rest}
     />
   );
@@ -499,27 +459,33 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
     }
     return (
       <ChartLegendWrapper
-        chartHeight={pieSize}
         chartType="pie"
-        chartWidth={pieSize}
-        dx={legendDx}
-        dy={legendDy}
+        height={height}
         orientation={legendOrientation}
+        padding={defaultPadding}
         position={legendPosition}
-        svgHeight={height}
-        svgWidth={width}
         theme={theme}
+        width={width}
       >
         {legend}
       </ChartLegendWrapper>
     );
   };
 
+  const container = React.cloneElement(containerComponent, {
+    children: [chart, getWrappedLegend()],
+    desc: ariaDesc,
+    height,
+    title: ariaTitle,
+    width,
+    theme,
+    ...containerComponent.props
+  });
+
   return standalone ? (
-    <ChartContainer desc={ariaDesc} height={height} title={ariaTitle} width={width}>
-      {chart}
-      {getWrappedLegend()}
-    </ChartContainer>
+    <React.Fragment>
+      {container}
+    </React.Fragment>
   ) : (
     <React.Fragment>
       {chart}

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
@@ -1,511 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChartPie 1`] = `
-<Component
-  height={230}
-  width={230}
->
-  <VictoryPie
-    containerComponent={
-      <VictoryContainer
-        className="VictoryContainer"
-        portalComponent={<Portal />}
-        portalZIndex={99}
-        responsive={true}
-      />
-    }
-    data={
-      Array [
-        Object {
-          "x": "A",
-          "y": 1,
-        },
-        Object {
-          "x": "B",
-          "y": 2,
-        },
-        Object {
-          "x": "C",
-          "y": 3,
-        },
-        Object {
-          "x": "D",
-          "y": 1,
-        },
-        Object {
-          "x": "E",
-          "y": 2,
-        },
-      ]
-    }
-    dataComponent={
-      <Slice
-        pathComponent={<Path />}
-      />
-    }
-    groupComponent={<g />}
+<Fragment>
+  <Component
     height={230}
-    labelComponent={
-      <Unknown
-        theme={
-          Object {
-            "area": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#06c",
-                  "fillOpacity": 0.3,
-                  "strokeWidth": 2,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "axis": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "axis": Object {
-                  "fill": "transparent",
-                  "stroke": "#d2d2d2",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                  "strokeWidth": 1,
-                },
-                "axisLabel": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 40,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-                "grid": Object {
-                  "fill": "none",
-                  "pointerEvents": "painted",
-                  "stroke": "none",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                },
-                "tickLabels": Object {
-                  "fill": "#4f5255",
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "ticks": Object {
-                  "fill": "transparent",
-                  "size": 5,
-                  "stroke": "#d2d2d2",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                  "strokeWidth": 1,
-                },
-              },
-              "width": 450,
-            },
-            "bar": Object {
-              "barWidth": 10,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#06c",
-                  "padding": 8,
-                  "stroke": "none",
-                  "strokeWidth": 0,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-              },
-              "width": 450,
-            },
-            "boxplot": Object {
-              "boxWidth": 20,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "max": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "maxLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "median": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "medianLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "min": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "minLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "q1": Object {
-                  "fill": "#8a8d90",
-                  "padding": 8,
-                },
-                "q1Labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "q3": Object {
-                  "fill": "#8a8d90",
-                  "padding": 8,
-                },
-                "q3Labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-              },
-              "width": 450,
-            },
-            "candlestick": Object {
-              "candleColors": Object {
-                "negative": "#151515",
-                "positive": "#fff",
-              },
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "chart": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "width": 450,
-            },
-            "errorbar": Object {
-              "borderWidth": 8,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "opacity": 1,
-                  "stroke": "#151515",
-                  "strokeWidth": 2,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "group": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "width": 450,
-            },
-            "legend": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "gutter": 20,
-              "orientation": "horizontal",
-              "style": Object {
-                "data": Object {
-                  "type": "square",
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "title": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 2,
-                  "stroke": "transparent",
-                },
-              },
-              "titleOrientation": "top",
-            },
-            "line": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "opacity": 1,
-                  "stroke": "#06c",
-                  "strokeWidth": 2,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "pie": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 230,
-              "padding": 20,
-              "style": Object {
-                "data": Object {
-                  "padding": 8,
-                  "stroke": "transparent",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 8,
-                  "stroke": "transparent",
-                },
-              },
-              "width": 230,
-            },
-            "scatter": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#151515",
-                  "opacity": 1,
-                  "stroke": "transparent",
-                  "strokeWidth": 0,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "stack": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "strokeWidth": 1,
-                },
-              },
-              "width": 450,
-            },
-            "tooltip": Object {
-              "cornerRadius": 0,
-              "flyoutStyle": Object {
-                "cornerRadius": 0,
-                "fill": "#151515",
-                "pointerEvents": "none",
-                "stroke": "#151515",
-                "strokeWidth": 0,
-              },
-              "pointerLength": 10,
-              "pointerWidth": 20,
-              "style": Object {
-                "fill": "#ededed",
-                "padding": 16,
-                "pointerEvents": "none",
-              },
-            },
-            "voronoi": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "stroke": "transparent",
-                  "strokeWidth": 0,
-                },
-                "flyout": Object {
-                  "fill": "#151515",
-                  "pointerEvents": "none",
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fill": "#ededed",
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 8,
-                  "pointerEvents": "none",
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-          }
-        }
-      />
-    }
-    origin={
-      Object {
-        "x": 115,
-        "y": 115,
-      }
-    }
-    sortOrder="ascending"
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -956,516 +454,965 @@ exports[`ChartPie 1`] = `
       }
     }
     width={230}
-  />
-</Component>
+  >
+    <VictoryPie
+      containerComponent={
+        <VictoryContainer
+          className="VictoryContainer"
+          portalComponent={<Portal />}
+          portalZIndex={99}
+          responsive={true}
+        />
+      }
+      data={
+        Array [
+          Object {
+            "x": "A",
+            "y": 1,
+          },
+          Object {
+            "x": "B",
+            "y": 2,
+          },
+          Object {
+            "x": "C",
+            "y": 3,
+          },
+          Object {
+            "x": "D",
+            "y": 1,
+          },
+          Object {
+            "x": "E",
+            "y": 2,
+          },
+        ]
+      }
+      dataComponent={
+        <Slice
+          pathComponent={<Path />}
+          role="presentation"
+          shapeRendering="auto"
+        />
+      }
+      groupComponent={<g />}
+      height={230}
+      labelComponent={
+        <Unknown
+          constrainToVisibleArea={false}
+          theme={
+            Object {
+              "area": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#06c",
+                    "fillOpacity": 0.3,
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "axis": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "axis": Object {
+                    "fill": "transparent",
+                    "stroke": "#d2d2d2",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                    "strokeWidth": 1,
+                  },
+                  "axisLabel": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 40,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                  "grid": Object {
+                    "fill": "none",
+                    "pointerEvents": "painted",
+                    "stroke": "none",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                  },
+                  "tickLabels": Object {
+                    "fill": "#4f5255",
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "ticks": Object {
+                    "fill": "transparent",
+                    "size": 5,
+                    "stroke": "#d2d2d2",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                    "strokeWidth": 1,
+                  },
+                },
+                "width": 450,
+              },
+              "bar": Object {
+                "barWidth": 10,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#06c",
+                    "padding": 8,
+                    "stroke": "none",
+                    "strokeWidth": 0,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                },
+                "width": 450,
+              },
+              "boxplot": Object {
+                "boxWidth": 20,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "max": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "maxLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "median": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "medianLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "min": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "minLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "q1": Object {
+                    "fill": "#8a8d90",
+                    "padding": 8,
+                  },
+                  "q1Labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "q3": Object {
+                    "fill": "#8a8d90",
+                    "padding": 8,
+                  },
+                  "q3Labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                },
+                "width": 450,
+              },
+              "candlestick": Object {
+                "candleColors": Object {
+                  "negative": "#151515",
+                  "positive": "#fff",
+                },
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "chart": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "width": 450,
+              },
+              "errorbar": Object {
+                "borderWidth": 8,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "opacity": 1,
+                    "stroke": "#151515",
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "group": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "width": 450,
+              },
+              "legend": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "gutter": 20,
+                "orientation": "horizontal",
+                "style": Object {
+                  "data": Object {
+                    "type": "square",
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "title": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 2,
+                    "stroke": "transparent",
+                  },
+                },
+                "titleOrientation": "top",
+              },
+              "line": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "opacity": 1,
+                    "stroke": "#06c",
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "pie": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 230,
+                "padding": 20,
+                "style": Object {
+                  "data": Object {
+                    "padding": 8,
+                    "stroke": "transparent",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 8,
+                    "stroke": "transparent",
+                  },
+                },
+                "width": 230,
+              },
+              "scatter": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#151515",
+                    "opacity": 1,
+                    "stroke": "transparent",
+                    "strokeWidth": 0,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "stack": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "strokeWidth": 1,
+                  },
+                },
+                "width": 450,
+              },
+              "tooltip": Object {
+                "cornerRadius": 0,
+                "flyoutStyle": Object {
+                  "cornerRadius": 0,
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 0,
+                },
+                "pointerLength": 10,
+                "pointerWidth": 20,
+                "style": Object {
+                  "fill": "#ededed",
+                  "padding": 16,
+                  "pointerEvents": "none",
+                },
+              },
+              "voronoi": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "stroke": "transparent",
+                    "strokeWidth": 0,
+                  },
+                  "flyout": Object {
+                    "fill": "#151515",
+                    "pointerEvents": "none",
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fill": "#ededed",
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 8,
+                    "pointerEvents": "none",
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+            }
+          }
+        />
+      }
+      radius={95}
+      sortOrder="ascending"
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`ChartPie 2`] = `
-<Component
-  height={230}
-  width={230}
->
-  <VictoryPie
-    containerComponent={
-      <VictoryContainer
-        className="VictoryContainer"
-        portalComponent={<Portal />}
-        portalZIndex={99}
-        responsive={true}
-      />
-    }
-    data={
-      Array [
-        Object {
-          "x": "A",
-          "y": 1,
-        },
-        Object {
-          "x": "B",
-          "y": 2,
-        },
-        Object {
-          "x": "C",
-          "y": 3,
-        },
-        Object {
-          "x": "D",
-          "y": 1,
-        },
-        Object {
-          "x": "E",
-          "y": 2,
-        },
-      ]
-    }
-    dataComponent={
-      <Slice
-        pathComponent={<Path />}
-      />
-    }
-    groupComponent={<g />}
+<Fragment>
+  <Component
     height={230}
-    labelComponent={
-      <Unknown
-        theme={
-          Object {
-            "area": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#06c",
-                  "fillOpacity": 0.3,
-                  "strokeWidth": 2,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "axis": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "axis": Object {
-                  "fill": "transparent",
-                  "stroke": "#d2d2d2",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                  "strokeWidth": 1,
-                },
-                "axisLabel": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 40,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-                "grid": Object {
-                  "fill": "none",
-                  "pointerEvents": "painted",
-                  "stroke": "none",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                },
-                "tickLabels": Object {
-                  "fill": "#4f5255",
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "ticks": Object {
-                  "fill": "transparent",
-                  "size": 5,
-                  "stroke": "#d2d2d2",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                  "strokeWidth": 1,
-                },
-              },
-              "width": 450,
-            },
-            "bar": Object {
-              "barWidth": 10,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#06c",
-                  "padding": 8,
-                  "stroke": "none",
-                  "strokeWidth": 0,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-              },
-              "width": 450,
-            },
-            "boxplot": Object {
-              "boxWidth": 20,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "max": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "maxLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "median": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "medianLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "min": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "minLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "q1": Object {
-                  "fill": "#8a8d90",
-                  "padding": 8,
-                },
-                "q1Labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "q3": Object {
-                  "fill": "#8a8d90",
-                  "padding": 8,
-                },
-                "q3Labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-              },
-              "width": 450,
-            },
-            "candlestick": Object {
-              "candleColors": Object {
-                "negative": "#151515",
-                "positive": "#fff",
-              },
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "chart": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "width": 450,
-            },
-            "errorbar": Object {
-              "borderWidth": 8,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "opacity": 1,
-                  "stroke": "#151515",
-                  "strokeWidth": 2,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "group": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "width": 450,
-            },
-            "legend": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "gutter": 20,
-              "orientation": "horizontal",
-              "style": Object {
-                "data": Object {
-                  "type": "square",
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "title": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 2,
-                  "stroke": "transparent",
-                },
-              },
-              "titleOrientation": "top",
-            },
-            "line": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "opacity": 1,
-                  "stroke": "#06c",
-                  "strokeWidth": 2,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "pie": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 230,
-              "padding": 20,
-              "style": Object {
-                "data": Object {
-                  "padding": 8,
-                  "stroke": "transparent",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 8,
-                  "stroke": "transparent",
-                },
-              },
-              "width": 230,
-            },
-            "scatter": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#151515",
-                  "opacity": 1,
-                  "stroke": "transparent",
-                  "strokeWidth": 0,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "stack": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "strokeWidth": 1,
-                },
-              },
-              "width": 450,
-            },
-            "tooltip": Object {
-              "cornerRadius": 0,
-              "flyoutStyle": Object {
-                "cornerRadius": 0,
-                "fill": "#151515",
-                "pointerEvents": "none",
-                "stroke": "#151515",
-                "strokeWidth": 0,
-              },
-              "pointerLength": 10,
-              "pointerWidth": 20,
-              "style": Object {
-                "fill": "#ededed",
-                "padding": 16,
-                "pointerEvents": "none",
-              },
-            },
-            "voronoi": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "stroke": "transparent",
-                  "strokeWidth": 0,
-                },
-                "flyout": Object {
-                  "fill": "#151515",
-                  "pointerEvents": "none",
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fill": "#ededed",
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 8,
-                  "pointerEvents": "none",
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-          }
-        }
-      />
-    }
-    origin={
-      Object {
-        "x": 115,
-        "y": 115,
-      }
-    }
-    sortOrder="ascending"
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -1916,508 +1863,965 @@ exports[`ChartPie 2`] = `
       }
     }
     width={230}
-  />
-</Component>
-`;
-
-exports[`renders component data 1`] = `
-<Component
-  height={200}
-  width={200}
->
-  <VictoryPie
-    containerComponent={
-      <VictoryContainer
-        className="VictoryContainer"
-        portalComponent={<Portal />}
-        portalZIndex={99}
-        responsive={true}
-      />
-    }
-    data={
-      Array [
-        Object {
-          "x": "Cats",
-          "y": 35,
-        },
-        Object {
-          "x": "Dogs",
-          "y": 55,
-        },
-        Object {
-          "x": "Birds",
-          "y": 10,
-        },
-      ]
-    }
-    dataComponent={
-      <Slice
-        pathComponent={<Path />}
-      />
-    }
-    groupComponent={<g />}
-    height={200}
-    labelComponent={
-      <Unknown
-        theme={
+  >
+    <VictoryPie
+      containerComponent={
+        <VictoryContainer
+          className="VictoryContainer"
+          portalComponent={<Portal />}
+          portalZIndex={99}
+          responsive={true}
+        />
+      }
+      data={
+        Array [
           Object {
-            "area": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#06c",
-                  "fillOpacity": 0.3,
-                  "strokeWidth": 2,
+            "x": "A",
+            "y": 1,
+          },
+          Object {
+            "x": "B",
+            "y": 2,
+          },
+          Object {
+            "x": "C",
+            "y": 3,
+          },
+          Object {
+            "x": "D",
+            "y": 1,
+          },
+          Object {
+            "x": "E",
+            "y": 2,
+          },
+        ]
+      }
+      dataComponent={
+        <Slice
+          pathComponent={<Path />}
+          role="presentation"
+          shapeRendering="auto"
+        />
+      }
+      groupComponent={<g />}
+      height={230}
+      labelComponent={
+        <Unknown
+          constrainToVisibleArea={false}
+          theme={
+            Object {
+              "area": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#06c",
+                    "fillOpacity": 0.3,
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
                 },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
+                "width": 450,
               },
-              "width": 450,
-            },
-            "axis": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "axis": Object {
-                  "fill": "transparent",
-                  "stroke": "#d2d2d2",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                  "strokeWidth": 1,
+              "axis": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "axis": Object {
+                    "fill": "transparent",
+                    "stroke": "#d2d2d2",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                    "strokeWidth": 1,
+                  },
+                  "axisLabel": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 40,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                  "grid": Object {
+                    "fill": "none",
+                    "pointerEvents": "painted",
+                    "stroke": "none",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                  },
+                  "tickLabels": Object {
+                    "fill": "#4f5255",
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "ticks": Object {
+                    "fill": "transparent",
+                    "size": 5,
+                    "stroke": "#d2d2d2",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                    "strokeWidth": 1,
+                  },
                 },
-                "axisLabel": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 40,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-                "grid": Object {
-                  "fill": "none",
-                  "pointerEvents": "painted",
-                  "stroke": "none",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                },
-                "tickLabels": Object {
-                  "fill": "#4f5255",
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "ticks": Object {
-                  "fill": "transparent",
-                  "size": 5,
-                  "stroke": "#d2d2d2",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                  "strokeWidth": 1,
-                },
+                "width": 450,
               },
-              "width": 450,
-            },
-            "bar": Object {
-              "barWidth": 10,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#06c",
-                  "padding": 8,
-                  "stroke": "none",
-                  "strokeWidth": 0,
+              "bar": Object {
+                "barWidth": 10,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#06c",
+                    "padding": 8,
+                    "stroke": "none",
+                    "strokeWidth": 0,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
                 },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
+                "width": 450,
               },
-              "width": 450,
-            },
-            "boxplot": Object {
-              "boxWidth": 20,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "max": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
+              "boxplot": Object {
+                "boxWidth": 20,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "max": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "maxLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "median": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "medianLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "min": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "minLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "q1": Object {
+                    "fill": "#8a8d90",
+                    "padding": 8,
+                  },
+                  "q1Labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "q3": Object {
+                    "fill": "#8a8d90",
+                    "padding": 8,
+                  },
+                  "q3Labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
                 },
-                "maxLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "median": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "medianLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "min": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "minLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "q1": Object {
-                  "fill": "#8a8d90",
-                  "padding": 8,
-                },
-                "q1Labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "q3": Object {
-                  "fill": "#8a8d90",
-                  "padding": 8,
-                },
-                "q3Labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
+                "width": 450,
               },
-              "width": 450,
-            },
-            "candlestick": Object {
-              "candleColors": Object {
-                "negative": "#151515",
-                "positive": "#fff",
+              "candlestick": Object {
+                "candleColors": Object {
+                  "negative": "#151515",
+                  "positive": "#fff",
+                },
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
               },
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
+              "chart": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "width": 450,
               },
-              "width": 450,
-            },
-            "chart": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "width": 450,
-            },
-            "errorbar": Object {
-              "borderWidth": 8,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "opacity": 1,
-                  "stroke": "#151515",
-                  "strokeWidth": 2,
+              "errorbar": Object {
+                "borderWidth": 8,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "opacity": 1,
+                    "stroke": "#151515",
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
                 },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
+                "width": 450,
               },
-              "width": 450,
-            },
-            "group": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "width": 450,
-            },
-            "legend": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "gutter": 20,
-              "orientation": "horizontal",
-              "style": Object {
-                "data": Object {
-                  "type": "square",
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "title": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 2,
-                  "stroke": "transparent",
-                },
+              "group": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "width": 450,
               },
-              "titleOrientation": "top",
-            },
-            "line": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "opacity": 1,
-                  "stroke": "#06c",
-                  "strokeWidth": 2,
+              "legend": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "gutter": 20,
+                "orientation": "horizontal",
+                "style": Object {
+                  "data": Object {
+                    "type": "square",
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "title": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 2,
+                    "stroke": "transparent",
+                  },
                 },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
+                "titleOrientation": "top",
               },
-              "width": 450,
-            },
-            "pie": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 230,
-              "padding": 20,
-              "style": Object {
-                "data": Object {
-                  "padding": 8,
-                  "stroke": "transparent",
-                  "strokeWidth": 1,
+              "line": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "opacity": 1,
+                    "stroke": "#06c",
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
                 },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 8,
-                  "stroke": "transparent",
-                },
+                "width": 450,
               },
-              "width": 230,
-            },
-            "scatter": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#151515",
-                  "opacity": 1,
-                  "stroke": "transparent",
-                  "strokeWidth": 0,
+              "pie": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 230,
+                "padding": 20,
+                "style": Object {
+                  "data": Object {
+                    "padding": 8,
+                    "stroke": "transparent",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 8,
+                    "stroke": "transparent",
+                  },
                 },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
+                "width": 230,
               },
-              "width": 450,
-            },
-            "stack": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "strokeWidth": 1,
+              "scatter": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#151515",
+                    "opacity": 1,
+                    "stroke": "transparent",
+                    "strokeWidth": 0,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
                 },
+                "width": 450,
               },
-              "width": 450,
-            },
-            "tooltip": Object {
-              "cornerRadius": 0,
-              "flyoutStyle": Object {
+              "stack": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "strokeWidth": 1,
+                  },
+                },
+                "width": 450,
+              },
+              "tooltip": Object {
                 "cornerRadius": 0,
+                "flyoutStyle": Object {
+                  "cornerRadius": 0,
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 0,
+                },
+                "pointerLength": 10,
+                "pointerWidth": 20,
+                "style": Object {
+                  "fill": "#ededed",
+                  "padding": 16,
+                  "pointerEvents": "none",
+                },
+              },
+              "voronoi": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "stroke": "transparent",
+                    "strokeWidth": 0,
+                  },
+                  "flyout": Object {
+                    "fill": "#151515",
+                    "pointerEvents": "none",
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fill": "#ededed",
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 8,
+                    "pointerEvents": "none",
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+            }
+          }
+        />
+      }
+      radius={95}
+      sortOrder="ascending"
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
                 "fill": "#151515",
                 "pointerEvents": "none",
                 "stroke": "#151515",
-                "strokeWidth": 0,
+                "strokeWidth": 1,
               },
-              "pointerLength": 10,
-              "pointerWidth": 20,
-              "style": Object {
+              "labels": Object {
                 "fill": "#ededed",
-                "padding": 16,
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
                 "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
               },
             },
-            "voronoi": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "stroke": "transparent",
-                  "strokeWidth": 0,
-                },
-                "flyout": Object {
-                  "fill": "#151515",
-                  "pointerEvents": "none",
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fill": "#ededed",
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 8,
-                  "pointerEvents": "none",
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-          }
+            "width": 450,
+          },
         }
-      />
-    }
-    origin={
-      Object {
-        "x": 100,
-        "y": 100,
       }
-    }
-    sortOrder="ascending"
-    standalone={false}
+      width={230}
+    />
+  </Component>
+</Fragment>
+`;
+
+exports[`renders component data 1`] = `
+<Fragment>
+  <Component
+    height={200}
     theme={
       Object {
         "area": Object {
@@ -2868,6 +3272,949 @@ exports[`renders component data 1`] = `
       }
     }
     width={200}
-  />
-</Component>
+  >
+    <VictoryPie
+      containerComponent={
+        <VictoryContainer
+          className="VictoryContainer"
+          portalComponent={<Portal />}
+          portalZIndex={99}
+          responsive={true}
+        />
+      }
+      data={
+        Array [
+          Object {
+            "x": "Cats",
+            "y": 35,
+          },
+          Object {
+            "x": "Dogs",
+            "y": 55,
+          },
+          Object {
+            "x": "Birds",
+            "y": 10,
+          },
+        ]
+      }
+      dataComponent={
+        <Slice
+          pathComponent={<Path />}
+          role="presentation"
+          shapeRendering="auto"
+        />
+      }
+      groupComponent={<g />}
+      height={200}
+      labelComponent={
+        <Unknown
+          constrainToVisibleArea={false}
+          theme={
+            Object {
+              "area": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#06c",
+                    "fillOpacity": 0.3,
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "axis": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "axis": Object {
+                    "fill": "transparent",
+                    "stroke": "#d2d2d2",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                    "strokeWidth": 1,
+                  },
+                  "axisLabel": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 40,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                  "grid": Object {
+                    "fill": "none",
+                    "pointerEvents": "painted",
+                    "stroke": "none",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                  },
+                  "tickLabels": Object {
+                    "fill": "#4f5255",
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "ticks": Object {
+                    "fill": "transparent",
+                    "size": 5,
+                    "stroke": "#d2d2d2",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                    "strokeWidth": 1,
+                  },
+                },
+                "width": 450,
+              },
+              "bar": Object {
+                "barWidth": 10,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#06c",
+                    "padding": 8,
+                    "stroke": "none",
+                    "strokeWidth": 0,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                },
+                "width": 450,
+              },
+              "boxplot": Object {
+                "boxWidth": 20,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "max": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "maxLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "median": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "medianLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "min": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "minLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "q1": Object {
+                    "fill": "#8a8d90",
+                    "padding": 8,
+                  },
+                  "q1Labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "q3": Object {
+                    "fill": "#8a8d90",
+                    "padding": 8,
+                  },
+                  "q3Labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                },
+                "width": 450,
+              },
+              "candlestick": Object {
+                "candleColors": Object {
+                  "negative": "#151515",
+                  "positive": "#fff",
+                },
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "chart": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "width": 450,
+              },
+              "errorbar": Object {
+                "borderWidth": 8,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "opacity": 1,
+                    "stroke": "#151515",
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "group": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "width": 450,
+              },
+              "legend": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "gutter": 20,
+                "orientation": "horizontal",
+                "style": Object {
+                  "data": Object {
+                    "type": "square",
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "title": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 2,
+                    "stroke": "transparent",
+                  },
+                },
+                "titleOrientation": "top",
+              },
+              "line": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "opacity": 1,
+                    "stroke": "#06c",
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "pie": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 230,
+                "padding": 20,
+                "style": Object {
+                  "data": Object {
+                    "padding": 8,
+                    "stroke": "transparent",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 8,
+                    "stroke": "transparent",
+                  },
+                },
+                "width": 230,
+              },
+              "scatter": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#151515",
+                    "opacity": 1,
+                    "stroke": "transparent",
+                    "strokeWidth": 0,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "stack": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "strokeWidth": 1,
+                  },
+                },
+                "width": 450,
+              },
+              "tooltip": Object {
+                "cornerRadius": 0,
+                "flyoutStyle": Object {
+                  "cornerRadius": 0,
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 0,
+                },
+                "pointerLength": 10,
+                "pointerWidth": 20,
+                "style": Object {
+                  "fill": "#ededed",
+                  "padding": 16,
+                  "pointerEvents": "none",
+                },
+              },
+              "voronoi": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "stroke": "transparent",
+                    "strokeWidth": 0,
+                  },
+                  "flyout": Object {
+                    "fill": "#151515",
+                    "pointerEvents": "none",
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fill": "#ededed",
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 8,
+                    "pointerEvents": "none",
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+            }
+          }
+        />
+      }
+      radius={80}
+      sortOrder="ascending"
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={200}
+    />
+  </Component>
+</Fragment>
 `;

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -5,8 +5,22 @@ typescript: true
 propComponents: ['ChartLegend', 'ChartPie']
 ---
 
-import { ChartLegend, ChartPie, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
+import { ChartPie, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
 import './chart-pie.scss';
+
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+## Tutorial
+
+PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, 
+along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React 
+based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+In this tutorial, we will build a bar chart together - starting with a simple chart, adding tooltips, a legend,
+and concluding by changing the theme color. You'll learn how to use React chart components together to build a 
+consistent user experience.
+
+[Start course](https://katacoda.com/patternfly/courses/charts/module-pie)
 
 ## Simple pie chart with right aligned legend
 ```js
@@ -18,12 +32,19 @@ import { ChartPie } from '@patternfly/react-charts';
     <ChartPie
       ariaDesc="Average number of pets"
       ariaTitle="Pie chart example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
       height={230}
-      labels={datum => `${datum.x}: ${datum.y}`}
+      labels={({ datum }) => `${datum.x}: ${datum.y}`}
       legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
       legendOrientation="vertical"
       legendPosition="right"
+      padding={{
+        bottom: 20,
+        left: 20,
+        right: 140, // Adjusted to accommodate legend
+        top: 20
+      }}
       width={350}
     />
   </div>
@@ -40,12 +61,19 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     <ChartPie
       ariaDesc="Average number of pets"
       ariaTitle="Pie chart example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
       height={230}
-      labels={datum => `${datum.x}: ${datum.y}`}
+      labels={({ datum }) => `${datum.x}: ${datum.y}`}
       legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
       legendOrientation="vertical"
       legendPosition="right"
+      padding={{
+        bottom: 20,
+        left: 20,
+        right: 140, // Adjusted to accommodate legend
+        top: 20
+      }}
       themeColor={ChartThemeColor.orange}
       width={350}
     />
@@ -63,15 +91,33 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     <ChartPie
       ariaDesc="Average number of pets"
       ariaTitle="Pie chart example"
+      constrainToVisibleArea={true}
       data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
       height={275}
-      labels={datum => `${datum.x}: ${datum.y}`}
+      labels={({ datum }) => `${datum.x}: ${datum.y}`}
       legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
       legendPosition="bottom"
-      pieHeight={230}
+      padding={{
+        bottom: 65,
+        left: 20,
+        right: 20,
+        top: 20
+      }}
       themeColor={ChartThemeColor.multiOrdered}
       width={300}
     />
   </div>
 </div>
 ```
+
+## Tips
+
+- For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+- `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `ChartLegend` props, see <a href="https://formidable.com/open-source/victory/docs/victory-legend" target="_blank">VictoryLegend</a>
+ - For `ChartPie` props, see <a href="https://formidable.com/open-source/victory/docs/victory-pie" target="_blank">VictoryPie</a>

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.tsx
@@ -4,10 +4,6 @@ import { PathHelpers } from './path-helpers';
 
 export interface ChartPointProps {
   /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-primitives#point
-   */
-  ' '?: any;
-  /**
    * A flag signifying whether the component is active
    */
   active?: boolean;

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/__snapshots__/ChartPoint.test.tsx.snap
@@ -5,6 +5,8 @@ exports[`ChartPoint 1`] = `
   borderComponent={
     <Border
       rectComponent={<Rect />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   containerComponent={
@@ -949,6 +951,8 @@ exports[`ChartPoint 2`] = `
   borderComponent={
     <Border
       rectComponent={<Rect />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   containerComponent={
@@ -1893,6 +1897,8 @@ exports[`renders component data 1`] = `
   borderComponent={
     <Border
       rectComponent={<Rect />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   containerComponent={

--- a/packages/patternfly-4/react-charts/src/components/ChartScatter/ChartScatter.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartScatter/ChartScatter.tsx
@@ -16,6 +16,7 @@ import {
   VictoryScatter,
   VictoryScatterProps
 } from 'victory';
+import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
 
@@ -28,10 +29,6 @@ export enum ChartScatterSortOrder {
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
  */
 export interface ChartScatterProps extends VictoryScatterProps {
-  /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-scatter/
-   */
-  ' '?: any;
   /**
    * The animate prop specifies props for VictoryAnimation to use.
    * The animate prop should also be used to specify enter and exit
@@ -122,7 +119,7 @@ export interface ChartScatterProps extends VictoryScatterProps {
    * The mutation function will be called with the calculated props for the individual selected
    * element (i.e. a line), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
-   * @examples
+   * @example
    * events={[
    *   {
    *     target: "data",
@@ -393,7 +390,10 @@ export interface ChartScatterProps extends VictoryScatterProps {
 export const ChartScatter: React.FunctionComponent<ChartScatterProps> = ({
   themeColor,
   themeVariant,
-  theme = getTheme(themeColor, themeVariant), // destructure last
+
+  // destructure last
+  theme = getTheme(themeColor, themeVariant),
+  containerComponent = <ChartContainer theme={theme} />,
   ...rest
 }: ChartScatterProps) => <VictoryScatter theme={theme} {...rest} />;
 

--- a/packages/patternfly-4/react-charts/src/components/ChartScatter/__snapshots__/ChartScatter.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartScatter/__snapshots__/ChartScatter.test.tsx.snap
@@ -13,6 +13,8 @@ exports[`ChartScatter 1`] = `
   dataComponent={
     <Point
       pathComponent={<Path />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   groupComponent={<g />}
@@ -493,6 +495,8 @@ exports[`ChartScatter 2`] = `
   dataComponent={
     <Point
       pathComponent={<Path />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   groupComponent={<g />}
@@ -964,6 +968,7 @@ exports[`renders component data 1`] = `
 <VictoryChart
   containerComponent={
     <Unknown
+      className="pf-c-chart"
       theme={
         Object {
           "area": Object {
@@ -1421,6 +1426,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -1446,6 +1453,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -1929,6 +1938,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -1946,6 +1957,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -1970,6 +1983,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2453,6 +2468,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -2474,6 +2491,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -2489,12 +2508,16 @@ exports[`renders component data 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2511,6 +2534,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2996,6 +3021,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -3013,6 +3040,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -3028,12 +3057,16 @@ exports[`renders component data 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3049,6 +3082,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3534,6 +3569,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/ChartStack.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/ChartStack.tsx
@@ -15,6 +15,7 @@ import {
   VictoryStack,
   VictoryStackProps
 } from 'victory';
+import { ChartContainer } from '../ChartContainer';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
 
@@ -22,10 +23,6 @@ import { getTheme } from '../ChartUtils';
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
  */
 export interface ChartStackProps extends VictoryStackProps {
-  /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-stack/
-   */
-  ' '?: any;
   /**
    * The animate prop specifies props for VictoryAnimation to use.
    * The animate prop should also be used to specify enter and exit
@@ -110,7 +107,7 @@ export interface ChartStackProps extends VictoryStackProps {
    * The mutation function will be called with the calculated props for the individual selected
    * element (i.e. a single bar), and the object returned from the mutation function
    * will override the props of the selected element via object assignment.
-   * @examples
+   * @example
    * events={[
    *   {
    *     target: "data",
@@ -327,7 +324,10 @@ export const ChartStack: React.FunctionComponent<ChartStackProps> = ({
   children,
   themeColor,
   themeVariant,
-  theme = getTheme(themeColor, themeVariant), // destructure last
+
+    // destructure last
+  theme = getTheme(themeColor, themeVariant),
+  containerComponent = <ChartContainer theme={theme} />,
   ...rest
 }: ChartStackProps) => (
   <VictoryStack theme={theme} {...rest}>

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/__snapshots__/ChartStack.test.tsx.snap
@@ -934,6 +934,7 @@ exports[`renders component data 1`] = `
 <VictoryChart
   containerComponent={
     <Unknown
+      className="pf-c-chart"
       theme={
         Object {
           "area": Object {
@@ -1391,6 +1392,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -1416,6 +1419,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -1899,6 +1904,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -1916,6 +1923,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -1940,6 +1949,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2423,6 +2434,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -2444,6 +2457,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -2459,12 +2474,16 @@ exports[`renders component data 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2481,6 +2500,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -2966,6 +2987,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }
@@ -2983,6 +3006,8 @@ exports[`renders component data 1`] = `
         axisComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
@@ -2998,12 +3023,16 @@ exports[`renders component data 1`] = `
         circularAxisComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="axis"
           />
         }
         circularGridComponent={
           <Arc
             pathComponent={<Path />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3019,6 +3048,8 @@ exports[`renders component data 1`] = `
         gridComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="grid"
           />
         }
@@ -3504,6 +3535,8 @@ exports[`renders component data 1`] = `
         tickComponent={
           <LineSegment
             lineComponent={<Line />}
+            role="presentation"
+            shapeRendering="auto"
             type="tick"
           />
         }

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -2,73 +2,57 @@
 title: 'Stack'
 section: 'charts'
 typescript: true
-propComponents: ['Chart', 'ChartBar', 'ChartStack']
+propComponents: ['Chart', 'ChartArea', 'ChartBar', 'ChartLegend', 'ChartStack', 'ChartTooltip']
 ---
 
-import { Chart, ChartBar, ChartStack, ChartThemeColor, ChartTooltip } from '@patternfly/react-charts';
+import { Chart, ChartArea, ChartBar, ChartStack, ChartThemeColor, ChartTooltip } from '@patternfly/react-charts';
 import './chart-stack.scss';
 
-## Simple stacked bar chart with right aligned legend
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+## Tutorial
+
+PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, 
+along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React 
+based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+In this tutorial, we will build a bar chart together - starting with a simple chart, adding multiple datasets, 
+tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart 
+components together to build a consistent user experience.
+
+[Start course](https://katacoda.com/patternfly/courses/charts/module-stack)
+
+## Simple stack chart with right aligned legend
 ```js
 import React from 'react';
-import { Chart, ChartStack,ChartTooltip } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartStack } from '@patternfly/react-charts';
 
 <div>
   <div className="stack-chart-legend-right">
     <Chart
       ariaDesc="Average number of pets"
       ariaTitle="Stack chart example"
-      legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }, { name: 'Mice' }]}
+      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+      domainPadding={{ x: [30, 25] }}
+      legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
       legendOrientation="vertical"
       legendPosition="right"
       height={250}
       padding={{
         bottom: 50,
         left: 50,
-        right: 200, // Adjusted to accomodate legend
+        right: 200, // Adjusted to accommodate legend
         top: 50
       }}
       width={600}
     >
       <ChartAxis />
       <ChartAxis dependentAxis showGrid />
-      <ChartStack domainPadding={{x: [10, 2]}}>
-        <ChartBar 
-          data={[
-            { name: 'Cats', x: '2015', y: 1, label: 'Cats: 1' }, 
-            { name: 'Cats', x: '2016', y: 2, label: 'Cats: 2' }, 
-            { name: 'Cats', x: '2017', y: 5, label: 'Cats: 5' }, 
-            { name: 'Cats', x: '2018', y: 3, label: 'Cats: 3' }
-          ]} 
-          labelComponent={<ChartTooltip />}
-        />
-        <ChartBar 
-          data={[
-            { name: 'Dogs', x: '2015', y: 2, label: 'Dogs: 2' }, 
-            { name: 'Dogs', x: '2016', y: 1, label: 'Dogs: 1' }, 
-            { name: 'Dogs', x: '2017', y: 7, label: 'Dogs: 7' }, 
-            { name: 'Dogs', x: '2018', y: 4, label: 'Dogs: 4' }
-          ]}
-          labelComponent={<ChartTooltip />}
-        />
-        <ChartBar 
-          data={[
-            { name: 'Birds', x: '2015', y: 4, label: 'Birds: 4' }, 
-            { name: 'Birds', x: '2016', y: 4, label: 'Birds: 4' }, 
-            { name: 'Birds', x: '2017', y: 9, label: 'Birds: 9' }, 
-            { name: 'Birds', x: '2018', y: 7, label: 'Birds: 7' }
-          ]}
-          labelComponent={<ChartTooltip />}
-        />
-        <ChartBar 
-          data={[
-            { name: 'Mice', x: '2015', y: 3, label: 'Mice: 3' }, 
-            { name: 'Mice', x: '2016', y: 3, label: 'Mice: 3' }, 
-            { name: 'Mice', x: '2017', y: 8, label: 'Mice: 8' }, 
-            { name: 'Mice', x: '2018', y: 5, label: 'Mice: 5' }
-          ]}
-          labelComponent={<ChartTooltip />}
-        />
+      <ChartStack>
+        <ChartBar data={[{ name: 'Cats', x: '2015', y: 1 }, { name: 'Cats', x: '2016', y: 2 }, { name: 'Cats', x: '2017', y: 5 }, { name: 'Cats', x: '2018', y: 3 }]} />
+        <ChartBar data={[{ name: 'Dogs', x: '2015', y: 2 }, { name: 'Dogs', x: '2016', y: 1 }, { name: 'Dogs', x: '2017', y: 7 }, { name: 'Dogs', x: '2018', y: 4 }]} />
+        <ChartBar data={[{ name: 'Birds', x: '2015', y: 4 }, { name: 'Birds', x: '2016', y: 4 }, { name: 'Birds', x: '2017', y: 9 }, { name: 'Birds', x: '2018', y: 7 }]} />
+        <ChartBar data={[{ name: 'Mice', x: '2015', y: 3 }, { name: 'Mice', x: '2016', y: 3 }, { name: 'Mice', x: '2017', y: 8 }, { name: 'Mice', x: '2018', y: 5 }]} />
       </ChartStack>
     </Chart>
   </div>
@@ -78,19 +62,20 @@ import { Chart, ChartStack,ChartTooltip } from '@patternfly/react-charts';
 ## Gold, horizontal stacked bar chart with bottom aligned legend
 ```js
 import React from 'react';
-import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
 
 <div>
   <div className="stack-chart-legend-bottom">
     <Chart
       ariaDesc="Average number of pets"
       ariaTitle="Stack chart example"
+      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
       domainPadding={{ x: [30, 25] }}
-      legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }, { name: 'Mice' }]}
+      legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
       legendPosition="bottom"
       height={275}
       padding={{
-        bottom: 75, // Adjusted to accomodate legend
+        bottom: 75, // Adjusted to accommodate legend
         left: 50,
         right: 50, 
         top: 50
@@ -100,43 +85,11 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
     >
       <ChartAxis />
       <ChartAxis dependentAxis showGrid />
-      <ChartStack domainPadding={{x: [10, 2]}}>
-        <ChartBar 
-          data={[
-            { name: 'Cats', x: '2015', y: 1, label: 'Cats: 1' }, 
-            { name: 'Cats', x: '2016', y: 2, label: 'Cats: 2' }, 
-            { name: 'Cats', x: '2017', y: 5, label: 'Cats: 5' }, 
-            { name: 'Cats', x: '2018', y: 3, label: 'Cats: 3' }
-          ]} 
-          labelComponent={<ChartTooltip />}
-        />
-        <ChartBar 
-          data={[
-            { name: 'Dogs', x: '2015', y: 2, label: 'Dogs: 2' }, 
-            { name: 'Dogs', x: '2016', y: 1, label: 'Dogs: 1' }, 
-            { name: 'Dogs', x: '2017', y: 7, label: 'Dogs: 7' }, 
-            { name: 'Dogs', x: '2018', y: 4, label: 'Dogs: 4' }
-          ]}
-          labelComponent={<ChartTooltip />}
-        />
-        <ChartBar 
-          data={[
-            { name: 'Birds', x: '2015', y: 4, label: 'Birds: 4' }, 
-            { name: 'Birds', x: '2016', y: 4, label: 'Birds: 4' }, 
-            { name: 'Birds', x: '2017', y: 9, label: 'Birds: 9' }, 
-            { name: 'Birds', x: '2018', y: 7, label: 'Birds: 7' }
-          ]}
-          labelComponent={<ChartTooltip />}
-        />
-        <ChartBar 
-          data={[
-            { name: 'Mice', x: '2015', y: 3, label: 'Mice: 3' }, 
-            { name: 'Mice', x: '2016', y: 3, label: 'Mice: 3' }, 
-            { name: 'Mice', x: '2017', y: 8, label: 'Mice: 8' }, 
-            { name: 'Mice', x: '2018', y: 5, label: 'Mice: 5' }
-          ]}
-          labelComponent={<ChartTooltip />}
-        />
+      <ChartStack>
+        <ChartBar data={[{ name: 'Cats', x: '2015', y: 1 }, { name: 'Cats', x: '2016', y: 2 }, { name: 'Cats', x: '2017', y: 5 }, { name: 'Cats', x: '2018', y: 3 }]} />
+        <ChartBar data={[{ name: 'Dogs', x: '2015', y: 2 }, { name: 'Dogs', x: '2016', y: 1 }, { name: 'Dogs', x: '2017', y: 7 }, { name: 'Dogs', x: '2018', y: 4 }]} />
+        <ChartBar data={[{ name: 'Birds', x: '2015', y: 4 }, { name: 'Birds', x: '2016', y: 4 }, { name: 'Birds', x: '2017', y: 9 }, { name: 'Birds', x: '2018', y: 7 }]} />
+        <ChartBar data={[{ name: 'Mice', x: '2015', y: 3 }, { name: 'Mice', x: '2016', y: 3 }, { name: 'Mice', x: '2017', y: 8 }, { name: 'Mice', x: '2018', y: 5 }]} />
       </ChartStack>
     </Chart>
   </div>
@@ -144,9 +97,10 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
 ```
 
 ## Multi-color (ordered), horizontal stacked bar chart with bottom-left aligned legend
+This demonstrates an alternate way of applying tooltips using data labels
 ```js
 import React from 'react';
-import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
 
 <div>
   <div className="stack-chart-legend-bottom">
@@ -154,11 +108,11 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
       ariaDesc="Average number of pets"
       ariaTitle="Stack chart example"
       domainPadding={{ x: [30, 25] }}
-      legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }, { name: 'Mice' }]}
+      legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
       legendPosition="bottom-left"
       height={275}
       padding={{
-        bottom: 75, // Adjusted to accomodate legend
+        bottom: 75, // Adjusted to accommodate legend
         left: 50,
         right: 50, 
         top: 50
@@ -168,7 +122,7 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
     >
       <ChartAxis />
       <ChartAxis dependentAxis showGrid />
-      <ChartStack domainPadding={{x: [10, 2]}} horizontal>
+      <ChartStack horizontal>
         <ChartBar 
           data={[
             { name: 'Cats', x: '2015', y: 1, label: 'Cats: 1' }, 
@@ -176,7 +130,7 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
             { name: 'Cats', x: '2017', y: 5, label: 'Cats: 5' }, 
             { name: 'Cats', x: '2018', y: 3, label: 'Cats: 3' }
           ]} 
-          labelComponent={<ChartTooltip />}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
         />
         <ChartBar 
           data={[
@@ -185,7 +139,7 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
             { name: 'Dogs', x: '2017', y: 7, label: 'Dogs: 7' }, 
             { name: 'Dogs', x: '2018', y: 4, label: 'Dogs: 4' }
           ]}
-          labelComponent={<ChartTooltip />}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
         />
         <ChartBar 
           data={[
@@ -194,7 +148,7 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
             { name: 'Birds', x: '2017', y: 9, label: 'Birds: 9' }, 
             { name: 'Birds', x: '2018', y: 7, label: 'Birds: 7' }
           ]}
-          labelComponent={<ChartTooltip />}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
         />
         <ChartBar 
           data={[
@@ -203,7 +157,7 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
             { name: 'Mice', x: '2017', y: 8, label: 'Mice: 8' }, 
             { name: 'Mice', x: '2018', y: 5, label: 'Mice: 5' }
           ]}
-          labelComponent={<ChartTooltip />}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
         />
       </ChartStack>
     </Chart>
@@ -215,7 +169,7 @@ import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
 This demonstrates monthly data and responsiveness for mobile
 ```js
 import React from 'react';
-import { Chart, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
+import { Chart, ChartAxis, ChartStack, ChartTooltip } from '@patternfly/react-charts';
 
 class ResponsiveStack extends React.Component {
   constructor(props) {
@@ -266,15 +220,15 @@ class ResponsiveStack extends React.Component {
       return [
         <ChartBar 
           data={socketBars} 
-          labelComponent={<ChartTooltip />}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
         />,
         <ChartBar 
           data={coresBars} 
-          labelComponent={<ChartTooltip />}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
         />,
         <ChartBar 
           data={nodesBars} 
-          labelComponent={<ChartTooltip />}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
         />,
       ];
     }
@@ -311,7 +265,7 @@ class ResponsiveStack extends React.Component {
             legendPosition="bottom"
             height={275}
             padding={{
-              bottom: 75, // Adjusted to accomodate legend
+              bottom: 75, // Adjusted to accommodate legend
               left: 50,
               right: 50, 
               top: 50
@@ -368,7 +322,7 @@ class MultiColorChart extends React.Component {
           <Chart
             ariaDesc="Average number of pets"
             ariaTitle="Area chart example"
-            containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+            containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
             legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
             legendPosition="bottom-left"
             height={225}
@@ -429,3 +383,20 @@ class MultiColorChart extends React.Component {
   }
 }
 ```
+
+## Tips
+
+- For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+- `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `Chart` props, see <a href="https://formidable.com/open-source/victory/docs/victory-chart" target="_blank">VictoryChart</a>
+ - For `ChartArea` props, see <a href="https://formidable.com/open-source/victory/docs/victory-area" target="_blank">VictoryArea</a>
+ - For `ChartAxis` props, see <a href="https://formidable.com/open-source/victory/docs/victory-axis" target="_blank">VictoryAxis</a>
+ - For `ChartBar` props, see <a href="https://formidable.com/open-source/victory/docs/victory-bar" target="_blank">VictoryBar</a>
+ - For `ChartLegend` props, see <a href="https://formidable.com/open-source/victory/docs/victory-legend" target="_blank">VictoryLegend</a>
+ - For `ChartStack` props, see <a href="https://formidable.com/open-source/victory/docs/victory-stack" target="_blank">VictoryStack</a>
+ - For `ChartTooltip` props, see <a href="https://formidable.com/open-source/victory/docs/victory-tooltip" target="_blank">VictoryTooltip</a>

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/ChartTheme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/ChartTheme.ts
@@ -61,10 +61,28 @@ interface ChartThemeVariantInterface {
 }
 
 /**
- * The multiOrdered theme is intended for ordered charts; donut, pie, bar, & stack
- * The multiUnordered theme is intended for unordered charts; area & line
+ * The color family to be applied to a theme. For example, 'blue' represents an ordered list of colors
+ * (i.e., a color scale) composed from the blue color family defined by PatternFly core.
  *
- * Note: multi defaults to multiOrdered
+ * For example, the 'blue' color scale looks like:
+ *
+ * chart_color_blue_100
+ * chart_color_blue_200
+ * chart_color_blue_300
+ * chart_color_blue_400
+ * chart_color_blue_500
+ *
+ * In this case, the chart_color_blue_100 value would be applied to the first data point in a chart.
+ * The chart_color_blue_200 value would be applied to the second data point in a chart. And so on...
+ *
+ * If legend data is provided to a chart, those colors would be synced with the legend as well.
+ *
+ * The 'multiOrdered' color family is intended for ordered charts; donut, pie, bar, & stack
+ * The 'multiUnordered' color family is intended for unordered charts; area & line
+ * The 'multi' defaults to the 'multiOrdered' color family
+ *
+ * Note: These values are not intended to be applied directly as a component's fill style. For example, "multi" would
+ * not be a valid fill color. Please use chart variables from PatternFly core (e.g., via the react-charts package)
  */
 export const ChartThemeColor: ChartThemeColorInterface = {
   blue: 'blue',
@@ -80,6 +98,11 @@ export const ChartThemeColor: ChartThemeColorInterface = {
   purple: 'purple'
 };
 
+/**
+ * The variant to be applied to a theme.
+ *
+ * Note: Only the light variant is currently supported
+ */
 export const ChartThemeVariant: ChartThemeVariantInterface = {
   dark: 'dark',
   default: 'light',

--- a/packages/patternfly-4/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartTooltip/ChartTooltip.tsx
@@ -16,10 +16,6 @@ import { getTheme } from '../ChartUtils';
  */
 export interface ChartTooltipProps extends VictoryTooltipProps {
   /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-tooltip/
-   */
-  ' '?: any;
-  /**
    * The active prop specifies whether the tooltip component should be displayed.
    */
   active?: boolean;
@@ -31,6 +27,27 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    * The angle prop specifies the angle to rotate the tooltip around its origin point.
    */
   angle?: string | number;
+  /**
+   * The center prop determines the position of the center of the tooltip flyout. This prop should be given as an object
+   * that describes the desired x and y svg coordinates of the center of the tooltip. This prop is useful for
+   * positioning the flyout of a tooltip independent from the pointer. When ChartTooltip is used with
+   * ChartVoronoiContainer, the center prop is what enables the mouseFollowTooltips option. When this prop is set,
+   * non-zero pointerLength values will no longer be respected.
+   */
+  center?: { x: number, y: number };
+  /**
+   * The centerOffset prop determines the position of the center of the tooltip flyout in relation to the flyout
+   * pointer. This prop should be given as an object of x and y, where each is either a numeric offset value or a
+   * function that returns a numeric value. When this prop is set, non-zero pointerLength values will no longer be
+   * respected.
+   */
+  centerOffset?: { x: number | Function, y: number | Function };
+  /**
+   * The constrainToVisibleArea prop determines whether to coerce tooltips so that they fit within the visible area of
+   * the chart. When this prop is set to true, tooltip pointers will still point to the correct data point, but the
+   * center of the tooltip will be shifted to fit within the overall width and height of the svg Victory renders.
+   */
+  constrainToVisibleArea?: boolean;
   /**
    * The cornerRadius prop determines corner radius of the flyout container. This prop may be given as a positive number
    * or a function of datum.
@@ -72,21 +89,27 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    */
   flyoutComponent?: React.ReactElement<any>;
   /**
+   * The flyoutHeight prop defines the height of the tooltip flyout. This prop may be given as a positive number or a function
+   * of datum. If this prop is not set, height will be determined based on an approximate text size calculated from the
+   * text and style props provided to ChartTooltip.
+   */
+  flyoutHeight?: NumberOrCallback;
+  /**
    * The style prop applies SVG style properties to the rendered flyout container. These props will be passed to the
    * flyoutComponent.
    */
   flyoutStyle?: VictoryStyleObject;
   /**
+   * The flyoutWidth prop defines the width of the tooltip flyout. This prop may be given as a positive number or a
+   * function of datum. If this prop is not set, flyoutWidth will be determined based on an approximate text size
+   * calculated from the text and style props provided to VictoryTooltip.
+   */
+  flyoutWidth?: NumberOrCallback,
+  /**
    * The groupComponent prop takes a component instance which will be used to create group elements for use within
    * container elements. This prop defaults to a <g> tag.}
    */
   groupComponent?: React.ReactElement<any>;
-  /**
-   * The height prop defines the height of the tooltip flyout. This prop may be given as a positive number or a function
-   * of datum. If this prop is not set, height will be determined based on an approximate text size calculated from the
-   * text and style props provided to ChartTooltip.
-   */
-  height?: NumberOrCallback;
   /**
    * The horizontal prop determines whether to plot the flyouts to the left / right of the (x, y) coordinate rather than top / bottom.
    * This is useful when an orientation prop is not provided, and data will determine the default orientation. i.e.
@@ -118,6 +141,12 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    * given as a positive number or a function of datum.
    */
   pointerLength?: NumberOrCallback;
+  /**
+   * This prop determines which side of the tooltip flyout the pointer should originate on. When this prop is not set,
+   * it will be determined based on the overall orientation of the flyout in relation to its data point, and any center
+   * or centerOffset values.
+   */
+  pointerOrientation?: 'top' | 'bottom' | 'left' | 'right' | Function;
   /**
    * The pointerWidth prop determines the width of the base of the triangular pointer extending from
    * the flyout. This prop may be given as a positive number or a function of datum.
@@ -160,12 +189,6 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
    */
   themeVariant?: string;
   /**
-   * The width prop defines the width of the tooltip flyout. This prop may be given as a positive number or a function
-   * of datum. If this prop is not set, width will be determined based on an approximate text size calculated from the
-   * text and style props provided to ChartTooltip.
-   */
-  width?: NumberOrCallback;
-  /**
    * The x prop defines the x coordinate to use as a basis for horizontal positioning.
    */
   x?: number;
@@ -176,11 +199,19 @@ export interface ChartTooltipProps extends VictoryTooltipProps {
 }
 
 export const ChartTooltip: React.FunctionComponent<ChartTooltipProps> = ({
+  constrainToVisibleArea = false,
   themeColor,
   themeVariant,
-  theme = getTheme(themeColor, themeVariant), // destructure last
+
+  // destructure last
+  theme = getTheme(themeColor, themeVariant),
   ...rest
-}: ChartTooltipProps) => <VictoryTooltip theme={theme} {...rest} />;
+}: ChartTooltipProps) => {
+  // Note: constrainToVisibleArea is valid, but @types/victory is missing a prop type
+
+  // @ts-ignore
+  return <VictoryTooltip constrainToVisibleArea={constrainToVisibleArea} theme={theme} {...rest} />;
+}
 
 // Note: VictoryTooltip.defaultEvents must be hoisted
 hoistNonReactStatics(ChartTooltip, VictoryTooltip);

--- a/packages/patternfly-4/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartTooltip/__snapshots__/ChartTooltip.test.tsx.snap
@@ -3,9 +3,12 @@
 exports[`ChartTooltip 1`] = `
 <VictoryTooltip
   active={false}
+  constrainToVisibleArea={false}
   flyoutComponent={
     <Flyout
       pathComponent={<Path />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   groupComponent={<g />}
@@ -475,9 +478,12 @@ exports[`ChartTooltip 1`] = `
 exports[`ChartTooltip 2`] = `
 <VictoryTooltip
   active={false}
+  constrainToVisibleArea={false}
   flyoutComponent={
     <Flyout
       pathComponent={<Path />}
+      role="presentation"
+      shapeRendering="auto"
     />
   }
   groupComponent={<g />}
@@ -950,13 +956,15 @@ exports[`allows tooltip via container component 1`] = `
     <Unknown
       activateData={true}
       activateLabels={true}
-      className="VictoryContainer"
+      className="pf-c-chart"
       labelComponent={
         <VictoryTooltip
           active={false}
           flyoutComponent={
             <Flyout
               pathComponent={<Path />}
+              role="presentation"
+              shapeRendering="auto"
             />
           }
           groupComponent={<g />}

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-class-name.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-class-name.ts
@@ -1,0 +1,18 @@
+interface ChartClassNameInterface {
+  className?: string;
+}
+
+// Returns the class name that will be applied to the outer-most div rendered by the chart's container
+export const getClassName = ({
+  className
+}: ChartClassNameInterface) => {
+  let cleanClassName;
+
+  // Workaround for VictoryContainer class name
+  if (className) {
+    cleanClassName = className.replace(/VictoryContainer/g, '')
+      .replace(/pf-c-chart/g, '')
+      .replace(/\s+/g,' ').trim();
+  }
+  return (cleanClassName && cleanClassName.length) ? `pf-c-chart ${cleanClassName}` : 'pf-c-chart';
+}

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-label.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-label.ts
@@ -1,18 +1,27 @@
-import {ChartCommonStyles, ChartThemeDefinition} from '../ChartTheme';
-import { TextSize } from 'victory-core';
+import { Helpers, TextSize } from 'victory-core';
+import { getPieOrigin } from './chart-origin';
+import { ChartCommonStyles, ChartThemeDefinition } from '../ChartTheme';
 
-interface ChartLabelPaddingXInterface {
+interface ChartBulletLabelInterface {
   dx?: number; // Horizontal shift from the x coordinate
-  chartWidth: number; // Width of chart (e.g., donut) within SVG
-  labelPosition?: 'bottom' | 'center' | 'left' | 'right' | 'top' | 'top-left'; // Position of label
+  dy?: number; // Vertical shift from the x coordinate
+  chartHeight?: number; // Width of chart within SVG
+  chartWidth?: number; // Width of chart (e.g., donut) within SVG
+  labelPosition?: 'bottom' | 'left' | 'top' | 'top-left'; // Position of label
   legendPosition?: 'bottom' | 'bottom-left' | 'right'; // Position of legend
+  svgHeight?: number; // Overall height of SVG
   svgWidth?: number; // Overall width of SVG
+  width?: number; // Chart width
 }
 
-interface ChartLabelPaddingYInterface {
-  dy?: number; // Vertical shift from the x coordinate
-  chartHeight: number; // Width of chart (e.g., donut) within SVG
-  labelPosition?: 'bottom' | 'center' | 'left' | 'right' | 'top' | 'top-left'; // Position of label
+interface ChartPieLabelInterface {
+  dx?: number; // Horizontal shift from the x coordinate
+  dy?: number; // Horizontal shift from the y coordinate
+  height: number; // Chart height
+  labelPosition?: 'bottom' | 'center' | 'right' ; // Position of label
+  legendPosition?: 'bottom' | 'right'; // Position of legend
+  padding: any; // Chart padding
+  width: number; // Chart width
 }
 
 interface ChartLabelTextSizeInterface {
@@ -20,62 +29,78 @@ interface ChartLabelTextSizeInterface {
   theme: ChartThemeDefinition; // The theme that will be applied to the chart
 }
 
-// Returns x coordinate for label
-export const getLabelX = ({
+// Returns x coordinate for bullet labels
+export const getBulletLabelX = ({
   chartWidth,
   dx = 0,
+  labelPosition
+}: ChartBulletLabelInterface) => {
+  return (labelPosition === 'top' && chartWidth) ? Math.round(chartWidth / 2) : dx;
+};
+
+// Returns y coordinate for bullet labels
+export const getBulletLabelY = ({
+  chartHeight,
+  dy = 0,
+  labelPosition
+}: ChartBulletLabelInterface) => {
+  switch (labelPosition) {
+    case 'bottom':
+      return chartHeight + ChartCommonStyles.label.margin + dy;
+    case 'left':
+      return chartHeight ? Math.round(chartHeight / 2) + dy : dy;
+    default:
+      return dy;
+  }
+};
+
+// Returns x coordinate for pie labels
+export const getPieLabelX = ({
+  dx = 0,
+  height,
   labelPosition,
   legendPosition,
-  svgWidth
-}: ChartLabelPaddingXInterface) => {
-  if (!chartWidth) {
-    return 0;
-  }
+  padding,
+  width
+}: ChartPieLabelInterface) => {
+  const origin = getPieOrigin({ height, padding, width });
+  const radius = Helpers.getRadius({ height, width, padding });
+
   switch (labelPosition) {
-    case 'center':
-      switch (legendPosition) {
-        case 'bottom':
-          return Math.round(svgWidth / 2) + dx;
-        default:
-          return Math.round(chartWidth / 2) + dx;
-      }
     case 'bottom':
-    case 'top':
-      return Math.round(chartWidth / 2) + dx;
+    case 'center':
+      return origin.x + dx;
     case 'right':
       switch (legendPosition) {
         case 'bottom':
-          return Math.round(svgWidth / 2) + Math.round(chartWidth / 2) + ChartCommonStyles.label.margin + dx;
+          return origin.x + ChartCommonStyles.label.margin + dx + radius;
         case 'right':
-          return chartWidth + ChartCommonStyles.label.margin + dx;
+          return origin.x + ChartCommonStyles.label.margin + dx;
         default:
           return dx;
       }
-    case 'left':
-    case 'top-left':
     default:
       return dx;
   }
 };
 
-// Returns y coordinate for label
-export const getLabelY = ({
-  chartHeight,
+// Returns x coordinate for pie labels
+export const getPieLabelY = ({
   dy = 0,
-  labelPosition
-}: ChartLabelPaddingYInterface) => {
-  if (!chartHeight) {
-    return 0;
-  }
+  height,
+  labelPosition,
+  padding,
+  width
+}: ChartPieLabelInterface) => {
+  const origin = getPieOrigin({ height, padding, width });
+  const radius = Helpers.getRadius({ height, width, padding });
+
   switch (labelPosition) {
     case 'center':
-    case 'left':
     case 'right':
-      return Math.round(chartHeight / 2) + dy;
+      return origin.y + dy;
     case 'bottom':
-      return chartHeight + ChartCommonStyles.label.margin + dy;
-    case 'top':
-    case 'top-left':
+      return origin.y + radius + ChartCommonStyles.label.margin * 2 + dy;
     default:
       return dy;
   }

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-origin.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/chart-origin.ts
@@ -1,61 +1,24 @@
-interface ChartOriginInterface {
-  chartHeight: number; // Height of chart (e.g., donut) within SVG
-  chartWidth: number; // Width of chart (e.g., donut) within SVG
-  dx?: number; // Horizontal shift from the x coordinate
-  dy?: number; // vertical shift from the x coordinate
-  legendPosition?: 'bottom' | 'bottom-left' | 'right'; // Position of legend
-  svgWidth: number; // Overall width of SVG
+import { Helpers } from 'victory-core';
+
+interface ChartPieOriginInterface {
+  height: number; // Chart height
+  padding: any; // Chart padding
+  width: number; // Chart width
 }
 
-interface ChartOriginXInterface {
-  chartWidth: number; // Width of chart (e.g., donut) within SVG
-  dx?: number; // Horizontal shift from the x coordinate
-  legendPosition?: 'bottom' | 'bottom-left' | 'right'; // Position of legend
-  svgWidth: number; // Overall width of SVG
+// Returns te origin for pie based charts. For example, something with a radius such as pie, donut, donut utilization,
+// and donut threshold.
+export const getPieOrigin = ({
+  height,
+  padding,
+  width
+}: ChartPieOriginInterface) => {
+  const { top, bottom, left, right } = Helpers.getPadding({padding});
+  const radius = Helpers.getRadius({ height, width, padding });
+  const offsetX = (width - radius * 2 - left - right) / 2;
+  const offsetY = (height - radius * 2 - top - bottom) / 2;
+  return {
+    x: radius + left + offsetX,
+    y: radius + top + offsetY
+  };
 }
-
-interface ChartOriginYInterface {
-  chartHeight: number; // Height of chart (e.g., donut) within SVG
-  dy?: number; // vertical shift from the x coordinate
-  legendPosition?: 'bottom' | 'bottom-left' | 'right'; // Position of legend
-}
-
-// Returns origin x and y coordinates
-export const getChartOrigin = ({
-  chartHeight,
-  chartWidth,
-  dx = 0,
-  dy = 0,
-  legendPosition,
-  svgWidth
-}: ChartOriginInterface) => ({
-  x: getChartOriginX({ chartWidth, dx, legendPosition, svgWidth }),
-  y: getChartOriginY({ chartHeight, dy, legendPosition })
-});
-
-// Returns origin x coordinate
-export const getChartOriginX = ({
-  chartWidth,
-  dx = 0,
-  legendPosition,
-  svgWidth
-}: ChartOriginXInterface) => {
-  switch (legendPosition) {
-    case 'bottom':
-      return Math.round(svgWidth / 2) + dx;
-    default:
-      return Math.round(chartWidth / 2) + dx;
-  }
-};
-
-// Returns origin y coordinate
-export const getChartOriginY = ({
-  chartHeight,
-  dy = 0,
-  legendPosition
-}: ChartOriginYInterface) => {
-  switch (legendPosition) {
-    default:
-      return Math.round(chartHeight / 2) + dy;
-  }
-};

--- a/packages/patternfly-4/react-charts/src/components/ChartUtils/index.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartUtils/index.ts
@@ -1,3 +1,4 @@
+export * from './chart-class-name';
 export * from './chart-domain';
 export * from './chart-label';
 export * from './chart-legend';

--- a/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/ChartVoronoiContainer.tsx
@@ -6,7 +6,7 @@ import {
 } from 'victory';
 import { ChartThemeDefinition } from '../ChartTheme';
 import { ChartTooltip } from '../ChartTooltip';
-import { getTheme } from '../ChartUtils';
+import { getClassName, getTheme } from '../ChartUtils';
 
 export enum ChartVoronoiDimension {
   x = 'x',
@@ -17,10 +17,6 @@ export enum ChartVoronoiDimension {
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
  */
 export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps {
-  /**
-   * See Victory type docs: https://formidable.com/open-source/victory/docs/victory-voronoi-container
-   */
-  ' '?: any;
   /**
    * When the activateData prop is set to true, the active prop will be set to true on all
    * data components within a voronoi area. When this prop is set to false, the onActivated
@@ -36,6 +32,22 @@ export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps
    * ChartVoronoiContainer via the labels prop will still appear when this prop is set to false.
    */
   activateLabels?: boolean;
+  /**
+   * Specifies the tooltip capability of the container component. A value of true allows the chart to add a
+   * ChartTooltip component to the labelComponent property. This is a shortcut to display tooltips when the labels
+   * property is also provided.
+   */
+  allowTooltip?: boolean;
+  /**
+   * The className prop specifies a className that will be applied to the outer-most div rendered by the container
+   */
+  className?: string;
+  /**
+   * The constrainToVisibleArea prop determines whether to coerce tooltips so that they fit within the visible area of
+   * the chart. When this prop is set to true, tooltip pointers will still point to the correct data point, but the
+   * center of the tooltip will be shifted to fit within the overall width and height of the svg Victory renders.
+   */
+  constrainToVisibleArea?: boolean;
   /**
    * When the disable prop is set to true, ChartVoronoiContainer events will not fire.
    */
@@ -54,6 +66,11 @@ export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps
    * on ChartVoronoiContainer. If the labels prop is omitted, no label component will be rendered.
    */
   labelComponent?: React.ReactElement<any>;
+  /**
+   * When the mouseFollowTooltip prop is set on VictoryVoronoiContainer, The position of the center of the tooltip
+   * follows the position of the mouse.
+   */
+  mouseFollowTooltips?: boolean,
   /**
    * The onActivated prop accepts a function to be called whenever new data points are activated.
    * The function is called with the parameters points (an array of active data objects) and props
@@ -115,18 +132,27 @@ export interface ChartVoronoiContainerProps extends VictoryVoronoiContainerProps
 }
 
 export const ChartVoronoiContainer: React.FunctionComponent<ChartVoronoiContainerProps> = ({
+  className,
+  allowTooltip = true,
+  constrainToVisibleArea = false,
   themeColor,
   themeVariant,
 
   // destructure last
   theme = getTheme(themeColor, themeVariant),
-  labelComponent = <ChartTooltip theme={theme} />,
+  labelComponent = allowTooltip ? <ChartTooltip /> : undefined,
   ...rest
 }: ChartVoronoiContainerProps) => {
-  // Note: theme is required by voronoiContainerMixin, but VictoryVoronoiContainer is missing a prop type
+  const chartClassName = getClassName({className});
+  const chartLabelComponent = React.cloneElement(labelComponent, {
+    constrainToVisibleArea,
+    theme,
+    ...labelComponent.props,
+  });
 
+  // Note: theme is required by voronoiContainerMixin, but @types/victory is missing a prop type
   // @ts-ignore
-  return <VictoryVoronoiContainer labelComponent={labelComponent} theme={theme} {...rest} />;
+  return <VictoryVoronoiContainer className={chartClassName} labelComponent={chartLabelComponent} theme={theme} {...rest} />;
 };
 ChartVoronoiContainer.defaultProps = (VictoryVoronoiContainer as any).defaultProps;
 

--- a/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartVoronoiContainer/__snapshots__/ChartVoronoContainer.test.tsx.snap
@@ -4,13 +4,16 @@ exports[`ChartVoronoiContainer 1`] = `
 <VictoryVoronoiContainer
   activateData={true}
   activateLabels={true}
-  className="VictoryContainer"
+  className="pf-c-chart"
   labelComponent={
     <VictoryTooltip
       active={false}
+      constrainToVisibleArea={false}
       flyoutComponent={
         <Flyout
           pathComponent={<Path />}
+          role="presentation"
+          shapeRendering="auto"
         />
       }
       groupComponent={<g />}
@@ -24,6 +27,455 @@ exports[`ChartVoronoiContainer 1`] = `
         />
       }
       renderInPortal={true}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
     />
   }
   portalComponent={<Portal />}
@@ -486,13 +938,16 @@ exports[`ChartVoronoiContainer 2`] = `
 <VictoryVoronoiContainer
   activateData={true}
   activateLabels={true}
-  className="VictoryContainer"
+  className="pf-c-chart"
   labelComponent={
     <VictoryTooltip
       active={false}
+      constrainToVisibleArea={false}
       flyoutComponent={
         <Flyout
           pathComponent={<Path />}
+          role="presentation"
+          shapeRendering="auto"
         />
       }
       groupComponent={<g />}
@@ -506,6 +961,455 @@ exports[`ChartVoronoiContainer 2`] = `
         />
       }
       renderInPortal={true}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
     />
   }
   portalComponent={<Portal />}
@@ -970,13 +1874,15 @@ exports[`renders container via ChartGroup 1`] = `
     <Unknown
       activateData={true}
       activateLabels={true}
-      className="VictoryContainer"
+      className="pf-c-chart"
       labelComponent={
         <VictoryTooltip
           active={false}
           flyoutComponent={
             <Flyout
               pathComponent={<Path />}
+              role="presentation"
+              shapeRendering="auto"
             />
           }
           groupComponent={<g />}

--- a/packages/patternfly-4/react-charts/src/components/Sparkline/examples/sparkline.md
+++ b/packages/patternfly-4/react-charts/src/components/Sparkline/examples/sparkline.md
@@ -2,39 +2,30 @@
 title: 'Sparkline'
 section: 'charts'
 typescript: true
-propComponents: ['ChartArea']
+propComponents: ['ChartArea', 'ChartGroup', 'ChartLabel']
 ---
 
 import { ChartArea, ChartGroup, ChartLabel, ChartThemeColor } from '@patternfly/react-charts';
 import './sparkline.scss';
 
-## Tutorial
-```js
-import React from 'react';
-import { Text, TextContent, TextVariants } from '@patternfly/react-charts';
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-<TextContent>
-  <Text component={TextVariants.p}>
-    PatternFly React charts are based on the Victory chart library, along with additional functionality, custom 
-    components, and theming for PatternFly. This provides a collection of React components you can use to build 
-    interfaces with consistent markup, styling, and behavior.
-  </Text>
-  <Text component={TextVariants.p}>
-    In this 
-    <Text component={TextVariants.a} href="https://katacoda.com/patternfly/courses/charts/module-sparkline" target="_blank">
-      tutorial
-    </Text>,
-    we will build a PatternFly sparkline chart together - starting with a simple chart, adding tooltips, and concluding 
-    by changing the theme color. You'll learn a little bit about React and how to use PatternFly components together to 
-    build a consistent experience.
-  </Text>
-</TextContent>
-```
+## Tutorial
+
+PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, 
+along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React 
+based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+In this tutorial, we will build a bar chart together - starting with a simple chart, adding tooltips, and 
+concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent 
+user experience.
+
+[Start course](https://katacoda.com/patternfly/courses/charts/module-sparkline)
 
 ## Sparkline chart
 ```js
 import React from 'react';
-import { ChartArea, ChartGroup, ChartLabel } from '@patternfly/react-charts';
+import { ChartArea, ChartGroup, ChartLabel, ChartVoronoiContainer } from '@patternfly/react-charts';
 
 <div>
   <div className="sparkline-container">
@@ -42,7 +33,7 @@ import { ChartArea, ChartGroup, ChartLabel } from '@patternfly/react-charts';
       <ChartGroup
         ariaDesc="Average number of pets"
         ariaTitle="Sparkline chart example"
-        containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+        containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
         height={100}
         maxDomain={{y: 9}}
         padding={0}
@@ -50,10 +41,10 @@ import { ChartArea, ChartGroup, ChartLabel } from '@patternfly/react-charts';
       >
         <ChartArea
           data={[
-            { name: 'Cats', x: 1, y: 3 },
-            { name: 'Cats', x: 2, y: 4 },
-            { name: 'Cats', x: 3, y: 8 },
-            { name: 'Cats', x: 4, y: 6 }
+            { name: 'Cats', x: '2015', y: 3 },
+            { name: 'Cats', x: '2016', y: 4 },
+            { name: 'Cats', x: '2017', y: 8 },
+            { name: 'Cats', x: '2018', y: 6 }
           ]}
         />
       </ChartGroup>
@@ -67,7 +58,7 @@ import { ChartArea, ChartGroup, ChartLabel } from '@patternfly/react-charts';
 This demonstrates an alternate way of applying tooltips using CSS overflow
 ```js
 import React from 'react';
-import { ChartArea, ChartGroup, ChartLabel, ChartThemeColor } from '@patternfly/react-charts';
+import { ChartArea, ChartGroup, ChartLabel, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
 
 <div>
   <div className="sparkline-container sparkline-overflow">
@@ -75,7 +66,7 @@ import { ChartArea, ChartGroup, ChartLabel, ChartThemeColor } from '@patternfly/
       <ChartGroup
         ariaDesc="Average number of pets"
         ariaTitle="Sparkline chart example"
-        containerComponent={<ChartVoronoiContainer labels={datum => `${datum.name}: ${datum.y}`} />}
+        containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} />}
         height={100}
         maxDomain={{y: 9}}
         padding={0}
@@ -84,10 +75,10 @@ import { ChartArea, ChartGroup, ChartLabel, ChartThemeColor } from '@patternfly/
       >
         <ChartArea
           data={[
-            { name: 'Cats', x: 1, y: 3 },
-            { name: 'Cats', x: 2, y: 4 },
-            { name: 'Cats', x: 3, y: 8 },
-            { name: 'Cats', x: 4, y: 6 }
+            { name: 'Cats', x: '2015', y: 3 },
+            { name: 'Cats', x: '2016', y: 4 },
+            { name: 'Cats', x: '2017', y: 8 },
+            { name: 'Cats', x: '2018', y: 6 }
           ]}
         />
       </ChartGroup>
@@ -96,3 +87,16 @@ import { ChartArea, ChartGroup, ChartLabel, ChartThemeColor } from '@patternfly/
   </div>
 </div>
 ```
+
+## Tips
+
+- For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `ChartArea` props, see <a href="https://formidable.com/open-source/victory/docs/victory-area" target="_blank">VictoryArea</a>
+ - For `ChartGroup` props, see <a href="https://formidable.com/open-source/victory/docs/victory-group" target="_blank">VictoryGroup</a>
+ - For `ChartLabel` props, see <a href="https://formidable.com/open-source/victory/docs/victory-label" target="_blank">VictoryLabel</a>
+ - For `ChartVoronoiContainer` props, see <a href="https://formidable.com/open-source/victory/docs/victory-voronoi-container" target="_blank">VictoryVoronoiContainer</a>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/AreaChart/ColorAreaBottomLegendDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/AreaChart/ColorAreaBottomLegendDemo.tsx
@@ -7,12 +7,12 @@ render() {
     <div>
       <div style={{height: '225px', width: '650px'}}>
         <Chart
-          containerComponent={<ChartVoronoiContainer labels={(datum) => `${datum.name}: ${datum.y}`} />}
+          containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} />}
           legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
           legendPosition="bottom"
           height={225}
           padding={{
-            bottom: 75, // Adjusted to accomodate legend
+            bottom: 75, // Adjusted to accommodate legend
             left: 50,
             right: 50,
             top: 50,

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/AreaChart/CyanAreaDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/AreaChart/CyanAreaDemo.tsx
@@ -8,7 +8,7 @@ export class CyanAreaDemo extends React.Component {
       <div>
         <div style={{height: '200px', width: '800px'}}>
           <Chart
-            containerComponent={<ChartVoronoiContainer labels={(datum) => `${datum.name}: ${datum.y}`} />}
+            containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} />}
             legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }]}
             legendOrientation="vertical"
             legendPosition="right"
@@ -16,7 +16,7 @@ export class CyanAreaDemo extends React.Component {
             padding={{
               bottom: 50,
               left: 50,
-              right: 200, // Adjusted to accomodate legend
+              right: 200, // Adjusted to accommodate legend
               top: 50
             }}
             themeColor={ChartThemeColor.cyan}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/BarChartDemo/ColorBarZoomDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/BarChartDemo/ColorBarZoomDemo.tsx
@@ -18,7 +18,7 @@ export class ColorBarZoomDemo extends React.Component {
             legendPosition="bottom"
             height={400}
             padding={{
-              bottom: 75, // Adjusted to accomodate legend
+              bottom: 75, // Adjusted to accommodate legend
               left: 50,
               right: 50,
               top: 50

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/BarChartDemo/PurpleBarGroupedDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/BarChartDemo/PurpleBarGroupedDemo.tsx
@@ -12,7 +12,7 @@ export class PurpleBarGroupedDemo extends React.Component {
       <div>
         <div style={{width: '600px', height: '250px', paddingLeft: '50px'}}>
           <Chart
-            containerComponent={<ChartVoronoiContainer labels={(datum) => `${datum.name}: ${datum.y}`} />}
+            containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} />}
             domainPadding={{ x: [30, 25] }}
             legendData={[{ name: 'Cats' }, { name: 'Birds' }, { name: 'Dogs' }, { name: 'Mice' }]}
             legendOrientation="vertical"
@@ -21,7 +21,7 @@ export class PurpleBarGroupedDemo extends React.Component {
             padding={{
               bottom: 50,
               left: 50,
-              right: 200, // Adjusted to accomodate legend
+              right: 200, // Adjusted to accommodate legend
               top: 50
             }}
             themeColor={ChartThemeColor.purple}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/BarChartDemo/SimpleBarDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/BarChartDemo/SimpleBarDemo.tsx
@@ -21,7 +21,7 @@ export class SimpleBarDemo extends React.Component {
             padding={{
               bottom: 50,
               left: 50,
-              right: 200, // Adjusted to accomodate legend
+              right: 200, // Adjusted to accommodate legend
               top: 50
             }}
             width={600}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutChartDemo/DonutBottomAlignedLegendDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutChartDemo/DonutBottomAlignedLegendDemo.tsx
@@ -13,12 +13,10 @@ export class DonutBottomAlignedLegendDemo extends React.Component {
         <div style={{height: '275px', width: '300px', paddingTop: '50px', paddingLeft: '50px'}}>
           <ChartDonut
             data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-            donutHeight={230}
             height={275}
-            labels={(datum) => `${datum.x}: ${datum.y}%`}
+            labels={({ datum }) => `${datum.x}: ${datum.y}%`}
             legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
             legendPosition="bottom"
-            donutWidth={225}
             subTitle="Pets"
             title="100"
             width={300}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutChartDemo/DonutRightAlignedLegendColorDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutChartDemo/DonutRightAlignedLegendColorDemo.tsx
@@ -13,7 +13,7 @@ export class DonutRightAlignedLegendColorDemo extends React.Component {
         <div style={{height: '230px', width: '350px', paddingTop: '50px', paddingLeft: '50px'}}>
           <ChartDonut
             data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-            labels={(datum) => `${datum.x}: ${datum.y}%`}
+            labels={({ datum }) => `${datum.x}: ${datum.y}%`}
             legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
             legendOrientation="vertical"
             legendPosition="right"

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutChartDemo/DonutRightAlignedLegendDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutChartDemo/DonutRightAlignedLegendDemo.tsx
@@ -13,7 +13,7 @@ export class DonutRightAlignedLegendDemo extends React.Component {
         <div style={{height: '230px', width: '350px', paddingTop: '50px', paddingLeft: '50px'}}>
           <ChartDonut
             data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-            labels={(datum) => `${datum.x}: ${datum.y}%`}
+            labels={({ datum }) => `${datum.x}: ${datum.y}%`}
             legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
             legendOrientation="vertical"
             legendPosition="right"

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutChartDemo/DonutSmallBottomAlignedLegend.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutChartDemo/DonutSmallBottomAlignedLegend.tsx
@@ -11,12 +11,20 @@ export class DonutSmallBottomAlignedLegend extends React.Component {
       <div>
         <div style={{height: '200px', width: '300px', paddingTop: '50px', paddingLeft: '50px'}}>
           <ChartDonut
+            ariaDesc="Average number of pets"
+            ariaTitle="Donut chart example"
+            constrainToVisibleArea={true}
             data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-            donutHeight={150}
             height={200}
-            labels={(datum) => `${datum.x}: ${datum.y}%`}
+            labels={({ datum }) => `${datum.x}: ${datum.y}%`}
             legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
             legendPosition="bottom"
+            padding={{
+              bottom: 50, // Adjusted to accommodate legend
+              left: 8,
+              right: 50, // Adjusted to accommodate subTitle
+              top: 8
+            }}
             subTitle="Pets"
             subTitlePosition="right"
             title="100"

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutChartDemo/DonutSmallDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutChartDemo/DonutSmallDemo.tsx
@@ -14,7 +14,7 @@ export class DonutSmallDemo extends React.Component {
           <ChartDonut
             data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
             height={150}
-            labels={(datum) => `${datum.x}: ${datum.y}%`}
+            labels={({ datum }) => `${datum.x}: ${datum.y}%`}
             subTitle="Pets"
             title="100"
             width={150}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutChartDemo/DonutSmallRightAlignedLegendDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutChartDemo/DonutSmallRightAlignedLegendDemo.tsx
@@ -10,17 +10,24 @@ export class DonutSmallRightAlignedLegendDemo extends React.Component {
   render() {
     return (
       <div>
-        <div style={{height: '175px', width: '275px', paddingTop: '50px', paddingLeft: '50px'}}>
+        <div style={{height: '150px', width: '275px', paddingTop: '50px', paddingLeft: '50px'}}>
           <ChartDonut
+            ariaDesc="Average number of pets"
+            ariaTitle="Donut chart example"
+            constrainToVisibleArea={true}
             data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-            donutHeight={150}
-            height={175}
-            labels={(datum) => `${datum.x}: ${datum.y}%`}
+            height={150}
+            labels={({ datum }) => `${datum.x}: ${datum.y}%`}
             legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
             legendOrientation="vertical"
             legendPosition="right"
+            padding={{
+              bottom: 8,
+              left: 8,
+              right: 125, // Adjusted to accommodate legend
+              top: 8
+            }}
             subTitle="Pets"
-            subTitlePosition="bottom"
             title="100"
             width={275}
           />

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationGreenStaticRightDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationGreenStaticRightDemo.tsx
@@ -33,13 +33,13 @@ export class DonutUtilizationGreenStaticRightDemo extends React.Component <{}, {
           <ChartDonutThreshold
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
             height={350}
-            labels={(datum) => datum.x ? datum.x : null}
+            labels={({ datum }) => datum.x ? datum.x : null}
             legendPosition="bottom"
             width={230}
           >
             <ChartDonutUtilization
               data={{ x: 'Storage capacity', y: used }}
-              labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
               legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
               legendOrientation="vertical"
               subTitle="of 100 GBps"

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationInvertedRightDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationInvertedRightDemo.tsx
@@ -37,7 +37,7 @@ export class DonutUtilizationInvertedRightDemo extends React.Component<{}, { use
           <ChartDonutUtilization
             data={{ x: 'GBps capacity', y: used }}
             invert
-            labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
             legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
             legendOrientation="vertical"
             subTitle="of 100 GBps"

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSimpleBottomDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSimpleBottomDemo.tsx
@@ -11,19 +11,26 @@ export class DonutUtilizationSimpleBottomDemo extends React.Component {
   render() {
     return (
     <div>
-      <div style={{backgroundColor: 'white', height: '275px', width: '500px', paddingTop: '25px'}}>
+      <div style={{backgroundColor: 'white', height: '275px', width: '300px', paddingTop: '25px'}}>
         <ChartDonutUtilization
-          data={{ x: 'GBps capacity', y: 45 }}
-          donutHeight={230}
+          ariaDesc="Storage capacity"
+          ariaTitle="Donut utilization chart example"
+          constrainToVisibleArea={true}
+          data={{ x: 'Storage capacity', y: 45 }}
           height={275}
-          labels={(datum) => datum.x ? `${datum.x} - ${datum.y}%` : null}
-          legendData={[{ name: 'GBps capacity - 45%' }, { name: 'Unused' }]}
-          legendOrientation="horizontal"
-          donutWidth={282}
+          labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+          legendData={[{ name: `Storage capacity: 45%` }, { name: 'Unused' }]}
+          legendPosition="bottom"
+          padding={{
+            bottom: 50, // Adjusted to accommodate legend
+            left: 8,
+            right: 8,
+            top: 8
+          }}
           subTitle="of 100 GBps"
           title="45%"
           thresholds={[{ value: 60 }, { value: 90 }]}
-          width={500}
+          width={300}
         />
       </div>
     </div>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSimpleDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSimpleDemo.tsx
@@ -13,7 +13,7 @@ export class DonutUtilizationSimpleDemo extends React.Component {
         <div style={{backgroundColor: 'white', height: '230px', width: '500px'}}>
           <ChartDonutUtilization
             data={{ x: 'GBps capacity', y: 75 }}
-            labels={(datum) => datum.x ? `${datum.x} - ${datum.y}%` : null}
+            labels={({ datum }) => datum.x ? `${datum.x} - ${datum.y}%` : null}
             subTitle="of 100 GBps"
             title="75%"
             width={500}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSimpleRightDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSimpleRightDemo.tsx
@@ -37,7 +37,7 @@ export class DonutUtilizationSimpleRightDemo extends React.Component<{}, { used:
         <div style={{backgroundColor: 'white', height: '230px', width: '435px'}}>
           <ChartDonutUtilization
             data={{ x: 'GBps capacity', y: used }}
-            labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
             legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
             legendOrientation="vertical"
             subTitle="of 100 GBps"

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSimpleRightGreenDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSimpleRightGreenDemo.tsx
@@ -35,13 +35,21 @@ export class DonutUtilizationSimpleRightGreenDemo extends React.Component<{}, { 
       <div>
         <div style={{backgroundColor: 'white', height: '300px', width: '230px'}}>
           <ChartDonutUtilization
+            ariaDesc="Storage capacity"
+            ariaTitle="Donut utilization chart example"
+            constrainToVisibleArea={true}
             data={{ x: 'Storage capacity', y: used }}
-            donutHeight={230}
             height={300}
-            labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
             legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
             legendOrientation="vertical"
             legendPosition="bottom"
+            padding={{
+              bottom: 75, // Adjusted to accommodate legend
+              left: 8,
+              right: 8,
+              top: 8
+            }}
             subTitle="of 100 GBps"
             title={`${used}%`}
             themeColor={ChartThemeColor.green}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSmallDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSmallDemo.tsx
@@ -14,7 +14,7 @@ export class DonutUtilizationSmallDemo extends React.Component {
           <ChartDonutUtilization
             data={{ x: 'Storage capacity', y: 75 }}
             height={150}
-            labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
             subTitle="of 100 GBps"
             title="75%"
             width={150}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSmallRightDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSmallRightDemo.tsx
@@ -37,7 +37,7 @@ export class DonutUtilizationSmallRightDemo extends React.Component<{}, { used: 
           <ChartDonutUtilization
             data={{ x: 'Storage capacity', y: used }}
             height={150}
-            labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+            labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
             legendData={[{ name: `Storage capacity: ${spacer}${used}%` }, { name: 'Unused' }]}
             legendOrientation="vertical"
             subTitle="of 100 GBps"

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSmallStaticBottomDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSmallStaticBottomDemo.tsx
@@ -10,23 +10,29 @@ export class DonutUtilizationSmallStaticBottomDemo extends React.Component {
   render() {
     return (
       <div>
-        <div style={{backgroundColor: 'white', height: '225px', width: '675px'}}>
+        <div style={{backgroundColor: 'white', height: '275px', width: '675px'}}>
           <ChartDonutThreshold
+            ariaDesc="Storage capacity"
+            ariaTitle="Donut utilization chart with static threshold example"
+            constrainToVisibleArea={true}
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-            donutHeight={175}
-            height={225}
-            labels={(datum) => datum.x ? datum.x : null}
+            height={275}
+            labels={({ datum }) => datum.x ? datum.x : null}
             legendPosition="bottom"
-            subTitlePosition="right"
+            padding={{
+              bottom: 50, // Adjusted to accommodate legend
+              left: 8,
+              right: 8,
+              top: 8
+            }}
             width={675}
           >
             <ChartDonutUtilization
               data={{ x: 'Storage capacity', y: 45 }}
-              labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-              legendData={[{ name: 'Storage capacity: 45%' }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
+              labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              legendData={[{ name: `Storage capacity: 45%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
               subTitle="of 100 GBps"
               title="45%"
-              thresholds={[{ value: 60 }, { value: 90 }]}
             />
           </ChartDonutThreshold>
         </div>

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSmallStaticDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSmallStaticDemo.tsx
@@ -14,12 +14,12 @@ export class DonutUtilizationSmallStaticDemo extends React.Component {
           <ChartDonutThreshold
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
             height={175}
-            labels={(datum) => datum.x ? datum.x : null}
+            labels={({ datum }) => datum.x ? datum.x : null}
             width={175}
           >
             <ChartDonutUtilization
               data={{ x: 'Storage capacity', y: 45 }}
-              labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
               subTitle="of 100 GBps"
               title="45%"
             />

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSmallStaticRightDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationSmallStaticRightDemo.tsx
@@ -32,12 +32,12 @@ export class DonutUtilizationSmallStaticRightDemo extends React.Component<{}, { 
           <ChartDonutThreshold
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
             height={175}
-            labels={(datum) => datum.x ? datum.x : null}
+            labels={({ datum }) => datum.x ? datum.x : null}
             width={425}
           >
             <ChartDonutUtilization
               data={{ x: 'Storage capacity', y: used }}
-              labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
               legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
               legendOrientation="vertical"
               subTitle="of 100 GBps"

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationStaticBottomDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationStaticBottomDemo.tsx
@@ -10,20 +10,28 @@ export class DonutUtilizationStaticBottomDemo extends React.Component {
   render() {
     return (
       <div>
-        <div style={{backgroundColor: 'white', height: '275px', width: '675px', paddingTop: '20px'}}>
+        <div style={{backgroundColor: 'white', height: '225px', width: '675px', paddingTop: '20px'}}>
           <ChartDonutThreshold
+            ariaDesc="Storage capacity"
+            ariaTitle="Donut utilization chart with static threshold example"
+            constrainToVisibleArea={true}
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-            donutHeight={175}
             height={225}
-            labels={(datum) => datum.x ? datum.x : null}
+            labels={({ datum }) => datum.x ? datum.x : null}
             legendPosition="bottom"
+            padding={{
+              bottom: 50, // Adjusted to accommodate legend
+              left: 8,
+              right: 8,
+              top: 8
+            }}
             subTitlePosition="right"
             width={675}
           >
             <ChartDonutUtilization
               data={{ x: 'Storage capacity', y: 45 }}
-              labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
-              legendData={[{ name: 'Storage capacity: 45%' }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
+              labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              legendData={[{ name: `Storage capacity: 45%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
               subTitle="of 100 GBps"
               title="45%"
               thresholds={[{ value: 60 }, { value: 90 }]}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationStaticDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationStaticDemo.tsx
@@ -13,11 +13,11 @@ export class DonutUtilizationStaticDemo extends React.Component {
         <div style={{backgroundColor: 'white', height: '230px', width: '230px'}}>
           <ChartDonutThreshold
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-            labels={(datum) => datum.x ? datum.x : null}
+            labels={({ datum }) => datum.x ? datum.x : null}
           >
             <ChartDonutUtilization
               data={{ x: 'Storage capacity', y: 45 }}
-              labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
               subTitle="of 100 GBps"
               title="45%"
             />

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationStaticInvertedRightDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationStaticInvertedRightDemo.tsx
@@ -37,12 +37,12 @@ export class DonutUtilizationStaticInvertedRightDemo extends React.Component<{},
           <ChartDonutThreshold
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 20%', y: 20 }]}
             invert
-            labels={(datum) => datum.x ? datum.x : null}
+            labels={({ datum }) => datum.x ? datum.x : null}
             width={500}
           >
             <ChartDonutUtilization
               data={{ x: 'Storage capacity', y: used }}
-              labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
               legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 20%' }]}
               legendOrientation="vertical"
               subTitle="of 100 GBps"

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationStaticRightDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DonutUtilizationChartDemo/DonutUtilizationStaticRightDemo.tsx
@@ -31,12 +31,12 @@ export class DonutUtilizationStaticRightDemo extends React.Component<{}, { used:
         <div style={{backgroundColor: 'white', height: '230px', width: '500px'}}>
           <ChartDonutThreshold
             data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-            labels={(datum) => datum.x ? datum.x : null}
+            labels={({ datum }) => datum.x ? datum.x : null}
             width={500}
           >
             <ChartDonutUtilization
               data={{ x: 'Storage capacity', y: used }}
-              labels={(datum) => datum.x ? `${datum.x}: ${datum.y}%` : null}
+              labels={({ datum }) => datum.x ? `${datum.x}: ${datum.y}%` : null}
               legendData={[{ name: `Storage capacity: ${used}%` }, { name: 'Warning threshold at 60%' }, { name: 'Danger threshold at 90%' }]}
               legendOrientation="vertical"
               subTitle="of 100 GBps"

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/LineChartDemo/LineChartColorDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/LineChartDemo/LineChartColorDemo.tsx
@@ -18,7 +18,7 @@ export class LineChartColorDemo extends React.Component {
             legendPosition="bottom"
             height={275}
             padding={{
-              bottom: 75, // Adjusted to accomodate legend
+              bottom: 75, // Adjusted to accommodate legend
               left: 50,
               right: 50,
               top: 50

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/LineChartDemo/LineChartGreenDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/LineChartDemo/LineChartGreenDemo.tsx
@@ -13,7 +13,7 @@ export class LineChartGreenDemo extends React.Component {
       <div>
         <div style={{height: '250px', width: '600px'}}>
           <Chart
-            containerComponent={<ChartVoronoiContainer labels={(datum) => `${datum.name}: ${datum.y}`} />}
+            containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} />}
             legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
             legendOrientation="vertical"
             legendPosition="right"
@@ -21,7 +21,7 @@ export class LineChartGreenDemo extends React.Component {
             padding={{
               bottom: 50,
               left: 50,
-              right: 200, // Adjusted to accomodate legend
+              right: 200, // Adjusted to accommodate legend
               top: 50
             }}
             themeColor={ChartThemeColor.green}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/LineChartDemo/LineChartSimpleDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/LineChartDemo/LineChartSimpleDemo.tsx
@@ -20,7 +20,7 @@ export class LineChartSimpleDemo extends React.Component {
             padding={{
               bottom: 50,
               left: 50,
-              right: 200, // Adjusted to accomodate legend
+              right: 200, // Adjusted to accommodate legend
               top: 50
             }}
             width={600}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/PieChartDemo/PieBlueDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/PieChartDemo/PieBlueDemo.tsx
@@ -14,7 +14,7 @@ export class PieBlueDemo extends React.Component {
           <ChartPie
             data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
             height={230}
-            labels={(datum) => `${datum.x}: ${datum.y}`}
+            labels={({ datum }) => `${datum.x}: ${datum.y}`}
             legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
             legendOrientation="vertical"
             legendPosition="right"

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/PieChartDemo/PieColorDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/PieChartDemo/PieColorDemo.tsx
@@ -14,10 +14,9 @@ export class PieColorDemo extends React.Component {
           <ChartPie
             data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
             height={275}
-            labels={(datum) => `${datum.x}: ${datum.y}`}
+            labels={({ datum }) => `${datum.x}: ${datum.y}`}
             legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
             legendPosition="bottom"
-            pieHeight={230}
             themeColor={ChartThemeColor.multi}
             width={300}
           />

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/PieChartDemo/PieOrangeDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/PieChartDemo/PieOrangeDemo.tsx
@@ -14,7 +14,7 @@ export class PieOrangeDemo extends React.Component {
           <ChartPie
             data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
             height={230}
-            labels={(datum) => `${datum.x}: ${datum.y}`}
+            labels={({ datum }) => `${datum.x}: ${datum.y}`}
             legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
             legendOrientation="vertical"
             legendPosition="right"

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/StackChartDemo/StackBlueDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/StackChartDemo/StackBlueDemo.tsx
@@ -19,7 +19,7 @@ export class StackBlueDemo extends React.Component {
             padding={{
               bottom: 50,
               left: 50,
-              right: 200, // Adjusted to accomodate legend
+              right: 200, // Adjusted to accommodate legend
               top: 50
             }}
             width={600}

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/StackChartDemo/StackColorZoomDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/StackChartDemo/StackColorZoomDemo.tsx
@@ -17,7 +17,7 @@ export class StackColorZoomDemo extends React.Component {
             legendPosition="bottom"
             height={275}
             padding={{
-              bottom: 75, // Adjusted to accomodate legend
+              bottom: 75, // Adjusted to accommodate legend
               left: 50,
               right: 50,
               top: 50

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/StackChartDemo/StackGoldBottomLegendDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/StackChartDemo/StackGoldBottomLegendDemo.tsx
@@ -17,7 +17,7 @@ export class StackGoldBottomLegendDemo extends React.Component {
             legendPosition="bottom"
             height={275}
             padding={{
-              bottom: 75, // Adjusted to accomodate legend
+              bottom: 75, // Adjusted to accommodate legend
               left: 50,
               right: 50,
               top: 50

--- a/yarn.lock
+++ b/yarn.lock
@@ -1717,7 +1717,6 @@
 "@patternfly/patternfly@2.31.7":
   version "2.31.7"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.31.7.tgz#04bc22e9128524b4c91961566782ded4c3c1b04f"
-  integrity sha512-AgELRkLD6OON7k+CRikcEYAJtB/c5563DgR8jhcWQwTiibUDjRFdv5ojr/NES8PtJg31ZDiFya2ZKZViD0AgzA==
 
 "@pieh/friendly-errors-webpack-plugin@1.7.0-chalk-2":
   version "1.7.0-chalk-2"
@@ -2062,7 +2061,6 @@
 "@types/classnames@^2.2.9":
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.9.tgz#d868b6febb02666330410fe7f58f3c4b8258be7b"
-  integrity sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==
 
 "@types/configstore@^2.1.1":
   version "2.1.1"
@@ -2304,14 +2302,12 @@
 "@types/lodash-es@^4.17.3":
   version "4.17.3"
   resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.3.tgz#87eb0b3673b076b8ee655f1890260a136af09a2d"
-  integrity sha512-iHI0i7ZAL1qepz1Y7f3EKg/zUMDwDfTzitx+AlHhJJvXwenP682ZyGbgPSc5Ej3eEAKVbNWKFuwOadCj5vBbYQ==
   dependencies:
     "@types/lodash" "*"
 
 "@types/lodash@*":
   version "4.14.136"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"
-  integrity sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==
 
 "@types/lodash@^4.14.132":
   version "4.14.132"
@@ -2413,9 +2409,9 @@
     "@types/unist" "*"
     "@types/vfile-message" "*"
 
-"@types/victory@^31.0.18":
-  version "31.0.18"
-  resolved "https://registry.yarnpkg.com/@types/victory/-/victory-31.0.18.tgz#9132ce77120f38e044d38aa5940e68c039bb3699"
+"@types/victory@^31.0.21":
+  version "31.0.21"
+  resolved "https://registry.yarnpkg.com/@types/victory/-/victory-31.0.21.tgz#c212a57aab6aebefdfb9c90da3eb4983b29740dc"
   dependencies:
     "@types/react" "*"
 
@@ -3158,7 +3154,6 @@ any-promise@^1.0.0, any-promise@^1.1.0:
 anymatch@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
-  integrity sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==
   dependencies:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
@@ -3555,7 +3550,6 @@ axobject-query@^2.0.1, axobject-query@^2.0.2:
 babel-cli@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
-  integrity sha1-UCq1SHTX24itALiHoGODzgPQAvE=
   dependencies:
     babel-core "^6.26.0"
     babel-polyfill "^6.26.0"
@@ -4312,7 +4306,6 @@ babel-plugin-transform-function-bind@^6.22.0:
 babel-plugin-transform-imports@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-imports/-/babel-plugin-transform-imports-1.5.1.tgz#b3756696aea907719d0d63b0e67c88fba963adb0"
-  integrity sha512-Jkb0tjqye8kjOD7GdcKJTGB3dC9fruQhwRFZCeYS0sZO2otyjG6SohKR8nZiSm/OvhY+Ny2ktzVE59XKgIqskA==
   dependencies:
     babel-types "^6.6.0"
     is-valid-path "^0.1.1"
@@ -4340,7 +4333,6 @@ babel-plugin-transform-minify-booleans@^6.9.0:
 babel-plugin-transform-object-assign@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz#f99d2f66f1a0b0d498e346c5359684740caa20ba"
-  integrity sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=
   dependencies:
     babel-runtime "^6.22.0"
 
@@ -4445,7 +4437,6 @@ babel-plugin-typescript-to-proptypes@^0.17.1:
 babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
-  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
   dependencies:
     babel-runtime "^6.26.0"
     core-js "^2.5.0"
@@ -5660,7 +5651,6 @@ chokidar@2.1.2:
 chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
-  integrity sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=
   dependencies:
     anymatch "^1.3.0"
     async-each "^1.0.0"
@@ -7272,6 +7262,16 @@ del@^4.1.1:
     p-map "^2.0.0"
     pify "^4.0.1"
     rimraf "^2.6.3"
+
+delaunator@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.0.tgz#3630f477b4923f472f534c62a028aeca6fe22d96"
+
+delaunay-find@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/delaunay-find/-/delaunay-find-0.0.3.tgz#b9863465c4cbca963b3d75a54550e73b2fc56c30"
+  dependencies:
+    delaunator "^4.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -12622,7 +12622,6 @@ lodash.filter@^4.4.0:
 lodash.findkey@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.findkey/-/lodash.findkey-4.6.0.tgz#83058e903b51cbb759d09ccf546dea3ea39c4718"
-  integrity sha1-gwWOkDtRy7dZ0JzPVG3qPqOcRxg=
 
 lodash.findlastindex@^4.6.0:
   version "4.6.0"
@@ -12723,7 +12722,6 @@ lodash.set@^4.3.2:
 lodash.snakecase@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
-  integrity sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=
 
 lodash.some@^4.4.0, lodash.some@^4.6.0:
   version "4.6.0"
@@ -12765,6 +12763,10 @@ lodash.uniq@^4.5.0:
 lodash@4.17.11, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
 
 log-symbols@2.2.0, log-symbols@^2.0.0, log-symbols@^2.2.0:
   version "2.2.0"
@@ -13942,7 +13944,6 @@ node-releases@^1.1.21, node-releases@^1.1.3:
 node-sass@^4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.12.0.tgz#0914f531932380114a30cc5fa4fa63233a25f017"
-  integrity sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -14450,7 +14451,6 @@ osenv@0, osenv@^0.1.4, osenv@^0.1.5:
 output-file-sync@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/output-file-sync/-/output-file-sync-1.1.2.tgz#d0a33eefe61a205facb90092e826598d5245ce76"
-  integrity sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=
   dependencies:
     graceful-fs "^4.1.4"
     mkdirp "^0.5.1"
@@ -16822,7 +16822,6 @@ react-treebeard@^2.1.0:
 react-virtualized@^9.21.1:
   version "9.21.1"
   resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.21.1.tgz#4dbbf8f0a1420e2de3abf28fbb77120815277b3a"
-  integrity sha512-E53vFjRRMCyUTEKuDLuGH1ld/9TFzjf/fFW816PE4HFXWZorESbSTYtiZz1oAjra0MminaUU1EnvUxoGuEFFPA==
   dependencies:
     babel-runtime "^6.26.0"
     clsx "^1.0.1"
@@ -17134,7 +17133,6 @@ regenerate@^1.2.1, regenerate@^1.4.0:
 regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
-  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -19164,7 +19162,6 @@ tinycolor2@^1.4.1:
 tippy.js@3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-3.4.1.tgz#f0eb3081824ad6c5d364336451ad77ae2f543da8"
-  integrity sha512-ZiyGP9WZyCCcjxKM4G88cm4U1r1ytjeMDGa5FSKPaPzwc/3yZJVZsb1ffcmqUMCpryRp5LNxRNGKLzbs11sb/Q==
   dependencies:
     popper.js "^1.14.6"
 
@@ -19981,259 +19978,259 @@ vfile@^3.0.0:
     unist-util-stringify-position "^1.0.0"
     vfile-message "^1.0.0"
 
-victory-area@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-32.2.3.tgz#0142ee68575ae065741094314f53e891622d10dd"
+victory-area@^33.0.5:
+  version "33.0.5"
+  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-33.0.5.tgz#4dff4e5aebe2865bfa78c20bf9af1b8b51301054"
   dependencies:
     d3-shape "^1.2.0"
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-axis@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-32.2.3.tgz#783915c44cdae1b1fd3913922ff86aa53f247406"
+victory-axis@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-33.0.1.tgz#a1a8ebcf0f91ea32e46df626f229ba17196b9584"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-bar@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-32.2.3.tgz#64aa6dd29907299e793f976954e00874072f6f4f"
+victory-bar@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-33.0.1.tgz#25d644db3bc4c56ac86a17fc24a5a6fb348dd6c4"
   dependencies:
     d3-shape "^1.2.0"
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-box-plot@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-32.2.3.tgz#0e42f41d0770cef688f2a90faa1e2976a1e4df1b"
+victory-box-plot@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-33.0.1.tgz#9d17d7992d7a1ba2195a3c924e3b420d2d43334e"
   dependencies:
     d3-array "^1.2.0"
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-brush-container@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-32.2.3.tgz#abe84830f27dd0d20f35941d38f6bb55b1c74e4a"
+victory-brush-container@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-33.0.1.tgz#d74cab7bc10565fdbcc9fb8c4341ee12887ae955"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-brush-line@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-32.2.3.tgz#f1341da0ce103ebe1b14bacbbe658c24f4b5f64c"
+victory-brush-line@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-33.0.1.tgz#22cea6da8df720d12dab082c7a0781447db3d905"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-candlestick@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-32.2.3.tgz#5cb9227a31f077ac37046ecbb1bf0b66b3e0371b"
+victory-candlestick@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-33.0.1.tgz#880bf91f70742bea5b60f2e0b44784d472bc9680"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-chart@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-32.2.3.tgz#c191f6cf37fe3ce27d6b05c9c6e16c233d95358f"
+victory-chart@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-33.0.1.tgz#a984439e26c088a174c77ff2899d4efd4ca523bf"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-axis "^32.2.3"
-    victory-core "^32.2.3"
-    victory-polar-axis "^32.2.3"
-    victory-shared-events "^32.2.3"
+    victory-axis "^33.0.1"
+    victory-core "^33.0.1"
+    victory-polar-axis "^33.0.1"
+    victory-shared-events "^33.0.1"
 
-victory-core@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-32.2.3.tgz#15e2c5c9d616c79dcb58e84ccecae91acc82e72d"
+victory-core@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-33.0.1.tgz#ae86cc5f1025d275062da10e35388df12cdc10e2"
   dependencies:
     d3-ease "^1.0.0"
     d3-interpolate "^1.1.1"
     d3-scale "^1.0.0"
     d3-shape "^1.2.0"
     d3-timer "^1.0.0"
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
 
-victory-create-container@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-32.2.3.tgz#e594f4775e44ac04f002200e007bb1cde9280ce6"
+victory-create-container@^33.0.4:
+  version "33.0.4"
+  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-33.0.4.tgz#40d4ef2483714db88ecc5954af243d11c45602ac"
   dependencies:
-    lodash "^4.17.5"
-    victory-brush-container "^32.2.3"
-    victory-core "^32.2.3"
-    victory-cursor-container "^32.2.3"
-    victory-selection-container "^32.2.3"
-    victory-voronoi-container "^32.2.3"
-    victory-zoom-container "^32.2.3"
+    lodash "^4.17.15"
+    victory-brush-container "^33.0.1"
+    victory-core "^33.0.1"
+    victory-cursor-container "^33.0.1"
+    victory-selection-container "^33.0.1"
+    victory-voronoi-container "^33.0.4"
+    victory-zoom-container "^33.0.1"
 
-victory-cursor-container@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-32.2.3.tgz#14eac1f97a8eb6382ee6b7450e3536332190d496"
+victory-cursor-container@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-33.0.1.tgz#41050c5d1f2cea25906e06ec0667c0aeb77cb96b"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-errorbar@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-32.2.3.tgz#9ce5020529246cda8a6c8808b62493ae450c0199"
+victory-errorbar@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-33.0.1.tgz#97b98730944c7090ba4c21eec70176e4b13a477f"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-group@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-32.2.3.tgz#b612a06959af2e52e5daf6f515d066a1381ca2ae"
+victory-group@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-33.0.1.tgz#ea4b244a24bae5b174eefe3d7af21d5ecfefd92b"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-legend@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-32.2.3.tgz#6802d45b1410f94998c11fc8573a3da420c2d6f1"
+victory-legend@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-33.0.1.tgz#7380b8c3f7bc3c1ead4c3ae50a4e741b2a79da80"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-line@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-32.2.3.tgz#5d974ec5d28df02d80cd6d0ced1ad48bd23d6f60"
+victory-line@^33.0.5:
+  version "33.0.5"
+  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-33.0.5.tgz#602f8312d8f143357edc2b1e8de059a07ff98e16"
   dependencies:
     d3-shape "^1.2.0"
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-pie@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-32.2.3.tgz#2e2f24d670edafe0186ed6210b1327e458f5867a"
+victory-pie@^33.0.3:
+  version "33.0.3"
+  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-33.0.3.tgz#38549320aa2b8e78b6da01254ca651264f3312da"
   dependencies:
     d3-shape "^1.0.0"
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-polar-axis@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-32.2.3.tgz#d772ba24c7654e87709727779bdf925d4b49c285"
+victory-polar-axis@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-33.0.1.tgz#340564fe57b241e396c1b353f13d16fb4d7d5cf9"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-scatter@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-32.2.3.tgz#7a7181db7166f94ecdd3edb60ffe6aea4feb904f"
+victory-scatter@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-33.0.1.tgz#7a947b7e9860fd93f06e5bfaf1aa89470afc6b67"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-selection-container@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-32.2.3.tgz#d2ddc126f1a025a82eaeb6ebf7da8e5125096635"
+victory-selection-container@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-33.0.1.tgz#401e1a5a37d5d5052dc2e95c0090828b4953de13"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-shared-events@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-32.2.3.tgz#748020fa79905929c8c1324d6aaddc6b518d421c"
+victory-shared-events@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-33.0.1.tgz#55497682df32d38672f54242e4b9148146415e10"
   dependencies:
-    lodash "^4.17.5"
-    prop-types "^15.5.8"
-    react-fast-compare "^2.0.0"
-    victory-core "^32.2.3"
-
-victory-stack@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-32.2.3.tgz#3142a3b44810e44bdc988a2f26ba72ad0245bca2"
-  dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-tooltip@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-32.2.3.tgz#2e37bb69175c1e26667f2cc896e487c8c164ba68"
+victory-stack@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-33.0.1.tgz#48d43a9d6a4194495bbd865a791baf81033dc26f"
   dependencies:
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    react-fast-compare "^2.0.0"
+    victory-core "^33.0.1"
 
-victory-voronoi-container@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-32.2.3.tgz#d4d15670bb9cb2c408451e6c95140cf459cb786f"
+victory-tooltip@^33.0.4:
+  version "33.0.4"
+  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-33.0.4.tgz#c4e2da461ed755a6a64714585871fd7118614548"
+  dependencies:
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^33.0.1"
+
+victory-voronoi-container@^33.0.4:
+  version "33.0.4"
+  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-33.0.4.tgz#daea662215b5666144e126af8b06729c39a94229"
+  dependencies:
+    delaunay-find "0.0.3"
+    lodash "^4.17.15"
+    prop-types "^15.5.8"
+    victory-core "^33.0.1"
+    victory-tooltip "^33.0.4"
+
+victory-voronoi@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-33.0.1.tgz#912e15cdc0199d237ae1ffc5ce2829d219fdc4c1"
   dependencies:
     d3-voronoi "^1.1.2"
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
-    victory-tooltip "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-voronoi@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-32.2.3.tgz#525cdca6a432e7e7315a01889bd875548d66c7cb"
+victory-zoom-container@^33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-33.0.1.tgz#122b0920ed3cc89039407333be6f690a77423524"
   dependencies:
-    d3-voronoi "^1.1.2"
-    lodash "^4.17.5"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.2.3"
+    victory-core "^33.0.1"
 
-victory-zoom-container@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-32.2.3.tgz#1bcd931532ccbc6a47a7de6ce99f254935864301"
+victory@^33.0.5:
+  version "33.0.5"
+  resolved "https://registry.yarnpkg.com/victory/-/victory-33.0.5.tgz#9265afd85cd07f2c4142eacc52159752ebfac69c"
   dependencies:
-    lodash "^4.17.5"
-    prop-types "^15.5.8"
-    victory-core "^32.2.3"
-
-victory@^32.2.3:
-  version "32.2.3"
-  resolved "https://registry.yarnpkg.com/victory/-/victory-32.2.3.tgz#64d09ac1d31be57616f89c16f76cc3c49f93942e"
-  dependencies:
-    victory-area "^32.2.3"
-    victory-axis "^32.2.3"
-    victory-bar "^32.2.3"
-    victory-box-plot "^32.2.3"
-    victory-brush-container "^32.2.3"
-    victory-brush-line "^32.2.3"
-    victory-candlestick "^32.2.3"
-    victory-chart "^32.2.3"
-    victory-core "^32.2.3"
-    victory-create-container "^32.2.3"
-    victory-cursor-container "^32.2.3"
-    victory-errorbar "^32.2.3"
-    victory-group "^32.2.3"
-    victory-legend "^32.2.3"
-    victory-line "^32.2.3"
-    victory-pie "^32.2.3"
-    victory-polar-axis "^32.2.3"
-    victory-scatter "^32.2.3"
-    victory-selection-container "^32.2.3"
-    victory-shared-events "^32.2.3"
-    victory-stack "^32.2.3"
-    victory-tooltip "^32.2.3"
-    victory-voronoi "^32.2.3"
-    victory-voronoi-container "^32.2.3"
-    victory-zoom-container "^32.2.3"
+    victory-area "^33.0.5"
+    victory-axis "^33.0.1"
+    victory-bar "^33.0.1"
+    victory-box-plot "^33.0.1"
+    victory-brush-container "^33.0.1"
+    victory-brush-line "^33.0.1"
+    victory-candlestick "^33.0.1"
+    victory-chart "^33.0.1"
+    victory-core "^33.0.1"
+    victory-create-container "^33.0.4"
+    victory-cursor-container "^33.0.1"
+    victory-errorbar "^33.0.1"
+    victory-group "^33.0.1"
+    victory-legend "^33.0.1"
+    victory-line "^33.0.5"
+    victory-pie "^33.0.3"
+    victory-polar-axis "^33.0.1"
+    victory-scatter "^33.0.1"
+    victory-selection-container "^33.0.1"
+    victory-shared-events "^33.0.1"
+    victory-stack "^33.0.1"
+    victory-tooltip "^33.0.4"
+    victory-voronoi "^33.0.1"
+    victory-voronoi-container "^33.0.4"
+    victory-zoom-container "^33.0.1"
 
 vlq@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Victory just released a much anticipated, major update. This should help solve many of the issues folks have been noting with tooltips in #2541. For example, the new `constrainToVisibleArea` property will alter the position of the tooltip so that it exactly fits within the rendered SVG.

Unfortunately, this is not a trivial bump of the Victory package number. Victory introduced breaking changes that directly affect our chart components.

> The x and y values passed to labels by their parent components have all been adjusted so that their values match the position of the data point they correspond to. All padding is now accounted for in the dx and dy props instead of being added directly to x and y.
> 
> This will be a breaking change for anyone who is wrapping label components and relying on the x and y props they receive, or providing their own dx / dy props. These breaking changes may take a bit of manual adjustment to correct, but we hope this change will make label positioning easier to reason about in the long run.

In order to use the `constrainToVisibleArea` property with pie, donut, donut utilization, and donut threshold, those components must be refactored. For example, instead of using properties such as `donutHeight` and `donutWidth`, we must use the `padding` property, along with `height` and `width`. It is imperative that the underlying component tooltips match the SVG container height and width -- otherwise, the tooltip's flyout position is misaligned.

These properties were introduced to help make space to render components such as legends, but this can also be done via `padding`. If users have not included legends with donuts; for example, chances are these changes won't affect them. Charts such as area, bar, line, & stack already use the `padding` approach.

The changes in this PR also include new Victory component properties, updates to the demo app, and documentation.

Fixes https://github.com/patternfly/patternfly-react/issues/2786

BREAKING CHANGES

- All components
  - replace ```labels={(d) => `x: ${d.x}`}``` with ```labels={({ datum }) => `x: ${datum.x}`}```
  - See: https://github.com/FormidableLabs/victory/releases/tag/v33.0.0
- ChartPie
  - removed `pieHeight` & `pieWidth` props -- use `padding` prop
  - adjusted padding from 8px to 20px
- ChartDonut
  - removed `donutHeight` & `donutWidth`  props -- use `padding` prop
  - adjusted padding from 8px to 20px
- ChartDonutUtilization
  - removed `donutHeight` & `donutWidth` props -- use `padding` prop
  - adjusted padding from 8px to 20px
- ChartDonutThreshold
  - removed `donutHeight` & `donutWidth` props -- use `padding` prop
  - adjusted padding from 8px to 20px
- ChartBullet
  - removed `bulletHeight` & `bulletWidth`  props -- use `bulletSize` prop
- ChartContainer
  - renamed the `VictoryContainer` CSS selector as `pf-c-chart` for specificity

The following are unused, internal only props, documented as not to be set manually. They were used internally to position donut utilization within donut threshold.

- ChartPie
  - removed `pieDx`, `pieDy`, `legendDx`, `legendDy`
- ChartDonut
  - removed `donutDx`, `donutDy`, `legendDx`, `legendDy`, `subTitleDx`, `subTitleDy`
- ChartDonutUtilization
  - removed `donutDx`, `donutDy`, `legendDx`, `legendDy`, `subTitleDx`, `subTitleDy`, `dx`, `dy`