### PR TITLE
fix(charts): replace empty tags with React.Fragment

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -784,7 +784,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
   });
 
   const bulletChart = (
-    <>
+    <React.Fragment>
       {axis}
       {bulletGroupTitle}
       {bulletTitle}
@@ -795,7 +795,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
       {comparativeWarningMeasure}
       {getComparativeZeroMeasure()}
       {getWrappedLegend()}
-    </>
+    </React.Fragment>
   );
 
   return standalone ? (

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletGroupTitle.tsx
@@ -186,10 +186,10 @@ export const ChartBulletGroupTitle: React.FunctionComponent<ChartBulletGroupTitl
 
   const groupTitle = (
     Boolean(title) && (
-      <>
+      <React.Fragment>
         {getTitle()}
         {getDivider()}
-      </>
+      </React.Fragment>
     )
   );
 


### PR DESCRIPTION
In ChartBullet, we're use empty <>...</> tags instead of React.Fragment. For consistency, we want to use React.Fragment. It's possible that gatsby / empty tags generate a "Minified React error" on pf.org?

Fixes https://github.com/patternfly/patternfly-org/issues/1477
