### PR TITLE
fix(table): set height auto modifier on table row

### DIFF
--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEmptyStateDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEmptyStateDemo.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableProps,
+  textCenter,
+  IRow,
+  ICell,
+} from '@patternfly/react-table';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateSecondaryActions,
+  EmptyStateVariant,
+  Title,
+  Button
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
+class EmptyStateTable extends React.Component<TableProps, { columns: (ICell | string)[]; rows: IRow[] }> {
+  constructor(props: TableProps) {
+    super(props);
+    this.state = {
+      columns: [
+        { title: 'Repositories' },
+        'Branches',
+        { title: 'Pull requests' },
+        'Workspaces',
+        { title: 'Last Commit' }
+      ],
+      rows: [
+        {
+          heightAuto: true,
+          props: { colSpan: '8' },
+          title: (
+            <EmptyState variant={EmptyStateVariant.small}>
+              <EmptyStateIcon icon={CubesIcon} />
+              <Title headingLevel="h5" size="lg">
+                Empty State
+              </Title>
+              <EmptyStateBody>
+                This represents an the empty state pattern in Patternfly 4. Hopefully it's simple enough to use but
+                flexible enough to meet a variety of needs.
+              </EmptyStateBody>
+              <Button variant="primary">Primary Action</Button>
+              <EmptyStateSecondaryActions>
+                <Button variant="link">Multiple</Button>
+                <Button variant="link">Action Buttons</Button>
+                <Button variant="link">Can</Button>
+                <Button variant="link">Go here</Button>
+                <Button variant="link">In the secondary</Button>
+                <Button variant="link">Action area</Button>
+              </EmptyStateSecondaryActions>
+            </EmptyState>
+          )
+        }
+      ]
+    };
+  }
+  render() {
+    const { columns, rows } = this.state;
+    return (
+      <Table caption="Empty State Table" cells={columns} rows={rows}>
+        <TableHeader />
+        <TableBody />
+      </Table>
+    );
+  }
+}

--- a/packages/patternfly-4/react-table/src/components/Table/Body.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/Body.tsx
@@ -85,6 +85,7 @@ class ContextBody extends React.Component<TableBodyProps, {}> {
         ...oneRow,
         ...this.mapCells(headerData, oneRow, oneRowKey),
         isExpanded: isRowExpanded(oneRow, rows),
+        isHeightAuto: oneRow.heightAuto || false,
         isFirst: oneRowKey === 0,
         isLast: oneRowKey === rows.length - 1,
         isFirstVisible: false,

--- a/packages/patternfly-4/react-table/src/components/Table/RowWrapper.test.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/RowWrapper.test.tsx
@@ -21,4 +21,9 @@ describe('RowWrapper', () => {
     const view = mount(getRowWrapper({ row: { isExpanded: true } }));
     expect(view).toMatchSnapshot();
   });
+  test('renders height auto modifier correctly', () => {
+    const view = mount(getRowWrapper({ row: { isHeightAuto: true } }));
+    console.log(view.debug())
+    expect(view.find('tr').prop('className')).toBe('pf-m-height-auto');
+  });
 });

--- a/packages/patternfly-4/react-table/src/components/Table/RowWrapper.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/RowWrapper.tsx
@@ -7,6 +7,7 @@ import { css } from '@patternfly/react-styles';
 export interface RowWrapperRow {
   isOpen?: Boolean;
   isExpanded?: Boolean;
+  isHeightAuto?: Boolean;
 }
 
 export interface RowWrapperProps {
@@ -23,7 +24,8 @@ class RowWrapper extends React.Component<RowWrapperProps & InjectedOuiaProps, {}
     className: '' as string,
     row: {
       isOpen: undefined as boolean,
-      isExpanded: undefined as boolean
+      isExpanded: undefined as boolean,
+      isHeightAuto: undefined as boolean
     } as RowWrapperRow,
     rowProps: null as any
   };
@@ -80,7 +82,7 @@ class RowWrapper extends React.Component<RowWrapperProps & InjectedOuiaProps, {}
       className,
       onScroll,
       onResize,
-      row: { isExpanded },
+      row: { isExpanded, isHeightAuto },
       rowProps,
       ouiaContext,
       ouiaId,
