### PR TITLE
fix(Dropdown/Application Launcher/Options Menu): Fix unit tests and options menu

### DIFF
--- a/packages/patternfly-4/react-core/src/components/ApplicationLauncher/__snapshots__/ApplicationLauncher.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/ApplicationLauncher/__snapshots__/ApplicationLauncher.test.js.snap
@@ -167,21 +167,25 @@ exports[`ApplicationLauncher custom icon 1`] = `
                 role="menu"
               >
                 <li
+                  id=""
                   role="menuitem"
                 >
                   <a
                     aria-disabled="false"
                     class="pf-c-app-launcher__menu-item"
+                    id=""
                     tabindex="-1"
                   >
                     Link
                   </a>
                 </li>
                 <li
+                  id=""
                   role="menuitem"
                 >
                   <button
                     class="pf-c-app-launcher__menu-item"
+                    id=""
                     tabindex="-1"
                     type="button"
                   >
@@ -189,22 +193,26 @@ exports[`ApplicationLauncher custom icon 1`] = `
                   </button>
                 </li>
                 <li
+                  id=""
                   role="menuitem"
                 >
                   <a
                     aria-disabled="true"
                     class="pf-m-disabled pf-c-app-launcher__menu-item"
+                    id=""
                     tabindex="-1"
                   >
                     Disabled Link
                   </a>
                 </li>
                 <li
+                  id=""
                   role="menuitem"
                 >
                   <button
                     class="pf-m-disabled pf-c-app-launcher__menu-item"
                     disabled=""
+                    id=""
                     tabindex="-1"
                     type="button"
                   >
@@ -212,28 +220,34 @@ exports[`ApplicationLauncher custom icon 1`] = `
                   </button>
                 </li>
                 <li
+                  id=""
                   role="separator"
                 >
                   <div
                     class="pf-c-app-launcher__separator"
+                    id=""
                   />
                 </li>
                 <li
+                  id=""
                   role="menuitem"
                 >
                   <a
                     aria-disabled="false"
                     class="pf-c-app-launcher__menu-item"
+                    id=""
                     tabindex="-1"
                   >
                     Separated Link
                   </a>
                 </li>
                 <li
+                  id=""
                   role="menuitem"
                 >
                   <button
                     class="pf-c-app-launcher__menu-item"
+                    id=""
                     tabindex="-1"
                     type="button"
                   >
@@ -298,21 +312,25 @@ exports[`ApplicationLauncher custom icon 1`] = `
                   role="menu"
                 >
                   <li
+                    id=""
                     role="menuitem"
                   >
                     <a
                       aria-disabled="false"
                       class="pf-c-app-launcher__menu-item"
+                      id=""
                       tabindex="-1"
                     >
                       Link
                     </a>
                   </li>
                   <li
+                    id=""
                     role="menuitem"
                   >
                     <button
                       class="pf-c-app-launcher__menu-item"
+                      id=""
                       tabindex="-1"
                       type="button"
                     >
@@ -320,22 +338,26 @@ exports[`ApplicationLauncher custom icon 1`] = `
                     </button>
                   </li>
                   <li
+                    id=""
                     role="menuitem"
                   >
                     <a
                       aria-disabled="true"
                       class="pf-m-disabled pf-c-app-launcher__menu-item"
+                      id=""
                       tabindex="-1"
                     >
                       Disabled Link
                     </a>
                   </li>
                   <li
+                    id=""
                     role="menuitem"
                   >
                     <button
                       class="pf-m-disabled pf-c-app-launcher__menu-item"
                       disabled=""
+                      id=""
                       tabindex="-1"
                       type="button"
                     >
@@ -343,28 +365,34 @@ exports[`ApplicationLauncher custom icon 1`] = `
                     </button>
                   </li>
                   <li
+                    id=""
                     role="separator"
                   >
                     <div
                       class="pf-c-app-launcher__separator"
+                      id=""
                     />
                   </li>
                   <li
+                    id=""
                     role="menuitem"
                   >
                     <a
                       aria-disabled="false"
                       class="pf-c-app-launcher__menu-item"
+                      id=""
                       tabindex="-1"
                     >
                       Separated Link
                     </a>
                   </li>
                   <li
+                    id=""
                     role="menuitem"
                   >
                     <button
                       class="pf-c-app-launcher__menu-item"
+                      id=""
                       tabindex="-1"
                       type="button"
                     >
@@ -446,6 +474,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             <InternalDropdownItem
               className=""
               component="a"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -453,6 +482,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                 }
               }
               href=""
+              id=""
               index={0}
               isDisabled={false}
               isHovered={false}
@@ -465,6 +495,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="menuitem"
@@ -473,6 +504,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                   aria-disabled={false}
                   className="pf-c-app-launcher__menu-item"
                   href={null}
+                  id=""
                   onSelect={[Function]}
                   tabIndex={-1}
                 >
@@ -489,6 +521,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             <InternalDropdownItem
               className=""
               component="button"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -496,6 +529,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                 }
               }
               href=""
+              id=""
               index={1}
               isDisabled={false}
               isHovered={false}
@@ -508,6 +542,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="menuitem"
@@ -516,6 +551,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                   className="pf-c-app-launcher__menu-item"
                   disabled={false}
                   href={null}
+                  id=""
                   onSelect={[Function]}
                   tabIndex={-1}
                   type="button"
@@ -533,6 +569,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             <InternalDropdownItem
               className=""
               component="a"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -540,6 +577,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                 }
               }
               href=""
+              id=""
               index={2}
               isDisabled={true}
               isHovered={false}
@@ -552,6 +590,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="menuitem"
@@ -560,6 +599,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                   aria-disabled={true}
                   className="pf-m-disabled pf-c-app-launcher__menu-item"
                   href={null}
+                  id=""
                   onSelect={[Function]}
                   tabIndex={-1}
                 >
@@ -577,6 +617,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             <InternalDropdownItem
               className=""
               component="button"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -584,6 +625,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                 }
               }
               href=""
+              id=""
               index={3}
               isDisabled={true}
               isHovered={false}
@@ -596,6 +638,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="menuitem"
@@ -604,6 +647,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                   className="pf-m-disabled pf-c-app-launcher__menu-item"
                   disabled={true}
                   href={null}
+                  id=""
                   onSelect={[Function]}
                   tabIndex={-1}
                   type="button"
@@ -620,6 +664,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             <InternalDropdownItem
               className="pf-c-app-launcher__separator"
               component="div"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -627,6 +672,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                 }
               }
               href=""
+              id=""
               index={4}
               isDisabled={false}
               isHovered={false}
@@ -637,6 +683,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="separator"
@@ -644,6 +691,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                 <div
                   className="pf-c-app-launcher__separator"
                   href={null}
+                  id=""
                   onSelect={[Function]}
                 />
               </li>
@@ -656,6 +704,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             <InternalDropdownItem
               className=""
               component="a"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -663,6 +712,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                 }
               }
               href=""
+              id=""
               index={5}
               isDisabled={false}
               isHovered={false}
@@ -675,6 +725,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="menuitem"
@@ -683,6 +734,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                   aria-disabled={false}
                   className="pf-c-app-launcher__menu-item"
                   href={null}
+                  id=""
                   onSelect={[Function]}
                   tabIndex={-1}
                 >
@@ -699,6 +751,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             <InternalDropdownItem
               className=""
               component="button"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -706,6 +759,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                 }
               }
               href=""
+              id=""
               index={6}
               isDisabled={false}
               isHovered={false}
@@ -718,6 +772,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="menuitem"
@@ -726,6 +781,7 @@ exports[`ApplicationLauncher custom icon 1`] = `
                   className="pf-c-app-launcher__menu-item"
                   disabled={false}
                   href={null}
+                  id=""
                   onSelect={[Function]}
                   tabIndex={-1}
                   type="button"
@@ -1428,21 +1484,25 @@ exports[`ApplicationLauncher expanded 1`] = `
                 role="menu"
               >
                 <li
+                  id=""
                   role="menuitem"
                 >
                   <a
                     aria-disabled="false"
                     class="pf-c-app-launcher__menu-item"
+                    id=""
                     tabindex="-1"
                   >
                     Link
                   </a>
                 </li>
                 <li
+                  id=""
                   role="menuitem"
                 >
                   <button
                     class="pf-c-app-launcher__menu-item"
