### PR TITLE
Charts: Add custom theme example

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -20,9 +20,7 @@ import './chart-area.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build an area chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
@@ -251,6 +249,9 @@ class MultiColorChart extends React.Component {
 
 - For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
 - `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+- Use `ChartGroup` to apply color scales and other properties to multiple components
+- Themes are inherited, so a default theme may override `themeColor` for a child component
+- The `theme` and `themeColor` props should be applied at the most top level component
 
 ## Docs
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -10,9 +10,7 @@ import './chart-bar.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a bar chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
@@ -166,6 +164,9 @@ import { Chart, ChartBar } from '@patternfly/react-charts';
 
 - For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
 - `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+- Use `ChartGroup` to apply color scales and other properties to multiple components
+- Themes are inherited, so a default theme may override `themeColor` for a child component
+- The `theme` and `themeColor` props should be applied at the most top level component
 
 ## Docs
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -11,9 +11,7 @@ import './chart-bullet.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a bullet chart using a Katacoda tutorial starting with a simple chart, adding qualitative ranges, primary comparative measures, a comparative warning measure, tooltips, labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -11,9 +11,7 @@ import './chart-donut.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a donut chart using a Katacoda tutorial starting with a simple chart, adding thresholds, tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
@@ -94,7 +92,6 @@ import { ChartDonut, ChartThemeColor, ChartThemeVariant } from '@patternfly/reac
       subTitle="Pets"
       title="100"
       themeColor={ChartThemeColor.multiOrdered}
-      themeVariant={ChartThemeVariant.light}
       width={350}
     />
   </div>

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -11,9 +11,7 @@ import './chart-donut-utilization.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a donut utilization chart using a Katacoda tutorial starting with a simple chart, adding thresholds, tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
@@ -213,7 +211,6 @@ class UtilizationChart extends React.Component {
             subTitle="of 100 GBps"
             title={`${used}%`}
             themeColor={ChartThemeColor.green}
-            themeVariant={ChartThemeVariant.light}
             thresholds={[{ value: 60 }, { value: 90 }]}
             width={230}
           />
@@ -459,7 +456,6 @@ class ThresholdChart extends React.Component {
               subTitle="of 100 GBps"
               title={`${used}%`}
               themeColor={ChartThemeColor.green}
-              themeVariant={ChartThemeVariant.light}
               thresholds={[{ value: 60 }, { value: 90 }]}
             />
           </ChartDonutThreshold>

--- a/packages/patternfly-4/react-charts/src/components/ChartLabel/ChartLabel.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartLabel/ChartLabel.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { defaults } from 'lodash';
-import { StringOrNumberOrCallback, VictoryLabel, VictoryLabelProps } from 'victory';
+import {
+  StringOrNumberOrCallback,
+  TextAnchorType,
+  VerticalAnchorType,
+  VictoryLabel,
+  VictoryLabelProps
+} from 'victory';
 import { ChartCommonStyles } from '../ChartTheme';
 
 export enum ChartLabelDirection {
@@ -15,8 +21,6 @@ export enum ChartLabelPlacement {
   perpendicular = 'perpendicular',
   vertical = 'vertical'
 }
-
-type TextAnchorType = 'start' | 'middle' | 'end' | 'inherit';
 
 /**
  * See https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/victory/index.d.ts
@@ -135,19 +139,16 @@ export interface ChartLabelProps extends VictoryLabelProps {
   /**
    * The textAnchor prop defines how the text is horizontally positioned relative to the given `x` and `y` coordinates.
    */
-  // Todo: function not working as type
-  // textAnchor?: TextAnchorType | { (): TextAnchorType };
+  textAnchor?: TextAnchorType | (() => TextAnchorType);
   /**
    * The transform prop applies a transform to the rendered `<text>` element.
    * In addition to being a string, it can be an object containing transform definitions for easier authoring.
    */
-  // Todo: function not working as type
-  // transform?: string | {} | { (): string | {} };
+  transform?: string | {} | (() => string);
   /**
    * The verticalAnchor prop defines how the text is vertically positioned relative to the given `x` and `y` coordinates
    */
-  // Todo: function not working as type
-  // verticalAnchor?: VerticalAnchorType | { (): VerticalAnchorType };
+  verticalAnchor?: VerticalAnchorType | (() => VerticalAnchorType);
   /**
    * The x prop defines the x coordinate to use as a basis for horizontal positioning.
    */

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -11,9 +11,7 @@ import './chart-line.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a line chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
@@ -268,6 +266,9 @@ class MultiColorChart extends React.Component {
 
 - For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
 - `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+- Use `ChartGroup` to apply color scales and other properties to multiple components
+- Themes are inherited, so a default theme may override `themeColor` for a child component
+- The `theme` and `themeColor` props should be applied at the most top level component
 
 ## Docs
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -11,9 +11,7 @@ import './chart-pie.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a pie chart using a Katacoda tutorial starting with a simple chart, adding tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -10,9 +10,7 @@ import './chart-stack.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a stack chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
@@ -381,6 +379,8 @@ class MultiColorChart extends React.Component {
 
 - For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
 - `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+- Themes are inherited, so a default theme may override `themeColor` for a child component
+- The `theme` and `themeColor` props should be applied at the most top level component
 
 ## Docs
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/examples/ChartTheme.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/examples/ChartTheme.md
@@ -1,0 +1,404 @@
+---
+title: 'Theme'
+section: 'charts'
+typescript: true
+propComponents: ['Chart', 'ChartAxis', 'ChartBar', 'ChartGroup', 'ChartLegend', 'ChartVoronoiContainer']
+---
+
+import { Chart, ChartArea, ChartAxis, ChartBar, ChartDonut, ChartGroup, CharLegend, ChartLine, ChartStack, ChartThemeColor, ChartThemeVariant, ChartVoronoiContainer, getCustomTheme } from '@patternfly/react-charts';
+import './chart-theme.scss';
+import {
+  chart_color_blue_300,
+  chart_color_green_300,
+  chart_color_cyan_300,
+  chart_color_gold_300,
+  chart_color_purple_300
+} from '@patternfly/react-tokens';
+
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+## Green theme
+This demonstrates how to apply basic theme colors
+```js
+import React from 'react';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+
+<div>
+  <div className="line-chart-legend-bottom">
+    <Chart
+      ariaDesc="Average number of pets"
+      ariaTitle="Line chart example"
+      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+      legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
+      legendPosition="bottom"
+      height={275}
+      maxDomain={{y: 10}}
+      minDomain={{y: 0}}
+      padding={{
+        bottom: 75, // Adjusted to accommodate legend
+        left: 50,
+        right: 50,
+        top: 50
+      }}
+      themeColor={ChartThemeColor.green}
+      width={450}
+    >
+      <ChartAxis tickValues={[2, 3, 4]} />
+      <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} />
+      <ChartGroup>
+        <ChartLine
+          data={[
+            { name: 'Cats', x: '2015', y: 1 },
+            { name: 'Cats', x: '2016', y: 2 },
+            { name: 'Cats', x: '2017', y: 5 },
+            { name: 'Cats', x: '2018', y: 3 }
+          ]}
+        />
+        <ChartLine
+          data={[
+            { name: 'Dogs', x: '2015', y: 2 },
+            { name: 'Dogs', x: '2016', y: 1 },
+            { name: 'Dogs', x: '2017', y: 7 },
+            { name: 'Dogs', x: '2018', y: 4 }
+          ]}
+          style={{
+            data: {
+              strokeDasharray: '3,3'
+            }
+          }}
+        />
+        <ChartLine
+          data={[
+            { name: 'Birds', x: '2015', y: 3 },
+            { name: 'Birds', x: '2016', y: 4 },
+            { name: 'Birds', x: '2017', y: 9 },
+            { name: 'Birds', x: '2018', y: 5 }
+          ]}
+        />
+        <ChartLine
+          data={[
+            { name: 'Mice', x: '2015', y: 3 },
+            { name: 'Mice', x: '2016', y: 3 },
+            { name: 'Mice', x: '2017', y: 8 },
+            { name: 'Mice', x: '2018', y: 7 }
+          ]}
+        />
+      </ChartGroup>
+    </Chart>
+  </div>
+</div>
+```
+
+## Multi-color (ordered) theme
+This demonstrates how to apply theme colors for ordered charts like bar, donut, pie, and stack
+```js
+import React from 'react';
+import { ChartDonut, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
+
+<div>
+  <div className="donut-chart-legend-right">
+    <ChartDonut
+      ariaDesc="Average number of pets"
+      ariaTitle="Donut chart example"
+      constrainToVisibleArea={true}
+      data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+      labels={({ datum }) => `${datum.x}: ${datum.y}%`}
+      legendData={[{ name: 'Cats: 35' }, { name: 'Dogs: 55' }, { name: 'Birds: 10' }]}
+      legendOrientation="vertical"
+      legendPosition="right"
+      padding={{
+        bottom: 20,
+        left: 20,
+        right: 140, // Adjusted to accommodate legend
+        top: 20
+      }}
+      subTitle="Pets"
+      title="100"
+      themeColor={ChartThemeColor.multiOrdered}
+      width={350}
+    />
+  </div>
+</div>
+```
+
+## Multi-color (unordered) theme
+This demonstrates how to apply theme colors for unordered charts like area, line, and sparkline
+```js
+import React from 'react';
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '@patternfly/react-charts';
+// import '@patternfly/patternfly/patternfly-charts.css'; // For mixed blend mode
+
+<div>
+  <div className="area-chart-legend-right">
+    <Chart
+      ariaDesc="Average number of pets"
+      ariaTitle="Area chart example"
+      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+      legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
+      legendOrientation="vertical"
+      legendPosition="right"
+      height={200}
+      maxDomain={{y: 9}}
+      padding={{
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accommodate legend
+        top: 50
+      }}
+      themeColor={ChartThemeColor.multiUnordered}
+      width={800}
+    >
+      <ChartAxis />
+      <ChartAxis dependentAxis showGrid/>
+      <ChartGroup>
+        <ChartArea
+          data={[
+            { name: 'Cats', x: '2015', y: 3 },
+            { name: 'Cats', x: '2016', y: 4 },
+            { name: 'Cats', x: '2017', y: 8 },
+            { name: 'Cats', x: '2018', y: 6 }
+          ]}
+          interpolation="basis"
+        />
+        <ChartArea
+          data={[
+            { name: 'Dogs', x: '2015', y: 2 },
+            { name: 'Dogs', x: '2016', y: 3 },
+            { name: 'Dogs', x: '2017', y: 4 },
+            { name: 'Dogs', x: '2018', y: 5 },
+            { name: 'Dogs', x: '2019', y: 6 }
+          ]}
+          interpolation="basis"
+        />
+        <ChartArea
+          data={[
+            { name: 'Birds', x: '2015', y: 1 },
+            { name: 'Birds', x: '2016', y: 2 },
+            { name: 'Birds', x: '2017', y: 3 },
+            { name: 'Birds', x: '2018', y: 2 },
+            { name: 'Birds', x: '2019', y: 4 }
+          ]}
+          interpolation="basis"
+        />
+      </ChartGroup>
+    </Chart>
+  </div>
+</div>
+```
+
+## Custom colors
+This demonstrates an alternate way of applying custom colors to individual charts
+```js
+import React from 'react';
+import { Chart, ChartAxis, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
+
+<div>
+  <div className="stack-chart-legend-bottom">
+    <Chart
+      ariaDesc="Average number of pets"
+      ariaTitle="Stack chart example"
+      domainPadding={{ x: [30, 25] }}
+      legendComponent={
+        <ChartLegend
+          data={[
+            { 
+              name: 'Cats',
+              symbol: { fill: chart_color_blue_300.value }
+            },
+            { 
+              name: 'Dogs',
+              symbol: { fill: chart_color_gold_300.value }
+            },
+            {
+              name: 'Birds',
+              symbol: { fill: chart_color_green_300.value }
+            },
+            {
+              name: 'Mice',
+              symbol: { fill: chart_color_purple_300.value }
+            }
+          ]}
+        />
+      }
+      legendPosition="bottom-left"
+      height={275}
+      padding={{
+        bottom: 75, // Adjusted to accommodate legend
+        left: 50,
+        right: 50, 
+        top: 50
+      }}
+      themeColor={ChartThemeColor.multiOrdered}
+      width={450}
+    >
+      <ChartAxis />
+      <ChartAxis dependentAxis showGrid />
+      <ChartStack 
+        horizontal
+        colorScale={[
+          chart_color_blue_300.value,
+          chart_color_gold_300.value,
+          chart_color_green_300.value,
+          chart_color_purple_300.value
+        ]}
+      >
+        <ChartBar 
+          data={[
+            { name: 'Cats', x: '2015', y: 1, label: 'Cats: 1' }, 
+            { name: 'Cats', x: '2016', y: 2, label: 'Cats: 2' }, 
+            { name: 'Cats', x: '2017', y: 5, label: 'Cats: 5' }, 
+            { name: 'Cats', x: '2018', y: 3, label: 'Cats: 3' }
+          ]} 
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Dogs', x: '2015', y: 2, label: 'Dogs: 2' }, 
+            { name: 'Dogs', x: '2016', y: 1, label: 'Dogs: 1' }, 
+            { name: 'Dogs', x: '2017', y: 7, label: 'Dogs: 7' }, 
+            { name: 'Dogs', x: '2018', y: 4, label: 'Dogs: 4' }
+          ]}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Birds', x: '2015', y: 4, label: 'Birds: 4' }, 
+            { name: 'Birds', x: '2016', y: 4, label: 'Birds: 4' }, 
+            { name: 'Birds', x: '2017', y: 9, label: 'Birds: 9' }, 
+            { name: 'Birds', x: '2018', y: 7, label: 'Birds: 7' }
+          ]}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Mice', x: '2015', y: 3, label: 'Mice: 3' }, 
+            { name: 'Mice', x: '2016', y: 3, label: 'Mice: 3' }, 
+            { name: 'Mice', x: '2017', y: 8, label: 'Mice: 8' }, 
+            { name: 'Mice', x: '2018', y: 5, label: 'Mice: 5' }
+          ]}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
+        />
+      </ChartStack>
+    </Chart>
+  </div>
+</div>
+```
+
+## Custom theme
+This demonstrates custom theme properties, which may be applied across multiple charts
+```js
+import React from 'react';
+import { Chart, ChartBar, ChartAxis, ChartGroup, ChartThemeColor, ChartThemeVariant, getCustomTheme } from '@patternfly/react-charts';
+import {
+  chart_color_blue_300,
+  chart_color_green_300,
+  chart_color_cyan_300,
+  chart_color_gold_300,
+} from '@patternfly/react-tokens';
+
+class MultiColorChart extends React.Component {
+  constructor(props) {
+    super(props);
+
+    // Colors
+    this.colorScale = [
+      chart_color_blue_300.value,
+      chart_color_green_300.value,
+      chart_color_cyan_300.value,
+      chart_color_gold_300.value
+    ];
+
+    // Layout
+    this.layoutProps = {
+      padding: {
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accommodate legend
+        top: 50
+      }
+    };
+
+    // Victory theme properties only
+    this.themeProps = {
+      bar: {
+        colorScale: this.colorScale,
+        ...this.layoutProps,
+      },
+      chart: {
+        colorScale: this.colorScale,
+        ...this.layoutProps,
+      },
+      group: {
+        colorScale: this.colorScale,
+        ...this.layoutProps,
+      },
+      legend: {
+        colorScale: this.colorScale
+      }
+    };
+
+    // Applies theme color and variant to base theme
+    this.myCustomTheme = getCustomTheme(
+      ChartThemeColor.default,
+      ChartThemeVariant.default,
+      this.themeProps
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        <div className="theme-legend-right">
+          <Chart
+            ariaDesc="Average number of pets"
+            ariaTitle="Bar chart example"
+            containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+            domain={{y: [0,9]}}
+            domainPadding={{ x: [30, 25] }}
+            legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
+            legendOrientation="vertical"
+            legendPosition="right"
+            height={250}
+            theme={this.myCustomTheme}
+            width={600}
+          >
+            <ChartAxis />
+            <ChartAxis dependentAxis showGrid />
+            <ChartGroup offset={11}>
+              <ChartBar data={[{ name: 'Cats', x: '2015', y: 1 }, { name: 'Cats', x: '2016', y: 2 }, { name: 'Cats', x: '2017', y: 5 }, { name: 'Cats', x: '2018', y: 3 }]} />
+              <ChartBar data={[{ name: 'Dogs', x: '2015', y: 2 }, { name: 'Dogs', x: '2016', y: 1 }, { name: 'Dogs', x: '2017', y: 7 }, { name: 'Dogs', x: '2018', y: 4 }]} />
+              <ChartBar data={[{ name: 'Birds', x: '2015', y: 4 }, { name: 'Birds', x: '2016', y: 4 }, { name: 'Birds', x: '2017', y: 9 }, { name: 'Birds', x: '2018', y: 7 }]} />
+              <ChartBar data={[{ name: 'Mice', x: '2015', y: 3 }, { name: 'Mice', x: '2016', y: 3 }, { name: 'Mice', x: '2017', y: 8 }, { name: 'Mice', x: '2018', y: 5 }]} />
+            </ChartGroup>
+          </Chart>
+        </div>
+      </div>
+    );
+  }
+}
+```
+
+## Tips
+
+- For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+- `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+- Use `ChartGroup` to apply color scales and other properties to multiple components
+- Themes are inherited, so a default theme may override `themeColor` for a child component
+- The `theme` and `themeColor` props should be applied at the most top level component
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `Chart` props, see <a href="https://formidable.com/open-source/victory/docs/victory-chart" target="_blank">VictoryChart</a>
+ - For `ChartArea` props, see <a href="https://formidable.com/open-source/victory/docs/victory-area" target="_blank">VictoryArea</a>
+ - For `ChartAxis` props, see <a href="https://formidable.com/open-source/victory/docs/victory-axis" target="_blank">VictoryAxis</a>
+ - For `ChartBar` props, see <a href="https://formidable.com/open-source/victory/docs/victory-bar" target="_blank">VictoryBar</a>
+ - For `ChartDonut` props, see <a href="https://formidable.com/open-source/victory/docs/victory-pie" target="_blank">VictoryPie</a>
+ - For `ChartGroup` props, see <a href="https://formidable.com/open-source/victory/docs/victory-group" target="_blank">VictoryGroup</a>
+ - For `ChartLegend` props, see <a href="https://formidable.com/open-source/victory/docs/victory-legend" target="_blank">VictoryLegend</a>
+ - For `ChartLine` props, see <a href="https://formidable.com/open-source/victory/docs/victory-line" target="_blank">VictoryLine</a>
+ - For `ChartStack` props, see <a href="https://formidable.com/open-source/victory/docs/victory-stack" target="_blank">VictoryStack</a>
+ - For `ChartVoronoiContainer` props, see <a href="https://formidable.com/open-source/victory/docs/victory-voronoi-container" target="_blank">VictoryVoronoiContainer</a>

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/examples/chart-theme.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/examples/chart-theme.scss
@@ -1,0 +1,8 @@
+.ws-preview {
+  & > * {
+    .theme-legend-right {
+      height: 250px;
+      width: 600px;
+    }
+  }
+}

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/base-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/base-theme.ts
@@ -3,7 +3,6 @@ import {
   chart_global_FontFamily,
   chart_global_letter_spacing,
   chart_global_FontSize_sm,
-  chart_global_label_Fill,
   chart_global_label_Padding,
   chart_global_label_stroke,
   chart_global_label_text_anchor,

--- a/packages/patternfly-4/react-charts/src/components/Sparkline/examples/sparkline.md
+++ b/packages/patternfly-4/react-charts/src/components/Sparkline/examples/sparkline.md
@@ -10,9 +10,7 @@ import './sparkline.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a sparkline chart using a Katacoda tutorial starting with a simple chart, adding tooltips, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
@@ -91,6 +89,9 @@ import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartThemeColor, Cha
 ## Tips
 
 - For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+- Use `ChartGroup` in place of `Chart` when an axis and labels are not desired
+- Themes are inherited, so a default theme may override `themeColor` for a child component
+- The `theme` and `themeColor` props should be applied at the most top level component
 
 ## Docs
 Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 


### PR DESCRIPTION
Added an example showing how to create a custom theme that overrides default padding and colors. And as an alternative, an example showing how to override those same properties via the chart's style attribute.

Fixes https://github.com/patternfly/patternfly-react/issues/3015

![Screen Shot 2019-10-03 at 9 38 30 AM](https://user-images.githubusercontent.com/17481322/66131560-9f906500-e5c1-11e9-8e37-a0ad5909a13e.png)

![Screen Shot 2019-10-03 at 9 51 05 AM](https://user-images.githubusercontent.com/17481322/66132623-56d9ab80-e5c3-11e9-9fa9-cd1c87c36752.png)


