### PR TITLE
Charts: Tooltip examples

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -20,9 +20,7 @@ import './chart-area.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build an area chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -10,9 +10,7 @@ import './chart-bar.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a bar chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -11,9 +11,7 @@ import './chart-bullet.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a bullet chart using a Katacoda tutorial starting with a simple chart, adding qualitative ranges, primary comparative measures, a comparative warning measure, tooltips, labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
@@ -81,7 +79,7 @@ import { ChartBullet } from '@patternfly/react-charts';
 import React from 'react';
 import { ChartBullet } from '@patternfly/react-charts';
 
-class MultiColorChart extends React.Component {
+class BulletChart extends React.Component {
   constructor(props) {
     super(props);
     this.containerRef = React.createRef();
@@ -864,52 +862,6 @@ import { ChartBullet, ChartContainer } from '@patternfly/react-charts';
     </ChartContainer>
   </div>
 </div>
-```
-
-## Bullet chart with custom tooltip
-This demonstrates an alternate way of applying a custom tooltip for the entire chart
-```js
-import React from 'react';
-import { ChartBullet } from '@patternfly/react-charts';
-import { Button, Tooltip } from '@patternfly/react-core';
-
-class TooltipChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isVisible: false
-    };
-    this.showTooltip = () => {
-      this.setState({ isVisible: true });
-    };
-  }
-
-  render() {
-    const { isVisible } = this.state;
-
-    return (
-      <div>
-        <div className="bullet-chart-horz">
-          <Tooltip content={<div>My custom tooltip</div>} isVisible={isVisible} position={TooltipPosition.right} trigger="manual">
-            <ChartBullet
-              allowTooltip={false}
-              ariaDesc="Storage capacity"
-              ariaTitle="Bullet chart example"
-              comparativeWarningMeasureData={[{ name: 'Warning', y: 88 }]}
-              height={150}
-              labels={() => null}
-              maxDomain={{y: 100}}
-              primarySegmentedMeasureData={[{ name: 'Measure', y: 60 }]}
-              qualitativeRangeData={[{ name: 'Range', y: 50 }, { name: 'Range', y: 75 }]}
-              width={600}
-            />
-          </Tooltip>
-        </div>
-        <Button onClick={this.showTooltip}>Show Tooltip</Button>
-      </div>
-    );
-  }
-}
 ```
 
 ## Tips

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -6,14 +6,11 @@ propComponents: ['ChartDonut', 'ChartLegend']
 ---
 
 import { ChartDonut, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
-import { Button, Tooltip } from '@patternfly/react-core';
 import './chart-donut.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a donut chart using a Katacoda tutorial starting with a simple chart, adding thresholds, tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
@@ -247,49 +244,6 @@ import { ChartDonut } from '@patternfly/react-charts';
     />
   </div>
 </div>
-```
-
-## Donut chart with custom tooltip
-This demonstrates an alternate way of applying a custom tooltip for the entire chart
-```js
-import React from 'react';
-import { ChartDonut } from '@patternfly/react-charts';
-import { Button, Tooltip } from '@patternfly/react-core';
-
-class TooltipChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isVisible: false
-    };
-    this.showTooltip = () => {
-      this.setState({ isVisible: true });
-    };
-  }
-
-  render() {
-    const { isVisible } = this.state;
-
-    return (
-      <div>
-        <div className="donut-chart">
-          <Tooltip content={<div>My custom tooltip</div>} isVisible={isVisible} position={TooltipPosition.right} trigger="manual">
-            <ChartDonut
-              allowTooltip={false}
-              ariaDesc="Average number of pets"
-              ariaTitle="Donut chart example"
-              data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-              labels={() => null}
-              subTitle="Pets"
-              title="100"
-            />
-          </Tooltip>
-        </div>
-        <Button onClick={this.showTooltip}>Show Tooltip</Button>
-      </div>
-    );
-  }
-}
 ```
 
 ## Tips

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -6,14 +6,11 @@ propComponents: ['ChartLegend', 'ChartDonutThreshold', 'ChartDonutUtilization']
 ---
 
 import { ChartDonutThreshold, ChartDonutUtilization, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
-import { Button, Tooltip } from '@patternfly/react-core';
 import './chart-donut-utilization.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a donut utilization chart using a Katacoda tutorial starting with a simple chart, adding thresholds, tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
@@ -814,55 +811,6 @@ import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-ch
     </ChartDonutThreshold>
   </div>
 </div>
-```
-
-## Donut utilization chart with custom tooltip
-This demonstrates an alternate way of applying a custom tooltip for the entire chart
-```js
-import React from 'react';
-import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
-import { Button, Tooltip } from '@patternfly/react-core';
-
-class TooltipChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isVisible: false
-    };
-    this.showTooltip = () => {
-      this.setState({ isVisible: true });
-    };
-  }
-
-  render() {
-    const { isVisible } = this.state;
-
-    return (
-      <div>
-        <div className="donut-threshold-chart">
-          <Tooltip content={<div>My custom tooltip</div>} isVisible={isVisible} position={TooltipPosition.right} trigger="manual">
-            <ChartDonutThreshold
-              allowTooltip={false}
-              ariaDesc="Storage capacity"
-              ariaTitle="Donut utilization chart with static threshold example"
-              data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
-              labels={() => null}
-            >
-              <ChartDonutUtilization
-                allowTooltip={false}
-                data={{ x: 'Storage capacity', y: 45 }}
-                labels={() => null}
-                subTitle="of 100 GBps"
-                title="45%"
-              />
-            </ChartDonutThreshold>
-          </Tooltip>
-        </div>
-        <Button onClick={this.showTooltip}>Show Tooltip</Button>
-      </div>
-    );
-  }
-}
 ```
 
 ## Tips

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -11,9 +11,7 @@ import './chart-line.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a line chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -6,14 +6,11 @@ propComponents: ['ChartLegend', 'ChartPie']
 ---
 
 import { ChartPie, ChartThemeColor, ChartThemeVariant } from '@patternfly/react-charts';
-import { Button, Tooltip } from '@patternfly/react-core';
 import './chart-pie.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a pie chart using a Katacoda tutorial starting with a simple chart, adding tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
@@ -105,47 +102,6 @@ import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
     />
   </div>
 </div>
-```
-
-## Pie chart with custom tooltip
-This demonstrates an alternate way of applying a custom tooltip for the entire chart
-```js
-import React from 'react';
-import { ChartPie } from '@patternfly/react-charts';
-import { Button, Tooltip } from '@patternfly/react-core';
-
-class TooltipChart extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isVisible: false
-    };
-    this.showTooltip = () => {
-      this.setState({ isVisible: true });
-    };
-  }
-
-  render() {
-    const { isVisible } = this.state;
-
-    return (
-      <div>
-        <div className="donut-chart">
-          <Tooltip content={<div>My custom tooltip</div>} isVisible={isVisible} position={TooltipPosition.right} trigger="manual">
-            <ChartPie
-              allowTooltip={false}
-              ariaDesc="Average number of pets"
-              ariaTitle="Pie chart example"
-              data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
-              labels={() => null}
-            />
-          </Tooltip>
-        </div>
-        <Button onClick={this.showTooltip}>Show Tooltip</Button>
-      </div>
-    );
-  }
-}
 ```
 
 ## Tips

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -10,9 +10,7 @@ import './chart-stack.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a stack chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
@@ -390,6 +388,5 @@ components used in the examples above, Victory pass-thru props are also document
  - For `ChartArea` props, see <a href="https://formidable.com/open-source/victory/docs/victory-area" target="_blank">VictoryArea</a>
  - For `ChartAxis` props, see <a href="https://formidable.com/open-source/victory/docs/victory-axis" target="_blank">VictoryAxis</a>
  - For `ChartBar` props, see <a href="https://formidable.com/open-source/victory/docs/victory-bar" target="_blank">VictoryBar</a>
