### PR TITLE
feat(emptyState): Support primary and icon as div elements

### DIFF
--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.md
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.md
@@ -14,7 +14,8 @@ import {
   EmptyStateVariant,
   EmptyStateIcon,
   EmptyStateBody,
-  EmptyStateSecondaryActions
+  EmptyStateSecondaryActions,
+  EmptyStatePrimary
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 
@@ -126,4 +127,70 @@ SimpleEmptyState = () => (
     </EmptyStateSecondaryActions>
   </EmptyState>
 );
+```
+
+## Empty state spinner
+```js
+import React from 'react';
+import {
+  Title,
+  Button,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateSecondaryActions
+} from '@patternfly/react-core';
+
+
+EmptyStateSpinner = () => {
+  const Spinner = () => (
+    <span className="pf-c-spinner" role="progressbar" aria-valuetext="Loading...">
+      <span class="pf-c-spinner__clipper" />
+      <span class="pf-c-spinner__lead-ball" />
+      <span class="pf-c-spinner__tail-ball" />
+    </span>
+  )
+  return (
+    <EmptyState>
+      <EmptyStateIcon variant="container" component={Spinner} />
+      <Title size="lg">
+        Loading
+      </Title>
+    </EmptyState>
+  );
+}
+```
+
+## Empty state no match found
+```js
+import React from 'react';
+import {
+  Title,
+  Button,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateSecondaryActions
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+
+
+NoMatchEmptyState = () => {
+  return (
+    <EmptyState>
+      <EmptyStateIcon icon={SearchIcon} />
+      <Title size="lg">
+        No results found
+      </Title>
+      <EmptyStateBody>
+        No results match the filter criteria. Remove all filters or clear all filters to show results.
+      </EmptyStateBody>
+      <EmptyStatePrimary>
+        <Button variant="link">Clear all filters</Button>
+      </EmptyStatePrimary>
+    </EmptyState>
+  );
+}
 ```

--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.test.tsx
@@ -5,6 +5,7 @@ import { EmptyState, EmptyStateVariant } from './EmptyState';
 import { EmptyStateBody } from './EmptyStateBody';
 import { EmptyStateSecondaryActions } from './EmptyStateSecondaryActions';
 import { EmptyStateIcon } from './EmptyStateIcon';
+import { EmptyStatePrimary } from './EmptyStatePrimary';
 import { Button } from '../Button';
 import { Title } from '../Title';
 import {BaseSizes} from '../../styles/sizes';
@@ -64,5 +65,24 @@ describe('EmptyState', () => {
     );
     expect(view.props().className).toBe('pf-c-empty-state__icon custom-empty-state-icon');
     expect(view.props().id).toBe('empty-state-icon');
+  });
+
+  test('Wrap icon in a div', () => {
+    const view = shallow(
+      <EmptyStateIcon variant="container" component={AddressBookIcon} className="custom-empty-state-icon" id="empty-state-icon" />
+    );
+    console.log(view.debug());
+    expect(view.find('div').props().className).toBe('pf-c-empty-state__icon custom-empty-state-icon');
+    expect(view.find('AddressBookIcon').length).toBe(1);
+  });
+
+  test('Primary div', () => {
+    const view = shallow(
+      <EmptyStatePrimary className="custom-empty-state-prim-cls" id="empty-state-prim-id">
+          <Button variant="link">Link</Button>
+      </EmptyStatePrimary>
+    );
+    expect(view.props().className).toBe('pf-c-empty-state__primary custom-empty-state-prim-cls');
+    expect(view.props().id).toBe('empty-state-prim-id');
   });
 });

--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateIcon.tsx
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStateIcon.tsx
@@ -19,14 +19,25 @@ export interface IconProps extends Omit<React.HTMLProps<SVGElement>, 'size'> {
 export interface EmptyStateIconProps extends IconProps {
   /** Additional classes added to the EmptyState */
   className?: string;
-  /** Icon component to be rendered inside the EmptyState */
-  icon: string | React.FunctionComponent<IconProps>;
+  /** Icon component to be rendered inside the EmptyState on icon variant */
+  icon?: string | React.FunctionComponent<IconProps>
+  /** Component to be rendered inside the EmptyState on container variant */
+  component?:  React.FunctionComponent<any>;
+  /** Adds empty state icon variant styles  */
+  variant?: 'icon' | 'container';
 }
 
 export const EmptyStateIcon: React.FunctionComponent<EmptyStateIconProps> = ({
   className = '',
-  icon: IconComponent,
+  icon: IconComponent = null,
+  component: AnyComponent = null,
+  variant = 'icon',
   ...props
-}: EmptyStateIconProps) => (
-  <IconComponent className={css(styles.emptyStateIcon, className)} {...props} aria-hidden="true" />
-);
+}: EmptyStateIconProps) => {
+  const classNames = css(styles.emptyStateIcon, className);
+  return variant === 'icon' ? (
+    <IconComponent className={classNames} {...props} aria-hidden="true" />
+  ) : (
+    <div className={classNames}><AnyComponent /></div>
+  );
+};

--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStatePrimary.tsx
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyStatePrimary.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/EmptyState/empty-state';
+
+export interface EmptyStatePrimaryProps
+  extends React.HTMLProps<HTMLDivElement> {
+  /** Additional classes added to the EmptyStatePrimary */
+  className?: string;
+  /** Content rendered inside the EmptyStatePrimary */
+  children: React.ReactNode;
+}
+
+export const EmptyStatePrimary: React.FunctionComponent<
+  EmptyStatePrimaryProps
+> = ({ children, className = '', ...props }: EmptyStatePrimaryProps) => {
+  return (
+    <div className={css(styles.emptyStatePrimary, className)} {...props}>
+      {children}
+    </div>
+  );
+};

--- a/packages/patternfly-4/react-core/src/components/EmptyState/index.ts
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/index.ts
@@ -2,3 +2,4 @@ export * from './EmptyState';
 export * from './EmptyStateBody';
 export * from './EmptyStateIcon';
 export * from './EmptyStateSecondaryActions';
+export * from './EmptyStatePrimary';


### PR DESCRIPTION
**What**:

closes #2929 

I wanted to add the demos (loading state table and empty state table) but I couldn't because:
1. I don't have the spinner component in react-core
2. They're relayed on the height-auto modifier which isn't in master yet: https://github.com/patternfly/patternfly-react/pull/2932
3. I am waiting on patternfly core to be upgraded to `2.31.9` (please ignore the second commit).