### PR TITLE
Adds an example of copy clipboard with array of objects.

### DIFF
--- a/packages/patternfly-4/react-core/src/components/ClipboardCopy/ClipboardCopy.md
+++ b/packages/patternfly-4/react-core/src/components/ClipboardCopy/ClipboardCopy.md
@@ -43,3 +43,20 @@ import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
   expansion.
 </ClipboardCopy>
 ```
+
+## Expanded clipboard copy with arraycc
+```js
+import React from 'react';
+import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
+
+ClipboardCopyArrayOfElements = () => {
+  let text = [
+    "Got a lot of text here," ,
+    "need to see all of it?" ,
+    "Click that arrow on the left side and check out the resulting expansion."
+  ]
+  return <ClipboardCopy variant={ClipboardCopyVariant.expansion}>
+    {text.join(" ")}
+  </ClipboardCopy>
+}
+```

--- a/packages/patternfly-4/react-core/src/components/ClipboardCopy/ClipboardCopy.md
+++ b/packages/patternfly-4/react-core/src/components/ClipboardCopy/ClipboardCopy.md
@@ -44,7 +44,7 @@ import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';
 </ClipboardCopy>
 ```
 
-## Expanded clipboard copy with arraycc
+## Expanded clipboard copy with array
 ```js
 import React from 'react';
 import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core';


### PR DESCRIPTION
Updated the copy clipboard examples to add one that has an array of object.  This fixes Issue #2845 