### PR TITLE
Broken link for donut chart tutorial

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -20,7 +20,7 @@ In this tutorial, we will build a bar chart together - starting with a simple ch
 a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build 
 a consistent user experience.
 
-[Start course](https://katacoda.com/patternfly/courses/charts/module-pie)
+[Start course](https://katacoda.com/patternfly/courses/charts/module-donut)
 
 ## Simple donut chart
 ```js


### PR DESCRIPTION
Simple fix for the donut chart tutorial link.

Fixes https://github.com/patternfly/patternfly-react/issues/2939
