### PR TITLE
Charts: Cannot wrap chart with Tippy tooltip

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBullet.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBullet.tsx
@@ -36,17 +36,19 @@ import { getPaddingForSide } from '../ChartUtils';
  */
 export interface ChartBulletProps {
   /**
+   * Specifies the tooltip capability of the container component. A value of true allows the chart to add a
+   * ChartTooltip component to the labelComponent property. This is a shortcut to display tooltips when the labels
+   * property is also provided.
+   */
+  allowTooltip?: boolean;
+  /**
    * The ariaDesc prop specifies the description of the chart/SVG to assist with
    * accessibility for screen readers.
-   *
-   * Note: Overridden by the desc prop of containerComponent
    */
   ariaDesc?: string;
   /**
    * The ariaTitle prop specifies the title to be applied to the SVG to assist
    * accessibility for screen readers.
-   *
-   * Note: Overridden by the title prop of containerComponent
    */
   ariaTitle?: string;
   /**
@@ -448,6 +450,7 @@ export interface ChartBulletProps {
 }
 
 export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
+  allowTooltip = true,
   ariaDesc,
   ariaTitle,
   axisComponent = <ChartAxis />,
@@ -570,13 +573,14 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
 
   // Comparative error measure
   const comparativeErrorMeasure = React.cloneElement(comparativeErrorMeasureComponent, {
+    allowTooltip,
     barWidth: getComparativeMeasureErrorWidth({height: chartSize.height, horizontal, width: chartSize.width}),
     constrainToVisibleArea,
     data: comparativeErrorMeasureData,
     domain,
     height: chartSize.height,
     horizontal,
-    labelComponent: <ChartTooltip height={height} width={width}/>,
+    labelComponent: allowTooltip ? <ChartTooltip height={height} theme={theme} width={width} /> : undefined,
     labels,
     padding,
     standalone: false,
@@ -587,13 +591,14 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
 
   // Comparative warning measure
   const comparativeWarningMeasure = React.cloneElement(comparativeWarningMeasureComponent, {
+    allowTooltip,
     barWidth: getComparativeMeasureWarningWidth({height: chartSize.height, horizontal, width: chartSize.width}),
     constrainToVisibleArea,
     data: comparativeWarningMeasureData,
     domain,
     height: chartSize.height,
     horizontal,
-    labelComponent: <ChartTooltip height={height} width={width}/>,
+    labelComponent: allowTooltip ? <ChartTooltip height={height} theme={theme} width={width} /> : undefined,
     labels,
     padding,
     standalone: false,
@@ -633,13 +638,14 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
 
   // Primary dot measure
   const primaryDotMeasure = React.cloneElement(primaryDotMeasureComponent, {
+    allowTooltip,
     constrainToVisibleArea,
     data: primaryDotMeasureData,
     domain,
     height: chartSize.height,
     horizontal,
     invert,
-    labelComponent: <ChartTooltip height={height} width={width}/>,
+    labelComponent: allowTooltip ? <ChartTooltip height={height} theme={theme} width={width} /> : undefined,
     labels,
     padding,
     size: getPrimaryDotMeasureSize({height: chartSize.height, horizontal, width: chartSize.width}),
@@ -653,6 +659,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
 
   // Primary segmented measure
   const primarySegmentedMeasure = React.cloneElement(primarySegmentedMeasureComponent, {
+    allowTooltip,
     constrainToVisibleArea,
     barWidth: getPrimarySegmentedMeasureWidth({height: chartSize.height, horizontal, width: chartSize.width}),
     data: primarySegmentedMeasureData,
@@ -660,7 +667,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
     height: chartSize.height,
     horizontal,
     invert,
-    labelComponent: <ChartTooltip height={height} width={width}/>,
+    labelComponent: allowTooltip ? <ChartTooltip height={height} theme={theme} width={width} /> : undefined,
     labels,
     padding,
     standalone: false,
@@ -673,6 +680,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
 
   // Qualitative range
   const qualitativeRange = React.cloneElement(qualitativeRangeComponent, {
+    allowTooltip,
     constrainToVisibleArea,
     barWidth: getQualitativeRangeBarWidth({height: chartSize.height, horizontal, width: chartSize.width}),
     data: qualitativeRangeData,
@@ -680,7 +688,7 @@ export const ChartBullet: React.FunctionComponent<ChartBulletProps> = ({
     height: chartSize.height,
     horizontal,
     invert,
-    labelComponent: <ChartTooltip height={height} width={width}/>,
+    labelComponent: allowTooltip ? <ChartTooltip height={height} theme={theme} width={width} /> : undefined,
     labels,
     padding,
     standalone: false,

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeErrorMeasure.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeErrorMeasure.tsx
@@ -17,6 +17,12 @@ import { ChartBulletComparativeMeasure } from './ChartBulletComparativeMeasure';
  */
 export interface ChartBulletComparativeErrorMeasureProps {
   /**
+   * Specifies the tooltip capability of the container component. A value of true allows the chart to add a
+   * ChartTooltip component to the labelComponent property. This is a shortcut to display tooltips when the labels
+   * property is also provided.
+   */
+  allowTooltip?: boolean;
+  /**
    * The ariaDesc prop specifies the description of the chart/SVG to assist with
    * accessibility for screen readers.
    *
@@ -156,6 +162,7 @@ export interface ChartBulletComparativeErrorMeasureProps {
 }
 
 export const ChartBulletComparativeErrorMeasure: React.FunctionComponent<ChartBulletComparativeErrorMeasureProps> = ({
+  allowTooltip = true,
   ariaDesc,
   ariaTitle,
   barWidth,
@@ -180,23 +187,24 @@ export const ChartBulletComparativeErrorMeasure: React.FunctionComponent<ChartBu
 }: ChartBulletComparativeErrorMeasureProps) => {
   // Comparative measure component
   const measure = React.cloneElement(measureComponent, {
-      ariaDesc,
-      ariaTitle,
-      barWidth,
-      constrainToVisibleArea,
-      data,
-      domain,
-      height,
-      horizontal,
-      labelComponent,
-      labels,
-      padding,
-      standalone: false,
-      theme,
-      width,
-      y,
-      ...measureComponent.props
-    });
+    allowTooltip,
+    ariaDesc,
+    ariaTitle,
+    barWidth,
+    constrainToVisibleArea,
+    data,
+    domain,
+    height,
+    horizontal,
+    labelComponent,
+    labels,
+    padding,
+    standalone: false,
+    theme,
+    width,
+    y,
+    ...measureComponent.props
+  });
 
   return standalone ? (
     <ChartContainer desc={ariaDesc} height={height} title={ariaTitle} width={width}>

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeMeasure.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeMeasure.tsx
@@ -19,6 +19,12 @@ import { getBulletComparativeMeasureTheme } from '../ChartUtils';
  */
 export interface ChartBulletComparativeMeasureProps {
   /**
+   * Specifies the tooltip capability of the container component. A value of true allows the chart to add a
+   * ChartTooltip component to the labelComponent property. This is a shortcut to display tooltips when the labels
+   * property is also provided.
+   */
+  allowTooltip?: boolean;
+  /**
    * The ariaDesc prop specifies the description of the chart/SVG to assist with
    * accessibility for screen readers.
    *
@@ -158,6 +164,7 @@ export interface ChartBulletComparativeMeasureProps {
 }
 
 export const ChartBulletComparativeMeasure: React.FunctionComponent<ChartBulletComparativeMeasureProps> = ({
+  allowTooltip = true,
   ariaDesc,
   ariaTitle,
   barWidth = ChartBulletStyles.comparativeMeasureWidth,
@@ -216,7 +223,7 @@ export const ChartBulletComparativeMeasure: React.FunctionComponent<ChartBulletC
       domain,
       height,
       horizontal,
-      labelComponent: tooltip,
+      labelComponent: allowTooltip ? tooltip : undefined,
       labels,
       key: `pf-chart-bullet-comparative-measure-${index}`,
       padding,

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeWarningMeasure.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletComparativeWarningMeasure.tsx
@@ -17,6 +17,12 @@ import { ChartBulletComparativeMeasure } from './ChartBulletComparativeMeasure';
  */
 export interface ChartBulletComparativeWarningMeasureProps {
   /**
+   * Specifies the tooltip capability of the container component. A value of true allows the chart to add a
+   * ChartTooltip component to the labelComponent property. This is a shortcut to display tooltips when the labels
+   * property is also provided.
+   */
+  allowTooltip?: boolean;
+  /**
    * The ariaDesc prop specifies the description of the chart/SVG to assist with
    * accessibility for screen readers.
    *
@@ -156,6 +162,7 @@ export interface ChartBulletComparativeWarningMeasureProps {
 }
 
 export const ChartBulletComparativeWarningMeasure: React.FunctionComponent<ChartBulletComparativeWarningMeasureProps> = ({
+  allowTooltip = true,
   ariaDesc,
   ariaTitle,
   barWidth,
@@ -180,6 +187,7 @@ export const ChartBulletComparativeWarningMeasure: React.FunctionComponent<Chart
 }: ChartBulletComparativeWarningMeasureProps) => {
   // Comparative measure component
   const measure = React.cloneElement(measureComponent, {
+    allowTooltip,
     ariaDesc,
     ariaTitle,
     barWidth,

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletPrimaryDotMeasure.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletPrimaryDotMeasure.tsx
@@ -18,6 +18,12 @@ import { getBulletPrimaryDotMeasureTheme } from '../ChartUtils';
  */
 export interface ChartBulletPrimaryDotMeasureProps {
   /**
+   * Specifies the tooltip capability of the container component. A value of true allows the chart to add a
+   * ChartTooltip component to the labelComponent property. This is a shortcut to display tooltips when the labels
+   * property is also provided.
+   */
+  allowTooltip?: boolean;
+  /**
    * The ariaDesc prop specifies the description of the chart/SVG to assist with
    * accessibility for screen readers.
    *
@@ -164,6 +170,7 @@ export interface ChartBulletPrimaryDotMeasureProps {
 }
 
 export const ChartBulletPrimaryDotMeasure: React.FunctionComponent<ChartBulletPrimaryDotMeasureProps> = ({
+  allowTooltip = true,
   ariaDesc,
   ariaTitle,
   constrainToVisibleArea = false,
@@ -214,7 +221,7 @@ export const ChartBulletPrimaryDotMeasure: React.FunctionComponent<ChartBulletPr
       height,
       horizontal,
       key: `pf-chart-bullet-primary-dot-measure-${index}`,
-      labelComponent: tooltip,
+      labelComponent: allowTooltip ? tooltip : undefined,
       labels,
       padding,
       size,

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletPrimarySegmentedMeasure.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletPrimarySegmentedMeasure.tsx
@@ -19,6 +19,12 @@ import { getBulletPrimaryNegativeMeasureTheme, getBulletPrimarySegmentedMeasureT
  */
 export interface ChartBulletPrimarySegmentedMeasureProps {
   /**
+   * Specifies the tooltip capability of the container component. A value of true allows the chart to add a
+   * ChartTooltip component to the labelComponent property. This is a shortcut to display tooltips when the labels
+   * property is also provided.
+   */
+  allowTooltip?: boolean;
+  /**
    * The ariaDesc prop specifies the description of the chart/SVG to assist with
    * accessibility for screen readers.
    *
@@ -177,6 +183,7 @@ export interface ChartBulletPrimarySegmentedMeasureProps {
 }
 
 export const ChartBulletPrimarySegmentedMeasure: React.FunctionComponent<ChartBulletPrimarySegmentedMeasureProps> = ({
+  allowTooltip = true,
   ariaDesc,
   ariaTitle,
   barWidth = ChartBulletStyles.primarySegmentedMeasureWidth,
@@ -242,7 +249,7 @@ export const ChartBulletPrimarySegmentedMeasure: React.FunctionComponent<ChartBu
       height,
       horizontal,
       key: `pf-chart-bullet-primary-segmented-measure-${index}`,
-      labelComponent: tooltip,
+      labelComponent: allowTooltip ? tooltip : undefined,
       labels,
       padding,
       standalone: false,

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletQualitativeRange.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/ChartBulletQualitativeRange.tsx
@@ -19,6 +19,12 @@ import { getBulletQualitativeRangeTheme } from '../ChartUtils';
  */
 export interface ChartBulletQualitativeRangeProps {
   /**
+   * Specifies the tooltip capability of the container component. A value of true allows the chart to add a
+   * ChartTooltip component to the labelComponent property. This is a shortcut to display tooltips when the labels
+   * property is also provided.
+   */
+  allowTooltip?: boolean;
+  /**
    * The ariaDesc prop specifies the description of the chart/SVG to assist with
    * accessibility for screen readers.
    *
@@ -187,6 +193,7 @@ interface ConstrainToVisibleAreaInterface {
 }
 
 export const ChartBulletQualitativeRange: React.FunctionComponent<ChartBulletQualitativeRangeProps> = ({
+  allowTooltip = true,
   ariaDesc,
   ariaTitle,
   barWidth = ChartBulletStyles.qualitativeRangeWidth,
@@ -253,7 +260,7 @@ export const ChartBulletQualitativeRange: React.FunctionComponent<ChartBulletQua
       height,
       horizontal,
       key: `pf-chart-bullet-qualitative-range-${index}`,
-      labelComponent: tooltip,
+      labelComponent: allowTooltip ? tooltip : undefined,
       labels,
       padding,
       standalone: false,

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBullet.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBullet.test.tsx.snap
@@ -931,6 +931,7 @@ exports[`ChartBulletQualitativeRange 1`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     barWidth={30}
     constrainToVisibleArea={false}
     domain={
@@ -951,6 +952,449 @@ exports[`ChartBulletQualitativeRange 1`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -958,6 +1402,7 @@ exports[`ChartBulletQualitativeRange 1`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     barWidth={9}
     constrainToVisibleArea={false}
     domain={
@@ -978,6 +1423,449 @@ exports[`ChartBulletQualitativeRange 1`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -985,6 +1873,7 @@ exports[`ChartBulletQualitativeRange 1`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     constrainToVisibleArea={false}
     domain={
       Object {
@@ -1004,6 +1893,449 @@ exports[`ChartBulletQualitativeRange 1`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -1012,6 +2344,7 @@ exports[`ChartBulletQualitativeRange 1`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     barWidth={30}
     constrainToVisibleArea={false}
     domain={
@@ -1031,6 +2364,449 @@ exports[`ChartBulletQualitativeRange 1`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -1038,6 +2814,7 @@ exports[`ChartBulletQualitativeRange 1`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     barWidth={30}
     constrainToVisibleArea={false}
     domain={
@@ -1057,6 +2834,449 @@ exports[`ChartBulletQualitativeRange 1`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -2899,6 +5119,7 @@ exports[`ChartBulletQualitativeRange 2`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     barWidth={30}
     constrainToVisibleArea={false}
     domain={
@@ -2919,6 +5140,449 @@ exports[`ChartBulletQualitativeRange 2`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -2926,6 +5590,7 @@ exports[`ChartBulletQualitativeRange 2`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     barWidth={9}
     constrainToVisibleArea={false}
     domain={
@@ -2946,6 +5611,449 @@ exports[`ChartBulletQualitativeRange 2`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -2953,6 +6061,7 @@ exports[`ChartBulletQualitativeRange 2`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     constrainToVisibleArea={false}
     domain={
       Object {
@@ -2972,6 +6081,449 @@ exports[`ChartBulletQualitativeRange 2`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -2980,6 +6532,7 @@ exports[`ChartBulletQualitativeRange 2`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     barWidth={30}
     constrainToVisibleArea={false}
     domain={
@@ -2999,6 +6552,449 @@ exports[`ChartBulletQualitativeRange 2`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -3006,6 +7002,7 @@ exports[`ChartBulletQualitativeRange 2`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     barWidth={30}
     constrainToVisibleArea={false}
     domain={
@@ -3025,6 +7022,449 @@ exports[`ChartBulletQualitativeRange 2`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -4873,6 +9313,7 @@ exports[`renders component data 1`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     barWidth={30}
     constrainToVisibleArea={false}
     data={
@@ -4905,6 +9346,449 @@ exports[`renders component data 1`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -4913,6 +9797,7 @@ exports[`renders component data 1`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     barWidth={9}
     constrainToVisibleArea={false}
     data={
@@ -4941,6 +9826,449 @@ exports[`renders component data 1`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -4949,6 +10277,7 @@ exports[`renders component data 1`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     constrainToVisibleArea={false}
     domain={
       Object {
@@ -4968,6 +10297,449 @@ exports[`renders component data 1`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -4977,6 +10749,7 @@ exports[`renders component data 1`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     barWidth={30}
     constrainToVisibleArea={false}
     domain={
@@ -4996,6 +10769,449 @@ exports[`renders component data 1`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }
@@ -5004,6 +11220,7 @@ exports[`renders component data 1`] = `
     width={450}
   />
   <Component
+    allowTooltip={true}
     barWidth={30}
     constrainToVisibleArea={false}
     data={
@@ -5031,6 +11248,449 @@ exports[`renders component data 1`] = `
     labelComponent={
       <Unknown
         height={140}
+        theme={
+          Object {
+            "area": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "fillOpacity": 0.3,
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "axis": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "axis": Object {
+                  "fill": "transparent",
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+                "axisLabel": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 40,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+                "grid": Object {
+                  "fill": "none",
+                  "pointerEvents": "painted",
+                  "stroke": "none",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                },
+                "tickLabels": Object {
+                  "fill": "#4f5255",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "ticks": Object {
+                  "fill": "transparent",
+                  "size": 5,
+                  "stroke": "#d2d2d2",
+                  "strokeLinecap": "round",
+                  "strokeLinejoin": "round",
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "bar": Object {
+              "barWidth": 10,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#06c",
+                  "padding": 8,
+                  "stroke": "none",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "boxplot": Object {
+              "boxWidth": 20,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "max": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "maxLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "median": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "medianLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "min": Object {
+                  "padding": 8,
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "minLabels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q1": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q1Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "q3": Object {
+                  "fill": "#8a8d90",
+                  "padding": 8,
+                },
+                "q3Labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 450,
+            },
+            "candlestick": Object {
+              "candleColors": Object {
+                "negative": "#151515",
+                "positive": "#fff",
+              },
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "chart": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 140,
+              "padding": 50,
+              "width": 450,
+            },
+            "errorbar": Object {
+              "borderWidth": 8,
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#151515",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "group": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "width": 450,
+            },
+            "legend": Object {
+              "colorScale": Array [],
+              "gutter": 20,
+              "orientation": "horizontal",
+              "style": Object {
+                "data": Object {
+                  "type": "square",
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                },
+                "title": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 2,
+                  "stroke": "transparent",
+                },
+              },
+              "titleOrientation": "top",
+            },
+            "line": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "opacity": 1,
+                  "stroke": "#06c",
+                  "strokeWidth": 2,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "pie": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 230,
+              "padding": 20,
+              "style": Object {
+                "data": Object {
+                  "padding": 8,
+                  "stroke": "transparent",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "stroke": "transparent",
+                },
+              },
+              "width": 230,
+            },
+            "scatter": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "#151515",
+                  "opacity": 1,
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "labels": Object {
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 10,
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+            "stack": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "strokeWidth": 1,
+                },
+              },
+              "width": 450,
+            },
+            "tooltip": Object {
+              "cornerRadius": 0,
+              "flyoutStyle": Object {
+                "cornerRadius": 0,
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 0,
+              },
+              "pointerLength": 10,
+              "pointerWidth": 20,
+              "style": Object {
+                "fill": "#ededed",
+                "padding": 16,
+                "pointerEvents": "none",
+              },
+            },
+            "voronoi": Object {
+              "colorScale": Array [
+                "#06c",
+                "#8bc1f7",
+                "#002f5d",
+                "#519de9",
+                "#004b95",
+              ],
+              "height": 300,
+              "padding": 50,
+              "style": Object {
+                "data": Object {
+                  "fill": "transparent",
+                  "stroke": "transparent",
+                  "strokeWidth": 0,
+                },
+                "flyout": Object {
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 1,
+                },
+                "labels": Object {
+                  "fill": "#ededed",
+                  "fontFamily": "var(--pf-chart-global--FontFamily)",
+                  "fontSize": 14,
+                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                  "padding": 8,
+                  "pointerEvents": "none",
+                  "stroke": "transparent",
+                  "textAnchor": "middle",
+                },
+              },
+              "width": 450,
+            },
+          }
+        }
         width={450}
       />
     }

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeErrorMeasure.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeErrorMeasure.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`ChartBulletComparativeErrorMeasure 1`] = `
   width={450}
 >
   <Component
+    allowTooltip={true}
     constrainToVisibleArea={false}
     height={140}
     horizontal={true}
@@ -470,6 +471,7 @@ exports[`ChartBulletComparativeErrorMeasure 2`] = `
   width={450}
 >
   <Component
+    allowTooltip={true}
     constrainToVisibleArea={false}
     height={140}
     horizontal={true}
@@ -934,6 +936,7 @@ exports[`renders component data 1`] = `
   width={450}
 >
   <Component
+    allowTooltip={true}
     constrainToVisibleArea={false}
     data={
       Array [

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeWarningMeasure.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/__snapshots__/ChartBulletComparativeWarningMeasure.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`ChartBulletComparativeZeroMeasure 1`] = `
   width={450}
 >
   <Component
+    allowTooltip={true}
     constrainToVisibleArea={false}
     height={140}
     horizontal={true}
@@ -470,6 +471,7 @@ exports[`ChartBulletComparativeZeroMeasure 2`] = `
   width={450}
 >
   <Component
+    allowTooltip={true}
     constrainToVisibleArea={false}
     height={140}
     horizontal={true}
@@ -934,6 +936,7 @@ exports[`renders component data 1`] = `
   width={450}
 >
   <Component
+    allowTooltip={true}
     constrainToVisibleArea={false}
     data={
       Array [

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -6,6 +6,7 @@ propComponents: ['ChartAxis', 'ChartBullet', 'ChartContainer', 'ChartLegend']
 ---
 
 import { ChartAxis, ChartBullet, ChartContainer, ChartThemeColor } from '@patternfly/react-charts';
+import { Button, Tooltip } from '@patternfly/react-core';
 import './chart-bullet.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
@@ -867,6 +868,52 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
     </ChartContainer>
   </div>
 </div>
+```
+
+## Bullet chart with custom tooltip
+This demonstrates an alternate way of applying a custom tooltip for the entire chart
+```js
+import React from 'react';
+import { ChartBullet } from '@patternfly/react-charts';
+import { Button, Tooltip } from '@patternfly/react-core';
+
+class TooltipChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isVisible: false
+    };
+    this.showTooltip = () => {
+      this.setState({ isVisible: true });
+    };
+  }
+
+  render() {
+    const { isVisible } = this.state;
+
+    return (
+      <div>
+        <div className="bullet-chart-horz">
+          <Tooltip content={<div>My custom tooltip</div>} isVisible={isVisible} position={TooltipPosition.right} trigger="manual">
+            <ChartBullet
+              allowTooltip={false}
+              ariaDesc="Storage capacity"
+              ariaTitle="Bullet chart example"
+              comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
+              height={150}
+              labels={() => null}
+              maxDomain={{y: 100}}
+              primarySegmentedMeasureData={[{ name: 'Measure', y: 60 }]}
+              qualitativeRangeData={[{ name: 'Range', y: 50 }, { name: 'Range', y: 75 }]}
+              width={600}
+            />
+          </Tooltip>
+        </div>
+        <Button onClick={this.showTooltip}>Show Tooltip</Button>
+      </div>
+    );
+  }
+}
 ```
 
 ## Tips

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/ChartDonut.tsx
@@ -17,7 +17,7 @@ import { ChartContainer } from '../ChartContainer';
 import { ChartLabel } from '../ChartLabel';
 import { ChartPie, ChartPieLegendPosition, ChartPieProps } from '../ChartPie';
 import { ChartCommonStyles, ChartDonutStyles, ChartThemeDefinition } from '../ChartTheme';
-import { getPieLabelX, getPieLabelY, getPaddingForSide} from '../ChartUtils';
+import { getPieLabelX, getPieLabelY, getPaddingForSide } from '../ChartUtils';
 
 export enum ChartDonutLabelPosition {
   centroid = 'centroid',
@@ -474,6 +474,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
     const subTitleProps = subTitleComponent.props ? subTitleComponent.props : {};
 
     return React.cloneElement(subTitleComponent, {
+      key: 'pf-chart-donut-subtitle',
       style: ChartDonutStyles.label.subTitle,
       text: subTitle,
       textAnchor: subTitlePosition === 'right' ? 'start' : 'middle',
@@ -505,6 +506,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
 
     return React.cloneElement(titleComponent, {
       ...showBoth && { capHeight },
+      key: 'pf-chart-donut-title',
       style: [ChartDonutStyles.label.title, ChartDonutStyles.label.subTitle],
       text: showBoth ? [title, subTitle] : title,
       textAnchor: 'middle',
@@ -531,6 +533,7 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
       allowTooltip={allowTooltip}
       height={height}
       innerRadius={chartInnerRadius > 0 ? chartInnerRadius : 0}
+      key="pf-chart-donut-pie"
       legendPosition={legendPosition}
       padding={padding}
       radius={chartRadius > 0 ? chartRadius : 0}
@@ -542,21 +545,19 @@ export const ChartDonut: React.FunctionComponent<ChartDonutProps> = ({
   );
 
   // Clone so users can override container props
-  const StandaloneContainer = ({children}: any) => React.cloneElement(containerComponent, {
+  const container = React.cloneElement(containerComponent, {
     desc: ariaDesc,
     height,
     title: ariaTitle,
     width,
     theme,
     ...containerComponent.props
-  }, children);
+  }, [chart, getTitle(), getSubTitle()]);
 
   return standalone ? (
-    <StandaloneContainer>
-      {chart}
-      {getTitle()}
-      {getSubTitle()}
-    </StandaloneContainer>
+    <React.Fragment>
+      {container}
+    </React.Fragment>
   ) : (
     <React.Fragment>
       {chart}

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/__snapshots__/ChartDonut.test.tsx.snap
@@ -1,14 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChartDonut 1`] = `
-<StandaloneContainer>
+<Fragment>
   <Component
-    allowTooltip={true}
     height={230}
-    innerRadius={86}
-    legendPosition="right"
-    radius={95}
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -460,19 +455,475 @@ exports[`ChartDonut 1`] = `
       }
     }
     width={230}
-  />
-</StandaloneContainer>
+  >
+    <Component
+      allowTooltip={true}
+      height={230}
+      innerRadius={86}
+      key="pf-chart-donut-pie"
+      legendPosition="right"
+      radius={95}
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`ChartDonut 2`] = `
-<StandaloneContainer>
+<Fragment>
   <Component
-    allowTooltip={true}
     height={230}
-    innerRadius={86}
-    legendPosition="right"
-    radius={95}
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -924,35 +1375,475 @@ exports[`ChartDonut 2`] = `
       }
     }
     width={230}
-  />
-</StandaloneContainer>
+  >
+    <Component
+      allowTooltip={true}
+      height={230}
+      innerRadius={86}
+      key="pf-chart-donut-pie"
+      legendPosition="right"
+      radius={95}
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`renders component data 1`] = `
-<StandaloneContainer>
+<Fragment>
   <Component
-    allowTooltip={true}
-    data={
-      Array [
-        Object {
-          "x": "Cats",
-          "y": 35,
-        },
-        Object {
-          "x": "Dogs",
-          "y": 55,
-        },
-        Object {
-          "x": "Birds",
-          "y": 10,
-        },
-      ]
-    }
     height={200}
-    innerRadius={71}
-    legendPosition="right"
-    radius={80}
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -1404,6 +2295,483 @@ exports[`renders component data 1`] = `
       }
     }
     width={200}
-  />
-</StandaloneContainer>
+  >
+    <Component
+      allowTooltip={true}
+      data={
+        Array [
+          Object {
+            "x": "Cats",
+            "y": 35,
+          },
+          Object {
+            "x": "Dogs",
+            "y": 55,
+          },
+          Object {
+            "x": "Birds",
+            "y": 10,
+          },
+        ]
+      }
+      height={200}
+      innerRadius={71}
+      key="pf-chart-donut-pie"
+      legendPosition="right"
+      radius={80}
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={200}
+    />
+  </Component>
+</Fragment>
 `;

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -6,6 +6,7 @@ propComponents: ['ChartDonut', 'ChartLegend']
 ---
 
 import { ChartDonut, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
+import { Button, Tooltip } from '@patternfly/react-core';
 import './chart-donut.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
@@ -250,6 +251,49 @@ import { ChartDonut } from '@patternfly/react-charts';
     />
   </div>
 </div>
+```
+
+## Donut chart with custom tooltip
+This demonstrates an alternate way of applying a custom tooltip for the entire chart
+```js
+import React from 'react';
+import { ChartDonut } from '@patternfly/react-charts';
+import { Button, Tooltip } from '@patternfly/react-core';
+
+class TooltipChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isVisible: false
+    };
+    this.showTooltip = () => {
+      this.setState({ isVisible: true });
+    };
+  }
+
+  render() {
+    const { isVisible } = this.state;
+
+    return (
+      <div>
+        <div className="donut-chart">
+          <Tooltip content={<div>My custom tooltip</div>} isVisible={isVisible} position={TooltipPosition.right} trigger="manual">
+            <ChartDonut
+              allowTooltip={false}
+              ariaDesc="Average number of pets"
+              ariaTitle="Donut chart example"
+              data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+              labels={() => null}
+              subTitle="Pets"
+              title="100"
+            />
+          </Tooltip>
+        </div>
+        <Button onClick={this.showTooltip}>Show Tooltip</Button>
+      </div>
+    );
+  }
+}
 ```
 
 ## Tips

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutThreshold.tsx
@@ -474,7 +474,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
           endAngle: 360 * (datum[0]._y ? datum[0]._y / 100 : 0),
           height,
           invert,
-          key: `pf-chart-donut-utilization-${index}`,
+          key: `pf-chart-donut-threshold-child-${index}`,
           legendPosition: childProps.legendPosition || legendPosition,
           padding: defaultPadding,
           radius: chartRadius - 14, // Donut utilization radius is threshold radius minus 14px spacing
@@ -496,6 +496,7 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
       constrainToVisibleArea={constrainToVisibleArea}
       data={getComputedData()}
       height={height}
+      key="pf-chart-donut-threshold"
       labels={labels}
       padding={defaultPadding}
       standalone={false}
@@ -506,20 +507,19 @@ export const ChartDonutThreshold: React.FunctionComponent<ChartDonutThresholdPro
   );
 
   // Clone so users can override container props
-  const StandaloneContainer = ({children}: any) => React.cloneElement(containerComponent, {
+  const container = React.cloneElement(containerComponent, {
     desc: ariaDesc,
     height,
     title: ariaTitle,
     width,
     theme,
     ...containerComponent.props
-  }, children);
+  }, [chart, renderChildren()]);
 
   return standalone ? (
-    <StandaloneContainer>
-      {chart}
-      {renderChildren()}
-    </StandaloneContainer>
+    <React.Fragment>
+      {container}
+    </React.Fragment>
   ) : (
     <React.Fragment>
       {chart}

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/ChartDonutUtilization.tsx
@@ -544,6 +544,7 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
       allowTooltip={allowTooltip}
       data={getComputedData()}
       height={height}
+      key="pf-chart-donut-utilization"
       padding={padding}
       standalone={false}
       theme={getThresholdTheme()}
@@ -553,19 +554,19 @@ export const ChartDonutUtilization: React.FunctionComponent<ChartDonutUtilizatio
   );
 
   // Clone so users can override container props
-  const StandaloneContainer = ({children}: any) => React.cloneElement(containerComponent, {
+  const container = React.cloneElement(containerComponent, {
     desc: ariaDesc,
     height,
     title: ariaTitle,
     width,
     theme,
     ...containerComponent.props
-  }, children);
+  }, [chart]);
 
   return standalone ? (
-    <StandaloneContainer>
-      {chart}
-    </StandaloneContainer>
+    <React.Fragment>
+      {container}
+    </React.Fragment>
   ) : (
     <React.Fragment>
       {chart}

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutThreshold.test.tsx.snap
@@ -1,28 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChartDonutThreshold 1`] = `
-<StandaloneContainer>
+<Fragment>
   <Component
-    allowTooltip={true}
-    constrainToVisibleArea={false}
-    data={
-      Array [
-        Object {
-          "y": 0,
-        },
-      ]
-    }
     height={230}
-    labels={Array []}
-    padding={
-      Object {
-        "bottom": 20,
-        "left": 20,
-        "right": 20,
-        "top": 20,
-      }
-    }
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -474,33 +455,489 @@ exports[`ChartDonutThreshold 1`] = `
       }
     }
     width={230}
-  />
-</StandaloneContainer>
+  >
+    <Component
+      allowTooltip={true}
+      constrainToVisibleArea={false}
+      data={
+        Array [
+          Object {
+            "y": 0,
+          },
+        ]
+      }
+      height={230}
+      key="pf-chart-donut-threshold"
+      labels={Array []}
+      padding={
+        Object {
+          "bottom": 20,
+          "left": 20,
+          "right": 20,
+          "top": 20,
+        }
+      }
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#ededed",
+              "#d2d2d2",
+              "#b8bbbe",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`ChartDonutThreshold 2`] = `
-<StandaloneContainer>
+<Fragment>
   <Component
-    allowTooltip={true}
-    constrainToVisibleArea={false}
-    data={
-      Array [
-        Object {
-          "y": 0,
-        },
-      ]
-    }
     height={230}
-    labels={Array []}
-    padding={
-      Object {
-        "bottom": 20,
-        "left": 20,
-        "right": 20,
-        "top": 20,
-      }
-    }
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -952,45 +1389,489 @@ exports[`ChartDonutThreshold 2`] = `
       }
     }
     width={230}
-  />
-</StandaloneContainer>
+  >
+    <Component
+      allowTooltip={true}
+      constrainToVisibleArea={false}
+      data={
+        Array [
+          Object {
+            "y": 0,
+          },
+        ]
+      }
+      height={230}
+      key="pf-chart-donut-threshold"
+      labels={Array []}
+      padding={
+        Object {
+          "bottom": 20,
+          "left": 20,
+          "right": 20,
+          "top": 20,
+        }
+      }
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#ededed",
+              "#d2d2d2",
+              "#b8bbbe",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`renders component data 1`] = `
-<StandaloneContainer>
+<Fragment>
   <Component
-    allowTooltip={true}
-    constrainToVisibleArea={false}
-    data={
-      Array [
-        Object {
-          "x": "Birds",
-          "y": 10,
-        },
-        Object {
-          "x": "Cats",
-          "y": 25,
-        },
-        Object {
-          "x": "Dogs",
-          "y": 20,
-        },
-        Object {
-          "y": 45,
-        },
-      ]
-    }
     height={200}
-    labels={Array []}
-    padding={
-      Object {
-        "bottom": 20,
-        "left": 20,
-        "right": 20,
-        "top": 20,
-      }
-    }
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -1442,6 +2323,493 @@ exports[`renders component data 1`] = `
       }
     }
     width={200}
-  />
-</StandaloneContainer>
+  >
+    <Component
+      allowTooltip={true}
+      constrainToVisibleArea={false}
+      data={
+        Array [
+          Object {
+            "x": "Birds",
+            "y": 10,
+          },
+          Object {
+            "x": "Cats",
+            "y": 25,
+          },
+          Object {
+            "x": "Dogs",
+            "y": 20,
+          },
+          Object {
+            "y": 45,
+          },
+        ]
+      }
+      height={200}
+      key="pf-chart-donut-threshold"
+      labels={Array []}
+      padding={
+        Object {
+          "bottom": 20,
+          "left": 20,
+          "right": 20,
+          "top": 20,
+        }
+      }
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#ededed",
+              "#d2d2d2",
+              "#b8bbbe",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={200}
+    />
+  </Component>
+</Fragment>
 `;

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/__snapshots__/ChartDonutUtilization.test.tsx.snap
@@ -1,22 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChartDonutUtilization 1`] = `
-<StandaloneContainer>
+<Fragment>
   <Component
-    allowTooltip={true}
-    data={
-      Array [
-        Object {
-          "x": 0,
-          "y": Object {},
-        },
-        Object {
-          "y": 100,
-        },
-      ]
-    }
     height={230}
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -464,27 +451,479 @@ exports[`ChartDonutUtilization 1`] = `
       }
     }
     width={230}
-  />
-</StandaloneContainer>
+  >
+    <Component
+      allowTooltip={true}
+      data={
+        Array [
+          Object {
+            "x": 0,
+            "y": Object {},
+          },
+          Object {
+            "y": 100,
+          },
+        ]
+      }
+      height={230}
+      key="pf-chart-donut-utilization"
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#ededed",
+              "#d2d2d2",
+              "#b8bbbe",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#ededed",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`ChartDonutUtilization 2`] = `
-<StandaloneContainer>
+<Fragment>
   <Component
-    allowTooltip={true}
-    data={
-      Array [
-        Object {
-          "x": 0,
-          "y": Object {},
-        },
-        Object {
-          "y": 100,
-        },
-      ]
-    }
     height={230}
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -932,27 +1371,479 @@ exports[`ChartDonutUtilization 2`] = `
       }
     }
     width={230}
-  />
-</StandaloneContainer>
+  >
+    <Component
+      allowTooltip={true}
+      data={
+        Array [
+          Object {
+            "x": 0,
+            "y": Object {},
+          },
+          Object {
+            "y": 100,
+          },
+        ]
+      }
+      height={230}
+      key="pf-chart-donut-utilization"
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#ededed",
+              "#d2d2d2",
+              "#b8bbbe",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#ededed",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`renders component data 1`] = `
-<StandaloneContainer>
+<Fragment>
   <Component
-    allowTooltip={true}
-    data={
-      Array [
-        Object {
-          "x": "Cats",
-          "y": 35,
-        },
-        Object {
-          "y": 65,
-        },
-      ]
-    }
     height={200}
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -1400,6 +2291,471 @@ exports[`renders component data 1`] = `
       }
     }
     width={200}
-  />
-</StandaloneContainer>
+  >
+    <Component
+      allowTooltip={true}
+      data={
+        Array [
+          Object {
+            "x": "Cats",
+            "y": 35,
+          },
+          Object {
+            "y": 65,
+          },
+        ]
+      }
+      height={200}
+      key="pf-chart-donut-utilization"
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#ededed",
+              "#d2d2d2",
+              "#b8bbbe",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#ededed",
+            ],
+            "height": 230,
+            "padAngle": 1,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={200}
+    />
+  </Component>
+</Fragment>
 `;

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -6,6 +6,7 @@ propComponents: ['ChartLegend', 'ChartDonutThreshold', 'ChartDonutUtilization']
 ---
 
 import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
+import { Button, Tooltip } from '@patternfly/react-core';
 import './chart-donut-utilization.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
@@ -817,6 +818,55 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     </ChartDonutThreshold>
   </div>
 </div>
+```
+
+## Donut utilization chart with custom tooltip
+This demonstrates an alternate way of applying a custom tooltip for the entire chart
+```js
+import React from 'react';
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
+import { Button, Tooltip } from '@patternfly/react-core';
+
+class TooltipChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isVisible: false
+    };
+    this.showTooltip = () => {
+      this.setState({ isVisible: true });
+    };
+  }
+
+  render() {
+    const { isVisible } = this.state;
+
+    return (
+      <div>
+        <div className="donut-threshold-chart">
+          <Tooltip content={<div>My custom tooltip</div>} isVisible={isVisible} position={TooltipPosition.right} trigger="manual">
+            <ChartDonutThreshold
+              allowTooltip={false}
+              ariaDesc="Storage capacity"
+              ariaTitle="Donut utilization chart with static threshold example"
+              data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
+              labels={() => null}
+            >
+              <ChartDonutUtilization
+                allowTooltip={false}
+                data={{ x: 'Storage capacity', y: 45 }}
+                labels={() => null}
+                subTitle="of 100 GBps"
+                title="45%"
+              />
+            </ChartDonutThreshold>
+          </Tooltip>
+        </div>
+        <Button onClick={this.showTooltip}>Show Tooltip</Button>
+      </div>
+    );
+  }
+}
 ```
 
 ## Tips

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/ChartPie.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/ChartPie.tsx
@@ -437,6 +437,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   const chart = (
     <VictoryPie
       height={height}
+      key="pf-chart-pie"
       labels={labels}
       labelComponent={labelComponent}
       padding={padding}
@@ -464,6 +465,7 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
       <ChartLegendWrapper
         chartType="pie"
         height={height}
+        key="pf-chart-pie-legend"
         legendComponent={legend}
         orientation={legendOrientation}
         padding={defaultPadding}
@@ -475,20 +477,19 @@ export const ChartPie: React.FunctionComponent<ChartPieProps> = ({
   };
 
   // Clone so users can override container props
-  const StandaloneContainer = ({children}: any) => React.cloneElement(containerComponent, {
+  const container = React.cloneElement(containerComponent, {
     desc: ariaDesc,
     height,
     title: ariaTitle,
     width,
     theme,
     ...containerComponent.props
-  }, children);
+  }, [chart, getWrappedLegend()]);
 
   return standalone ? (
-    <StandaloneContainer>
-      {chart}
-      {getWrappedLegend()}
-    </StandaloneContainer>
+    <React.Fragment>
+      {container}
+    </React.Fragment>
   ) : (
     <React.Fragment>
       {chart}

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/__snapshots__/ChartPie.test.tsx.snap
@@ -1,506 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChartPie 1`] = `
-<StandaloneContainer>
-  <VictoryPie
-    containerComponent={
-      <VictoryContainer
-        className="VictoryContainer"
-        portalComponent={<Portal />}
-        portalZIndex={99}
-        responsive={true}
-      />
-    }
-    data={
-      Array [
-        Object {
-          "x": "A",
-          "y": 1,
-        },
-        Object {
-          "x": "B",
-          "y": 2,
-        },
-        Object {
-          "x": "C",
-          "y": 3,
-        },
-        Object {
-          "x": "D",
-          "y": 1,
-        },
-        Object {
-          "x": "E",
-          "y": 2,
-        },
-      ]
-    }
-    dataComponent={
-      <Slice
-        pathComponent={<Path />}
-        role="presentation"
-        shapeRendering="auto"
-      />
-    }
-    groupComponent={<g />}
+<Fragment>
+  <Component
     height={230}
-    labelComponent={
-      <Unknown
-        constrainToVisibleArea={false}
-        theme={
-          Object {
-            "area": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#06c",
-                  "fillOpacity": 0.3,
-                  "strokeWidth": 2,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "axis": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "axis": Object {
-                  "fill": "transparent",
-                  "stroke": "#d2d2d2",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                  "strokeWidth": 1,
-                },
-                "axisLabel": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 40,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-                "grid": Object {
-                  "fill": "none",
-                  "pointerEvents": "painted",
-                  "stroke": "none",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                },
-                "tickLabels": Object {
-                  "fill": "#4f5255",
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "ticks": Object {
-                  "fill": "transparent",
-                  "size": 5,
-                  "stroke": "#d2d2d2",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                  "strokeWidth": 1,
-                },
-              },
-              "width": 450,
-            },
-            "bar": Object {
-              "barWidth": 10,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#06c",
-                  "padding": 8,
-                  "stroke": "none",
-                  "strokeWidth": 0,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-              },
-              "width": 450,
-            },
-            "boxplot": Object {
-              "boxWidth": 20,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "max": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "maxLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "median": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "medianLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "min": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "minLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "q1": Object {
-                  "fill": "#8a8d90",
-                  "padding": 8,
-                },
-                "q1Labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "q3": Object {
-                  "fill": "#8a8d90",
-                  "padding": 8,
-                },
-                "q3Labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-              },
-              "width": 450,
-            },
-            "candlestick": Object {
-              "candleColors": Object {
-                "negative": "#151515",
-                "positive": "#fff",
-              },
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "chart": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "width": 450,
-            },
-            "errorbar": Object {
-              "borderWidth": 8,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "opacity": 1,
-                  "stroke": "#151515",
-                  "strokeWidth": 2,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "group": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "width": 450,
-            },
-            "legend": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "gutter": 20,
-              "orientation": "horizontal",
-              "style": Object {
-                "data": Object {
-                  "type": "square",
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "title": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 2,
-                  "stroke": "transparent",
-                },
-              },
-              "titleOrientation": "top",
-            },
-            "line": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "opacity": 1,
-                  "stroke": "#06c",
-                  "strokeWidth": 2,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "pie": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 230,
-              "padding": 20,
-              "style": Object {
-                "data": Object {
-                  "padding": 8,
-                  "stroke": "transparent",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 8,
-                  "stroke": "transparent",
-                },
-              },
-              "width": 230,
-            },
-            "scatter": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#151515",
-                  "opacity": 1,
-                  "stroke": "transparent",
-                  "strokeWidth": 0,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "stack": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "strokeWidth": 1,
-                },
-              },
-              "width": 450,
-            },
-            "tooltip": Object {
-              "cornerRadius": 0,
-              "flyoutStyle": Object {
-                "cornerRadius": 0,
-                "fill": "#151515",
-                "pointerEvents": "none",
-                "stroke": "#151515",
-                "strokeWidth": 0,
-              },
-              "pointerLength": 10,
-              "pointerWidth": 20,
-              "style": Object {
-                "fill": "#ededed",
-                "padding": 16,
-                "pointerEvents": "none",
-              },
-            },
-            "voronoi": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "stroke": "transparent",
-                  "strokeWidth": 0,
-                },
-                "flyout": Object {
-                  "fill": "#151515",
-                  "pointerEvents": "none",
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fill": "#ededed",
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 8,
-                  "pointerEvents": "none",
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-          }
-        }
-      />
-    }
-    radius={95}
-    sortOrder="ascending"
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -951,511 +454,966 @@ exports[`ChartPie 1`] = `
       }
     }
     width={230}
-  />
-</StandaloneContainer>
+  >
+    <VictoryPie
+      containerComponent={
+        <VictoryContainer
+          className="VictoryContainer"
+          portalComponent={<Portal />}
+          portalZIndex={99}
+          responsive={true}
+        />
+      }
+      data={
+        Array [
+          Object {
+            "x": "A",
+            "y": 1,
+          },
+          Object {
+            "x": "B",
+            "y": 2,
+          },
+          Object {
+            "x": "C",
+            "y": 3,
+          },
+          Object {
+            "x": "D",
+            "y": 1,
+          },
+          Object {
+            "x": "E",
+            "y": 2,
+          },
+        ]
+      }
+      dataComponent={
+        <Slice
+          pathComponent={<Path />}
+          role="presentation"
+          shapeRendering="auto"
+        />
+      }
+      groupComponent={<g />}
+      height={230}
+      key="pf-chart-pie"
+      labelComponent={
+        <Unknown
+          constrainToVisibleArea={false}
+          theme={
+            Object {
+              "area": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#06c",
+                    "fillOpacity": 0.3,
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "axis": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "axis": Object {
+                    "fill": "transparent",
+                    "stroke": "#d2d2d2",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                    "strokeWidth": 1,
+                  },
+                  "axisLabel": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 40,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                  "grid": Object {
+                    "fill": "none",
+                    "pointerEvents": "painted",
+                    "stroke": "none",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                  },
+                  "tickLabels": Object {
+                    "fill": "#4f5255",
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "ticks": Object {
+                    "fill": "transparent",
+                    "size": 5,
+                    "stroke": "#d2d2d2",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                    "strokeWidth": 1,
+                  },
+                },
+                "width": 450,
+              },
+              "bar": Object {
+                "barWidth": 10,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#06c",
+                    "padding": 8,
+                    "stroke": "none",
+                    "strokeWidth": 0,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                },
+                "width": 450,
+              },
+              "boxplot": Object {
+                "boxWidth": 20,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "max": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "maxLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "median": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "medianLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "min": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "minLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "q1": Object {
+                    "fill": "#8a8d90",
+                    "padding": 8,
+                  },
+                  "q1Labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "q3": Object {
+                    "fill": "#8a8d90",
+                    "padding": 8,
+                  },
+                  "q3Labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                },
+                "width": 450,
+              },
+              "candlestick": Object {
+                "candleColors": Object {
+                  "negative": "#151515",
+                  "positive": "#fff",
+                },
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "chart": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "width": 450,
+              },
+              "errorbar": Object {
+                "borderWidth": 8,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "opacity": 1,
+                    "stroke": "#151515",
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "group": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "width": 450,
+              },
+              "legend": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "gutter": 20,
+                "orientation": "horizontal",
+                "style": Object {
+                  "data": Object {
+                    "type": "square",
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "title": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 2,
+                    "stroke": "transparent",
+                  },
+                },
+                "titleOrientation": "top",
+              },
+              "line": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "opacity": 1,
+                    "stroke": "#06c",
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "pie": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 230,
+                "padding": 20,
+                "style": Object {
+                  "data": Object {
+                    "padding": 8,
+                    "stroke": "transparent",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 8,
+                    "stroke": "transparent",
+                  },
+                },
+                "width": 230,
+              },
+              "scatter": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#151515",
+                    "opacity": 1,
+                    "stroke": "transparent",
+                    "strokeWidth": 0,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "stack": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "strokeWidth": 1,
+                  },
+                },
+                "width": 450,
+              },
+              "tooltip": Object {
+                "cornerRadius": 0,
+                "flyoutStyle": Object {
+                  "cornerRadius": 0,
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 0,
+                },
+                "pointerLength": 10,
+                "pointerWidth": 20,
+                "style": Object {
+                  "fill": "#ededed",
+                  "padding": 16,
+                  "pointerEvents": "none",
+                },
+              },
+              "voronoi": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "stroke": "transparent",
+                    "strokeWidth": 0,
+                  },
+                  "flyout": Object {
+                    "fill": "#151515",
+                    "pointerEvents": "none",
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fill": "#ededed",
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 8,
+                    "pointerEvents": "none",
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+            }
+          }
+        />
+      }
+      radius={95}
+      sortOrder="ascending"
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
 `;
 
 exports[`ChartPie 2`] = `
-<StandaloneContainer>
-  <VictoryPie
-    containerComponent={
-      <VictoryContainer
-        className="VictoryContainer"
-        portalComponent={<Portal />}
-        portalZIndex={99}
-        responsive={true}
-      />
-    }
-    data={
-      Array [
-        Object {
-          "x": "A",
-          "y": 1,
-        },
-        Object {
-          "x": "B",
-          "y": 2,
-        },
-        Object {
-          "x": "C",
-          "y": 3,
-        },
-        Object {
-          "x": "D",
-          "y": 1,
-        },
-        Object {
-          "x": "E",
-          "y": 2,
-        },
-      ]
-    }
-    dataComponent={
-      <Slice
-        pathComponent={<Path />}
-        role="presentation"
-        shapeRendering="auto"
-      />
-    }
-    groupComponent={<g />}
+<Fragment>
+  <Component
     height={230}
-    labelComponent={
-      <Unknown
-        constrainToVisibleArea={false}
-        theme={
-          Object {
-            "area": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#06c",
-                  "fillOpacity": 0.3,
-                  "strokeWidth": 2,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "axis": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "axis": Object {
-                  "fill": "transparent",
-                  "stroke": "#d2d2d2",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                  "strokeWidth": 1,
-                },
-                "axisLabel": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 40,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-                "grid": Object {
-                  "fill": "none",
-                  "pointerEvents": "painted",
-                  "stroke": "none",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                },
-                "tickLabels": Object {
-                  "fill": "#4f5255",
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "ticks": Object {
-                  "fill": "transparent",
-                  "size": 5,
-                  "stroke": "#d2d2d2",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                  "strokeWidth": 1,
-                },
-              },
-              "width": 450,
-            },
-            "bar": Object {
-              "barWidth": 10,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#06c",
-                  "padding": 8,
-                  "stroke": "none",
-                  "strokeWidth": 0,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-              },
-              "width": 450,
-            },
-            "boxplot": Object {
-              "boxWidth": 20,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "max": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "maxLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "median": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "medianLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "min": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "minLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "q1": Object {
-                  "fill": "#8a8d90",
-                  "padding": 8,
-                },
-                "q1Labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "q3": Object {
-                  "fill": "#8a8d90",
-                  "padding": 8,
-                },
-                "q3Labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-              },
-              "width": 450,
-            },
-            "candlestick": Object {
-              "candleColors": Object {
-                "negative": "#151515",
-                "positive": "#fff",
-              },
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "chart": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "width": 450,
-            },
-            "errorbar": Object {
-              "borderWidth": 8,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "opacity": 1,
-                  "stroke": "#151515",
-                  "strokeWidth": 2,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "group": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "width": 450,
-            },
-            "legend": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "gutter": 20,
-              "orientation": "horizontal",
-              "style": Object {
-                "data": Object {
-                  "type": "square",
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "title": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 2,
-                  "stroke": "transparent",
-                },
-              },
-              "titleOrientation": "top",
-            },
-            "line": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "opacity": 1,
-                  "stroke": "#06c",
-                  "strokeWidth": 2,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "pie": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 230,
-              "padding": 20,
-              "style": Object {
-                "data": Object {
-                  "padding": 8,
-                  "stroke": "transparent",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 8,
-                  "stroke": "transparent",
-                },
-              },
-              "width": 230,
-            },
-            "scatter": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#151515",
-                  "opacity": 1,
-                  "stroke": "transparent",
-                  "strokeWidth": 0,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-            "stack": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "strokeWidth": 1,
-                },
-              },
-              "width": 450,
-            },
-            "tooltip": Object {
-              "cornerRadius": 0,
-              "flyoutStyle": Object {
-                "cornerRadius": 0,
-                "fill": "#151515",
-                "pointerEvents": "none",
-                "stroke": "#151515",
-                "strokeWidth": 0,
-              },
-              "pointerLength": 10,
-              "pointerWidth": 20,
-              "style": Object {
-                "fill": "#ededed",
-                "padding": 16,
-                "pointerEvents": "none",
-              },
-            },
-            "voronoi": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "stroke": "transparent",
-                  "strokeWidth": 0,
-                },
-                "flyout": Object {
-                  "fill": "#151515",
-                  "pointerEvents": "none",
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fill": "#ededed",
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 8,
-                  "pointerEvents": "none",
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-          }
-        }
-      />
-    }
-    radius={95}
-    sortOrder="ascending"
-    standalone={false}
     theme={
       Object {
         "area": Object {
@@ -1906,503 +1864,966 @@ exports[`ChartPie 2`] = `
       }
     }
     width={230}
-  />
-</StandaloneContainer>
-`;
-
-exports[`renders component data 1`] = `
-<StandaloneContainer>
-  <VictoryPie
-    containerComponent={
-      <VictoryContainer
-        className="VictoryContainer"
-        portalComponent={<Portal />}
-        portalZIndex={99}
-        responsive={true}
-      />
-    }
-    data={
-      Array [
-        Object {
-          "x": "Cats",
-          "y": 35,
-        },
-        Object {
-          "x": "Dogs",
-          "y": 55,
-        },
-        Object {
-          "x": "Birds",
-          "y": 10,
-        },
-      ]
-    }
-    dataComponent={
-      <Slice
-        pathComponent={<Path />}
-        role="presentation"
-        shapeRendering="auto"
-      />
-    }
-    groupComponent={<g />}
-    height={200}
-    labelComponent={
-      <Unknown
-        constrainToVisibleArea={false}
-        theme={
+  >
+    <VictoryPie
+      containerComponent={
+        <VictoryContainer
+          className="VictoryContainer"
+          portalComponent={<Portal />}
+          portalZIndex={99}
+          responsive={true}
+        />
+      }
+      data={
+        Array [
           Object {
-            "area": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#06c",
-                  "fillOpacity": 0.3,
-                  "strokeWidth": 2,
+            "x": "A",
+            "y": 1,
+          },
+          Object {
+            "x": "B",
+            "y": 2,
+          },
+          Object {
+            "x": "C",
+            "y": 3,
+          },
+          Object {
+            "x": "D",
+            "y": 1,
+          },
+          Object {
+            "x": "E",
+            "y": 2,
+          },
+        ]
+      }
+      dataComponent={
+        <Slice
+          pathComponent={<Path />}
+          role="presentation"
+          shapeRendering="auto"
+        />
+      }
+      groupComponent={<g />}
+      height={230}
+      key="pf-chart-pie"
+      labelComponent={
+        <Unknown
+          constrainToVisibleArea={false}
+          theme={
+            Object {
+              "area": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#06c",
+                    "fillOpacity": 0.3,
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
                 },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
+                "width": 450,
               },
-              "width": 450,
-            },
-            "axis": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "axis": Object {
-                  "fill": "transparent",
-                  "stroke": "#d2d2d2",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                  "strokeWidth": 1,
+              "axis": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "axis": Object {
+                    "fill": "transparent",
+                    "stroke": "#d2d2d2",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                    "strokeWidth": 1,
+                  },
+                  "axisLabel": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 40,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                  "grid": Object {
+                    "fill": "none",
+                    "pointerEvents": "painted",
+                    "stroke": "none",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                  },
+                  "tickLabels": Object {
+                    "fill": "#4f5255",
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "ticks": Object {
+                    "fill": "transparent",
+                    "size": 5,
+                    "stroke": "#d2d2d2",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                    "strokeWidth": 1,
+                  },
                 },
-                "axisLabel": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 40,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-                "grid": Object {
-                  "fill": "none",
-                  "pointerEvents": "painted",
-                  "stroke": "none",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                },
-                "tickLabels": Object {
-                  "fill": "#4f5255",
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "ticks": Object {
-                  "fill": "transparent",
-                  "size": 5,
-                  "stroke": "#d2d2d2",
-                  "strokeLinecap": "round",
-                  "strokeLinejoin": "round",
-                  "strokeWidth": 1,
-                },
+                "width": 450,
               },
-              "width": 450,
-            },
-            "bar": Object {
-              "barWidth": 10,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#06c",
-                  "padding": 8,
-                  "stroke": "none",
-                  "strokeWidth": 0,
+              "bar": Object {
+                "barWidth": 10,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#06c",
+                    "padding": 8,
+                    "stroke": "none",
+                    "strokeWidth": 0,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
                 },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
+                "width": 450,
               },
-              "width": 450,
-            },
-            "boxplot": Object {
-              "boxWidth": 20,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "max": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
+              "boxplot": Object {
+                "boxWidth": 20,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "max": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "maxLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "median": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "medianLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "min": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "minLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "q1": Object {
+                    "fill": "#8a8d90",
+                    "padding": 8,
+                  },
+                  "q1Labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "q3": Object {
+                    "fill": "#8a8d90",
+                    "padding": 8,
+                  },
+                  "q3Labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
                 },
-                "maxLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "median": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "medianLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "min": Object {
-                  "padding": 8,
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "minLabels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "q1": Object {
-                  "fill": "#8a8d90",
-                  "padding": 8,
-                },
-                "q1Labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "q3": Object {
-                  "fill": "#8a8d90",
-                  "padding": 8,
-                },
-                "q3Labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
+                "width": 450,
               },
-              "width": 450,
-            },
-            "candlestick": Object {
-              "candleColors": Object {
-                "negative": "#151515",
-                "positive": "#fff",
+              "candlestick": Object {
+                "candleColors": Object {
+                  "negative": "#151515",
+                  "positive": "#fff",
+                },
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
               },
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
+              "chart": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "width": 450,
               },
-              "width": 450,
-            },
-            "chart": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "width": 450,
-            },
-            "errorbar": Object {
-              "borderWidth": 8,
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "opacity": 1,
-                  "stroke": "#151515",
-                  "strokeWidth": 2,
+              "errorbar": Object {
+                "borderWidth": 8,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "opacity": 1,
+                    "stroke": "#151515",
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
                 },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
+                "width": 450,
               },
-              "width": 450,
-            },
-            "group": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "width": 450,
-            },
-            "legend": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "gutter": 20,
-              "orientation": "horizontal",
-              "style": Object {
-                "data": Object {
-                  "type": "square",
-                },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                },
-                "title": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 2,
-                  "stroke": "transparent",
-                },
+              "group": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "width": 450,
               },
-              "titleOrientation": "top",
-            },
-            "line": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "opacity": 1,
-                  "stroke": "#06c",
-                  "strokeWidth": 2,
+              "legend": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "gutter": 20,
+                "orientation": "horizontal",
+                "style": Object {
+                  "data": Object {
+                    "type": "square",
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "title": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 2,
+                    "stroke": "transparent",
+                  },
                 },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
+                "titleOrientation": "top",
               },
-              "width": 450,
-            },
-            "pie": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 230,
-              "padding": 20,
-              "style": Object {
-                "data": Object {
-                  "padding": 8,
-                  "stroke": "transparent",
-                  "strokeWidth": 1,
+              "line": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "opacity": 1,
+                    "stroke": "#06c",
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
                 },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 8,
-                  "stroke": "transparent",
-                },
+                "width": 450,
               },
-              "width": 230,
-            },
-            "scatter": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "#151515",
-                  "opacity": 1,
-                  "stroke": "transparent",
-                  "strokeWidth": 0,
+              "pie": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 230,
+                "padding": 20,
+                "style": Object {
+                  "data": Object {
+                    "padding": 8,
+                    "stroke": "transparent",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 8,
+                    "stroke": "transparent",
+                  },
                 },
-                "labels": Object {
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 10,
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
+                "width": 230,
               },
-              "width": 450,
-            },
-            "stack": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "strokeWidth": 1,
+              "scatter": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#151515",
+                    "opacity": 1,
+                    "stroke": "transparent",
+                    "strokeWidth": 0,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
                 },
+                "width": 450,
               },
-              "width": 450,
-            },
-            "tooltip": Object {
-              "cornerRadius": 0,
-              "flyoutStyle": Object {
+              "stack": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "strokeWidth": 1,
+                  },
+                },
+                "width": 450,
+              },
+              "tooltip": Object {
                 "cornerRadius": 0,
+                "flyoutStyle": Object {
+                  "cornerRadius": 0,
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 0,
+                },
+                "pointerLength": 10,
+                "pointerWidth": 20,
+                "style": Object {
+                  "fill": "#ededed",
+                  "padding": 16,
+                  "pointerEvents": "none",
+                },
+              },
+              "voronoi": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "stroke": "transparent",
+                    "strokeWidth": 0,
+                  },
+                  "flyout": Object {
+                    "fill": "#151515",
+                    "pointerEvents": "none",
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fill": "#ededed",
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 8,
+                    "pointerEvents": "none",
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+            }
+          }
+        />
+      }
+      radius={95}
+      sortOrder="ascending"
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
                 "fill": "#151515",
                 "pointerEvents": "none",
                 "stroke": "#151515",
-                "strokeWidth": 0,
+                "strokeWidth": 1,
               },
-              "pointerLength": 10,
-              "pointerWidth": 20,
-              "style": Object {
+              "labels": Object {
                 "fill": "#ededed",
-                "padding": 16,
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
                 "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
               },
             },
-            "voronoi": Object {
-              "colorScale": Array [
-                "#06c",
-                "#8bc1f7",
-                "#002f5d",
-                "#519de9",
-                "#004b95",
-              ],
-              "height": 300,
-              "padding": 50,
-              "style": Object {
-                "data": Object {
-                  "fill": "transparent",
-                  "stroke": "transparent",
-                  "strokeWidth": 0,
-                },
-                "flyout": Object {
-                  "fill": "#151515",
-                  "pointerEvents": "none",
-                  "stroke": "#151515",
-                  "strokeWidth": 1,
-                },
-                "labels": Object {
-                  "fill": "#ededed",
-                  "fontFamily": "var(--pf-chart-global--FontFamily)",
-                  "fontSize": 14,
-                  "letterSpacing": "var(--pf-chart-global--letter-spacing)",
-                  "padding": 8,
-                  "pointerEvents": "none",
-                  "stroke": "transparent",
-                  "textAnchor": "middle",
-                },
-              },
-              "width": 450,
-            },
-          }
+            "width": 450,
+          },
         }
-      />
-    }
-    radius={80}
-    sortOrder="ascending"
-    standalone={false}
+      }
+      width={230}
+    />
+  </Component>
+</Fragment>
+`;
+
+exports[`renders component data 1`] = `
+<Fragment>
+  <Component
+    height={200}
     theme={
       Object {
         "area": Object {
@@ -2853,6 +3274,950 @@ exports[`renders component data 1`] = `
       }
     }
     width={200}
-  />
-</StandaloneContainer>
+  >
+    <VictoryPie
+      containerComponent={
+        <VictoryContainer
+          className="VictoryContainer"
+          portalComponent={<Portal />}
+          portalZIndex={99}
+          responsive={true}
+        />
+      }
+      data={
+        Array [
+          Object {
+            "x": "Cats",
+            "y": 35,
+          },
+          Object {
+            "x": "Dogs",
+            "y": 55,
+          },
+          Object {
+            "x": "Birds",
+            "y": 10,
+          },
+        ]
+      }
+      dataComponent={
+        <Slice
+          pathComponent={<Path />}
+          role="presentation"
+          shapeRendering="auto"
+        />
+      }
+      groupComponent={<g />}
+      height={200}
+      key="pf-chart-pie"
+      labelComponent={
+        <Unknown
+          constrainToVisibleArea={false}
+          theme={
+            Object {
+              "area": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#06c",
+                    "fillOpacity": 0.3,
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "axis": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "axis": Object {
+                    "fill": "transparent",
+                    "stroke": "#d2d2d2",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                    "strokeWidth": 1,
+                  },
+                  "axisLabel": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 40,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                  "grid": Object {
+                    "fill": "none",
+                    "pointerEvents": "painted",
+                    "stroke": "none",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                  },
+                  "tickLabels": Object {
+                    "fill": "#4f5255",
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "ticks": Object {
+                    "fill": "transparent",
+                    "size": 5,
+                    "stroke": "#d2d2d2",
+                    "strokeLinecap": "round",
+                    "strokeLinejoin": "round",
+                    "strokeWidth": 1,
+                  },
+                },
+                "width": 450,
+              },
+              "bar": Object {
+                "barWidth": 10,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#06c",
+                    "padding": 8,
+                    "stroke": "none",
+                    "strokeWidth": 0,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                },
+                "width": 450,
+              },
+              "boxplot": Object {
+                "boxWidth": 20,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "max": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "maxLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "median": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "medianLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "min": Object {
+                    "padding": 8,
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "minLabels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "q1": Object {
+                    "fill": "#8a8d90",
+                    "padding": 8,
+                  },
+                  "q1Labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "q3": Object {
+                    "fill": "#8a8d90",
+                    "padding": 8,
+                  },
+                  "q3Labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                },
+                "width": 450,
+              },
+              "candlestick": Object {
+                "candleColors": Object {
+                  "negative": "#151515",
+                  "positive": "#fff",
+                },
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "chart": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "width": 450,
+              },
+              "errorbar": Object {
+                "borderWidth": 8,
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "opacity": 1,
+                    "stroke": "#151515",
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "group": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "width": 450,
+              },
+              "legend": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "gutter": 20,
+                "orientation": "horizontal",
+                "style": Object {
+                  "data": Object {
+                    "type": "square",
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                  },
+                  "title": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 2,
+                    "stroke": "transparent",
+                  },
+                },
+                "titleOrientation": "top",
+              },
+              "line": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "opacity": 1,
+                    "stroke": "#06c",
+                    "strokeWidth": 2,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "pie": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 230,
+                "padding": 20,
+                "style": Object {
+                  "data": Object {
+                    "padding": 8,
+                    "stroke": "transparent",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 8,
+                    "stroke": "transparent",
+                  },
+                },
+                "width": 230,
+              },
+              "scatter": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "#151515",
+                    "opacity": 1,
+                    "stroke": "transparent",
+                    "strokeWidth": 0,
+                  },
+                  "labels": Object {
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 10,
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+              "stack": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "strokeWidth": 1,
+                  },
+                },
+                "width": 450,
+              },
+              "tooltip": Object {
+                "cornerRadius": 0,
+                "flyoutStyle": Object {
+                  "cornerRadius": 0,
+                  "fill": "#151515",
+                  "pointerEvents": "none",
+                  "stroke": "#151515",
+                  "strokeWidth": 0,
+                },
+                "pointerLength": 10,
+                "pointerWidth": 20,
+                "style": Object {
+                  "fill": "#ededed",
+                  "padding": 16,
+                  "pointerEvents": "none",
+                },
+              },
+              "voronoi": Object {
+                "colorScale": Array [
+                  "#06c",
+                  "#8bc1f7",
+                  "#002f5d",
+                  "#519de9",
+                  "#004b95",
+                ],
+                "height": 300,
+                "padding": 50,
+                "style": Object {
+                  "data": Object {
+                    "fill": "transparent",
+                    "stroke": "transparent",
+                    "strokeWidth": 0,
+                  },
+                  "flyout": Object {
+                    "fill": "#151515",
+                    "pointerEvents": "none",
+                    "stroke": "#151515",
+                    "strokeWidth": 1,
+                  },
+                  "labels": Object {
+                    "fill": "#ededed",
+                    "fontFamily": "var(--pf-chart-global--FontFamily)",
+                    "fontSize": 14,
+                    "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                    "padding": 8,
+                    "pointerEvents": "none",
+                    "stroke": "transparent",
+                    "textAnchor": "middle",
+                  },
+                },
+                "width": 450,
+              },
+            }
+          }
+        />
+      }
+      radius={80}
+      sortOrder="ascending"
+      standalone={false}
+      theme={
+        Object {
+          "area": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "fillOpacity": 0.3,
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "axis": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "axis": Object {
+                "fill": "transparent",
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+              "axisLabel": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 40,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+              "grid": Object {
+                "fill": "none",
+                "pointerEvents": "painted",
+                "stroke": "none",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+              },
+              "tickLabels": Object {
+                "fill": "#4f5255",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "ticks": Object {
+                "fill": "transparent",
+                "size": 5,
+                "stroke": "#d2d2d2",
+                "strokeLinecap": "round",
+                "strokeLinejoin": "round",
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "bar": Object {
+            "barWidth": 10,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#06c",
+                "padding": 8,
+                "stroke": "none",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "boxplot": Object {
+            "boxWidth": 20,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "max": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "maxLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "median": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "medianLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "min": Object {
+                "padding": 8,
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "minLabels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q1": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q1Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "q3": Object {
+                "fill": "#8a8d90",
+                "padding": 8,
+              },
+              "q3Labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+            },
+            "width": 450,
+          },
+          "candlestick": Object {
+            "candleColors": Object {
+              "negative": "#151515",
+              "positive": "#fff",
+            },
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "chart": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "errorbar": Object {
+            "borderWidth": 8,
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#151515",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "group": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "width": 450,
+          },
+          "legend": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "gutter": 20,
+            "orientation": "horizontal",
+            "style": Object {
+              "data": Object {
+                "type": "square",
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+              },
+              "title": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 2,
+                "stroke": "transparent",
+              },
+            },
+            "titleOrientation": "top",
+          },
+          "line": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "opacity": 1,
+                "stroke": "#06c",
+                "strokeWidth": 2,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "pie": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 230,
+            "padding": 20,
+            "style": Object {
+              "data": Object {
+                "padding": 8,
+                "stroke": "transparent",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "stroke": "transparent",
+              },
+            },
+            "width": 230,
+          },
+          "scatter": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "#151515",
+                "opacity": 1,
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "labels": Object {
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 10,
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+          "stack": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "strokeWidth": 1,
+              },
+            },
+            "width": 450,
+          },
+          "tooltip": Object {
+            "cornerRadius": 0,
+            "flyoutStyle": Object {
+              "cornerRadius": 0,
+              "fill": "#151515",
+              "pointerEvents": "none",
+              "stroke": "#151515",
+              "strokeWidth": 0,
+            },
+            "pointerLength": 10,
+            "pointerWidth": 20,
+            "style": Object {
+              "fill": "#ededed",
+              "padding": 16,
+              "pointerEvents": "none",
+            },
+          },
+          "voronoi": Object {
+            "colorScale": Array [
+              "#06c",
+              "#8bc1f7",
+              "#002f5d",
+              "#519de9",
+              "#004b95",
+            ],
+            "height": 300,
+            "padding": 50,
+            "style": Object {
+              "data": Object {
+                "fill": "transparent",
+                "stroke": "transparent",
+                "strokeWidth": 0,
+              },
+              "flyout": Object {
+                "fill": "#151515",
+                "pointerEvents": "none",
+                "stroke": "#151515",
+                "strokeWidth": 1,
+              },
+              "labels": Object {
+                "fill": "#ededed",
+                "fontFamily": "var(--pf-chart-global--FontFamily)",
+                "fontSize": 14,
+                "letterSpacing": "var(--pf-chart-global--letter-spacing)",
+                "padding": 8,
+                "pointerEvents": "none",
+                "stroke": "transparent",
+                "textAnchor": "middle",
+              },
+            },
+            "width": 450,
+          },
+        }
+      }
+      width={200}
+    />
+  </Component>
+</Fragment>
 `;

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -6,6 +6,7 @@ propComponents: ['ChartLegend', 'ChartPie']
 ---
 
 import { ChartPie, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
+import { Button, Tooltip } from '@patternfly/react-core';
 import './chart-pie.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
@@ -108,6 +109,47 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     />
   </div>
 </div>
+```
+
+## Pie chart with custom tooltip
+This demonstrates an alternate way of applying a custom tooltip for the entire chart
+```js
+import React from 'react';
+import { ChartPie } from '@patternfly/react-charts';
+import { Button, Tooltip } from '@patternfly/react-core';
+
+class TooltipChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isVisible: false
+    };
+    this.showTooltip = () => {
+      this.setState({ isVisible: true });
+    };
+  }
+
+  render() {
+    const { isVisible } = this.state;
+
+    return (
+      <div>
+        <div className="donut-chart">
+          <Tooltip content={<div>My custom tooltip</div>} isVisible={isVisible} position={TooltipPosition.right} trigger="manual">
+            <ChartPie
+              allowTooltip={false}
+              ariaDesc="Average number of pets"
+              ariaTitle="Pie chart example"
+              data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+              labels={() => null}
+            />
+          </Tooltip>
+        </div>
+        <Button onClick={this.showTooltip}>Show Tooltip</Button>
+      </div>
+    );
+  }
+}
 ```
 
 ## Tips


### PR DESCRIPTION
Slightly modified how chart containers are cloned and added examples. This ensures charts can be wrapped with the Tippy tooltip component as an alternate way of providing custom tooltips.

Fixes https://github.com/patternfly/patternfly-react/issues/3047
