### PR TITLE
feat(Popover): Ability to hide close button

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.md
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.md
@@ -149,3 +149,23 @@ HeadlessPopover = () => (
   </Popover>
 );
 ```
+
+## Popover without close button
+```js
+import React from 'react';
+import { Popover, PopoverPosition, Button } from '@patternfly/react-core';
+
+SimplePopover = () => (
+  <Popover
+    showClose={false}
+    disableFocusTrap={true}
+    headerContent={<div>Popover Header</div>}
+    bodyContent={
+      <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.</div>
+    }
+    footerContent="Popover Footer"
+  >
+    <Button>Toggle Popover</Button>
+  </Popover>
+);
+```

--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
@@ -96,6 +96,10 @@ export interface PopoverProps {
   zIndex?: number;
   /** additional Props to pass through to tippy.js */
   tippyProps?: TippyProps;
+  /** Flag to show the close button */
+  showClose?: boolean;
+  /** Flag to disable focus trap */
+  disableFocusTrap?: boolean;
 }
 
 export interface PopoverState {
@@ -127,7 +131,9 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     "boundary": 'window',
     // For every initial starting position, there are 3 escape positions
     "flipBehavior": ['top', 'right', 'bottom', 'left', 'top', 'right', 'bottom'],
-    "tippyProps": {}
+    "tippyProps": {},
+    "showClose": true,
+    "disableFocusTrap": false
   };
 
   constructor(props: PopoverProps) {
@@ -229,6 +235,8 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       boundary,
       flipBehavior,
       tippyProps,
+      showClose,
+      disableFocusTrap,
       ...rest
     } = this.props;
 
@@ -240,7 +248,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       <GenerateId>
         {(randomId) =>
           (
-            <FocusTrap active={this.state.isOpen} focusTrapOptions={{ clickOutsideDeactivates: true }}>
+            <FocusTrap active={!disableFocusTrap && this.state.isOpen} focusTrapOptions={{ clickOutsideDeactivates: true }}>
               <div
                 className={css(
                   !enableFlip && getModifier(styles, position, styles.modifiers.top),
@@ -254,7 +262,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
                 {...rest}
               >
                 <PopoverContent>
-                  <PopoverCloseButton onClose={this.closePopover} aria-label={closeBtnAriaLabel} />
+                  {showClose && <PopoverCloseButton onClose={this.closePopover} aria-label={closeBtnAriaLabel} />}
                   {headerContent && <PopoverHeader id={`popover-${randomId}-header`}>{headerContent}</PopoverHeader>}
                   <PopoverBody id={`popover-${randomId}-body`}>{bodyContent}</PopoverBody>
                   {footerContent && <PopoverFooter>{footerContent}</PopoverFooter>}


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Adds ability to show/hide close button. To do this two props was added, `showClose` and `disableFocusTrap`. The latter is required when no focusable elements are in the popover.

An example was added to the bottom of Popover documentation page

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: fixes #3043

<!-- feel free to add additional comments -->
cc @mtho11	