### PR TITLE
Fix live edit caret color so it is visible

### DIFF
--- a/packages/patternfly-4/react-docs/src/components/componentDocs/live-edit.scss
+++ b/packages/patternfly-4/react-docs/src/components/componentDocs/live-edit.scss
@@ -8,6 +8,7 @@
   border-right: none;
   border-bottom: none;
   border-left: none;
+  caret-color: white;
 }
 
 .toolbar {


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

Live editor caret was invisible since it was the same color as the background. Changed to white so that it is visible against the black background.


![screencast-localhost-8000-2019 09 10-12-01-42](https://user-images.githubusercontent.com/22625502/64630353-efb14880-d3c2-11e9-936c-23682738ec46.gif)

