### PR TITLE
Charts: Add chart scatter examples

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartScatter/ChartScatter.tsx
+++ b/packages/patternfly-4/react-charts/src/components/ChartScatter/ChartScatter.tsx
@@ -17,7 +17,7 @@ import {
   VictoryScatterProps
 } from 'victory';
 import { ChartContainer } from '../ChartContainer';
-import { ChartThemeDefinition } from '../ChartTheme';
+import { ChartScatterStyles, ChartThemeDefinition } from '../ChartTheme';
 import { getTheme } from '../ChartUtils';
 
 export enum ChartScatterSortOrder {
@@ -397,6 +397,7 @@ export const ChartScatter: React.FunctionComponent<ChartScatterProps> = ({
 
   // destructure last
   theme = getTheme(themeColor, themeVariant),
+  size = ({ active }) => (active ? ChartScatterStyles.activeSize : ChartScatterStyles.size),
   ...rest
 }: ChartScatterProps) => {
   // Clone so users can override container props
@@ -404,7 +405,7 @@ export const ChartScatter: React.FunctionComponent<ChartScatterProps> = ({
     theme,
     ...containerComponent.props
   });
-  return <VictoryScatter containerComponent={container} theme={theme} {...rest} />;
+  return <VictoryScatter containerComponent={container} size={size} theme={theme} {...rest} />;
 };
 
 // Note: VictoryLine.role must be hoisted

--- a/packages/patternfly-4/react-charts/src/components/ChartScatter/__snapshots__/ChartScatter.test.tsx.snap
+++ b/packages/patternfly-4/react-charts/src/components/ChartScatter/__snapshots__/ChartScatter.test.tsx.snap
@@ -473,6 +473,7 @@ exports[`ChartScatter 1`] = `
     />
   }
   samples={50}
+  size={[Function]}
   sortOrder="ascending"
   standalone={true}
   theme={
@@ -1400,6 +1401,7 @@ exports[`ChartScatter 2`] = `
     />
   }
   samples={50}
