### PR TITLE
fix(Radio): pass checked either from isChecked or checked

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.md
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.md
@@ -35,6 +35,7 @@ class ControlledRadio extends React.Component {
           onChange={this.handleChange}
           label="Controlled radio"
           id="radio-controlled"
+          value="check1"
         />
       </React.Fragment>
     );

--- a/packages/patternfly-4/react-core/src/components/Radio/Radio.tsx
+++ b/packages/patternfly-4/react-core/src/components/Radio/Radio.tsx
@@ -14,6 +14,8 @@ export interface RadioProps
   /** Flag to show if the radio label is shown before the radio button. */
   isLabelBeforeButton?: boolean;
   /** Flag to show if the radio is checked. */
+  checked?: boolean;
+  /** Flag to show if the radio is checked. */
   isChecked?: boolean;
   /** Flag to show if the radio is disabled. */
   isDisabled?: boolean;
@@ -74,6 +76,7 @@ export class Radio extends React.Component<RadioProps> {
         aria-invalid={!isValid}
         disabled={isDisabled}
         defaultChecked={checked || isChecked}
+        checked={checked || isChecked}
         {...(!isChecked && { defaultChecked })}
         {...(!label && { 'aria-label': ariaLabel })}
       />

--- a/packages/patternfly-4/react-core/src/components/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Radio/__snapshots__/Radio.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Radio check component controlled 1`] = `
   <input
     aria-invalid={false}
     aria-label="check"
+    checked={true}
     className="pf-c-radio__input"
     defaultChecked={true}
     disabled={false}
@@ -85,6 +86,7 @@ exports[`Radio check component label is function 1`] = `
 >
   <input
     aria-invalid={false}
+    checked={true}
     className="pf-c-radio__input"
     defaultChecked={true}
     disabled={false}
@@ -110,6 +112,7 @@ exports[`Radio check component label is node 1`] = `
 >
   <input
     aria-invalid={false}
+    checked={true}
     className="pf-c-radio__input"
     defaultChecked={true}
     disabled={false}
@@ -135,6 +138,7 @@ exports[`Radio check component label is string 1`] = `
 >
   <input
     aria-invalid={false}
+    checked={true}
     className="pf-c-radio__input"
     defaultChecked={true}
     disabled={false}
@@ -159,6 +163,7 @@ exports[`Radio check component passing HTML attribute 1`] = `
   <input
     aria-invalid={false}
     aria-labelledby="labelId"
+    checked={true}
     className="pf-c-radio__input"
     defaultChecked={true}
     disabled={false}
@@ -182,6 +187,7 @@ exports[`Radio check component passing class 1`] = `
 >
   <input
     aria-invalid={false}
+    checked={true}
     className="pf-c-radio__input"
     defaultChecked={true}
     disabled={false}


### PR DESCRIPTION
Fixes: #3065 

If consumer updates `isChecked` or `chacked` other than via clicking it will not propagate correctly to input, instead it will update `defaultChecked`. This PR fixes such issue by updating `checked` either from `checked` or `isChecked`.