+                    id=""
                     tabindex="-1"
                     type="button"
                   >
@@ -1450,22 +1510,26 @@ exports[`ApplicationLauncher expanded 1`] = `
                   </button>
                 </li>
                 <li
+                  id=""
                   role="menuitem"
                 >
                   <a
                     aria-disabled="true"
                     class="pf-m-disabled pf-c-app-launcher__menu-item"
+                    id=""
                     tabindex="-1"
                   >
                     Disabled Link
                   </a>
                 </li>
                 <li
+                  id=""
                   role="menuitem"
                 >
                   <button
                     class="pf-m-disabled pf-c-app-launcher__menu-item"
                     disabled=""
+                    id=""
                     tabindex="-1"
                     type="button"
                   >
@@ -1473,28 +1537,34 @@ exports[`ApplicationLauncher expanded 1`] = `
                   </button>
                 </li>
                 <li
+                  id=""
                   role="separator"
                 >
                   <div
                     class="pf-c-app-launcher__separator"
+                    id=""
                   />
                 </li>
                 <li
+                  id=""
                   role="menuitem"
                 >
                   <a
                     aria-disabled="false"
                     class="pf-c-app-launcher__menu-item"
+                    id=""
                     tabindex="-1"
                   >
                     Separated Link
                   </a>
                 </li>
                 <li
+                  id=""
                   role="menuitem"
                 >
                   <button
                     class="pf-c-app-launcher__menu-item"
+                    id=""
                     tabindex="-1"
                     type="button"
                   >
@@ -1558,21 +1628,25 @@ exports[`ApplicationLauncher expanded 1`] = `
                   role="menu"
                 >
                   <li
+                    id=""
                     role="menuitem"
                   >
                     <a
                       aria-disabled="false"
                       class="pf-c-app-launcher__menu-item"
+                      id=""
                       tabindex="-1"
                     >
                       Link
                     </a>
                   </li>
                   <li
+                    id=""
                     role="menuitem"
                   >
                     <button
                       class="pf-c-app-launcher__menu-item"
+                      id=""
                       tabindex="-1"
                       type="button"
                     >
@@ -1580,22 +1654,26 @@ exports[`ApplicationLauncher expanded 1`] = `
                     </button>
                   </li>
                   <li
+                    id=""
                     role="menuitem"
                   >
                     <a
                       aria-disabled="true"
                       class="pf-m-disabled pf-c-app-launcher__menu-item"
+                      id=""
                       tabindex="-1"
                     >
                       Disabled Link
                     </a>
                   </li>
                   <li
+                    id=""
                     role="menuitem"
                   >
                     <button
                       class="pf-m-disabled pf-c-app-launcher__menu-item"
                       disabled=""
+                      id=""
                       tabindex="-1"
                       type="button"
                     >
