### PR TITLE
fix(button): component type should accept react-router Link

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Button/Button.tsx
+++ b/packages/patternfly-4/react-core/src/components/Button/Button.tsx
@@ -25,7 +25,7 @@ export interface ButtonProps extends React.HTMLProps<HTMLButtonElement> {
   /** Additional classes added to the button */
   className?: string;
   /** Sets the base component to render. defaults to button */
-  component?: React.ReactNode;
+  component?: React.ElementType<any>;
   /** Adds active styling to button. */
   isActive?: boolean;
   /** Adds block styling to button */


### PR DESCRIPTION
**What**:

closes #2980 

ReactNode is any of the following types: `ReactChild`, `ReactFragment`, `ReactPortal`, `boolean`, `null`, `undefined`.[1]

While `Link` is a component type: `ComponentClass` or `FunctionComponent`.[2]

This PR adds `ComponentType` to the type of `component`. I did set it to `any` to allow other router components in the future or a custom router link. But if we want to support only react-router `Link` I can add a specific type to the component type there.

[1]https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L191
[2]https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L71

//cc @AlexSCorey