### PR TITLE
feat(Tab): Added two new props: mountOnEnter and unmountOnExit

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Tabs/Tabs.md
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tabs.md
@@ -59,6 +59,80 @@ class SimpleTabs extends React.Component {
 }
 ```
 
+## Simple tabs with children that mount on tab click
+```js
+import React from 'react';
+import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
+
+class MountingSimpleTabs extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeTabKey: 0
+    };
+    // Toggle currently active tab
+    this.handleTabClick = (event, tabIndex) => {
+      this.setState({
+        activeTabKey: tabIndex
+      });
+    };
+  }
+
+  render() {
+    return (
+      <Tabs mountOnEnter activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
+        <Tab eventKey={0} title="Tab item 1">
+          Tab 1 section
+        </Tab>
+        <Tab eventKey={1} title="Tab item 2">
+          Tab 2 section
+        </Tab>
+        <Tab eventKey={2} title="Tab item 3">
+          Tab 3 section
+        </Tab>
+      </Tabs>
+    );
+  }
+}
+```
+
+## Simple tabs with children that unmount when they're no longer visible
+```js
+import React from 'react';
+import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
+
+class UnmountingSimpleTabs extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeTabKey: 0
+    };
+    // Toggle currently active tab
+    this.handleTabClick = (event, tabIndex) => {
+      this.setState({
+        activeTabKey: tabIndex
+      });
+    };
+  }
+
+  render() {
+    return (
+      <Tabs unmountOnExit activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
+        <Tab eventKey={0} title="Tab item 1">
+          Tab 1 section
+        </Tab>
+        <Tab eventKey={1} title="Tab item 2">
+          Tab 2 section
+        </Tab>
+        <Tab eventKey={2} title="Tab item 3">
+          Tab 3 section
+        </Tab>
+      </Tabs>
+    );
+  }
+}
+```
+
 ## Scroll buttons primary tabs
 
 ```js

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tabs.tsx
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tabs.tsx
@@ -232,6 +232,7 @@ class Tabs extends React.Component<TabsProps & InjectedOuiaProps, TabsState> {
             'data-ouia-component-type': 'Tabs',
             'data-ouia-component-id': ouiaId || ouiaContext.ouiaId
           }}
+          id={id && id}
           {...props}
         >
           <button

--- a/packages/patternfly-4/react-core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
     >
       <div
         className="pf-c-tabs pf-m-fill"
+        id="handleScrollButtons"
         onSelect={[Function]}
       >
         <button
@@ -429,6 +430,7 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
     >
       <div
         className="pf-c-tabs pf-m-fill"
+        id="scrollLeft"
         onSelect={[Function]}
       >
         <button
@@ -799,6 +801,7 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
     >
       <div
         className="pf-c-tabs pf-m-fill"
+        id="scrollRight"
         onSelect={[Function]}
       >
         <button