@@ -1603,28 +1681,34 @@ exports[`ApplicationLauncher expanded 1`] = `
                     </button>
                   </li>
                   <li
+                    id=""
                     role="separator"
                   >
                     <div
                       class="pf-c-app-launcher__separator"
+                      id=""
                     />
                   </li>
                   <li
+                    id=""
                     role="menuitem"
                   >
                     <a
                       aria-disabled="false"
                       class="pf-c-app-launcher__menu-item"
+                      id=""
                       tabindex="-1"
                     >
                       Separated Link
                     </a>
                   </li>
                   <li
+                    id=""
                     role="menuitem"
                   >
                     <button
                       class="pf-c-app-launcher__menu-item"
+                      id=""
                       tabindex="-1"
                       type="button"
                     >
@@ -1704,6 +1788,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             <InternalDropdownItem
               className=""
               component="a"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -1711,6 +1796,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                 }
               }
               href=""
+              id=""
               index={0}
               isDisabled={false}
               isHovered={false}
@@ -1723,6 +1809,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="menuitem"
@@ -1731,6 +1818,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                   aria-disabled={false}
                   className="pf-c-app-launcher__menu-item"
                   href={null}
+                  id=""
                   onSelect={[Function]}
                   tabIndex={-1}
                 >
@@ -1747,6 +1835,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             <InternalDropdownItem
               className=""
               component="button"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -1754,6 +1843,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                 }
               }
               href=""
+              id=""
               index={1}
               isDisabled={false}
               isHovered={false}
@@ -1766,6 +1856,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="menuitem"
@@ -1774,6 +1865,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                   className="pf-c-app-launcher__menu-item"
                   disabled={false}
                   href={null}
+                  id=""
                   onSelect={[Function]}
                   tabIndex={-1}
                   type="button"
@@ -1791,6 +1883,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             <InternalDropdownItem
               className=""
               component="a"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -1798,6 +1891,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                 }
               }
               href=""
+              id=""
               index={2}
               isDisabled={true}
               isHovered={false}
@@ -1810,6 +1904,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="menuitem"
@@ -1818,6 +1913,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                   aria-disabled={true}
                   className="pf-m-disabled pf-c-app-launcher__menu-item"
                   href={null}
+                  id=""
                   onSelect={[Function]}
                   tabIndex={-1}
                 >
@@ -1835,6 +1931,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             <InternalDropdownItem
               className=""
               component="button"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -1842,6 +1939,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                 }
               }
               href=""
+              id=""
               index={3}
               isDisabled={true}
               isHovered={false}
@@ -1854,6 +1952,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="menuitem"
@@ -1862,6 +1961,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                   className="pf-m-disabled pf-c-app-launcher__menu-item"
                   disabled={true}
                   href={null}
+                  id=""
                   onSelect={[Function]}
                   tabIndex={-1}
                   type="button"
@@ -1878,6 +1978,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             <InternalDropdownItem
               className="pf-c-app-launcher__separator"
               component="div"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -1885,6 +1986,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                 }
               }
               href=""
+              id=""
               index={4}
               isDisabled={false}
               isHovered={false}
@@ -1895,6 +1997,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="separator"
@@ -1902,6 +2005,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                 <div
                   className="pf-c-app-launcher__separator"
                   href={null}
+                  id=""
                   onSelect={[Function]}
                 />
               </li>
@@ -1914,6 +2018,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             <InternalDropdownItem
               className=""
               component="a"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -1921,6 +2026,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                 }
               }
               href=""
+              id=""
               index={5}
               isDisabled={false}
               isHovered={false}
@@ -1933,6 +2039,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="menuitem"
@@ -1941,6 +2048,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                   aria-disabled={false}
                   className="pf-c-app-launcher__menu-item"
                   href={null}
+                  id=""
                   onSelect={[Function]}
                   tabIndex={-1}
                 >
@@ -1957,6 +2065,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             <InternalDropdownItem
               className=""
               component="button"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -1964,6 +2073,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                 }
               }
               href=""
+              id=""
               index={6}
               isDisabled={false}
               isHovered={false}
@@ -1976,6 +2086,7 @@ exports[`ApplicationLauncher expanded 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="menuitem"
@@ -1984,6 +2095,7 @@ exports[`ApplicationLauncher expanded 1`] = `
                   className="pf-c-app-launcher__menu-item"
                   disabled={false}
                   href={null}
+                  id=""
                   onSelect={[Function]}
                   tabIndex={-1}
                   type="button"

--- a/packages/patternfly-4/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -32,6 +32,8 @@ export interface InternalDropdownItemProps extends React.HTMLProps<HTMLAnchorEle
   };
   /** Callback for click event */
   onClick?: (event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => void;
+  /** ID for the list element */
+  id?: string;
 }
 
 export class InternalDropdownItem extends React.Component<InternalDropdownItemProps> {
@@ -94,6 +96,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
       href,
       tooltip,
       tooltipProps,
+      id,
       listItemClassName,
       ...additionalProps
     } = this.props;
@@ -141,6 +144,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
                   onSelect(event);
                 }
               }}
+              id={id}
             >
               {renderWithTooltip(
                 isComponentReactElement ? (

--- a/packages/patternfly-4/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -34,6 +34,8 @@ export interface InternalDropdownItemProps extends React.HTMLProps<HTMLAnchorEle
   onClick?: (event: React.MouseEvent<any> | React.KeyboardEvent | MouseEvent) => void;
   /** ID for the list element */
   id?: string;
+  /** ID for the component element */
+  componentID?: string;
 }
 
 export class InternalDropdownItem extends React.Component<InternalDropdownItemProps> {
@@ -53,7 +55,9 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
     context: {
       keyHandler: Function.prototype,
       sendRef: Function.prototype
-    }
+    },
+    id: '',
+    componentID: '',
   };
 
   componentDidMount() {
@@ -97,6 +101,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
       tooltip,
       tooltipProps,
       id,
+      componentID,
       listItemClassName,
       ...additionalProps
     } = this.props;
@@ -157,6 +162,7 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
                     {...additionalProps}
                     href={href || null}
                     className={css(classes, this.props.role !== 'separator' && itemClass)}
+                    id={componentID}
                   >
                     {children}
                   </Component>

--- a/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -203,6 +203,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -210,6 +211,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -223,6 +225,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -230,6 +233,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -243,6 +247,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -250,6 +255,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -263,6 +269,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -270,6 +277,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -284,6 +292,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -291,6 +300,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -304,6 +314,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -311,6 +322,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -339,6 +351,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -346,6 +359,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -359,6 +373,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -366,6 +381,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -379,6 +395,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -386,6 +403,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -399,6 +417,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -406,6 +425,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -420,6 +440,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -427,6 +448,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -440,6 +462,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -447,6 +470,7 @@ exports[`KebabToggle dropup + right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -612,6 +636,7 @@ exports[`KebabToggle dropup 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -619,6 +644,7 @@ exports[`KebabToggle dropup 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -632,6 +658,7 @@ exports[`KebabToggle dropup 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -639,6 +666,7 @@ exports[`KebabToggle dropup 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -652,6 +680,7 @@ exports[`KebabToggle dropup 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -659,6 +688,7 @@ exports[`KebabToggle dropup 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -672,6 +702,7 @@ exports[`KebabToggle dropup 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -679,6 +710,7 @@ exports[`KebabToggle dropup 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -693,6 +725,7 @@ exports[`KebabToggle dropup 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -700,6 +733,7 @@ exports[`KebabToggle dropup 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -713,6 +747,7 @@ exports[`KebabToggle dropup 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -720,6 +755,7 @@ exports[`KebabToggle dropup 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -747,6 +783,7 @@ exports[`KebabToggle dropup 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -754,6 +791,7 @@ exports[`KebabToggle dropup 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -767,6 +805,7 @@ exports[`KebabToggle dropup 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -774,6 +813,7 @@ exports[`KebabToggle dropup 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -787,6 +827,7 @@ exports[`KebabToggle dropup 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -794,6 +835,7 @@ exports[`KebabToggle dropup 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -807,6 +849,7 @@ exports[`KebabToggle dropup 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -814,6 +857,7 @@ exports[`KebabToggle dropup 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -828,6 +872,7 @@ exports[`KebabToggle dropup 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -835,6 +880,7 @@ exports[`KebabToggle dropup 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -848,6 +894,7 @@ exports[`KebabToggle dropup 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -855,6 +902,7 @@ exports[`KebabToggle dropup 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -1019,6 +1067,7 @@ exports[`KebabToggle expanded 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -1026,6 +1075,7 @@ exports[`KebabToggle expanded 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -1039,6 +1089,7 @@ exports[`KebabToggle expanded 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -1046,6 +1097,7 @@ exports[`KebabToggle expanded 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -1059,6 +1111,7 @@ exports[`KebabToggle expanded 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -1066,6 +1119,7 @@ exports[`KebabToggle expanded 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -1079,6 +1133,7 @@ exports[`KebabToggle expanded 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -1086,6 +1141,7 @@ exports[`KebabToggle expanded 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -1100,6 +1156,7 @@ exports[`KebabToggle expanded 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -1107,6 +1164,7 @@ exports[`KebabToggle expanded 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -1120,6 +1178,7 @@ exports[`KebabToggle expanded 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -1127,6 +1186,7 @@ exports[`KebabToggle expanded 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -1155,6 +1215,7 @@ exports[`KebabToggle expanded 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -1162,6 +1223,7 @@ exports[`KebabToggle expanded 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -1175,6 +1237,7 @@ exports[`KebabToggle expanded 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -1182,6 +1245,7 @@ exports[`KebabToggle expanded 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -1195,6 +1259,7 @@ exports[`KebabToggle expanded 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -1202,6 +1267,7 @@ exports[`KebabToggle expanded 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -1215,6 +1281,7 @@ exports[`KebabToggle expanded 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -1222,6 +1289,7 @@ exports[`KebabToggle expanded 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -1236,6 +1304,7 @@ exports[`KebabToggle expanded 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -1243,6 +1312,7 @@ exports[`KebabToggle expanded 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -1256,6 +1326,7 @@ exports[`KebabToggle expanded 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -1263,6 +1334,7 @@ exports[`KebabToggle expanded 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -1330,69 +1402,83 @@ exports[`KebabToggle expanded 1`] = `
                 role="menu"
               >
                 <li
+                  id=""
                   role="none"
                 >
                   <a
                     aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
+                    id=""
                   >
                     Link
                   </a>
                 </li>
                 <li
+                  id=""
                   role="none"
                 >
                   <button
                     class="pf-c-dropdown__menu-item"
+                    id=""
                     type="button"
                   >
                     Action
                   </button>
                 </li>
                 <li
+                  id=""
                   role="none"
                 >
                   <a
                     aria-disabled="true"
                     class="pf-m-disabled pf-c-dropdown__menu-item"
+                    id=""
                     tabindex="-1"
                   >
                     Disabled Link
                   </a>
                 </li>
                 <li
+                  id=""
                   role="none"
                 >
                   <button
                     class="pf-m-disabled pf-c-dropdown__menu-item"
                     disabled=""
+                    id=""
                     type="button"
                   >
                     Disabled Action
                   </button>
                 </li>
                 <li
+                  id=""
                   role="separator"
                 >
                   <div
                     class="pf-c-dropdown__separator"
+                    id=""
                   />
                 </li>
                 <li
+                  id=""
                   role="none"
                 >
                   <a
                     aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
+                    id=""
                   >
                     Separated Link
                   </a>
                 </li>
                 <li
+                  id=""
                   role="none"
                 >
                   <button
                     class="pf-c-dropdown__menu-item"
+                    id=""
                     type="button"
                   >
                     Separated Action
@@ -1452,69 +1538,83 @@ exports[`KebabToggle expanded 1`] = `
                   role="menu"
                 >
                   <li
+                    id=""
                     role="none"
                   >
                     <a
                       aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
+                      id=""
                     >
                       Link
                     </a>
                   </li>
                   <li
+                    id=""
                     role="none"
                   >
                     <button
                       class="pf-c-dropdown__menu-item"
+                      id=""
                       type="button"
                     >
                       Action
                     </button>
                   </li>
                   <li
+                    id=""
                     role="none"
                   >
                     <a
                       aria-disabled="true"
                       class="pf-m-disabled pf-c-dropdown__menu-item"
+                      id=""
                       tabindex="-1"
                     >
                       Disabled Link
                     </a>
                   </li>
                   <li
+                    id=""
                     role="none"
                   >
                     <button
                       class="pf-m-disabled pf-c-dropdown__menu-item"
                       disabled=""
+                      id=""
                       type="button"
                     >
                       Disabled Action
                     </button>
                   </li>
                   <li
+                    id=""
                     role="separator"
                   >
                     <div
                       class="pf-c-dropdown__separator"
+                      id=""
                     />
                   </li>
                   <li
+                    id=""
                     role="none"
                   >
                     <a
                       aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
+                      id=""
                     >
                       Separated Link
                     </a>
                   </li>
                   <li
+                    id=""
                     role="none"
                   >
                     <button
                       class="pf-c-dropdown__menu-item"
+                      id=""
                       type="button"
                     >
                       Separated Action
@@ -1585,6 +1685,7 @@ exports[`KebabToggle expanded 1`] = `
           <InternalDropdownItem
             className=""
             component="a"
+            componentID=""
             context={
               Object {
                 "keyHandler": [Function],
@@ -1592,6 +1693,7 @@ exports[`KebabToggle expanded 1`] = `
               }
             }
             href=""
+            id=""
             index={0}
             isDisabled={false}
             isHovered={false}
@@ -1603,6 +1705,7 @@ exports[`KebabToggle expanded 1`] = `
           >
             <li
               className={null}
+              id=""
               onClick={[Function]}
               onKeyDown={[Function]}
               role="none"
@@ -1611,6 +1714,7 @@ exports[`KebabToggle expanded 1`] = `
                 aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
                 href={null}
+                id=""
                 onSelect={[Function]}
               >
                 Link
@@ -1620,6 +1724,7 @@ exports[`KebabToggle expanded 1`] = `
           <InternalDropdownItem
             className=""
             component="button"
+            componentID=""
             context={
               Object {
                 "keyHandler": [Function],
@@ -1627,6 +1732,7 @@ exports[`KebabToggle expanded 1`] = `
               }
             }
             href=""
+            id=""
             index={1}
             isDisabled={false}
             isHovered={false}
@@ -1638,6 +1744,7 @@ exports[`KebabToggle expanded 1`] = `
           >
             <li
               className={null}
+              id=""
               onClick={[Function]}
               onKeyDown={[Function]}
               role="none"
@@ -1646,6 +1753,7 @@ exports[`KebabToggle expanded 1`] = `
                 className="pf-c-dropdown__menu-item"
                 disabled={false}
                 href={null}
+                id=""
                 onSelect={[Function]}
                 type="button"
               >
@@ -1656,6 +1764,7 @@ exports[`KebabToggle expanded 1`] = `
           <InternalDropdownItem
             className=""
             component="a"
+            componentID=""
             context={
               Object {
                 "keyHandler": [Function],
@@ -1663,6 +1772,7 @@ exports[`KebabToggle expanded 1`] = `
               }
             }
             href=""
+            id=""
             index={2}
             isDisabled={true}
             isHovered={false}
@@ -1674,6 +1784,7 @@ exports[`KebabToggle expanded 1`] = `
           >
             <li
               className={null}
+              id=""
               onClick={[Function]}
               onKeyDown={[Function]}
               role="none"
@@ -1682,6 +1793,7 @@ exports[`KebabToggle expanded 1`] = `
                 aria-disabled={true}
                 className="pf-m-disabled pf-c-dropdown__menu-item"
                 href={null}
+                id=""
                 onSelect={[Function]}
                 tabIndex={-1}
               >
@@ -1692,6 +1804,7 @@ exports[`KebabToggle expanded 1`] = `
           <InternalDropdownItem
             className=""
             component="button"
+            componentID=""
             context={
               Object {
                 "keyHandler": [Function],
@@ -1699,6 +1812,7 @@ exports[`KebabToggle expanded 1`] = `
               }
             }
             href=""
+            id=""
             index={3}
             isDisabled={true}
             isHovered={false}
@@ -1710,6 +1824,7 @@ exports[`KebabToggle expanded 1`] = `
           >
             <li
               className={null}
+              id=""
               onClick={[Function]}
               onKeyDown={[Function]}
               role="none"
@@ -1718,6 +1833,7 @@ exports[`KebabToggle expanded 1`] = `
                 className="pf-m-disabled pf-c-dropdown__menu-item"
                 disabled={true}
                 href={null}
+                id=""
                 onSelect={[Function]}
                 type="button"
               >
@@ -1732,6 +1848,7 @@ exports[`KebabToggle expanded 1`] = `
             <InternalDropdownItem
               className="pf-c-dropdown__separator"
               component="div"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -1739,6 +1856,7 @@ exports[`KebabToggle expanded 1`] = `
                 }
               }
               href=""
+              id=""
               index={4}
               isDisabled={false}
               isHovered={false}
@@ -1749,6 +1867,7 @@ exports[`KebabToggle expanded 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="separator"
@@ -1756,6 +1875,7 @@ exports[`KebabToggle expanded 1`] = `
                 <div
                   className="pf-c-dropdown__separator"
                   href={null}
+                  id=""
                   onSelect={[Function]}
                 />
               </li>
@@ -1764,6 +1884,7 @@ exports[`KebabToggle expanded 1`] = `
           <InternalDropdownItem
             className=""
             component="a"
+            componentID=""
             context={
               Object {
                 "keyHandler": [Function],
@@ -1771,6 +1892,7 @@ exports[`KebabToggle expanded 1`] = `
               }
             }
             href=""
+            id=""
             index={5}
             isDisabled={false}
             isHovered={false}
@@ -1782,6 +1904,7 @@ exports[`KebabToggle expanded 1`] = `
           >
             <li
               className={null}
+              id=""
               onClick={[Function]}
               onKeyDown={[Function]}
               role="none"
@@ -1790,6 +1913,7 @@ exports[`KebabToggle expanded 1`] = `
                 aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
                 href={null}
+                id=""
                 onSelect={[Function]}
               >
                 Separated Link
@@ -1799,6 +1923,7 @@ exports[`KebabToggle expanded 1`] = `
           <InternalDropdownItem
             className=""
             component="button"
+            componentID=""
             context={
               Object {
                 "keyHandler": [Function],
@@ -1806,6 +1931,7 @@ exports[`KebabToggle expanded 1`] = `
               }
             }
             href=""
+            id=""
             index={6}
             isDisabled={false}
             isHovered={false}
@@ -1817,6 +1943,7 @@ exports[`KebabToggle expanded 1`] = `
           >
             <li
               className={null}
+              id=""
               onClick={[Function]}
               onKeyDown={[Function]}
               role="none"
@@ -1825,6 +1952,7 @@ exports[`KebabToggle expanded 1`] = `
                 className="pf-c-dropdown__menu-item"
                 disabled={false}
                 href={null}
+                id=""
                 onSelect={[Function]}
                 type="button"
               >
@@ -1846,6 +1974,7 @@ exports[`KebabToggle plain 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -1853,6 +1982,7 @@ exports[`KebabToggle plain 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -1866,6 +1996,7 @@ exports[`KebabToggle plain 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -1873,6 +2004,7 @@ exports[`KebabToggle plain 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -1886,6 +2018,7 @@ exports[`KebabToggle plain 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -1893,6 +2026,7 @@ exports[`KebabToggle plain 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -1906,6 +2040,7 @@ exports[`KebabToggle plain 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -1913,6 +2048,7 @@ exports[`KebabToggle plain 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -1927,6 +2063,7 @@ exports[`KebabToggle plain 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -1934,6 +2071,7 @@ exports[`KebabToggle plain 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -1947,6 +2085,7 @@ exports[`KebabToggle plain 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -1954,6 +2093,7 @@ exports[`KebabToggle plain 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -1982,6 +2122,7 @@ exports[`KebabToggle plain 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -1989,6 +2130,7 @@ exports[`KebabToggle plain 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -2002,6 +2144,7 @@ exports[`KebabToggle plain 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2009,6 +2152,7 @@ exports[`KebabToggle plain 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -2022,6 +2166,7 @@ exports[`KebabToggle plain 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2029,6 +2174,7 @@ exports[`KebabToggle plain 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -2042,6 +2188,7 @@ exports[`KebabToggle plain 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2049,6 +2196,7 @@ exports[`KebabToggle plain 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -2063,6 +2211,7 @@ exports[`KebabToggle plain 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2070,6 +2219,7 @@ exports[`KebabToggle plain 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -2083,6 +2233,7 @@ exports[`KebabToggle plain 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2090,6 +2241,7 @@ exports[`KebabToggle plain 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -2254,6 +2406,7 @@ exports[`KebabToggle regular 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -2261,6 +2414,7 @@ exports[`KebabToggle regular 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -2274,6 +2428,7 @@ exports[`KebabToggle regular 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -2281,6 +2436,7 @@ exports[`KebabToggle regular 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -2294,6 +2450,7 @@ exports[`KebabToggle regular 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -2301,6 +2458,7 @@ exports[`KebabToggle regular 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -2314,6 +2472,7 @@ exports[`KebabToggle regular 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -2321,6 +2480,7 @@ exports[`KebabToggle regular 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -2335,6 +2495,7 @@ exports[`KebabToggle regular 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -2342,6 +2503,7 @@ exports[`KebabToggle regular 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -2355,6 +2517,7 @@ exports[`KebabToggle regular 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -2362,6 +2525,7 @@ exports[`KebabToggle regular 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -2389,6 +2553,7 @@ exports[`KebabToggle regular 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2396,6 +2561,7 @@ exports[`KebabToggle regular 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -2409,6 +2575,7 @@ exports[`KebabToggle regular 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2416,6 +2583,7 @@ exports[`KebabToggle regular 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -2429,6 +2597,7 @@ exports[`KebabToggle regular 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2436,6 +2605,7 @@ exports[`KebabToggle regular 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -2449,6 +2619,7 @@ exports[`KebabToggle regular 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2456,6 +2627,7 @@ exports[`KebabToggle regular 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -2470,6 +2642,7 @@ exports[`KebabToggle regular 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2477,6 +2650,7 @@ exports[`KebabToggle regular 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -2490,6 +2664,7 @@ exports[`KebabToggle regular 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2497,6 +2672,7 @@ exports[`KebabToggle regular 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -2661,6 +2837,7 @@ exports[`KebabToggle right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -2668,6 +2845,7 @@ exports[`KebabToggle right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -2681,6 +2859,7 @@ exports[`KebabToggle right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -2688,6 +2867,7 @@ exports[`KebabToggle right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -2701,6 +2881,7 @@ exports[`KebabToggle right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -2708,6 +2889,7 @@ exports[`KebabToggle right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -2721,6 +2903,7 @@ exports[`KebabToggle right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -2728,6 +2911,7 @@ exports[`KebabToggle right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -2742,6 +2926,7 @@ exports[`KebabToggle right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -2749,6 +2934,7 @@ exports[`KebabToggle right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -2762,6 +2948,7 @@ exports[`KebabToggle right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -2769,6 +2956,7 @@ exports[`KebabToggle right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -2797,6 +2985,7 @@ exports[`KebabToggle right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2804,6 +2993,7 @@ exports[`KebabToggle right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -2817,6 +3007,7 @@ exports[`KebabToggle right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2824,6 +3015,7 @@ exports[`KebabToggle right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -2837,6 +3029,7 @@ exports[`KebabToggle right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2844,6 +3037,7 @@ exports[`KebabToggle right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -2857,6 +3051,7 @@ exports[`KebabToggle right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2864,6 +3059,7 @@ exports[`KebabToggle right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -2878,6 +3074,7 @@ exports[`KebabToggle right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2885,6 +3082,7 @@ exports[`KebabToggle right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -2898,6 +3096,7 @@ exports[`KebabToggle right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -2905,6 +3104,7 @@ exports[`KebabToggle right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -3284,6 +3484,7 @@ exports[`dropdown dropup + right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -3291,6 +3492,7 @@ exports[`dropdown dropup + right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -3304,6 +3506,7 @@ exports[`dropdown dropup + right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -3311,6 +3514,7 @@ exports[`dropdown dropup + right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -3324,6 +3528,7 @@ exports[`dropdown dropup + right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -3331,6 +3536,7 @@ exports[`dropdown dropup + right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -3344,6 +3550,7 @@ exports[`dropdown dropup + right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -3351,6 +3558,7 @@ exports[`dropdown dropup + right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -3365,6 +3573,7 @@ exports[`dropdown dropup + right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -3372,6 +3581,7 @@ exports[`dropdown dropup + right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -3385,6 +3595,7 @@ exports[`dropdown dropup + right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -3392,6 +3603,7 @@ exports[`dropdown dropup + right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -3422,6 +3634,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -3429,6 +3642,7 @@ exports[`dropdown dropup + right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -3442,6 +3656,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -3449,6 +3664,7 @@ exports[`dropdown dropup + right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -3462,6 +3678,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -3469,6 +3686,7 @@ exports[`dropdown dropup + right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -3482,6 +3700,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -3489,6 +3708,7 @@ exports[`dropdown dropup + right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -3503,6 +3723,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -3510,6 +3731,7 @@ exports[`dropdown dropup + right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -3523,6 +3745,7 @@ exports[`dropdown dropup + right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -3530,6 +3753,7 @@ exports[`dropdown dropup + right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -3712,6 +3936,7 @@ exports[`dropdown dropup 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -3719,6 +3944,7 @@ exports[`dropdown dropup 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -3732,6 +3958,7 @@ exports[`dropdown dropup 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -3739,6 +3966,7 @@ exports[`dropdown dropup 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -3752,6 +3980,7 @@ exports[`dropdown dropup 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -3759,6 +3988,7 @@ exports[`dropdown dropup 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -3772,6 +4002,7 @@ exports[`dropdown dropup 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -3779,6 +4010,7 @@ exports[`dropdown dropup 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -3793,6 +4025,7 @@ exports[`dropdown dropup 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -3800,6 +4033,7 @@ exports[`dropdown dropup 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -3813,6 +4047,7 @@ exports[`dropdown dropup 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -3820,6 +4055,7 @@ exports[`dropdown dropup 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -3849,6 +4085,7 @@ exports[`dropdown dropup 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -3856,6 +4093,7 @@ exports[`dropdown dropup 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -3869,6 +4107,7 @@ exports[`dropdown dropup 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -3876,6 +4115,7 @@ exports[`dropdown dropup 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -3889,6 +4129,7 @@ exports[`dropdown dropup 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -3896,6 +4137,7 @@ exports[`dropdown dropup 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -3909,6 +4151,7 @@ exports[`dropdown dropup 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -3916,6 +4159,7 @@ exports[`dropdown dropup 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -3930,6 +4174,7 @@ exports[`dropdown dropup 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -3937,6 +4182,7 @@ exports[`dropdown dropup 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -3950,6 +4196,7 @@ exports[`dropdown dropup 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -3957,6 +4204,7 @@ exports[`dropdown dropup 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -4138,6 +4386,7 @@ exports[`dropdown expanded 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -4145,6 +4394,7 @@ exports[`dropdown expanded 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -4158,6 +4408,7 @@ exports[`dropdown expanded 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -4165,6 +4416,7 @@ exports[`dropdown expanded 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -4178,6 +4430,7 @@ exports[`dropdown expanded 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -4185,6 +4438,7 @@ exports[`dropdown expanded 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -4198,6 +4452,7 @@ exports[`dropdown expanded 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -4205,6 +4460,7 @@ exports[`dropdown expanded 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -4219,6 +4475,7 @@ exports[`dropdown expanded 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -4226,6 +4483,7 @@ exports[`dropdown expanded 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -4239,6 +4497,7 @@ exports[`dropdown expanded 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -4246,6 +4505,7 @@ exports[`dropdown expanded 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -4276,6 +4536,7 @@ exports[`dropdown expanded 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -4283,6 +4544,7 @@ exports[`dropdown expanded 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -4296,6 +4558,7 @@ exports[`dropdown expanded 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -4303,6 +4566,7 @@ exports[`dropdown expanded 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -4316,6 +4580,7 @@ exports[`dropdown expanded 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -4323,6 +4588,7 @@ exports[`dropdown expanded 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -4336,6 +4602,7 @@ exports[`dropdown expanded 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -4343,6 +4610,7 @@ exports[`dropdown expanded 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -4357,6 +4625,7 @@ exports[`dropdown expanded 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -4364,6 +4633,7 @@ exports[`dropdown expanded 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -4377,6 +4647,7 @@ exports[`dropdown expanded 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -4384,6 +4655,7 @@ exports[`dropdown expanded 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -4458,69 +4730,83 @@ exports[`dropdown expanded 1`] = `
                 role="menu"
               >
                 <li
+                  id=""
                   role="none"
                 >
                   <a
                     aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
+                    id=""
                   >
                     Link
                   </a>
                 </li>
                 <li
+                  id=""
                   role="none"
                 >
                   <button
                     class="pf-c-dropdown__menu-item"
+                    id=""
                     type="button"
                   >
                     Action
                   </button>
                 </li>
                 <li
+                  id=""
                   role="none"
                 >
                   <a
                     aria-disabled="true"
                     class="pf-m-disabled pf-c-dropdown__menu-item"
+                    id=""
                     tabindex="-1"
                   >
                     Disabled Link
                   </a>
                 </li>
                 <li
+                  id=""
                   role="none"
                 >
                   <button
                     class="pf-m-disabled pf-c-dropdown__menu-item"
                     disabled=""
+                    id=""
                     type="button"
                   >
                     Disabled Action
                   </button>
                 </li>
                 <li
+                  id=""
                   role="separator"
                 >
                   <div
                     class="pf-c-dropdown__separator"
+                    id=""
                   />
                 </li>
                 <li
+                  id=""
                   role="none"
                 >
                   <a
                     aria-disabled="false"
                     class="pf-c-dropdown__menu-item"
+                    id=""
                   >
                     Separated Link
                   </a>
                 </li>
                 <li
+                  id=""
                   role="none"
                 >
                   <button
                     class="pf-c-dropdown__menu-item"
+                    id=""
                     type="button"
                   >
                     Separated Action
@@ -4584,69 +4870,83 @@ exports[`dropdown expanded 1`] = `
                   role="menu"
                 >
                   <li
+                    id=""
                     role="none"
                   >
                     <a
                       aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
+                      id=""
                     >
                       Link
                     </a>
                   </li>
                   <li
+                    id=""
                     role="none"
                   >
                     <button
                       class="pf-c-dropdown__menu-item"
+                      id=""
                       type="button"
                     >
                       Action
                     </button>
                   </li>
                   <li
+                    id=""
                     role="none"
                   >
                     <a
                       aria-disabled="true"
                       class="pf-m-disabled pf-c-dropdown__menu-item"
+                      id=""
                       tabindex="-1"
                     >
                       Disabled Link
                     </a>
                   </li>
                   <li
+                    id=""
                     role="none"
                   >
                     <button
                       class="pf-m-disabled pf-c-dropdown__menu-item"
                       disabled=""
+                      id=""
                       type="button"
                     >
                       Disabled Action
                     </button>
                   </li>
                   <li
+                    id=""
                     role="separator"
                   >
                     <div
                       class="pf-c-dropdown__separator"
+                      id=""
                     />
                   </li>
                   <li
+                    id=""
                     role="none"
                   >
                     <a
                       aria-disabled="false"
                       class="pf-c-dropdown__menu-item"
+                      id=""
                     >
                       Separated Link
                     </a>
                   </li>
                   <li
+                    id=""
                     role="none"
                   >
                     <button
                       class="pf-c-dropdown__menu-item"
+                      id=""
                       type="button"
                     >
                       Separated Action
@@ -4723,6 +5023,7 @@ exports[`dropdown expanded 1`] = `
           <InternalDropdownItem
             className=""
             component="a"
+            componentID=""
             context={
               Object {
                 "keyHandler": [Function],
@@ -4730,6 +5031,7 @@ exports[`dropdown expanded 1`] = `
               }
             }
             href=""
+            id=""
             index={0}
             isDisabled={false}
             isHovered={false}
@@ -4741,6 +5043,7 @@ exports[`dropdown expanded 1`] = `
           >
             <li
               className={null}
+              id=""
               onClick={[Function]}
               onKeyDown={[Function]}
               role="none"
@@ -4749,6 +5052,7 @@ exports[`dropdown expanded 1`] = `
                 aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
                 href={null}
+                id=""
                 onSelect={[Function]}
               >
                 Link
@@ -4758,6 +5062,7 @@ exports[`dropdown expanded 1`] = `
           <InternalDropdownItem
             className=""
             component="button"
+            componentID=""
             context={
               Object {
                 "keyHandler": [Function],
@@ -4765,6 +5070,7 @@ exports[`dropdown expanded 1`] = `
               }
             }
             href=""
+            id=""
             index={1}
             isDisabled={false}
             isHovered={false}
@@ -4776,6 +5082,7 @@ exports[`dropdown expanded 1`] = `
           >
             <li
               className={null}
+              id=""
               onClick={[Function]}
               onKeyDown={[Function]}
               role="none"
@@ -4784,6 +5091,7 @@ exports[`dropdown expanded 1`] = `
                 className="pf-c-dropdown__menu-item"
                 disabled={false}
                 href={null}
+                id=""
                 onSelect={[Function]}
                 type="button"
               >
@@ -4794,6 +5102,7 @@ exports[`dropdown expanded 1`] = `
           <InternalDropdownItem
             className=""
             component="a"
+            componentID=""
             context={
               Object {
                 "keyHandler": [Function],
@@ -4801,6 +5110,7 @@ exports[`dropdown expanded 1`] = `
               }
             }
             href=""
+            id=""
             index={2}
             isDisabled={true}
             isHovered={false}
@@ -4812,6 +5122,7 @@ exports[`dropdown expanded 1`] = `
           >
             <li
               className={null}
+              id=""
               onClick={[Function]}
               onKeyDown={[Function]}
               role="none"
@@ -4820,6 +5131,7 @@ exports[`dropdown expanded 1`] = `
                 aria-disabled={true}
                 className="pf-m-disabled pf-c-dropdown__menu-item"
                 href={null}
+                id=""
                 onSelect={[Function]}
                 tabIndex={-1}
               >
@@ -4830,6 +5142,7 @@ exports[`dropdown expanded 1`] = `
           <InternalDropdownItem
             className=""
             component="button"
+            componentID=""
             context={
               Object {
                 "keyHandler": [Function],
@@ -4837,6 +5150,7 @@ exports[`dropdown expanded 1`] = `
               }
             }
             href=""
+            id=""
             index={3}
             isDisabled={true}
             isHovered={false}
@@ -4848,6 +5162,7 @@ exports[`dropdown expanded 1`] = `
           >
             <li
               className={null}
+              id=""
               onClick={[Function]}
               onKeyDown={[Function]}
               role="none"
@@ -4856,6 +5171,7 @@ exports[`dropdown expanded 1`] = `
                 className="pf-m-disabled pf-c-dropdown__menu-item"
                 disabled={true}
                 href={null}
+                id=""
                 onSelect={[Function]}
                 type="button"
               >
@@ -4870,6 +5186,7 @@ exports[`dropdown expanded 1`] = `
             <InternalDropdownItem
               className="pf-c-dropdown__separator"
               component="div"
+              componentID=""
               context={
                 Object {
                   "keyHandler": [Function],
@@ -4877,6 +5194,7 @@ exports[`dropdown expanded 1`] = `
                 }
               }
               href=""
+              id=""
               index={4}
               isDisabled={false}
               isHovered={false}
@@ -4887,6 +5205,7 @@ exports[`dropdown expanded 1`] = `
             >
               <li
                 className={null}
+                id=""
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="separator"
@@ -4894,6 +5213,7 @@ exports[`dropdown expanded 1`] = `
                 <div
                   className="pf-c-dropdown__separator"
                   href={null}
+                  id=""
                   onSelect={[Function]}
                 />
               </li>
@@ -4902,6 +5222,7 @@ exports[`dropdown expanded 1`] = `
           <InternalDropdownItem
             className=""
             component="a"
+            componentID=""
             context={
               Object {
                 "keyHandler": [Function],
@@ -4909,6 +5230,7 @@ exports[`dropdown expanded 1`] = `
               }
             }
             href=""
+            id=""
             index={5}
             isDisabled={false}
             isHovered={false}
@@ -4920,6 +5242,7 @@ exports[`dropdown expanded 1`] = `
           >
             <li
               className={null}
+              id=""
               onClick={[Function]}
               onKeyDown={[Function]}
               role="none"
@@ -4928,6 +5251,7 @@ exports[`dropdown expanded 1`] = `
                 aria-disabled={false}
                 className="pf-c-dropdown__menu-item"
                 href={null}
+                id=""
                 onSelect={[Function]}
               >
                 Separated Link
@@ -4937,6 +5261,7 @@ exports[`dropdown expanded 1`] = `
           <InternalDropdownItem
             className=""
             component="button"
+            componentID=""
             context={
               Object {
                 "keyHandler": [Function],
@@ -4944,6 +5269,7 @@ exports[`dropdown expanded 1`] = `
               }
             }
             href=""
+            id=""
             index={6}
             isDisabled={false}
             isHovered={false}
@@ -4955,6 +5281,7 @@ exports[`dropdown expanded 1`] = `
           >
             <li
               className={null}
+              id=""
               onClick={[Function]}
               onKeyDown={[Function]}
               role="none"
@@ -4963,6 +5290,7 @@ exports[`dropdown expanded 1`] = `
                 className="pf-c-dropdown__menu-item"
                 disabled={false}
                 href={null}
+                id=""
                 onSelect={[Function]}
                 type="button"
               >
@@ -4984,6 +5312,7 @@ exports[`dropdown primary 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -4991,6 +5320,7 @@ exports[`dropdown primary 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -5004,6 +5334,7 @@ exports[`dropdown primary 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5011,6 +5342,7 @@ exports[`dropdown primary 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -5024,6 +5356,7 @@ exports[`dropdown primary 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5031,6 +5364,7 @@ exports[`dropdown primary 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -5044,6 +5378,7 @@ exports[`dropdown primary 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5051,6 +5386,7 @@ exports[`dropdown primary 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -5065,6 +5401,7 @@ exports[`dropdown primary 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5072,6 +5409,7 @@ exports[`dropdown primary 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -5085,6 +5423,7 @@ exports[`dropdown primary 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5092,6 +5431,7 @@ exports[`dropdown primary 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -5122,6 +5462,7 @@ exports[`dropdown primary 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5129,6 +5470,7 @@ exports[`dropdown primary 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -5142,6 +5484,7 @@ exports[`dropdown primary 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5149,6 +5492,7 @@ exports[`dropdown primary 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -5162,6 +5506,7 @@ exports[`dropdown primary 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5169,6 +5514,7 @@ exports[`dropdown primary 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -5182,6 +5528,7 @@ exports[`dropdown primary 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5189,6 +5536,7 @@ exports[`dropdown primary 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -5203,6 +5551,7 @@ exports[`dropdown primary 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5210,6 +5559,7 @@ exports[`dropdown primary 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -5223,6 +5573,7 @@ exports[`dropdown primary 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5230,6 +5581,7 @@ exports[`dropdown primary 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -5413,6 +5765,7 @@ exports[`dropdown regular 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5420,6 +5773,7 @@ exports[`dropdown regular 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -5433,6 +5787,7 @@ exports[`dropdown regular 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5440,6 +5795,7 @@ exports[`dropdown regular 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -5453,6 +5809,7 @@ exports[`dropdown regular 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5460,6 +5817,7 @@ exports[`dropdown regular 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -5473,6 +5831,7 @@ exports[`dropdown regular 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5480,6 +5839,7 @@ exports[`dropdown regular 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -5494,6 +5854,7 @@ exports[`dropdown regular 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5501,6 +5862,7 @@ exports[`dropdown regular 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -5514,6 +5876,7 @@ exports[`dropdown regular 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5521,6 +5884,7 @@ exports[`dropdown regular 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -5550,6 +5914,7 @@ exports[`dropdown regular 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5557,6 +5922,7 @@ exports[`dropdown regular 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -5570,6 +5936,7 @@ exports[`dropdown regular 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5577,6 +5944,7 @@ exports[`dropdown regular 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -5590,6 +5958,7 @@ exports[`dropdown regular 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5597,6 +5966,7 @@ exports[`dropdown regular 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -5610,6 +5980,7 @@ exports[`dropdown regular 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5617,6 +5988,7 @@ exports[`dropdown regular 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -5631,6 +6003,7 @@ exports[`dropdown regular 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5638,6 +6011,7 @@ exports[`dropdown regular 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -5651,6 +6025,7 @@ exports[`dropdown regular 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5658,6 +6033,7 @@ exports[`dropdown regular 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -5839,6 +6215,7 @@ exports[`dropdown right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5846,6 +6223,7 @@ exports[`dropdown right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -5859,6 +6237,7 @@ exports[`dropdown right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5866,6 +6245,7 @@ exports[`dropdown right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -5879,6 +6259,7 @@ exports[`dropdown right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5886,6 +6267,7 @@ exports[`dropdown right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -5899,6 +6281,7 @@ exports[`dropdown right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5906,6 +6289,7 @@ exports[`dropdown right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={true}
         isHovered={false}
@@ -5920,6 +6304,7 @@ exports[`dropdown right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="a"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5927,6 +6312,7 @@ exports[`dropdown right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -5940,6 +6326,7 @@ exports[`dropdown right aligned 1`] = `
       <InternalDropdownItem
         className=""
         component="button"
+        componentID=""
         context={
           Object {
             "keyHandler": [Function],
@@ -5947,6 +6334,7 @@ exports[`dropdown right aligned 1`] = `
           }
         }
         href=""
+        id=""
         index={-1}
         isDisabled={false}
         isHovered={false}
@@ -5977,6 +6365,7 @@ exports[`dropdown right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -5984,6 +6373,7 @@ exports[`dropdown right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -5997,6 +6387,7 @@ exports[`dropdown right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -6004,6 +6395,7 @@ exports[`dropdown right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -6017,6 +6409,7 @@ exports[`dropdown right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -6024,6 +6417,7 @@ exports[`dropdown right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -6037,6 +6431,7 @@ exports[`dropdown right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -6044,6 +6439,7 @@ exports[`dropdown right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={true}
           isHovered={false}
@@ -6058,6 +6454,7 @@ exports[`dropdown right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="a"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -6065,6 +6462,7 @@ exports[`dropdown right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}
@@ -6078,6 +6476,7 @@ exports[`dropdown right aligned 1`] = `
         <InternalDropdownItem
           className=""
           component="button"
+          componentID=""
           context={
             Object {
               "keyHandler": [Function],
@@ -6085,6 +6484,7 @@ exports[`dropdown right aligned 1`] = `
             }
           }
           href=""
+          id=""
           index={-1}
           isDisabled={false}
           isHovered={false}

--- a/packages/patternfly-4/react-core/src/components/OptionsMenu/__snapshots__/OptionsMenu.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/OptionsMenu/__snapshots__/OptionsMenu.test.js.snap
@@ -141,6 +141,7 @@ exports[`optionsMenu expanded 1`] = `
                     class=""
                   >
                     <li
+                      id=""
                       role="menuitem"
                     >
                       <button
@@ -173,6 +174,7 @@ exports[`optionsMenu expanded 1`] = `
                       </button>
                     </li>
                     <li
+                      id=""
                       role="menuitem"
                     >
                       <button
@@ -205,6 +207,7 @@ exports[`optionsMenu expanded 1`] = `
                       </button>
                     </li>
                     <li
+                      id=""
                       role="menuitem"
                     >
                       <button
@@ -239,6 +242,7 @@ exports[`optionsMenu expanded 1`] = `
                       </button>
                     </li>
                     <li
+                      id=""
                       role="menuitem"
                     >
                       <button
@@ -285,6 +289,7 @@ exports[`optionsMenu expanded 1`] = `
                     class=""
                   >
                     <li
+                      id=""
                       role="menuitem"
                     >
                       <button
@@ -317,6 +322,7 @@ exports[`optionsMenu expanded 1`] = `
                       </button>
                     </li>
                     <li
+                      id=""
                       role="menuitem"
                     >
                       <button
@@ -413,6 +419,7 @@ exports[`optionsMenu expanded 1`] = `
                       class=""
                     >
                       <li
+                        id=""
                         role="menuitem"
                       >
                         <button
@@ -445,6 +452,7 @@ exports[`optionsMenu expanded 1`] = `
                         </button>
                       </li>
                       <li
+                        id=""
                         role="menuitem"
                       >
                         <button
@@ -477,6 +485,7 @@ exports[`optionsMenu expanded 1`] = `
                         </button>
                       </li>
                       <li
+                        id=""
                         role="menuitem"
                       >
                         <button
@@ -511,6 +520,7 @@ exports[`optionsMenu expanded 1`] = `
                         </button>
                       </li>
                       <li
+                        id=""
                         role="menuitem"
                       >
                         <button
@@ -557,6 +567,7 @@ exports[`optionsMenu expanded 1`] = `
                       class=""
                     >
                       <li
+                        id=""
                         role="menuitem"
                       >
                         <button
@@ -589,6 +600,7 @@ exports[`optionsMenu expanded 1`] = `
                         </button>
                       </li>
                       <li
+                        id=""
                         role="menuitem"
                       >
                         <button
@@ -689,6 +701,7 @@ exports[`optionsMenu expanded 1`] = `
                         class=""
                       >
                         <li
+                          id=""
                           role="menuitem"
                         >
                           <button
@@ -721,6 +734,7 @@ exports[`optionsMenu expanded 1`] = `
                           </button>
                         </li>
                         <li
+                          id=""
                           role="menuitem"
                         >
                           <button
@@ -753,6 +767,7 @@ exports[`optionsMenu expanded 1`] = `
                           </button>
                         </li>
                         <li
+                          id=""
                           role="menuitem"
                         >
                           <button
@@ -787,6 +802,7 @@ exports[`optionsMenu expanded 1`] = `
                           </button>
                         </li>
                         <li
+                          id=""
                           role="menuitem"
                         >
                           <button
@@ -833,6 +849,7 @@ exports[`optionsMenu expanded 1`] = `
                         class=""
                       >
                         <li
+                          id=""
                           role="menuitem"
                         >
                           <button
@@ -865,6 +882,7 @@ exports[`optionsMenu expanded 1`] = `
                           </button>
                         </li>
                         <li
+                          id=""
                           role="menuitem"
                         >
                           <button
@@ -988,6 +1006,7 @@ exports[`optionsMenu expanded 1`] = `
                     <InternalDropdownItem
                       className=""
                       component="button"
+                      componentID=""
                       context={
                         Object {
                           "keyHandler": [Function],
@@ -1008,6 +1027,7 @@ exports[`optionsMenu expanded 1`] = `
                     >
                       <li
                         className={null}
+                        id=""
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="menuitem"
@@ -1070,6 +1090,7 @@ exports[`optionsMenu expanded 1`] = `
                     <InternalDropdownItem
                       className=""
                       component="button"
+                      componentID=""
                       context={
                         Object {
                           "keyHandler": [Function],
@@ -1090,6 +1111,7 @@ exports[`optionsMenu expanded 1`] = `
                     >
                       <li
                         className={null}
+                        id=""
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="menuitem"
@@ -1156,6 +1178,7 @@ exports[`optionsMenu expanded 1`] = `
                       aria-disabled={true}
                       className=""
                       component="button"
+                      componentID=""
                       context={
                         Object {
                           "keyHandler": [Function],
@@ -1176,6 +1199,7 @@ exports[`optionsMenu expanded 1`] = `
                     >
                       <li
                         className={null}
+                        id=""
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="menuitem"
@@ -1239,6 +1263,7 @@ exports[`optionsMenu expanded 1`] = `
                     <InternalDropdownItem
                       className=""
                       component="button"
+                      componentID=""
                       context={
                         Object {
                           "keyHandler": [Function],
@@ -1259,6 +1284,7 @@ exports[`optionsMenu expanded 1`] = `
                     >
                       <li
                         className={null}
+                        id=""
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="menuitem"
@@ -1345,6 +1371,7 @@ exports[`optionsMenu expanded 1`] = `
                     <InternalDropdownItem
                       className=""
                       component="button"
+                      componentID=""
                       context={
                         Object {
                           "keyHandler": [Function],
@@ -1365,6 +1392,7 @@ exports[`optionsMenu expanded 1`] = `
                     >
                       <li
                         className={null}
+                        id=""
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="menuitem"
@@ -1427,6 +1455,7 @@ exports[`optionsMenu expanded 1`] = `
                     <InternalDropdownItem
                       className=""
                       component="button"
+                      componentID=""
                       context={
                         Object {
                           "keyHandler": [Function],
@@ -1447,6 +1476,7 @@ exports[`optionsMenu expanded 1`] = `
                     >
                       <li
                         className={null}
+                        id=""
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         role="menuitem"

--- a/packages/patternfly-4/react-core/src/helpers/util.test.js
+++ b/packages/patternfly-4/react-core/src/helpers/util.test.js
@@ -93,13 +93,13 @@ test('sideElementIsOutOfView Returns NONE when in view', () => {
 describe('keyHandler works on ApplicationLauncher', () => {
   document.body.innerHTML = '<!doctype html><html><body></body></html>';
   const dropdownItems = [
-    <DropdownItem key=" 1" id="first" component="button">
+    <DropdownItem key=" 1" id="first" componentID="first-button" component="button">
       Action 1
     </DropdownItem>,
-    <DropdownItem key="2" id="second" component="button">
+    <DropdownItem key="2" id="second" componentID="second-button" component="button">
       Action 2
     </DropdownItem>,
-    <DropdownItem key="3" id="third" component="button" isDisabled>
+    <DropdownItem key="3" id="third" componentID="third-button" component="button" isDisabled>
       Disabled Link
     </DropdownItem>
   ];
@@ -117,7 +117,7 @@ describe('keyHandler works on ApplicationLauncher', () => {
       which: KEY_CODES.ARROW_DOWN
     });
     const focusedElement = document.activeElement;
-    expect(focusedElement.getAttribute('id')).toEqual('second');
+    expect(focusedElement.getAttribute('id')).toEqual('second-button');
   });
 
   test('keyHandler regresses backward', () => {
@@ -127,7 +127,7 @@ describe('keyHandler works on ApplicationLauncher', () => {
       which: KEY_CODES.ARROW_UP
     });
     const focusedElement = document.activeElement;
-    expect(focusedElement.getAttribute('id')).toEqual('first');
+    expect(focusedElement.getAttribute('id')).toEqual('first-button');
   });
 
   test('keyHandler skips disabled items and loops down to top', () => {
@@ -137,7 +137,7 @@ describe('keyHandler works on ApplicationLauncher', () => {
       which: KEY_CODES.ARROW_DOWN
     });
     const focusedElement = document.activeElement;
-    expect(focusedElement.getAttribute('id')).toEqual('first');
+    expect(focusedElement.getAttribute('id')).toEqual('first-button');
   });
 
   test('keyHandler loops top to bottom', () => {
@@ -147,20 +147,20 @@ describe('keyHandler works on ApplicationLauncher', () => {
       which: KEY_CODES.ARROW_UP
     });
     const focusedElement = document.activeElement;
-    expect(focusedElement.getAttribute('id')).toEqual('second');
+    expect(focusedElement.getAttribute('id')).toEqual('second-button');
   });
 });
 
 describe('keyHandler works on Dropdown', () => {
   document.body.innerHTML = '<!doctype html><html><body></body></html>';
   const dropdownItems = [
-    <DropdownItem key=" 1" id="first" component="button">
+    <DropdownItem key="1" id="first" componentID="first-button" component="button">
       Action 1
     </DropdownItem>,
-    <DropdownItem key="2" id="second" component="button">
+    <DropdownItem key="2" id="second" componentID="second-button" component="button">
       Action 2
     </DropdownItem>,
-    <DropdownItem key="3" id="third" component="button" isDisabled>
+    <DropdownItem key="3" id="third" componentID="third-button" component="button" isDisabled>
       Disabled Link
     </DropdownItem>
   ];
@@ -180,7 +180,7 @@ describe('keyHandler works on Dropdown', () => {
       which: KEY_CODES.ARROW_DOWN
     });
     const focusedElement = document.activeElement;
-    expect(focusedElement.getAttribute('id')).toEqual('second');
+    expect(focusedElement.getAttribute('id')).toEqual('second-button');
   });
 
   test('keyHandler regresses backward', () => {
@@ -190,7 +190,7 @@ describe('keyHandler works on Dropdown', () => {
       which: KEY_CODES.ARROW_UP
     });
     const focusedElement = document.activeElement;
-    expect(focusedElement.getAttribute('id')).toEqual('first');
+    expect(focusedElement.getAttribute('id')).toEqual('first-button');
   });
 
   test('keyHandler skips disabled items and loops down to top', () => {
@@ -200,7 +200,7 @@ describe('keyHandler works on Dropdown', () => {
       which: KEY_CODES.ARROW_DOWN
     });
     const focusedElement = document.activeElement;
-    expect(focusedElement.getAttribute('id')).toEqual('first');
+    expect(focusedElement.getAttribute('id')).toEqual('first-button');
   });
 
   test('keyHandler loops top to bottom', () => {
@@ -210,7 +210,7 @@ describe('keyHandler works on Dropdown', () => {
       which: KEY_CODES.ARROW_UP
     });
     const focusedElement = document.activeElement;
-    expect(focusedElement.getAttribute('id')).toEqual('second');
+    expect(focusedElement.getAttribute('id')).toEqual('second-button');
   });
 });
 


### PR DESCRIPTION
Applied Nicole's fix for the Options menu.

Verified that keyhandler is working as expected. Added `componentID` prop in order to fix failing unit tests on keyhandler due to the id being passed to the `<li>`.

Fixes #3029.