### PR TITLE
feat(eslint): add eslint-plugin-react-hooks

### DIFF
--- a/packages/eslint-plugin-patternfly-react/lib/config/recommended.js
+++ b/packages/eslint-plugin-patternfly-react/lib/config/recommended.js
@@ -47,7 +47,9 @@ module.exports = {
     'react/jsx-filename-extension': 'off',
     'react/jsx-uses-vars': 'error',
     'react/no-danger': 'off',
-    'react/sort-comp': 'off'
+    'react/sort-comp': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn'
   },
   extends: [
     'standard',
@@ -64,6 +66,6 @@ module.exports = {
     node: true,
     jest: true
   },
-  plugins: ['prettier', 'jest', 'react', 'patternfly-react'],
+  plugins: ['prettier', 'jest', 'react', 'react-hooks', 'patternfly-react'],
   parser: 'babel-eslint'
 };

--- a/packages/eslint-plugin-patternfly-react/package.json
+++ b/packages/eslint-plugin-patternfly-react/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-promise": "^3.7.0",
     "eslint-plugin-react": "^7.7.0",
+    "eslint-plugin-react-hooks": "^2.1.2",
     "eslint-plugin-rulesdir": "^0.1.0",
     "eslint-plugin-standard": "^3.0.1"
   },


### PR DESCRIPTION

<!-- What changes are being made? (What issue is being addressed here?) -->

* Add [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) to `eslint-plugin-patternfly-react` so that Foreman and plugin devs will benefit from its guidance when using Hooks.

This plugin checks if you're following the [Rules of Hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) and is useful for anyone developing components that use React Hooks.

In Foreman we've started using Hooks, but don't yet have this rule.  See [this discussion](https://github.com/theforeman/foreman/pull/6981#issuecomment-535225407) with @sharvit 


<!-- Are there any upstream issues or separate issues you need to reference? -->


<!-- feel free to add additional comments -->
