### PR TITLE
Fix warnings about use of deprecated lifecycle methods

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/ClassificationBanner/ClassificationBanner.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ClassificationBanner/ClassificationBanner.js
@@ -28,7 +28,7 @@ class ClassificationBanner extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.closed !== this.state.closed) {
       this.setState({ closed: nextProps.closed });
     }

--- a/packages/patternfly-3/patternfly-react/src/components/LoginPage/components/LoginCardComponents/LoginLanguagePicker.js
+++ b/packages/patternfly-3/patternfly-react/src/components/LoginPage/components/LoginCardComponents/LoginLanguagePicker.js
@@ -13,7 +13,7 @@ class LoginLanguagePicker extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { selectedLanguage, availableLanguages } = nextProps;
     const title = selectedLanguage || (availableLanguages && availableLanguages[0].text);
 

--- a/packages/patternfly-3/patternfly-react/src/components/Pagination/Paginator.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Pagination/Paginator.js
@@ -15,7 +15,7 @@ class Paginator extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { pagination } = nextProps;
     if (this.state.pageChangeValue !== pagination.page) {
       this.setState({

--- a/packages/patternfly-3/patternfly-react/src/components/Slider/BootstrapSlider.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Slider/BootstrapSlider.js
@@ -25,7 +25,7 @@ class BootstrapSlider extends React.Component {
   // Instead of rendering the slider element again and again,
   // we took advantage of the bootstrap-slider library
   // and only update the new value or format when new props arrive.
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.slider.setValue(nextProps.value);
     // Sets the tooltip format.
     this.slider.setAttribute('formatter', nextProps.formatter);

--- a/packages/patternfly-3/patternfly-react/src/components/Table/__mocks__/mockServerPaginationTable.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Table/__mocks__/mockServerPaginationTable.js
@@ -202,7 +202,7 @@ export class MockServerPaginationTable extends React.Component {
     };
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { sortingColumns, pagination } = this.state;
     this.getPage(sortingColumns, pagination);
   }

--- a/packages/patternfly-3/patternfly-react/src/components/ToastNotification/TimedToastNotification.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ToastNotification/TimedToastNotification.js
@@ -23,7 +23,7 @@ class TimedToastNotification extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     /**
      * If paused prop changes, update our timer
      */

--- a/packages/patternfly-3/patternfly-react/src/components/ToastNotification/ToastNotificationList.js
+++ b/packages/patternfly-3/patternfly-react/src/components/ToastNotification/ToastNotificationList.js
@@ -10,7 +10,7 @@ import TimedToastNotification from './TimedToastNotification';
 class ToastNotificationList extends React.Component {
   state = { paused: false };
 
-  componentWillReceiveProps() {
+  UNSAFE_componentWillReceiveProps() {
     this.setState({ paused: false });
   }
 

--- a/packages/patternfly-3/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
+++ b/packages/patternfly-3/patternfly-react/src/components/VerticalNav/VerticalNavItemHelper.js
@@ -37,7 +37,7 @@ class BaseVerticalNavItemHelper extends React.Component {
     }
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     const {
       setControlledActivePath,
       setControlledHoverPath,

--- a/packages/patternfly-3/patternfly-react/src/components/Wizard/Stories/mockWizardDeployContents.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Wizard/Stories/mockWizardDeployContents.js
@@ -6,7 +6,7 @@ class MockWizardDeployContents extends React.Component {
     super();
     this.state = { deploying: true };
   }
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { active } = this.props;
     if (!nextProps.active) {
       this.setState({ deploying: true });

--- a/packages/patternfly-3/react-console/src/SerialConsole/XTerm.js
+++ b/packages/patternfly-3/react-console/src/SerialConsole/XTerm.js
@@ -17,7 +17,7 @@ const { noop } = helpers;
 class XTerm extends React.Component {
   state = { terminal: null, rows: null, cols: null, autoFit: false };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const term = new Terminal({
       cols: this.props.cols,
       rows: this.props.rows,
@@ -52,7 +52,7 @@ class XTerm extends React.Component {
     this.onWindowResize();
   }
 
-  componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(newProps) {
     if (
       newProps.cols !== this.state.cols ||
       newProps.rows !== this.state.rows ||
@@ -66,7 +66,7 @@ class XTerm extends React.Component {
     }
   }
 
-  componentWillUpdate(nextProps, nextState) {
+  UNSAFE_componentWillUpdate(nextProps, nextState) {
     if (
       nextState.cols !== this.state.cols ||
       nextState.rows !== this.state.rows ||


### PR DESCRIPTION
The above fixes where done automatically with:
$ npx react-codemod rename-unsafe-lifecycles

Relevant issue: https://github.com/patternfly/patternfly-react/issues/3170