### PR TITLE
Chart: New symbol for threshold

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/ChartPoint.tsx
@@ -80,7 +80,7 @@ export interface ChartPointProps {
    * the point should render
    */
   symbol?: 'circle' | 'diamond' | 'plus' | 'minus' | 'square' | 'star' | 'triangleDown' | 'triangleUp' | 'dash' |
-    Function;
+    'threshold' | Function;
   /**
    * A transform that will be supplied to elements this component renders
    */
@@ -122,7 +122,8 @@ export const ChartPoint: React.FunctionComponent<ChartPointProps> = ({
       plus: PathHelpers.plus,
       minus: PathHelpers.minus,
       star: PathHelpers.star,
-      dash: PathHelpers.dash
+      dash: PathHelpers.dash,
+      threshold: PathHelpers.threshold
     };
     const symbol = Helpers.evaluateProp(props.symbol, datum, active);
     const symbolFunction = typeof pathFunctions[symbol] === 'function' ? pathFunctions[symbol] : pathFunctions.circle;

--- a/packages/patternfly-4/react-charts/src/components/ChartPoint/path-helpers.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartPoint/path-helpers.ts
@@ -119,5 +119,24 @@ export const PathHelpers = {
       v-${lineHeight}
       h-${distance}
       z`;
+  },
+
+  threshold(x: number, y: number, size: number) {
+    const baseSize = 1.1 * size;
+    const lineHeight = baseSize - baseSize * 0.3;
+    const x0 = x - baseSize;
+    const y1 = y + lineHeight / 2;
+    const distance = (x + baseSize - x0) * 0.5;
+    const padding = distance / 3;
+    return `M ${x0}, ${y1}
+      h${distance}
+      v-${lineHeight}
+      h-${distance}
+      z
+      M ${x0 + distance + padding}, ${y1}
+      h${distance}
+      v-${lineHeight}
+      h-${distance}
+      z`;
   }
 };


### PR DESCRIPTION
Created a new legend symbol for thresholds (i.e., horizontal indicators). This is slightly different than the existing dash symbol, which is typically used to show differences between current and previous data, where the dashed symbol represents previous data.

This is to help fix: https://github.com/patternfly/patternfly-react/issues/2797
Also see: https://github.com/patternfly/patternfly-react/pull/2796

New `threshold` sybmol
<img width="494" alt="Screen Shot 2019-09-08 at 10 57 07 PM" src="https://user-images.githubusercontent.com/17481322/64500794-ab239100-d28c-11e9-9ab9-5412a0ad09df.png">

Existing `dash` symbol
<img width="439" alt="Screen Shot 2019-09-08 at 11 04 14 PM" src="https://user-images.githubusercontent.com/17481322/64500855-fe95df00-d28c-11e9-8443-eba906958bea.png">