- - For `ChartLegend` props, see <a href="https://formidable.com/open-source/victory/docs/victory-legend" target="_blank">VictoryLegend</a>
  - For `ChartStack` props, see <a href="https://formidable.com/open-source/victory/docs/victory-stack" target="_blank">VictoryStack</a>
  - For `ChartTooltip` props, see <a href="https://formidable.com/open-source/victory/docs/victory-tooltip" target="_blank">VictoryTooltip</a>

--- a/packages/patternfly-4/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -1,0 +1,420 @@
+---
+title: 'Tooltip'
+section: 'charts'
+typescript: true
+propComponents: ['Chart', 'ChartArea', 'ChartAxis', 'ChartBar', 'ChartDonut', 'ChartGroup', 'ChartLine', 'ChartLegend', 'ChartStack', 'ChartTooltip']
+---
+
+import { Chart, ChartArea, ChartAxis, ChartBar, ChartDonut, ChartGroup, ChartLabel, ChartLine, ChartStack, ChartThemeColor, ChartTooltip, getCustomTheme } from '@patternfly/react-charts';
+import { Button, Tooltip } from '@patternfly/react-core';
+import './chart-tooltip.scss';
+
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+## Voronoi container tooltips
+This demonstrates how to use a voronoi container to display tooltips
+```js
+import React from 'react';
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartVoronoiContainer } from '@patternfly/react-charts';
+// import '@patternfly/patternfly/patternfly-charts.css'; // For mixed blend mode
+
+<div>
+  <div className="area-chart-legend-right">
+    <Chart
+      ariaDesc="Average number of pets"
+      ariaTitle="Area chart example"
+      containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea />}
+      legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }]}
+      legendOrientation="vertical"
+      legendPosition="right"
+      height={200}
+      maxDomain={{y: 9}}
+      padding={{
+        bottom: 50,
+        left: 50,
+        right: 200, // Adjusted to accommodate legend
+        top: 50
+      }}
+      width={800}
+    >
+      <ChartAxis />
+      <ChartAxis dependentAxis showGrid/>
+      <ChartGroup>
+        <ChartArea
+          data={[
+            { name: 'Cats', x: '2015', y: 3 },
+            { name: 'Cats', x: '2016', y: 4 },
+            { name: 'Cats', x: '2017', y: 8 },
+            { name: 'Cats', x: '2018', y: 6 }
+          ]}
+          interpolation="basis"
+        />
+        <ChartArea
+          data={[
+            { name: 'Dogs', x: '2015', y: 2 },
+            { name: 'Dogs', x: '2016', y: 3 },
+            { name: 'Dogs', x: '2017', y: 4 },
+            { name: 'Dogs', x: '2018', y: 5 },
+            { name: 'Dogs', x: '2019', y: 6 }
+          ]}
+          interpolation="basis"
+        />
+        <ChartArea
+          data={[
+            { name: 'Birds', x: '2015', y: 1 },
+            { name: 'Birds', x: '2016', y: 2 },
+            { name: 'Birds', x: '2017', y: 3 },
+            { name: 'Birds', x: '2018', y: 2 },
+            { name: 'Birds', x: '2019', y: 4 }
+          ]}
+          interpolation="basis"
+        />
+      </ChartGroup>
+    </Chart>
+  </div>
+</div>
+```
+
+## Data label tooltips
+This demonstrates an alternate way of applying tooltips using data labels
+```js
+import React from 'react';
+import { Chart, ChartAxis, ChartStack, ChartThemeColor } from '@patternfly/react-charts';
+
+<div>
+  <div className="tooltip-bar-chart-legend-bottom">
+    <Chart
+      ariaDesc="Average number of pets"
+      ariaTitle="Stack chart example"
+      domainPadding={{ x: [30, 25] }}
+      legendData={[{ name: 'Cats' }, { name: 'Dogs' }, { name: 'Birds' }, { name: 'Mice' }]}
+      legendPosition="bottom-left"
+      height={275}
+      padding={{
+        bottom: 75, // Adjusted to accommodate legend
+        left: 50,
+        right: 50, 
+        top: 50
+      }}
+      themeColor={ChartThemeColor.multiOrdered}
+      width={450}
+    >
+      <ChartAxis />
+      <ChartAxis dependentAxis showGrid />
+      <ChartStack horizontal>
+        <ChartBar 
+          data={[
+            { name: 'Cats', x: '2015', y: 1, label: 'Cats: 1' }, 
+            { name: 'Cats', x: '2016', y: 2, label: 'Cats: 2' }, 
+            { name: 'Cats', x: '2017', y: 5, label: 'Cats: 5' }, 
+            { name: 'Cats', x: '2018', y: 3, label: 'Cats: 3' }
+          ]} 
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Dogs', x: '2015', y: 2, label: 'Dogs: 2' }, 
+            { name: 'Dogs', x: '2016', y: 1, label: 'Dogs: 1' }, 
+            { name: 'Dogs', x: '2017', y: 7, label: 'Dogs: 7' }, 
+            { name: 'Dogs', x: '2018', y: 4, label: 'Dogs: 4' }
+          ]}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Birds', x: '2015', y: 4, label: 'Birds: 4' }, 
+            { name: 'Birds', x: '2016', y: 4, label: 'Birds: 4' }, 
+            { name: 'Birds', x: '2017', y: 9, label: 'Birds: 9' }, 
+            { name: 'Birds', x: '2018', y: 7, label: 'Birds: 7' }
+          ]}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
+        />
+        <ChartBar 
+          data={[
+            { name: 'Mice', x: '2015', y: 3, label: 'Mice: 3' }, 
+            { name: 'Mice', x: '2016', y: 3, label: 'Mice: 3' }, 
+            { name: 'Mice', x: '2017', y: 8, label: 'Mice: 8' }, 
+            { name: 'Mice', x: '2018', y: 5, label: 'Mice: 5' }
+          ]}
+          labelComponent={<ChartTooltip constrainToVisibleArea />}
+        />
+      </ChartStack>
+    </Chart>
+  </div>
+</div>
+```
+
+## Legend tooltips
+This demonstrates an approach for applying tooltips to a legend using a custom label component
+```js
+import React from 'react';
+import { ChartLabel, ChartPie, ChartThemeColor } from '@patternfly/react-charts';
+import { Tooltip } from '@patternfly/react-core';
+
+class TooltipPieChart extends React.Component {
+  constructor(props) {
+    super(props);
+
+    // Custom legend label compoenent
+    this.LegendLabel = ({ content, ...rest }) => (
+      <Tooltip content={content(rest)} enableFlip>
+        <ChartLabel {...rest} />
+      </Tooltip>
+    );
+
+    // Custom legend component
+    this.getLegend = (legendData) => {
+      return (
+        <ChartLegend
+          data={legendData}
+          labelComponent={<this.LegendLabel content={this.getLegendTooltip} />}
+        />
+      );
+    };
+
+    // Custom tooltip
+    this.getLegendTooltip = ({ datum }) => {
+      return datum.label;
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        <div className="pie-chart-legend-bottom">
+          <ChartPie
+            ariaDesc="Average number of pets"
+            ariaTitle="Pie chart example"
+            constrainToVisibleArea={true}
+            data={[{ x: 'Cats', y: 35 }, { x: 'Dogs', y: 55 }, { x: 'Birds', y: 10 }]}
+            height={275}
+            labels={({ datum }) => `${datum.x}: ${datum.y}`}
+            legendComponent={this.getLegend([
+              { name: 'Cats: 35', label: 'Cats: 35' }, 
+              { name: 'Dogs: 55', label: 'Dogs: 55' }, 
+              { name: 'Birds: 10', label: 'Birds: 10' }
+            ])}
+            legendPosition="bottom"
+            padding={{
+              bottom: 65,
+              left: 20,
+              right: 20,
+              top: 20
+            }}
+            themeColor={ChartThemeColor.multiOrdered}
+            width={300}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+```
+
+## Left aligned tooltips
+This demonstrates how to customize tooltip label alignment using theme properties
+```js
+import React from 'react';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartThemeColor, ChartThemeVariant, getCustomTheme } from '@patternfly/react-charts';
+
+class TooltipThemeChart extends React.Component {
+  constructor(props) {
+    super(props);
+
+    // Victory theme properties only
+    this.themeProps = {
+      voronoi: {
+        style: {
+          labels: {
+            textAnchor: 'start' // Align tooltip labels left
+          }
+        }
+      }
+    };
+
+    // Applies theme color and variant to base theme
+    this.myCustomTheme = getCustomTheme(
+      ChartThemeColor.default,
+      ChartThemeVariant.default,
+      this.themeProps
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        <div className="tooltip-line-chart-legend-right">
+          <Chart
+            ariaDesc="Average number of pets"
+            ariaTitle="Line chart example"
+            containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} constrainToVisibleArea voronoiDimension="x"/>}
+            legendData={[{ name: 'Cats' }, { name: 'Dogs', symbol: { type: 'dash' } }, { name: 'Birds' }, { name: 'Mice' }]}
+            legendOrientation="vertical"
+            legendPosition="right"
+            height={250}
+            maxDomain={{y: 10}}
+            minDomain={{y: 0}}
+            padding={{
+              bottom: 50,
+              left: 50,
+              right: 200, // Adjusted to accommodate legend
+              top: 50
+            }}
+            theme={this.myCustomTheme}
+            width={600}
+          >
+            <ChartAxis tickValues={[2, 3, 4]} />
+            <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} />
+            <ChartGroup>
+              <ChartLine
+                data={[
+                  { name: 'Cats', x: '2015', y: 1 },
+                  { name: 'Cats', x: '2016', y: 2 },
+                  { name: 'Cats', x: '2017', y: 5 },
+                  { name: 'Cats', x: '2018', y: 3 }
+                ]}
+              />
+              <ChartLine
+                data={[
+                  { name: 'Dogs', x: '2015', y: 2 },
+                  { name: 'Dogs', x: '2016', y: 1 },
+                  { name: 'Dogs', x: '2017', y: 7 },
+                  { name: 'Dogs', x: '2018', y: 4 }
+                ]}
+                style={{
+                  data: {
+                    strokeDasharray: '3,3'
+                  }
+                }}
+              />
+              <ChartLine
+                data={[
+                  { name: 'Birds', x: '2015', y: 3 },
+                  { name: 'Birds', x: '2016', y: 4 },
+                  { name: 'Birds', x: '2017', y: 9 },
+                  { name: 'Birds', x: '2018', y: 5 }
+                ]}
+              />
+              <ChartLine
+                data={[
+                  { name: 'Mice', x: '2015', y: 3 },
+                  { name: 'Mice', x: '2016', y: 3 },
+                  { name: 'Mice', x: '2017', y: 8 },
+                  { name: 'Mice', x: '2018', y: 7 }
+                ]}
+              />
+            </ChartGroup>
+          </Chart>
+        </div>
+      </div>
+    );
+  }
+}
+```
+
+## CSS overflow tooltips
+This demonstrates an alternate way of applying tooltips using CSS overflow instead of `constrainToVisibleArea`
+```js
+import React from 'react';
+import { ChartArea, ChartContainer, ChartGroup, ChartLabel, ChartThemeColor, ChartVoronoiContainer } from '@patternfly/react-charts';
+
+<div>
+  <div className="tooltip-sparkline-container tooltip-sparkline-overflow">
+    <div className="tooltip-sparkline-chart">
+      <ChartGroup
+        ariaDesc="Average number of pets"
+        ariaTitle="Sparkline chart example"
+        containerComponent={<ChartVoronoiContainer labels={({ datum }) => `${datum.name}: ${datum.y}`} />}
+        height={100}
+        maxDomain={{y: 9}}
+        padding={0}
+        themeColor={ChartThemeColor.green}
+        width={400}
+      >
+        <ChartArea
+          data={[
+            { name: 'Cats', x: '2015', y: 3 },
+            { name: 'Cats', x: '2016', y: 4 },
+            { name: 'Cats', x: '2017', y: 8 },
+            { name: 'Cats', x: '2018', y: 6 }
+          ]}
+        />
+      </ChartGroup>
+    </div>
+    <ChartContainer>
+      <ChartLabel text="CPU utilization" dy={15}/>
+    </ChartContainer>
+  </div>
+</div>
+```
+
+## Wrapped chart tooltip
+This demonstrates an alternate way of applying tooltips by wrapping charts with the Tooltip component
+```js
+import React from 'react';
+import { ChartDonutThreshold, ChartDonutUtilization } from '@patternfly/react-charts';
+import { Button, Tooltip } from '@patternfly/react-core';
+
+class TooltipChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isVisible: false
+    };
+    this.showTooltip = () => {
+      this.setState({ isVisible: true });
+    };
+  }
+
+  render() {
+    const { isVisible } = this.state;
+
+    return (
+      <div>
+        <div className="tooltip-donut-threshold-chart">
+          <Tooltip content={<div>My custom tooltip</div>} isVisible={isVisible} position={TooltipPosition.right} trigger="manual">
+            <ChartDonutThreshold
+              allowTooltip={false}
+              ariaDesc="Storage capacity"
+              ariaTitle="Donut utilization chart with static threshold example"
+              data={[{ x: 'Warning at 60%', y: 60 }, { x: 'Danger at 90%', y: 90 }]}
+              labels={() => null}
+            >
+              <ChartDonutUtilization
+                allowTooltip={false}
+                data={{ x: 'Storage capacity', y: 45 }}
+                labels={() => null}
+                subTitle="of 100 GBps"
+                title="45%"
+              />
+            </ChartDonutThreshold>
+          </Tooltip>
+          <Button onClick={this.showTooltip}>Show Tooltip</Button>
+        </div>
+      </div>
+    );
+  }
+}
+```
+
+## Tips
+
+- For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+- `ChartLegend` may be used as a standalone component, instead of using `legendData` and `legendPosition`
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `Chart` props, see <a href="https://formidable.com/open-source/victory/docs/victory-chart" target="_blank">VictoryChart</a>
+ - For `ChartArea` props, see <a href="https://formidable.com/open-source/victory/docs/victory-area" target="_blank">VictoryArea</a>
+ - For `ChartAxis` props, see <a href="https://formidable.com/open-source/victory/docs/victory-axis" target="_blank">VictoryAxis</a>
+ - For `ChartBar` props, see <a href="https://formidable.com/open-source/victory/docs/victory-bar" target="_blank">VictoryBar</a>
+ - For `ChartDonut` props, see <a href="https://formidable.com/open-source/victory/docs/victory-pie" target="_blank">VictoryPie</a>
+ - For `ChartGroup` props, see <a href="https://formidable.com/open-source/victory/docs/victory-group" target="_blank">VictoryGroup</a>
+ - For `ChartLegend` props, see <a href="https://formidable.com/open-source/victory/docs/victory-legend" target="_blank">VictoryLegend</a>
+ - For `ChartLine` props, see <a href="https://formidable.com/open-source/victory/docs/victory-line" target="_blank">VictoryLine</a>
+ - For `ChartStack` props, see <a href="https://formidable.com/open-source/victory/docs/victory-stack" target="_blank">VictoryStack</a>
+ - For `ChartTooltip` props, see <a href="https://formidable.com/open-source/victory/docs/victory-tooltip" target="_blank">VictoryTooltip</a>

