### PR TITLE
fix(Cards): refactor sub-component references

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Cards/Card.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Cards/Card.js
@@ -1,6 +1,27 @@
 import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import CardBody from './CardBody';
+import CardDropdownButton from './CardDropdownButton';
+import CardFooter from './CardFooter';
+import CardGrid from './CardGrid';
+import CardHeading from './CardHeading';
+import CardHeightMatching from './CardHeightMatching';
+import CardLink from './CardLink';
+import CardTitle from './CardTitle';
+import {
+  AggregateStatusCount,
+  AggregateStatusNotification,
+  AggregateStatusNotifications
+} from './AggregateStatusCard';
+import {
+  UtilizationCard,
+  UtilizationCardDetails,
+  UtilizationCardDetailsCount,
+  UtilizationCardDetailsDesc,
+  UtilizationCardDetailsLine1,
+  UtilizationCardDetailsLine2
+} from './UtilizationTrendCard';
 
 /**
  * Card Component for PatternFly React
@@ -49,5 +70,23 @@ Card.defaultProps = {
   matchHeight: false,
   cardRef: null
 };
+
+Card.Title = CardTitle;
+Card.Body = CardBody;
+Card.Heading = CardHeading;
+Card.Footer = CardFooter;
+Card.Link = CardLink;
+Card.Grid = CardGrid;
+Card.DropdownButton = CardDropdownButton;
+Card.HeightMatching = CardHeightMatching;
+Card.AggregateStatusCount = AggregateStatusCount;
+Card.AggregateStatusNotification = AggregateStatusNotification;
+Card.AggregateStatusNotifications = AggregateStatusNotifications;
+Card.UtilizationCard = UtilizationCard;
+Card.UtilizationCardDetails = UtilizationCardDetails;
+Card.UtilizationCardDetailsCount = UtilizationCardDetailsCount;
+Card.UtilizationCardDetailsDesc = UtilizationCardDetailsDesc;
+Card.UtilizationCardDetailsLine1 = UtilizationCardDetailsLine1;
+Card.UtilizationCardDetailsLine2 = UtilizationCardDetailsLine2;
 
 export default Card;

--- a/packages/patternfly-3/patternfly-react/src/components/Cards/UtilizationTrendCard/UtilizationCard.test.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Cards/UtilizationTrendCard/UtilizationCard.test.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
+
+import { CardTitle } from '../index';
 import {
   UtilizationCard,
   UtilizationCardDetails,
@@ -9,7 +11,6 @@ import {
   UtilizationCardDetailsLine2
 } from './index';
 
-import { CardTitle } from '../index';
 
 test('Utilization Card is working properly', () => {
   const component = mount(
@@ -20,6 +21,7 @@ test('Utilization Card is working properly', () => {
 
   expect(component.render()).toMatchSnapshot();
 });
+
 test('Utilization Card Details is working properly', () => {
   const component = mount(
     <UtilizationCardDetails>
@@ -33,6 +35,7 @@ test('Utilization Card Details is working properly', () => {
 
   expect(component.render()).toMatchSnapshot();
 });
+
 test('Utilization Card Details Description is working properly', () => {
   const component = mount(
     <UtilizationCardDetailsDesc>
@@ -43,6 +46,7 @@ test('Utilization Card Details Description is working properly', () => {
 
   expect(component.render()).toMatchSnapshot();
 });
+
 test('Utilization Card Details Line1,2 is working properly', () => {
   const component = mount(
     <div>

--- a/packages/patternfly-3/patternfly-react/src/components/Cards/index.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Cards/index.js
@@ -1,13 +1,17 @@
 import Card from './Card';
-import CardTitle from './CardTitle';
 import CardBody from './CardBody';
+import CardDropdownButton from './CardDropdownButton';
+import CardFooter from './CardFooter';
 import CardGrid from './CardGrid';
 import CardHeading from './CardHeading';
-import CardFooter from './CardFooter';
-import CardLink from './CardLink';
-import CardDropdownButton from './CardDropdownButton';
 import CardHeightMatching from './CardHeightMatching';
-import { AggregateStatusCount, AggregateStatusNotifications, AggregateStatusNotification } from './AggregateStatusCard';
+import CardLink from './CardLink';
+import CardTitle from './CardTitle';
+import {
+  AggregateStatusCount,
+  AggregateStatusNotification,
+  AggregateStatusNotifications
+} from './AggregateStatusCard';
 import {
   UtilizationCard,
   UtilizationCardDetails,
@@ -17,37 +21,19 @@ import {
   UtilizationCardDetailsLine2
 } from './UtilizationTrendCard';
 
-Card.Title = CardTitle;
-Card.Body = CardBody;
-Card.Heading = CardHeading;
-Card.Footer = CardFooter;
-Card.Link = CardLink;
-Card.Grid = CardGrid;
-Card.DropdownButton = CardDropdownButton;
-Card.HeightMatching = CardHeightMatching;
-Card.UtilizationCard = UtilizationCard;
-Card.UtilizationCardDetails = UtilizationCardDetails;
-Card.UtilizationCardDetailsCount = UtilizationCardDetailsCount;
-Card.UtilizationCardDetailsDesc = UtilizationCardDetailsDesc;
-Card.UtilizationCardDetailsLine1 = UtilizationCardDetailsLine1;
-Card.UtilizationCardDetailsLine2 = UtilizationCardDetailsLine2;
-Card.AggregateStatusCount = AggregateStatusCount;
-Card.AggregateStatusNotifications = AggregateStatusNotifications;
-Card.AggregateStatusNotification = AggregateStatusNotification;
-
 export {
   Card,
   CardTitle,
   CardBody,
-  CardGrid,
   CardHeading,
   CardFooter,
   CardLink,
+  CardGrid,
   CardDropdownButton,
   CardHeightMatching,
   AggregateStatusCount,
-  AggregateStatusNotifications,
   AggregateStatusNotification,
+  AggregateStatusNotifications,
   UtilizationCard,
   UtilizationCardDetails,
   UtilizationCardDetailsCount,


### PR DESCRIPTION
Due to patternfly/patternfly-react#2931, rearrange the way `Card` includes the component's sub-components to match the way the `Wizard` (and all other components) does it.  The new style will allow the sub-component references to survive webpack tree shaking.