@@ -94,7 +96,8 @@ class RowWrapper extends React.Component<RowWrapperProps & InjectedOuiaProps, {}
         className={css(
           className,
           isExpanded !== undefined && styles.tableExpandableRow,
-          isExpanded && styles.modifiers.expanded
+          isExpanded && styles.modifiers.expanded,
+          isHeightAuto && styles.modifiers.heightAuto
         )}
         hidden={isExpanded !== undefined && !isExpanded}
         {...ouiaContext.isOuia && {

--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -26,10 +26,16 @@ import {
 } from '@patternfly/react-table';
 
 import {
-    Checkbox
+    Checkbox,
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStatePrimary,
+    Bullseye,
 } from '@patternfly/react-core';
 
 import {
+  SearchIcon,
   CodeBranchIcon,
   CodeIcon,
   CubeIcon
@@ -1108,5 +1114,45 @@ class WrappableHeadersTable extends React.Component {
       </Table>
     );
   }
+}
+```
+
+## Empty state table
+
+```js
+import React from 'react';
+import { Table, TableHeader, TableBody } from '@patternfly/react-table';
+import { Button, EmptyState, EmptyStateBody, EmptyStatePrimary, Bullseye } from '@patternfly/react-core';
+
+EmptyStateTable = () => {
+  const columns = ['Repositories', 'Branches', 'Pull request', 'Workspaces', 'LastCommit']
+  const rows = [{
+    heightAuto: true,
+    cells: [
+      {
+        props: {colspan: '8'},
+        title: (
+          <Bullseye>
+            <EmptyState variant={EmptyStateVariant.small}>
+              <EmptyStateIcon icon={SearchIcon} />
+              <Title headingLevel="h2" size="lg">
+                No results found
+              </Title>
+              <EmptyStateBody>
+                No results match the filter criteria. Remove all filters or clear all filters to show results.
+              </EmptyStateBody>
+              <Button variant="link">Clear all filters</Button>
+            </EmptyState>
+          </Bullseye>
+        )
+      },
+    ]
+  }]
+  return (
+    <Table cells={columns} rows={rows}>
+      <TableHeader />
+      <TableBody />
+    </Table>
+  );
 }
 ```

--- a/packages/patternfly-4/react-table/src/components/Table/Table.test.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.test.tsx
@@ -229,3 +229,28 @@ test('Selectable table with selected expandable row', () => {
 
   expect(view.find('input[name="check-all"]').prop('checked')).toEqual(true);
 });
+
+test('Empty state table', () => {
+  const data = {
+    cells: ['Hostname', 'IP address', 'Role', 'Team'],
+    rows: [
+      {
+        heightAuto: true,
+        cells: [{
+          title: (<div>Empty State Component</div>),
+          props: {colspan: '8'}
+        }],
+      }
+    ],
+  };
+
+  const view = mount(
+    <Table aria-label="Aria labeled" {...data}>
+      <TableHeader />
+      <TableBody />
+    </Table>
+  );
+
+  expect(view.find('tr').at(1).prop('className')).toEqual('pf-m-height-auto');
+  expect(view.find('tbody').find('td').prop('colspan')).toEqual('8');
+});

--- a/packages/patternfly-4/react-table/src/components/Table/Table.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.tsx
@@ -175,6 +175,7 @@ export interface IRow extends RowType {
   props?: any;
   fullWidth?: boolean;
   noPadding?: boolean;
+  heightAuto?: boolean;
   showSelect?: boolean;
   isExpanded?: boolean;
   isFirstVisible?: boolean;

--- a/packages/patternfly-4/react-table/src/components/Table/__snapshots__/RowWrapper.test.tsx.snap
+++ b/packages/patternfly-4/react-table/src/components/Table/__snapshots__/RowWrapper.test.tsx.snap
@@ -62,6 +62,7 @@ exports[`RowWrapper renders correctly 1`] = `
           row={
             Object {
               "isExpanded": undefined,
+              "isHeightAuto": undefined,
               "isOpen": undefined,
             }
           }

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/cellHeightAuto.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/cellHeightAuto.ts
@@ -1,6 +1,9 @@
 import { css, getModifier } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 
-export const cellHeightAuto = () => ({
-  className: css(getModifier(styles, 'heightAuto'))
-});
+export const cellHeightAuto = () => {
+  console.warn('cellHeightAuto:', 'is deprecated. Use heightAuto instead. Read more here: https://github.com/patternfly/patternfly-react/issues/3132')
+  return {
+    className: css(getModifier(styles, 'heightAuto'))
+  }
+};


### PR DESCRIPTION
**What**:

close #3132

I mistakenly added the `height auto` modifier to `td` element instead to `tr`.

This PR fixes this by adding the `HeightAuto` attribute to row item.
In addition to that, added a deprecation warning message to whom is using `cellHeightAuto`.

More tests and an example were added.

//cc @jenny-s51 @mcoker @karelhala @tlabaj @redallen 