--- a/packages/patternfly-4/react-charts/src/components/ChartTooltip/examples/chart-tooltip.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartTooltip/examples/chart-tooltip.scss
@@ -1,0 +1,41 @@
+.ws-preview {
+  & > * {
+    .tooltip-bar-chart-legend-bottom {
+      height: 275px;
+      width: 450px;
+    }
+
+    .tooltip-bar-chart-legend-right {
+      height: 250px;
+      width: 600px;
+    }
+
+    .tooltip-line-chart-legend-right {
+      height: 250px;
+      width: 600px;
+    }
+
+    .tooltip-donut-threshold-chart {
+      height: 285px;
+      width: 230px;
+      text-align: center;
+    }
+
+    .tooltip-sparkline-chart {
+      height: 100px;
+      width: 400px;
+    }
+
+    .tooltip-sparkline-container {
+      margin-left: 50px;
+      margin-top: 50px;
+      height: 135px;
+    }
+
+    .tooltip-sparkline-overflow {
+      & svg {
+        overflow: visible;
+      }
+    }
+  }
+}

--- a/packages/patternfly-4/react-charts/src/components/Sparkline/examples/sparkline.md
+++ b/packages/patternfly-4/react-charts/src/components/Sparkline/examples/sparkline.md
@@ -10,9 +10,7 @@ import './sparkline.scss';
 
 Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
 
-
 PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
-
 
 Learn to build a sparkline chart using a Katacoda tutorial starting with a simple chart, adding tooltips, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 


### PR DESCRIPTION
Added multiple examples of how to apply tooltips. The current examples do show tooltips, but there are several different ways they can be applied. It would be best these examples were all in one place.

- Using data labels
- Using a Voronoi container
- Wrapping a chart with a Tippy tooltip
- Adding custom tooltip component to legends
- Using CSS overflow Vs the constrainToVisibleArea prop
- Left aligned tooltips using a theme property

![Screen Shot 2019-10-02 at 4 02 53 PM](https://user-images.githubusercontent.com/17481322/66077804-b46fe880-e52e-11e9-8d0a-34d4c8eb1ff7.png)

![Screen Shot 2019-10-02 at 4 03 41 PM](https://user-images.githubusercontent.com/17481322/66077808-b9349c80-e52e-11e9-9c26-e4737edd3ff1.png)

![Screen Shot 2019-10-02 at 4 03 53 PM](https://user-images.githubusercontent.com/17481322/66077813-bb96f680-e52e-11e9-9b76-07dfaa290311.png)
