### PR TITLE
fix(table): Allow undefined in ActionsColumn

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/ActionsColumn.tsx
@@ -47,7 +47,7 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
   }
 
   onSelect = (event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent,
-              onClick: ((event: React.MouseEvent, rowIndex: number | undefined, rowData: IRowData, extraData: IExtraData) => void) | undefined): void => {
+              onClick: ((event: React.MouseEvent, rowIndex: number | undefined, rowData: IRowData | undefined, extraData: IExtraData | undefined) => void) | undefined): void => {
     const { rowData, extraData } = this.props;
     event.preventDefault();
     // tslint:disable-next-line:no-unused-expression

--- a/packages/patternfly-4/react-table/src/components/Table/Table.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.tsx
@@ -89,7 +89,7 @@ export interface IAction extends Omit<DropdownItemProps, 'title' | 'onClick'> {
   isSeparator?: boolean;
   itemKey?: string;
   title?: string | React.ReactNode;
-  onClick: (event: React.MouseEvent, rowIndex: number, rowData: IRowData, extraData: IExtraData) => void;
+  onClick: (event: React.MouseEvent, rowIndex: number | undefined, rowData: IRowData | undefined, extraData: IExtraData | undefined) => void;
 }
 
 export interface ISeparator extends IAction {


### PR DESCRIPTION
fix #2944

cc @lucasponce 


Props rowData and  extraData can be undefined
```typescript
export interface ActionsColumnProps {
  children?: React.ReactNode;
  items: IAction[];
  isDisabled?: boolean;
  dropdownPosition?: DropdownPosition;
  dropdownDirection?: DropdownDirection;
  rowData?: IRowData;
  extraData?: IExtraData;
}
```


# Output

```bash
Failed to compile
/home/aljesusg/Projects/kiali/kiali-ui/node_modules/@patternfly/react-table/src/components/Table/ActionsColumn.tsx
TypeScript error in /home/aljesusg/Projects/kiali/kiali-ui/node_modules/@patternfly/react-table/src/components/Table/ActionsColumn.tsx(54,84):
Argument of type 'IRowData | undefined' is not assignable to parameter of type 'IRowData'.
  Type 'undefined' is not assignable to type 'IRowData'.  TS2345

    52 |     event.preventDefault();
    53 |     // tslint:disable-next-line:no-unused-expression
  > 54 |     onClick && onClick(event as React.MouseEvent, extraData && extraData.rowIndex, rowData, extraData);
       |                                                                                    ^
    55 |     this.setState({
    56 |       isOpen: !this.state.isOpen
    57 |     });
```

This is a **blocker** for Kiali migration to PF4

cc @LHinson , @abonas