### PR TITLE
fix(react-table): fix cell title warning

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.tsx
@@ -125,7 +125,7 @@ export type IFormatters = ((
     rowKey?: RowKeyType ) => formatterValueType)[];
 
 export interface ICell {
-  title?: string;
+  title?: string | React.ReactNode;
   transforms?: ITransforms;
   cellTransforms?: ITransforms;
   columnTransforms?: ITransforms;
@@ -138,7 +138,7 @@ export interface ICell {
 }
 
 export interface IRowCell {
-  title?: React.ReactNode;
+  title?: string | React.ReactNode;
   props?: any;
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:
fix the warning in #2941 - the `title` prop should allow JSX too.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
