### PR TITLE
fix(react-table): Disable header controls with empty table

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/SelectColumn.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/SelectColumn.tsx
@@ -5,17 +5,19 @@ export interface SelectColumnProps {
   children?: React.ReactNode;
   className?: string;
   onSelect?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean
 }
 
 export const SelectColumn: React.FunctionComponent<SelectColumnProps> = ({
   children = null as React.ReactNode,
   className = '',
   onSelect = null as (event: React.ChangeEvent<HTMLInputElement>) => void,
+  disabled = false,
   ...props
 }: SelectColumnProps) => {
   return (
     <React.Fragment>
-      <input {...props} type="checkbox" onChange={onSelect} />
+      <input {...props} type="checkbox" onChange={onSelect} disabled={disabled} />
       {children}
     </React.Fragment>
   );

--- a/packages/patternfly-4/react-table/src/components/Table/SortColumn.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/SortColumn.tsx
@@ -10,6 +10,7 @@ export interface SortColumnProps extends React.HTMLAttributes<HTMLButtonElement>
   isSortedBy?: boolean;
   onSort?: Function;
   sortDirection?: string;
+  disabled?: boolean;
 }
 
 export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
@@ -18,6 +19,7 @@ export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
   isSortedBy = false,
   onSort = null,
   sortDirection = '',
+  disabled,
   ...props
 }: SortColumnProps) => {
   let SortedByIcon;
@@ -27,7 +29,7 @@ export const SortColumn: React.FunctionComponent<SortColumnProps> = ({
     SortedByIcon = ArrowsAltVIcon;
   }
   return (
-    <button {...props} className={css(className)} onClick={event => onSort && onSort(event)}>
+    <button {...props} className={css(className)} onClick={event => onSort && onSort(event)} disabled={disabled}>
       {children}
       <span className={css(styles.tableSortIndicator)}>
         <SortedByIcon />

--- a/packages/patternfly-4/react-table/src/components/Table/Table.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.tsx
@@ -77,6 +77,7 @@ export interface IColumn {
     dropdownPosition?: DropdownPosition;
     dropdownDirection?: DropdownDirection;
     allRowsSelected?: boolean;
+    isTableEmpty?: boolean;
   };
 }
 
@@ -250,8 +251,10 @@ class Table extends React.Component<TableProps & InjectedOuiaProps, {}> {
 
   isSelected = (row: IRow) => row.selected === true;
 
+  isTableEmpty = (this.props.rows === undefined || this.props.rows.length === 0);
+
   areAllRowsSelected = (rows: IRow[]) => {
-    if (rows === undefined || rows.length === 0) {
+    if (this.isTableEmpty) {
       return false;
     }
     return rows.every(row => this.isSelected(row) || (row.hasOwnProperty('parent') && !row.showSelect));
@@ -312,7 +315,8 @@ class Table extends React.Component<TableProps & InjectedOuiaProps, {}> {
       contentId,
       dropdownPosition,
       dropdownDirection,
-      firstUserColumnIndex: [onCollapse, onSelect].filter(callback => callback).length
+      firstUserColumnIndex: [onCollapse, onSelect].filter(callback => callback).length,
+      isTableEmpty: this.isTableEmpty
     });
 
     return (

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/selectable.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/selectable.tsx
@@ -9,7 +9,7 @@ export const selectable = (
   { rowIndex, columnIndex, rowData, column, property }: IExtra
 ) => {
   const {
-    extraParams: { onSelect, allRowsSelected, rowLabeledBy = 'simple-node' }
+    extraParams: { onSelect, allRowsSelected, isTableEmpty, rowLabeledBy = 'simple-node' }
   } = column;
   const extraData = {
     rowIndex,
@@ -49,7 +49,7 @@ export const selectable = (
     component: 'td',
     isVisible: true,
     children: (
-      <SelectColumn {...customProps} onSelect={selectClick} name={rowId !== -1 ? `checkrow${rowIndex}` : 'check-all'}>
+      <SelectColumn {...customProps} onSelect={selectClick} name={rowId !== -1 ? `checkrow${rowIndex}` : 'check-all'} disabled={isTableEmpty}>
         {label}
       </SelectColumn>
     )

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/sortable.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/sortable.tsx
@@ -7,7 +7,7 @@ import { SortColumn } from '../../SortColumn';
 
 export const sortable = (label: IFormatterValueType, { columnIndex, column, property }: IExtra) => {
   const {
-    extraParams: { sortBy, onSort }
+    extraParams: { sortBy, onSort, isTableEmpty }
   } = column;
   const extraData = {
     columnIndex,
@@ -26,7 +26,6 @@ export const sortable = (label: IFormatterValueType, { columnIndex, column, prop
     // tslint:disable-next-line:no-unused-expression
     onSort && onSort(event, columnIndex, reversedDirection, extraData);
   }
-
   return {
     className: css(styles.tableSort, isSortedBy && styles.modifiers.selected),
     'aria-sort': isSortedBy ? `${sortBy.direction}ending` : 'none',
@@ -36,6 +35,7 @@ export const sortable = (label: IFormatterValueType, { columnIndex, column, prop
         sortDirection={isSortedBy ? sortBy.direction : ''}
         onSort={sortClicked}
         className={css(buttonStyles.button, buttonStyles.modifiers.plain)}
+        disabled={isTableEmpty}
       >
         {label}
       </SortColumn>


### PR DESCRIPTION
Fixes: #1431

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:  When no rows exist in the table, disable the select all checkbox if present, and disable the sortable column mouse behavior (mouse pointer, text highlight)
<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