+  size={[Function]}
   sortOrder="ascending"
   standalone={true}
   theme={

--- a/packages/patternfly-4/react-charts/src/components/ChartScatter/examples/ChartScatter.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartScatter/examples/ChartScatter.md
@@ -1,0 +1,275 @@
+---
+title: 'Scatter'
+section: 'charts'
+typescript: true
+propComponents: ['Chart', 'ChartArea', 'ChartAxis', 'ChartGroup', 'ChartLine', 'ChartScatter']
+---
+
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartLine, ChartScatter, ChartThemeColor } from '@patternfly/react-charts';
+import { Button, Tooltip } from '@patternfly/react-core';
+import './chart-scatter.scss';
+
+Note: PatternFly React charts live in its own package at [@patternfly/react-charts](https://www.npmjs.com/package/@patternfly/react-charts)!
+
+PatternFly React charts are based on the [Victory](https://formidable.com/open-source/victory/docs/victory-chart/) chart library, along with additional functionality, custom components, and theming for PatternFly. This provides a collection of React based components you can use to build PatternFly patterns with consistent markup, styling, and behavior.
+
+## Scatter area chart
+This demonstrates how to add interactive data points to an area chart
+```js
+import React from 'react';
+import { Chart, ChartArea, ChartAxis, ChartGroup, ChartScatter, ChartThemeColor } from '@patternfly/react-charts';
+// import '@patternfly/patternfly/patternfly-charts.css'; // For mixed blend mode
+
+class ScatterAreaChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.containerRef = React.createRef();
+    this.state = {
+      width: 0
+    };
+    this.handleResize = () => {
+      if(this.containerRef.current && this.containerRef.current.clientWidth){
+        this.setState({ width: this.containerRef.current.clientWidth });
+      }
+    };
+
+    this.series = [
+    {
+      datapoints: [
+        { name: 'Cats', x: '2015', y: 3 },
+        { name: 'Cats', x: '2016', y: 4 },
+        { name: 'Cats', x: '2017', y: 8 },
+        { name: 'Cats', x: '2018', y: 6 }
+      ],
+      legendItem: { name: 'Cats' }
+    },
+    {
+      datapoints: [
+        { name: 'Dogs', x: '2015', y: 2 },
+        { name: 'Dogs', x: '2016', y: 3 },
+        { name: 'Dogs', x: '2017', y: 4 },
+        { name: 'Dogs', x: '2018', y: 5 },
+        { name: 'Dogs', x: '2019', y: 6 }
+      ],
+      legendItem: { name: 'Dogs' }
+    },
+    {
+      datapoints: [
+        { name: 'Birds', x: '2015', y: 1 },
+        { name: 'Birds', x: '2016', y: 2 },
+        { name: 'Birds', x: '2017', y: 3 },
+        { name: 'Birds', x: '2018', y: 2 },
+        { name: 'Birds', x: '2019', y: 4 }
+      ],
+      legendItem: { name: 'Birds' }
+    }];
+  }
+
+  componentDidMount() {
+    this.handleResize();
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  render() {
+    const { width } = this.state;
+
+    return (
+      <div ref={this.containerRef}>
+        <div className="scatter-area-chart-legend-bottom-responsive">
+          <Chart
+            ariaDesc="Average number of pets"
+            ariaTitle="Area chart example"
+            containerComponent={
+              <ChartVoronoiContainer 
+                labels={({ datum }) => datum.childName.includes('area-') ? `${datum.name}: ${datum.y}` : null} 
+                constrainToVisibleArea 
+              />
+            }
+            height={225}
+            legendData={this.series.map(s => s.legendItem)}
+            legendPosition="bottom-left"
+            padding={{
+              bottom: 75, // Adjusted to accommodate legend
+              left: 50,
+              right: 50,
+              top: 50,
+            }}
+            maxDomain={{y: 9}}
+            themeColor={ChartThemeColor.multiUnordered}
+            width={width}
+          >
+            <ChartAxis />
+            <ChartAxis dependentAxis showGrid />
+            <ChartGroup>
+              {this.series.map((s, idx) => {
+                return (
+                  <ChartScatter data={s.datapoints} key={'scatter-' + idx} name={'scatter-' + idx} />
+                );
+              })}
+            </ChartGroup>
+            <ChartGroup>
+              {this.series.map((s, idx) => {
+                return (
+                  <ChartArea key={'area-' + idx} name={'area-' + idx} data={s.datapoints} />
+                );
+              })}
+            </ChartGroup>
+          </Chart>
+        </div>
+      </div>
+    );
+  }
+}
+```
+
+## Scatter line chart
+This demonstrates how to add interactive data points to a line chart
+```js
+import React from 'react';
+import { Chart, ChartAxis, ChartGroup, ChartLine, ChartScatter, ChartThemeColor } from '@patternfly/react-charts';
+
+class ScatterLineChart extends React.Component {
+  constructor(props) {
+    super(props);
+    this.containerRef = React.createRef();
+    this.state = {
+      width: 0
+    };
+    this.handleResize = () => {
+      if(this.containerRef.current && this.containerRef.current.clientWidth){
+        this.setState({ width: this.containerRef.current.clientWidth });
+      }
+    };
+
+    this.series = [
+    {
+      datapoints: [
+        { name: 'Cats', x: '2015', y: 1 },
+        { name: 'Cats', x: '2016', y: 2 },
+        { name: 'Cats', x: '2017', y: 5 },
+        { name: 'Cats', x: '2018', y: 3 }
+      ],
+      legendItem: { name: 'Cats' }
+    },
+    {
+      datapoints: [
+        { name: 'Dogs', x: '2015', y: 2 },
+        { name: 'Dogs', x: '2016', y: 1 },
+        { name: 'Dogs', x: '2017', y: 7 },
+        { name: 'Dogs', x: '2018', y: 4 }
+      ],
+      legendItem: { name: 'Dogs' },
+      style: {
+        data: {
+          strokeDasharray: '3,3'
+        }
+      }
+    },
+    {
+      datapoints: [
+        { name: 'Birds', x: '2015', y: 3 },
+        { name: 'Birds', x: '2016', y: 4 },
+        { name: 'Birds', x: '2017', y: 9 },
+        { name: 'Birds', x: '2018', y: 5 }
+      ],
+      legendItem: { name: 'Birds' }
+    },
+    {
+      datapoints: [
+        { name: 'Mice', x: '2015', y: 3 },
+        { name: 'Mice', x: '2016', y: 3 },
+        { name: 'Mice', x: '2017', y: 8 },
+        { name: 'Mice', x: '2018', y: 7 }
+      ],
+      legendItem: { name: 'Birds' }
+    }];
+  }
+
+  componentDidMount() {
+    this.handleResize();
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  render() {
+    const { width } = this.state;
+
+    return (
+      <div ref={this.containerRef}>
+        <div className="scatter-line-chart-legend-bottom-responsive">
+          <Chart
+            ariaDesc="Average number of pets"
+            ariaTitle="Line chart example"
+            containerComponent={
+              <ChartVoronoiContainer 
+                labels={({ datum }) => datum.childName.includes('line-') ? `${datum.name}: ${datum.y}` : null}  
+                constrainToVisibleArea
+              />
+            }
+            legendData={this.series.map(s => s.legendItem)}
+            legendPosition="bottom-left"
+            height={275}
+            maxDomain={{y: 10}}
+            minDomain={{y: 0}}
+            padding={{
+              bottom: 75, // Adjusted to accommodate legend
+              left: 50,
+              right: 50,
+              top: 50
+            }}
+            themeColor={ChartThemeColor.orange}
+            width={width}
+          >
+            <ChartAxis tickValues={[2, 3, 4]} />
+            <ChartAxis dependentAxis showGrid tickValues={[2, 5, 8]} />
+            <ChartGroup>
+              {this.series.map((s, idx) => {
+                return (
+                    <ChartScatter
+                      data={s.datapoints}
+                      key={'scatter-' + idx}
+                      name={'scatter-' + idx}
+                    />
+                );
+              })}
+            </ChartGroup>
+            <ChartGroup>
+              {this.series.map((s, idx) => {
+                return (
+                    <ChartLine
+                      key={'line-' + idx}
+                      name={'line-' + idx}
+                      data={s.datapoints}
+                    />
+                );
+              })}
+            </ChartGroup>
+          </Chart>
+        </div>
+      </div>
+    );
+  }
+}
+```
+
+## Tips
+
+- For single data points or zero values, you may want to set the `domain` prop. See Victory's <a href="https://formidable.com/open-source/victory/docs/faq/#my-axis-labels-are-showing-very-small-numbers-how-do-i-fix-this" target="_blank">FAQ</a>
+
+## Docs
+Currently, the generated documention below is not able to resolve type definitions from Victory imports. For the 
+components used in the examples above, Victory pass-thru props are also documented here:
+
+ - For `Chart` props, see [VictoryChart](https://formidable.com/open-source/victory/docs/victory-chart)
+ - For `ChartArea` props, see [VictoryArea](https://formidable.com/open-source/victory/docs/victory-area)
+ - For `ChartAxis` props, see [VictoryAxis](https://formidable.com/open-source/victory/docs/victory-axis)
+ - For `ChartGroup` props, see [VictoryGroup](https://formidable.com/open-source/victory/docs/victory-group)
+ - For `ChartLine` props, see [VictoryLine](https://formidable.com/open-source/victory/docs/victory-line)
+ - For `ChartScatter` props, see [VictoryScatter](https://formidable.com/open-source/victory/docs/victory-scatter)

--- a/packages/patternfly-4/react-charts/src/components/ChartScatter/examples/chart-scatter.scss
+++ b/packages/patternfly-4/react-charts/src/components/ChartScatter/examples/chart-scatter.scss
@@ -1,0 +1,11 @@
+.ws-preview {
+  & > * {
+    .scatter-area-chart-threshold-bottom-responsive {
+      height: 250px;
+    }
+
+    .scatter-line-chart-legend-bottom-responsive {
+      height: 275px;
+    }
+  }
+}

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/ChartStyles.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/ChartStyles.ts
@@ -2,8 +2,10 @@ import { CommonStyles } from './styles/common-styles';
 import { BulletStyles } from './styles/bullet-styles';
 import { DonutStyles } from './styles/donut-styles';
 import { DonutUtilizationStyles } from './styles/donut-utilization-styles';
+import { ScatterStyles } from './styles/scatter-styles';
 
 export const ChartCommonStyles = CommonStyles;
 export const ChartBulletStyles = BulletStyles;
 export const ChartDonutStyles = DonutStyles;
 export const ChartDonutUtilizationStyles = DonutUtilizationStyles;
+export const ChartScatterStyles = ScatterStyles;

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/styles/scatter-styles.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/styles/scatter-styles.ts
@@ -1,0 +1,11 @@
+/* eslint-disable camelcase */
+import {
+  chart_scatter_active_size,
+  chart_scatter_size
+} from '@patternfly/react-tokens';
+
+// Donut styles
+export const ScatterStyles = {
+  activeSize: chart_scatter_active_size.value,
+  size: chart_scatter_size.value
+};

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/threshold-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/threshold-theme.ts
@@ -1,14 +1,9 @@
-/* eslint-disable camelcase */
-import {
-  chart_threshold_stroke_dash_array
-} from '@patternfly/react-tokens';
-
 // Threshold theme
 export const ThresholdTheme = {
   line: {
     style: {
       data: {
-        strokeDasharray: chart_threshold_stroke_dash_array.value
+        strokeDasharray: '6,6'
       }
     }
   }

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/threshold-theme.ts
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/themes/threshold-theme.ts
@@ -1,9 +1,14 @@
+/* eslint-disable camelcase */
+import {
+  chart_threshold_stroke_dash_array
+} from '@patternfly/react-tokens';
+
 // Threshold theme
 export const ThresholdTheme = {
   line: {
     style: {
       data: {
-        strokeDasharray: '6,6'
+        strokeDasharray: chart_threshold_stroke_dash_array.value
       }
     }
   }


### PR DESCRIPTION
Adds pf-core variables to the ChartScatter component and examples

Fixes https://github.com/patternfly/patternfly-react/issues/3079

<img width="1085" alt="Screen Shot 2019-10-07 at 5 43 03 PM" src="https://user-images.githubusercontent.com/17481322/66350693-fb445080-e929-11e9-853a-c1698f33bccd.png">
