### PR TITLE
fix(HorizontalNavMenuItem): Fix onItemClick PropType.

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/HorizontalNavMenuItem.js
+++ b/packages/patternfly-3/patternfly-react/src/components/HorizontalNav/HorizontalNavMenuItem.js
@@ -34,7 +34,7 @@ const HorizontalNavMenuItem = props => {
 
 HorizontalNavMenuItem.propTypes = {
   children: PropTypes.node,
-  onItemClick: PropTypes.object,
+  onItemClick: PropTypes.func,
   title: PropTypes.node,
   active: PropTypes.bool,
   dropdown: PropTypes.bool,


### PR DESCRIPTION
HorizontalNavMenuItem 's onItemClick should be a function not an object.

It's getting passed as `onClick` to `<a href ...>` so it must be a bug.

Issue: https://github.com/patternfly/patternfly-react/issues/2994

Ping @rvsia, @karelhala
