### PR TITLE
Update webpack config to output source maps

### DIFF
--- a/packages/patternfly-4/react-docs/gatsby-node.js
+++ b/packages/patternfly-4/react-docs/gatsby-node.js
@@ -80,6 +80,7 @@ exports.createPages = ({ graphql, actions }) => {
 
 exports.onCreateWebpackConfig = ({ actions }) => {
   actions.setWebpackConfig({
+    devtool: "eval-source-map",
     resolve: {
       alias: {
         // Resolve imports in our app to node_modules so they don't break


### PR DESCRIPTION
Added `eval-source-maps` to Gatsby's webpack config. This outputs source maps so we can debug the examples via Chrome, again.

Fixes https://github.com/patternfly/patternfly-react/issues/3114
