### PR TITLE
[WIP] Table column reorder

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Header.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/Header.tsx
@@ -6,17 +6,41 @@ import { ColumnsType } from './base/types';
 interface ContextHeaderProps {
   className?: string;
   headerRows?: IHeaderRow[];
-  reorderableColumns?: boolean;
+  draggable?: boolean;
+  onDragStart?: Function;
+  onDragEnd?: Function;
+  onDrop?: Function;
+  onDragOver?: Function;
+  onDragEnter?: Function;
+  onDragLeave?: Function;
 }
 
 const ContextHeader: React.FunctionComponent<ContextHeaderProps> = ({
   className = '',
   headerRows = undefined as IHeaderRow[],
-  reorderableColumns = false,
+  draggable,
+  onDragStart,
+  onDragEnd,
+  onDragEnter,
+  onDragLeave,
+  onDragOver,
+  onDrop,
   ...props
-}: ContextHeaderProps ) => (
-  <Header {...props} reorderableColumns={reorderableColumns} headerRows={headerRows as ColumnsType} className={className} />
-);
+}: ContextHeaderProps ) => {
+  return (
+    <Header
+      {...props}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onDrop={onDrop}
+      onDragOver={onDragOver}
+      onDragEnter={onDragEnter}
+      onDragLeave={onDragLeave}
+      reorderableColumns={draggable}
+      headerRows={headerRows as ColumnsType}
+      className={className} />
+  )
+};
 
 export interface HeaderProps extends React.HTMLProps<HTMLTableRowElement> {
   className?: string;
@@ -24,8 +48,32 @@ export interface HeaderProps extends React.HTMLProps<HTMLTableRowElement> {
 
 export const TableHeader: React.FunctionComponent<HeaderProps> = ({
   ...props
-}: HeaderProps ) => (
-  <TableContext.Consumer>
-  {({ headerRows }) => <ContextHeader {...props} headerRows={headerRows} />}
-  </TableContext.Consumer>
-);
+}: HeaderProps ) => {
+  return (
+    <TableContext.Consumer>
+    {({
+      headerRows,
+      draggable,
+      onDragStart,
+      onDragEnd,
+      onDrop,
+      onDragOver,
+      onDragEnter,
+      onDragLeave
+    }) => {
+      return (
+        <ContextHeader
+          {...props}
+          draggable={draggable}
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+          onDrop={onDrop}
+          onDragOver={onDragOver}
+          onDragEnter={onDragEnter}
+          onDragLeave={onDragLeave}
+          headerRows={headerRows} />
+      );
+    }}
+    </TableContext.Consumer>
+  )
+};