@@ -1115,6 +1118,7 @@ Array [
   <nav
     aria-label="accessible Tabs example"
     class="pf-c-tabs"
+    id="accessibleTabs"
   >
     <button
       aria-label="Scroll left"
@@ -1231,6 +1235,7 @@ exports[`should render filled tabs 1`] = `
 Array [
   <div
     class="pf-c-tabs pf-m-fill"
+    id="filledTabs"
   >
     <button
       aria-label="Scroll left"
@@ -1344,6 +1349,7 @@ exports[`should render secondary tabs 1`] = `
 Array [
   <div
     class="pf-c-tabs"
+    id="primarieTabs"
   >
     <button
       aria-label="Scroll left"
@@ -1430,6 +1436,7 @@ Array [
   >
     <div
       class="pf-c-tabs"
+      id="secondaryTabs"
     >
       <button
         aria-label="Scroll left"
@@ -1565,6 +1572,7 @@ exports[`should render simple tabs 1`] = `
 Array [
   <div
     class="pf-c-tabs"
+    id="simpleTabs"
   >
     <button
       aria-label="Scroll left"
@@ -1704,6 +1712,7 @@ exports[`should render tabs with eventKey Strings 1`] = `
 Array [
   <div
     class="pf-c-tabs"
+    id="eventKeyTabs"
   >
     <button
       aria-label="Scroll left"

--- a/packages/patternfly-4/react-core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -45,6 +45,7 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
       isFilled={true}
       isSecondary={false}
       leftScrollAriaLabel="Scroll left"
+      mountOnEnter={false}
       onSelect={[Function]}
       ouiaContext={
         Object {
@@ -53,6 +54,7 @@ exports[`should call handleScrollButtons tabs with scrolls 1`] = `
         }
       }
       rightScrollAriaLabel="Scroll right"
+      unmountOnExit={false}
       variant="div"
     >
       <div
@@ -413,6 +415,7 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
       isFilled={true}
       isSecondary={false}
       leftScrollAriaLabel="Scroll left"
+      mountOnEnter={false}
       onSelect={[Function]}
       ouiaContext={
         Object {
@@ -421,6 +424,7 @@ exports[`should call scrollLeft tabs with scrolls 1`] = `
         }
       }
       rightScrollAriaLabel="Scroll right"
+      unmountOnExit={false}
       variant="div"
     >
       <div
@@ -781,6 +785,7 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
       isFilled={true}
       isSecondary={false}
       leftScrollAriaLabel="Scroll left"
+      mountOnEnter={false}
       onSelect={[Function]}
       ouiaContext={
         Object {
@@ -789,6 +794,7 @@ exports[`should call scrollRight tabs with scrolls 1`] = `
         }
       }
       rightScrollAriaLabel="Scroll right"
+      unmountOnExit={false}
       variant="div"
     >
       <div

--- a/packages/patternfly-4/react-integration/cypress/integration/tabdemo.spec.ts
+++ b/packages/patternfly-4/react-integration/cypress/integration/tabdemo.spec.ts
@@ -2,11 +2,11 @@ describe('Tab Demo Test', () => {
   it('Navigate to demo section', () => {
     cy.visit('http://localhost:3000/');
     cy.get('#tab-demo-nav-item-link').click();
-    cy.url().should('eq', 'http://localhost:3000/tab-demo-nav-link') 
+    cy.url().should('eq', 'http://localhost:3000/tab-demo-nav-link')
   });
 
   it('Verify tabs, tab sections, and tab navigation', () => {
-    cy.get('.pf-c-tabs__button').each((demoButton: JQuery<HTMLButtonElement>, index: number) => {
+    cy.get('div#unconnectedChildren').find('.pf-c-tabs__button').each((demoButton: JQuery<HTMLButtonElement>, index: number) => {
       const currentItem: number = index + 1;
       expect(demoButton.text()).to.equal(`Tab item ${currentItem}`);
       cy.wrap(demoButton).click();
@@ -15,5 +15,21 @@ describe('Tab Demo Test', () => {
         expect(demoSection.text()).to.equal(`Tab ${currentItem} section`);
       });
     });
+  });
+
+  it('Verify tabs mount on enter when specified', () => {
+    cy.get('#pf-tab-section-0-mountOnEnter').should('exist');
+    cy.get('#pf-tab-section-1-mountOnEnter').should('not.exist');
+    cy.get('#pf-tab-1-mountOnEnter').click();
+    cy.get('#pf-tab-section-0-mountOnEnter').should('exist');
+    cy.get('#pf-tab-section-1-mountOnEnter').should('exist');
+  });
+
+  it('Verify tabs unmount on exit when specified', () => {
+    cy.get('#pf-tab-section-0-unmountOnExit').should('exist');
+    cy.get('#pf-tab-section-1-unmountOnExit').should('not.exist');
+    cy.get('#pf-tab-1-unmountOnExit').click();
+    cy.get('#pf-tab-section-0-unmountOnExit').should('not.exist');
+    cy.get('#pf-tab-section-1-unmountOnExit').should('exist');
   });
 });

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TabsDemo/TabsDemo.tsx
@@ -3,7 +3,9 @@ import React, { Component } from 'react';
 
 export class TabDemo extends Component {
   state = {
-    activeTabKey: 0
+    activeTabKey: 0,
+    activeTabKey2: 0,
+    activeTabKey3: 0
   };
   private contentRef1: any;
   private contentRef2: any;
@@ -24,6 +26,20 @@ export class TabDemo extends Component {
     });
   }
 
+  // Toggle currently active tab
+  private handleTabClick2 = (event, tabIndex) => {
+    this.setState({
+      activeTabKey2: tabIndex
+    });
+  };
+
+  // Toggle currently active tab
+  private handleTabClick3 = (event, tabIndex) => {
+    this.setState({
+      activeTabKey3: tabIndex
+    });
+  };
+
   componentDidMount() {
     window.scrollTo(0, 0);
   }
@@ -31,7 +47,7 @@ export class TabDemo extends Component {
   render() {
     return (
       <React.Fragment>
-        <Tabs activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
+        <Tabs id="unconnectedChildren" activeKey={this.state.activeTabKey} onSelect={this.handleTabClick}>
           <Tab id="demoTab1" eventKey={0} title="Tab item 1" tabContentId="demoTab1Section" tabContentRef={this.contentRef1} />
           <Tab id="demoTab2" eventKey={1} title="Tab item 2" tabContentId="demoTab2Section" tabContentRef={this.contentRef2} />
           <Tab id="demoTab3" eventKey={2} title={<i>Tab item 3</i>} tabContentId="demoTab3Section" tabContentRef={this.contentRef3} />
@@ -47,6 +63,28 @@ export class TabDemo extends Component {
             Tab 3 section
           </TabContent>
         </div>
+        <Tabs id="mountOnEnter" mountOnEnter activeKey={this.state.activeTabKey2} onSelect={this.handleTabClick2}>
+          <Tab eventKey={0} title="Tab item 1">
+            Tab 1 section
+          </Tab>
+          <Tab eventKey={1} title="Tab item 2">
+            Tab 2 section
+          </Tab>
+          <Tab eventKey={2} title="Tab item 3">
+            Tab 3 section
+          </Tab>
+      </Tabs>
+      <Tabs id="unmountOnExit" unmountOnExit activeKey={this.state.activeTabKey3} onSelect={this.handleTabClick3}>
+        <Tab eventKey={0} title="Tab item 1">
+          Tab 1 section
+        </Tab>
+        <Tab eventKey={1} title="Tab item 2">
+          Tab 2 section
+        </Tab>
+        <Tab eventKey={2} title="Tab item 3">
+          Tab 3 section
+        </Tab>
+      </Tabs>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
When mountOnEnter is provided as a prop, TabContents will mount on the DOM as you click the corresponding tab. When unmountOnExit is provided, TabContents will unmount from the DOM when no longer visible.

Fixes #2609 and #1448.