### PR TITLE
fix(table): Adds support for custom dataLabel prop on table header

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/HeaderCell.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/HeaderCell.tsx
@@ -9,6 +9,7 @@ export interface HeaderCellProps {
   isVisible?: boolean;
   scope?: string;
   textCenter?: boolean;
+  dataLabel?: string;
 }
 
 export const HeaderCell: React.FunctionComponent<HeaderCellProps> = ({
@@ -17,6 +18,7 @@ export const HeaderCell: React.FunctionComponent<HeaderCellProps> = ({
   isVisible,
   scope = '',
   textCenter = false,
+  dataLabel = '',
   ...props
 }: HeaderCellProps ) => {
   const Component = component as any;

--- a/packages/patternfly-4/react-table/src/components/Table/Table.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.tsx
@@ -135,6 +135,7 @@ export interface ICell {
   data?: any;
   header?: any;
   cell?: any;
+  dataLabel?: string;
 }
 
 export interface IRowCell {

--- a/packages/patternfly-4/react-table/src/components/Table/utils/headerUtils.test.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/headerUtils.test.tsx
@@ -171,6 +171,16 @@ describe('headerUtils', () => {
         expect(result[0].cell.formatters.find((formatter) => formatter.name === 'testFunc')).toBeDefined();
         expect(result[0].cell.transforms.find((transform) => transform.name === 'testFunc')).toBeDefined();
       });
+
+      describe('custom dataLabel', () => {
+        const cells = [{ title: 'expanded first', dataLabel: 'compact first' }, { title: 'expanded second'}] as ICell[];
+        const mixed = calculateColumns(cells, {});
+        cells.forEach((oneCell: ICell, key) => {
+          test(`${oneCell}`, () => {
+            expect(mixed[key].props['data-label']).toBe(oneCell.dataLabel ||oneCell.title);
+          });
+        });
+      });
     });
   });
 

--- a/packages/patternfly-4/react-table/src/components/Table/utils/headerUtils.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/headerUtils.tsx
@@ -59,7 +59,7 @@ const generateCell = ({ cellFormatters, cellTransforms, columnTransforms, cell }
 /**
  * Function to map custom simple object properties to expected format with property, header, cell, extra params
  * and props.
- * @param {*} column to be shown in header - either string or object with title, transformers and formatters (for cels as well).
+ * @param {*} column to be shown in header - either string or object with title, transformers and formatters (for cells as well).
  * @param {*} extra additional object with callbacks for specific formatters.
  * @param {*} key cell key to be shown in data-key.
  * @param {*} props additional props for each cell.
@@ -67,6 +67,7 @@ const generateCell = ({ cellFormatters, cellTransforms, columnTransforms, cell }
  */
 const mapHeader = (column: ICell, extra: any, key: number, ...props: any) => {
   const title = (column.hasOwnProperty('title') ? column.title : column) as string | ICell;
+  const dataLabel = (column.hasOwnProperty('dataLabel') ? column.dataLabel : typeof title === 'string' ? title : `column-${key}`) as string | ICell;
   return {
     property:
       (typeof title === 'string' &&
@@ -80,7 +81,7 @@ const mapHeader = (column: ICell, extra: any, key: number, ...props: any) => {
     header: generateHeader(column, title),
     cell: generateCell(column, extra),
     props: {
-      'data-label': typeof title === 'string' ? title : `column-${key}`,
+      'data-label': dataLabel,
       'data-key': key,
       ...(column.hasOwnProperty('props') ? column.props : {}),
       ...props


### PR DESCRIPTION
fixes #2941

but just in case you don't want to read the issue....  tl;dr: when collapsed table shows a very undesired `column-foo` when jsx is used as the table header.  So lets allow for a custom data-label attribute to be passed when a dev wants to do this, so they can avoid the erum, undesired collapsed header

#### just in case yah wanta see what we're attempting to fix... (top is collapsed, bottom is expanded)
<img width="544" alt="Screen Shot 2019-09-30 at 2 53 17 PM" src="https://user-images.githubusercontent.com/6640236/65907284-219a4700-e392-11e9-8ad4-d306d9f039a1.png">
<img width="1243" alt="Screen Shot 2019-09-30 at 2 53 30 PM" src="https://user-images.githubusercontent.com/6640236/65907296-24953780-e392-11e9-82b5-e37dbb29e638.png">