--- a/packages/patternfly-4/react-table/src/components/Table/Header.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/Header.tsx
@@ -6,14 +6,16 @@ import { ColumnsType } from './base/types';
 interface ContextHeaderProps {
   className?: string;
   headerRows?: IHeaderRow[];
+  reorderableColumns?: boolean;
 }
 
 const ContextHeader: React.FunctionComponent<ContextHeaderProps> = ({
   className = '',
   headerRows = undefined as IHeaderRow[],
+  reorderableColumns = false,
   ...props
 }: ContextHeaderProps ) => (
-  <Header {...props} headerRows={headerRows as ColumnsType} className={className} />
+  <Header {...props} reorderableColumns={reorderableColumns} headerRows={headerRows as ColumnsType} className={className} />
 );
 
 export interface HeaderProps extends React.HTMLProps<HTMLTableRowElement> {

--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -33,84 +33,6 @@ import {
 
 import DemoSortableTable from './demo/DemoSortableTable';
 
-## Reorderable Column Table
-
-```js
-import React from 'react';
-import {
-  Table,
-  TableHeader,
-  TableBody,
-  sortable,
-  SortByDirection,
-  headerCol,
-  TableVariant,
-  expandable,
-  cellWidth,
-  textCenter,
-} from '@patternfly/react-table';
-
-
-class ColReorderTable extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      columns: [
-        { title: 'Repositories' },
-        { title: 'Branches' },
-        { title: 'Pull requests' },
-        { title: 'Workspaces' },
-        {
-          title: 'Last Commit',
-          transforms: [textCenter],
-          cellTransforms: [textCenter]
-        }
-      ],
-      rows: [
-        {
-          cells: ['repositories', 'branches', 'PR', 'workspaces', 'last commit']
-        },
-        {
-          cells: [
-            {
-              title: <div>repositories - 2</div>,
-              props: { title: 'hover title', colSpan: 3 }
-            },
-            'workspaces - 2',
-            'last commit - 2'
-          ]
-        },
-        {
-          cells: [
-            'repositories - 3',
-            'branches - 3',
-            'PR - 3',
-            'workspaces - 3',
-            {
-              title: 'five - 3 (not centered)',
-              props: { textCenter: false }
-            }
-          ]
-        }
-      ]
-    };
-  }
-
-  render() {
-    const { columns, rows } = this.state;
-
-    return (
-      <Table caption="Reorderable Column Table" cells={columns} rows={rows}>
-        <TableHeader reorderableColumns={true} />
-        <TableBody />
-      </Table>
-    );
-  }
-}
-
-```
-
-
 ## Simple table
 
 ```js
@@ -184,6 +106,110 @@ class SimpleTable extends React.Component {
     );
   }
 }
+```
+
+## Reorderable Column Table
+
+```js
+import React from 'react';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  sortable,
+  SortByDirection,
+  headerCol,
+  TableVariant,
+  expandable,
+  cellWidth,
+  textCenter,
+} from '@patternfly/react-table';
+
+class ColReorderTable extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      columns: [
+        { title: 'Repositories' },
+        { title: 'Branches' },
+        { title: 'Pull requests' },
+        { title: 'Workspaces' },
+        {
+          title: 'Last Commit',
+          transforms: [textCenter],
+          cellTransforms: [textCenter]
+        }
+      ],
+      rows: [
+        {
+          cells: ['repositories', 'branches', 'PR', 'workspaces', 'last commit']
+        },
+        {
+          cells: [
+            {
+              title: <div>repositories - 2</div>,
+              props: { title: 'hover title' }
+            },
+            'branches - 2',
+            'PR - 2',
+            'workspaces - 2',
+            'last commit - 2'
+          ]
+        },
+        {
+          cells: [
+            'repositories - 3',
+            'branches - 3',
+            'PR - 3',
+            'workspaces - 3',
+            {
+              title: 'last commit - 3 (not centered)',
+              props: { textCenter: false }
+            }
+          ]
+        }
+      ]
+    };
+  }
+
+  render() {
+    const { columns, rows } = this.state;
+
+    const swapArrPosition = (from, to, arr) => {
+      let newArr = arr.slice();
+      [newArr[from], newArr[to]] = [newArr[to], newArr[from]];
+      return newArr;
+    }
+
+    const applyColumnReorder = (from, to) => {
+      if (from !== to) {
+        let newColumnArr = swapArrPosition(from, to, this.state.columns);
+        let newRowArr = this.state.rows.map((el, idx) => {
+          return {
+            cells: swapArrPosition(from, to, el.cells)
+          };
+        });
+        this.setState({
+          columns: newColumnArr,
+          rows: newRowArr
+        });
+      }
+    }
+
+    return (
+      <Table
+        reorderableColumns={true}
+        applyColumnReorder={applyColumnReorder}
+        caption="Reorderable Column Table"
+        cells={columns}
+        rows={rows}>
+        <TableHeader />
+        <TableBody />
+      </Table>
+    );
+  }
+}
+
 ```
 
 ## Sortable table

--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -33,6 +33,84 @@ import {
 
 import DemoSortableTable from './demo/DemoSortableTable';
 
+## Reorderable Column Table
+
+```js
+import React from 'react';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  sortable,
+  SortByDirection,
+  headerCol,
+  TableVariant,
+  expandable,
+  cellWidth,
+  textCenter,
+} from '@patternfly/react-table';
+
+
+class ColReorderTable extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      columns: [
+        { title: 'Repositories' },
+        { title: 'Branches' },
+        { title: 'Pull requests' },
+        { title: 'Workspaces' },
+        {
+          title: 'Last Commit',
+          transforms: [textCenter],
+          cellTransforms: [textCenter]
+        }
+      ],
+      rows: [
+        {
+          cells: ['repositories', 'branches', 'PR', 'workspaces', 'last commit']
+        },
+        {
+          cells: [
+            {
+              title: <div>repositories - 2</div>,
+              props: { title: 'hover title', colSpan: 3 }
+            },
+            'workspaces - 2',
+            'last commit - 2'
+          ]
+        },
+        {
+          cells: [
+            'repositories - 3',
+            'branches - 3',
+            'PR - 3',
+            'workspaces - 3',
+            {
+              title: 'five - 3 (not centered)',
+              props: { textCenter: false }
+            }
+          ]
+        }
+      ]
+    };
+  }
+
+  render() {
+    const { columns, rows } = this.state;
+
+    return (
+      <Table caption="Reorderable Column Table" cells={columns} rows={rows}>
+        <TableHeader reorderableColumns={true} />
+        <TableBody />
+      </Table>
+    );
+  }
+}
+
+```
+
+
 ## Simple table
 
 ```js
@@ -889,7 +967,7 @@ class CompoundExpandableTable extends React.Component {
             {
               title: (
                 <React.Fragment>
-                  <CodeBranchIcon key="icon" /> 10
+                  <CodeBranchIcon key="compound-codebranch-icon-1" /> 10
                 </React.Fragment>
               ),
               props: { isOpen: true, ariaControls : 'compoound-expansion-table-1' }
@@ -897,7 +975,7 @@ class CompoundExpandableTable extends React.Component {
             {
               title: (
                 <React.Fragment>
-                  <CodeIcon key="icon" /> 4
+                  <CodeIcon key="compound-code-icon-1" /> 4
                 </React.Fragment>
               ),
               props: { isOpen: false, ariaControls : 'compoound-expansion-table-2' }
@@ -905,7 +983,7 @@ class CompoundExpandableTable extends React.Component {
             {
               title: (
                 <React.Fragment>
-                  <CubeIcon key="icon" /> 4
+                  <CubeIcon key="compound-cube-icon-1" /> 4
                 </React.Fragment>
               ),
               props: { isOpen: false, ariaControls : 'compoound-expansion-table-3' }
@@ -918,7 +996,7 @@ class CompoundExpandableTable extends React.Component {
           parent: 0,
           compoundParent: 1,
           cells: [
-            { 
+            {
               title: <DemoSortableTable firstColumnRows={['parent-0', 'compound-1', 'three', 'four','five']} id="compoound-expansion-table-1" />,
               props: { colSpan: 6, className: 'pf-m-no-padding' }
             }
@@ -928,8 +1006,8 @@ class CompoundExpandableTable extends React.Component {
           parent: 0,
           compoundParent: 2,
           cells: [
-            { 
-              title: <DemoSortableTable firstColumnRows={['parent-0', 'compound-2', 'three', 'four','five']} id="compoound-expansion-table-2" />, 
+            {
+              title: <DemoSortableTable firstColumnRows={['parent-0', 'compound-2', 'three', 'four','five']} id="compoound-expansion-table-2" />,
               props: { colSpan: 6, className: 'pf-m-no-padding' }
             }
           ]
@@ -938,8 +1016,8 @@ class CompoundExpandableTable extends React.Component {
           parent: 0,
           compoundParent: 3,
           cells: [
-            { 
-              title: <DemoSortableTable firstColumnRows={['parent-0', 'compound-3', 'three', 'four','five']} id="compoound-expansion-table-3" />, 
+            {
+              title: <DemoSortableTable firstColumnRows={['parent-0', 'compound-3', 'three', 'four','five']} id="compoound-expansion-table-3" />,
               props: { colSpan: 6, className: 'pf-m-no-padding' }
             }
           ]
@@ -951,7 +1029,7 @@ class CompoundExpandableTable extends React.Component {
             {
               title: (
                 <React.Fragment>
-                  <CodeBranchIcon key="icon" /> 3
+                  <CodeBranchIcon key="compound-codebranch-icon-2" /> 3
                 </React.Fragment>
               ),
               props: { isOpen: false, ariaControls : 'compoound-expansion-table-4' }
@@ -959,7 +1037,7 @@ class CompoundExpandableTable extends React.Component {
             {
               title: (
                 <React.Fragment>
-                  <CodeIcon key="icon" /> 4
+                  <CodeIcon key="compound-code-icon-2" /> 4
                 </React.Fragment>
               ),
               props: { isOpen: false, ariaControls : 'compoound-expansion-table-5' }
@@ -967,7 +1045,7 @@ class CompoundExpandableTable extends React.Component {
             {
               title: (
                 <React.Fragment>
-                  <CubeIcon key="icon" /> 2
+                  <CubeIcon key="compound-cube-icon-2" /> 2
                 </React.Fragment>
               ),
               props: { isOpen: false, ariaControls : 'compoound-expansion-table-6' }
@@ -980,8 +1058,8 @@ class CompoundExpandableTable extends React.Component {
           parent: 4,
           compoundParent: 1,
           cells: [
-            { 
-              title: <DemoSortableTable firstColumnRows={['parent-4', 'compound-1', 'three', 'four','five']} id="compoound-expansion-table-4" />, 
+            {
+              title: <DemoSortableTable firstColumnRows={['parent-4', 'compound-1', 'three', 'four','five']} id="compoound-expansion-table-4" />,
               props: { colSpan: 6, className: 'pf-m-no-padding' }
             }
           ]
@@ -990,8 +1068,8 @@ class CompoundExpandableTable extends React.Component {
           parent: 4,
           compoundParent: 2,
           cells: [
-            { 
-              title: <DemoSortableTable firstColumnRows={['parent-4', 'compound-2', 'three', 'four','five']} id="compoound-expansion-table-5"/>, 
+            {
+              title: <DemoSortableTable firstColumnRows={['parent-4', 'compound-2', 'three', 'four','five']} id="compoound-expansion-table-5"/>,
               props: { colSpan: 6, className: 'pf-m-no-padding' }
             }
           ]
@@ -1000,8 +1078,8 @@ class CompoundExpandableTable extends React.Component {
           parent: 4,
           compoundParent: 3,
           cells: [
-            { 
-              title: <DemoSortableTable firstColumnRows={['parent-4', 'compound-3', 'three', 'four','five']} id="compoound-expansion-table-6"/>, 
+            {
+              title: <DemoSortableTable firstColumnRows={['parent-4', 'compound-3', 'three', 'four','five']} id="compoound-expansion-table-6"/>,
               props: { colSpan: 6, className: 'pf-m-no-padding' }
             }
           ]

--- a/packages/patternfly-4/react-table/src/components/Table/base/header-row.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/base/header-row.tsx
@@ -15,12 +15,26 @@ export interface HeaderRowProps {
   rowIndex: number;
   renderers: RendererType;
   onRow?: Function;
+  onDragStart?: Function;
+  onDragEnd?: Function;
+  onDrop?: Function;
+  onDragOver?: Function;
+  onDragEnter?: Function;
+  onDragLeave?: Function;
+  draggable?: boolean;
 }
 
 export const HeaderRow: React.FunctionComponent<HeaderRowProps> = ({
   rowData,
   rowIndex,
   renderers,
+  draggable,
+  onDragStart,
+  onDragEnd,
+  onDrop,
+  onDragOver,
+  onDragEnter,
+  onDragLeave,
   onRow = () => Object
 }) => {
   return React.createElement(
@@ -45,6 +59,13 @@ export const HeaderRow: React.FunctionComponent<HeaderRowProps> = ({
       return React.createElement(
         renderers.cell as createElementType,
         {
+          draggable,
+          onDragStart,
+          onDragEnd,
+          onDrop,
+          onDragOver,
+          onDragEnter,
+          onDragLeave,
           key: `${columnIndex}-header`,
           ...mergeProps(props, header && header.props, transformedProps)
         },

--- a/packages/patternfly-4/react-table/src/components/Table/base/header-row.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/base/header-row.tsx
@@ -60,6 +60,7 @@ export const HeaderRow: React.FunctionComponent<HeaderRowProps> = ({
         renderers.cell as createElementType,
         {
           draggable,
+          tabIndex: (draggable) ? 0 : undefined,
           onDragStart,
           onDragEnd,
           onDrop,

--- a/packages/patternfly-4/react-table/src/components/Table/base/header.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/base/header.tsx
@@ -17,71 +17,51 @@ export interface HeaderProps {
   onRow?: Function;
   className?: string;
   reorderableColumns?: boolean;
+  onDragStart?: Function;
+  onDragEnd?: Function;
+  onDrop?: Function;
+  onDragOver?: Function;
+  onDragEnter?: Function;
+  onDragLeave?: Function;
 }
 
-class BaseHeader extends React.Component<HeaderProps, {columns: any}> {
-  constructor(props: HeaderProps) {
-    super(props);
-    this.state = {
-      columns: (this.props.headerRows || [this.props.columns] as ColumnsType)
-    };
-  }
-  startDrag = -1;
-
-  applyDragDropOperation(from: number, to: number) {
-    if (from !== to) {
-      let newArr = this.state.columns[0];
-      [newArr[from], newArr[to]] = [newArr[to], newArr[from]];
-      this.setState({
-        columns: [newArr]
-      });
-    }
-  }
-
+class BaseHeader extends React.Component<HeaderProps, {}> {
   render() {
-    const { children, headerRows, onRow, renderers, columns, reorderableColumns, ...props } = this.props;
-    const dragAndDropProps = (reorderableColumns) ? { draggable: true } : null;
+    const {
+      children,
+      headerRows,
+      onRow,
+      renderers,
+      columns,
+      reorderableColumns,
+      onDragStart,
+      onDrop,
+      onDragOver,
+      onDragLeave,
+      onDragEnter,
+      onDragEnd,
+      ...props
+    } = this.props;
+    const isDraggable = (reorderableColumns) ? { draggable: true } : null;
     // If headerRows aren't passed, default to bodyColumns as header rows
     return React.createElement(
       renderers.header.wrapper as createElementType,
       props,
       [
-        this.state.columns.map((rowData: RowsType, rowIndex: number) =>
+        (this.props.headerRows || [this.props.columns] as ColumnsType).map((rowData: RowsType, rowIndex: number) =>
           React.createElement(HeaderRow, {
             key: `${rowIndex}-header-row`,
             renderers: renderers.header,
             onRow,
             rowData,
             rowIndex,
-            ...dragAndDropProps,
-            onDragStart: (e: any) => {
-              // TODO: why can't we use rowIndex? It's always zero for some reason
-              this.startDrag = e.target.getAttribute('data-key');
-              e.target.style.opacity = 0.4;
-            },
-            onDragEnd: (e: any) => {
-              e.target.style.opacity = 1;
-            },
-            onDrop: (e: any) => {
-              if (e.stopPropagation) {
-                e.stopPropagation();
-              }
-              e.target.style.border = 'none';
-              this.applyDragDropOperation(this.startDrag, e.target.getAttribute('data-key'));
-              return false;
-            },
-            onDragOver: (e: any) => {
-              if (e.preventDefault) {
-                e.preventDefault();
-              }
-              return false;
-            },
-            onDragEnter: (e: any) => {
-              e.target.style.border = '2px black dashed';
-            },
-            onDragLeave: (e: any) => {
-              e.target.style.border = 'none';
-            }
+            ...isDraggable,
+            onDragStart,
+            onDragLeave,
+            onDragEnter,
+            onDragOver,
+            onDrop,
+            onDragEnd
           })
         )
       ].concat(children as any)

--- a/packages/patternfly-4/react-table/src/components/Table/base/header.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/base/header.tsx
@@ -16,24 +16,72 @@ export interface HeaderProps {
   renderers?: RenderersTypes['renderers'];
   onRow?: Function;
   className?: string;
+  reorderableColumns?: boolean;
 }
 
-class BaseHeader extends React.Component<HeaderProps, {}> {
-  render() {
-    const { children, headerRows, onRow, renderers, columns, ...props } = this.props;
+class BaseHeader extends React.Component<HeaderProps, {columns: any}> {
+  constructor(props: HeaderProps) {
+    super(props);
+    this.state = {
+      columns: (this.props.headerRows || [this.props.columns] as ColumnsType)
+    };
+  }
+  startDrag = -1;
 
+  applyDragDropOperation(from: number, to: number) {
+    if (from !== to) {
+      let newArr = this.state.columns[0];
+      [newArr[from], newArr[to]] = [newArr[to], newArr[from]];
+      this.setState({
+        columns: [newArr]
+      });
+    }
+  }
+
+  render() {
+    const { children, headerRows, onRow, renderers, columns, reorderableColumns, ...props } = this.props;
+    const dragAndDropProps = (reorderableColumns) ? { draggable: true } : null;
     // If headerRows aren't passed, default to bodyColumns as header rows
     return React.createElement(
       renderers.header.wrapper as createElementType,
       props,
       [
-        (headerRows || [columns] as ColumnsType).map((rowData: RowsType, rowIndex) =>
+        this.state.columns.map((rowData: RowsType, rowIndex: number) =>
           React.createElement(HeaderRow, {
             key: `${rowIndex}-header-row`,
             renderers: renderers.header,
             onRow,
             rowData,
-            rowIndex
+            rowIndex,
+            ...dragAndDropProps,
+            onDragStart: (e: any) => {
+              // TODO: why can't we use rowIndex? It's always zero for some reason
+              this.startDrag = e.target.getAttribute('data-key');
+              e.target.style.opacity = 0.4;
+            },
+            onDragEnd: (e: any) => {
+              e.target.style.opacity = 1;
+            },
+            onDrop: (e: any) => {
+              if (e.stopPropagation) {
+                e.stopPropagation();
+              }
+              e.target.style.border = 'none';
+              this.applyDragDropOperation(this.startDrag, e.target.getAttribute('data-key'));
+              return false;
+            },
+            onDragOver: (e: any) => {
+              if (e.preventDefault) {
+                e.preventDefault();
+              }
+              return false;
+            },
+            onDragEnter: (e: any) => {
+              e.target.style.border = '2px black dashed';
+            },
+            onDragLeave: (e: any) => {
+              e.target.style.border = 'none';
+            }
           })
         )
       ].concat(children as any)


### PR DESCRIPTION
**What**: This PR is only here to give a very early look at what reorderable table columns could look/function like. It is far from complete both implementation and UX-wise, so please hold off on giving any comprehensive review. This PR is mainly just a way to share the demo with a few folks who will be gathering requirements for how this feature should _actually_ function and look.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: https://github.com/patternfly/patternfly-react/issues/2908

<!-- feel free to add additional comments -->
You can currently drag not only headings, but also row cells. Trying to drag anything other than a header onto another header will result in error - this is known, please ignore.

A limitation we should discuss is that currently, we allow users to specify `colSpan` for row data. This will cause the drag/drop logic to become much more elaborate than it is currently. We could make this work, but it may be better to simply require users to supply an empty object (or something of the sort) to represent empty row data.

Another talking point from UX standpoint is regarding the various drag states. How to best indicate where a column will be dropped - currently you drop a column ontop of another column, but now that we've gotten this far it doesn't really make sense. Might be better to have the visual indicator point to in-between columns instead of on top. This would align nicely with drop and drop in other components (treeview for example), where dropping on top of another node produces a child instead of a drag before/after operation.

![2019-09-17 16 34 28](https://user-images.githubusercontent.com/5942899/65077528-1cd49c80-d969-11e9-9548-7d0987059b40.gif)

