### PR TITLE
feat(clipboardcopy): add isExpanded to expand block by default

### DIFF
--- a/packages/patternfly-4/react-core/src/components/ClipboardCopy/ClipboardCopy.md
+++ b/packages/patternfly-4/react-core/src/components/ClipboardCopy/ClipboardCopy.md
@@ -33,6 +33,18 @@ import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
   expansion.
 </ClipboardCopy>
 ```
+
+## Expanded clipboard copy expanded by default
+```js
+import React from 'react';
+import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
+
+<ClipboardCopy variant={ClipboardCopyVariant.expansion} isExpanded>
+  Got a lot of text here, need to see all of it? Click that arrow on the left side and check out the resulting
+  expansion.
+</ClipboardCopy>
+```
+
 ## Read only expanded clipboard copy
 ```js
 import React from 'react';

--- a/packages/patternfly-4/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
+++ b/packages/patternfly-4/react-core/src/components/ClipboardCopy/ClipboardCopy.tsx
@@ -44,6 +44,8 @@ export interface ClipboardCopyProps extends Omit<React.HTMLProps<HTMLDivElement>
   toggleAriaLabel?: string;
   /** Flag to show if the input is read only. */
   isReadOnly?: boolean;
+  /** Flag in expansion variant to show if the expansion block is expanded by default. */
+  isExpanded?: boolean;
   /** Adds Clipboard Copy variant styles. */
   variant?: typeof ClipboardCopyVariant | 'inline' | 'expansion';
   /** Copy button popover position. */
@@ -70,7 +72,7 @@ export class ClipboardCopy extends React.Component<ClipboardCopyProps, Clipboard
     super(props);
     this.state = {
       text: this.props.children as string | number,
-      expanded: false,
+      expanded: this.props.isExpanded,
       copied: false
     };
   }


### PR DESCRIPTION
**What**:

Added the `isExpanded` props to ClipboardCopy to show the expanded block by default.

closes #2886 

//cc @christiemolloy 