### PR TITLE
Charts: update ChartThreshold to use pf-core variable

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/threshold-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/threshold-theme.ts
@@ -1,9 +1,14 @@
+/* eslint-disable camelcase */
+import {
+  chart_threshold_stroke_dash_array
+} from '@patternfly/react-tokens';
+
 // Threshold theme
 export const ThresholdTheme = {
   line: {
     style: {
       data: {
-        strokeDasharray: '6,6'
+        strokeDasharray: chart_threshold_stroke_dash_array.value
       }
     }
   }


### PR DESCRIPTION
Simply updated ChartThreshold theme to use pf-core variable

Fixes https://github.com/patternfly/patternfly-react/issues/3025

Threshold chart example
<img width="848" alt="Screen Shot 2019-10-07 at 4 50 05 PM" src="https://user-images.githubusercontent.com/17481322/66347535-90434b80-e922-11e9-8405-676a9eeaf55e.png">
