### PR TITLE
Charts: Move ChartThreshold to its own example

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -21,7 +21,7 @@ import './chart-area.scss';
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
 
-PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
 
 Learn to build an area chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
@@ -237,140 +237,6 @@ class MultiColorChart extends React.Component {
                   { name: 'Birds', x: '2019', y: 4 }
                 ]}
                 interpolation="basis"
-              />
-            </ChartGroup>
-          </Chart>
-        </div>
-      </div>
-    );
-  }
-}
-```
-
-## Multi-color chart with threshold indicators and responsive container
-
-```js
-import React from 'react';
-import {
-  Chart,
-  ChartArea,
-  ChartAxis,
-  ChartLegend,
-  ChartGroup,
-  ChartThreshold,
-  ChartThemeColor,
-  ChartThemeVariant
-} from '@patternfly/react-charts';
-
-class MultiColorChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.containerRef = React.createRef();
-    this.state = {
-      width: 0
-    };
-    this.handleResize = () => {
-      if (this.containerRef.current && this.containerRef.current.clientWidth) {
-        this.setState({ width: this.containerRef.current.clientWidth });
-      }
-    };
-  }
-
-  componentDidMount() {
-    this.handleResize();
-    window.addEventListener('resize', this.handleResize);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
-  }
-
-  render() {
-    const { width } = this.state;
-    const itemsPerRow = width > 650 ? 4 : 2;
-
-    return (
-      <div ref={this.containerRef}>
-        <div className="area-chart-threshold-bottom-responsive">
-          <Chart
-            ariaDesc="Average number of pets"
-            ariaTitle="Area chart example"
-            containerComponent={
-              <ChartVoronoiContainer
-                labels={({ datum }) => `${datum.name}: ${datum.y}`}
-                constrainToVisibleArea
-              />
-            }
-            legendPosition="bottom-left"
-            legendComponent={
-              <ChartLegend
-                data={[
-                  { name: 'Cats' },
-                  { name: 'Birds' },
-                  {
-                    name: 'Cats Threshold',
-                    symbol: { fill: ChartThemeColor.blue, type: 'threshold' }
-                  },
-                  {
-                    name: 'Birds Threshold',
-                    symbol: { fill: ChartThemeColor.orange, type: 'threshold' }
-                  }
-                ]}
-                itemsPerRow={itemsPerRow}
-              />
-            }
-            height={250}
-            padding={{
-              bottom: 100, // Adjusted to accomodate legend
-              left: 50,
-              right: 50,
-              top: 50
-            }}
-            maxDomain={{ y: 9 }}
-            themeColor={ChartThemeColor.multiUnordered}
-            width={width}
-          >
-            <ChartAxis />
-            <ChartAxis dependentAxis showGrid />
-            <ChartGroup>
-              <ChartArea
-                data={[
-                  { name: 'Cats', x: 1, y: 3 },
-                  { name: 'Cats', x: 2, y: 4 },
-                  { name: 'Cats', x: 3, y: 8 },
-                  { name: 'Cats', x: 4, y: 6 }
-                ]}
-                interpolation="basis"
-              />
-              <ChartArea
-                data={[
-                  { name: 'Birds', x: 1, y: 2 },
-                  { name: 'Birds', x: 2, y: 3 },
-                  { name: 'Birds', x: 3, y: 4 },
-                  { name: 'Birds', x: 4, y: 5 },
-                  { name: 'Birds', x: 5, y: 6 }
-                ]}
-                interpolation="basis"
-              />
-              <ChartThreshold
-                data={[
-                  { name: 'Cats Threshold', x: 0, y: 4 },
-                  { name: 'Cats Threshold', x: 3, y: 4 },
-                  { name: 'Cats Threshold', x: 3, y: 6 },
-                  { name: 'Cats Threshold', x: 5, y: 6 }
-                ]}
-                themeColor={ChartThemeColor.blue}
-                themeVariant={ChartThemeVariant.light}
-              />
-              <ChartThreshold
-                data={[
-                  { name: 'Birds Threshold', x: 0, y: 2 },
-                  { name: 'Birds Threshold', x: 2, y: 2 },
-                  { name: 'Birds Threshold', x: 2, y: 3 },
-                  { name: 'Birds Threshold', x: 5, y: 3 }
-                ]}
-                themeColor={ChartThemeColor.orange}
-                themeVariant={ChartThemeVariant.light}
               />
             </ChartGroup>
           </Chart>

--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/chart-area.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/chart-area.scss
@@ -17,7 +17,5 @@
       height: 200px;
       width: 800px;
     }
-
-    .VictoryContainer svg g[clip-path] { mix-blend-mode: multiply }
   }
 }

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -11,7 +11,7 @@ import './chart-bar.scss';
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
 
-PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
 
 Learn to build a bar chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -12,7 +12,7 @@ import './chart-bullet.scss';
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
 
-PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
 
 Learn to build a bullet chart using a Katacoda tutorial starting with a simple chart, adding qualitative ranges, primary comparative measures, a comparative warning measure, tooltips, labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -12,7 +12,7 @@ import './chart-donut.scss';
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
 
-PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
 
 Learn to build a donut chart using a Katacoda tutorial starting with a simple chart, adding thresholds, tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -12,7 +12,7 @@ import './chart-donut-utilization.scss';
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
 
-PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
 
 Learn to build a donut utilization chart using a Katacoda tutorial starting with a simple chart, adding thresholds, tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -12,7 +12,7 @@ import './chart-line.scss';
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
 
-PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
 
 Learn to build a line chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -12,7 +12,7 @@ import './chart-pie.scss';
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
 
-PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
 
 Learn to build a pie chart using a Katacoda tutorial starting with a simple chart, adding tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -11,7 +11,7 @@ import './chart-stack.scss';
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
 
-PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
 
 Learn to build a stack chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.

--- a/packages/patternfly-4/react-charts/src/components/ChartThreshold/examples/ChartThreshold.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartThreshold/examples/ChartThreshold.md
@@ -1,0 +1,170 @@
+---
+title: 'Threshold'
+section: 'charts'
+typescript: true
+propComponents:
+  [
+    'Chart',
+    'ChartAreaProps',
+    'ChartAxis',
+    'ChartGroup',
+    'ChartLegend',
+    'ChartThreshold',
+    'ChartVoronoiContainer',
+  ]
+---
+
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartLegend, ChartThreshold, ChartThemeColor, ChartThemeVariant, ChartVoronoiContainer } from '@patternfly/react-charts';
+import '@patternfly/patternfly/patternfly-charts.css';
+import './chart-threshold.scss';
+
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+## Multi-color, area chart with threshold indicators and responsive container
+
+```js
+import React from 'react';
+import {
+  Chart,
+  ChartArea,
+  ChartAxis,
+  ChartLegend,
+  ChartGroup,
+  ChartThreshold,
+  ChartThemeColor
+} from '@patternfly/react-charts';
+
+class MultiColorChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.containerRef = React.createRef();
+    this.state = {
+      width: 0
+    };
+    this.handleResize = () => {
+      if (this.containerRef.current && this.containerRef.current.clientWidth) {
+        this.setState({ width: this.containerRef.current.clientWidth });
+      }
+    };
+  }
+
+  componentDidMount() {
+    this.handleResize();
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  render() {
+    const { width } = this.state;
+    const itemsPerRow = width > 650 ? 4 : 2;
+
+    return (
+      <div ref={this.containerRef}>
+        <div className="threshold-chart-threshold-bottom-responsive">
+          <Chart
+            ariaDesc="Average number of pets"
+            ariaTitle="Area chart example"
+            containerComponent={
+              <ChartVoronoiContainer
+                labels={({ datum }) => `${datum.name}: ${datum.y}`}
+                constrainToVisibleArea
+              />
+            }
+            legendPosition="bottom-left"
+            legendComponent={
+              <ChartLegend
+                data={[
+                  { name: 'Cats' },
+                  { name: 'Birds' },
+                  {
+                    name: 'Cats Threshold',
+                    symbol: { fill: ChartThemeColor.blue, type: 'threshold' }
+                  },
+                  {
+                    name: 'Birds Threshold',
+                    symbol: { fill: ChartThemeColor.orange, type: 'threshold' }
+                  }
+                ]}
+                itemsPerRow={itemsPerRow}
+              />
+            }
+            height={250}
+            padding={{
+              bottom: 100, // Adjusted to accomodate legend
+              left: 50,
+              right: 50,
+              top: 50
+            }}
+            maxDomain={{ y: 9 }}
+            themeColor={ChartThemeColor.multiUnordered}
+            width={width}
+          >
+            <ChartAxis />
+            <ChartAxis dependentAxis showGrid />
+            <ChartGroup>
+              <ChartArea
+                data={[
+                  { name: 'Cats', x: 1, y: 3 },
+                  { name: 'Cats', x: 2, y: 4 },
+                  { name: 'Cats', x: 3, y: 8 },
+                  { name: 'Cats', x: 4, y: 6 }
+                ]}
+                interpolation="basis"
+              />
+              <ChartArea
+                data={[
+                  { name: 'Birds', x: 1, y: 2 },
+                  { name: 'Birds', x: 2, y: 3 },
+                  { name: 'Birds', x: 3, y: 4 },
+                  { name: 'Birds', x: 4, y: 5 },
+                  { name: 'Birds', x: 5, y: 6 }
+                ]}
+                interpolation="basis"
+              />
+              <ChartThreshold
+                data={[
+                  { name: 'Cats Threshold', x: 0, y: 4 },
+                  { name: 'Cats Threshold', x: 3, y: 4 },
+                  { name: 'Cats Threshold', x: 3, y: 6 },
+                  { name: 'Cats Threshold', x: 5, y: 6 }
+                ]}
+                themeColor={ChartThemeColor.blue}
+              />
+              <ChartThreshold
+                data={[
+                  { name: 'Birds Threshold', x: 0, y: 2 },
+                  { name: 'Birds Threshold', x: 2, y: 2 },
+                  { name: 'Birds Threshold', x: 2, y: 3 },
+                  { name: 'Birds Threshold', x: 5, y: 3 }
+                ]}
+                themeColor={ChartThemeColor.orange}
+              />
+            </ChartGroup>
+          </Chart>
+        </div>
+      </div>
+    );
+  }
+}
+```
+
+## Tips
+
+- For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+- `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `Chart` props, see <a href="https://formidable.com/open-source/victory/docs/victory-chart" target="_blank">VictoryChart</a>
+ - For `ChartArea` props, see <a href="https://formidable.com/open-source/victory/docs/victory-area" target="_blank">VictoryArea</a>
+ - For `ChartAxis` props, see <a href="https://formidable.com/open-source/victory/docs/victory-axis" target="_blank">VictoryAxis</a>
+ - For `ChartGroup` props, see <a href="https://formidable.com/open-source/victory/docs/victory-group" target="_blank">VictoryGroup</a>
+ - For `ChartLegend` props, see <a href="https://formidable.com/open-source/victory/docs/victory-legend" target="_blank">VictoryLegend</a>
+ - For `ChartVoronoiContainer` props, see <a href="https://formidable.com/open-source/victory/docs/victory-voronoi-container" target="_blank">VictoryVoronoiContainer</a>

--- a/packages/patternfly-4/react-charts/src/components/ChartThreshold/examples/chart-threshold.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartThreshold/examples/chart-threshold.scss
@@ -1,0 +1,7 @@
+.ws-preview {
+  & > * {
+    .threshold-chart-threshold-bottom-responsive {
+      height: 250px;
+    }
+  }
+}

--- a/packages/patternfly-4/react-charts/src/components/Sparkline/examples/sparkline.md
+++ b/packages/patternfly-4/react-charts/src/components/Sparkline/examples/sparkline.md
@@ -11,7 +11,7 @@ import './sparkline.scss';
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
 
-PatternFly React charts are based on the [Victory chart](https://formidable.com/open-source/victory/docs/victory-chart/) library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
 
 
 Learn to build a sparkline chart using a Katacoda tutorial starting with a simple chart, adding tooltips, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.


### PR DESCRIPTION
Moved the ChartThreshold to its own example. This will make it easier to find the example and we could potentially add more examples later (e.g., for a bar chart).

Fixes https://github.com/patternfly/patternfly-react/issues/3014

<img width="829" alt="Screen Shot 2019-09-27 at 12 05 49 AM" src="https://user-images.githubusercontent.com/17481322/65741599-9469a080-e0ba-11e9-8fb8-49c942493536.png">