### PR TITLE
fix(OUIA): Use consumer context if specified

### DIFF
--- a/packages/patternfly-4/react-core/src/components/withOuia/withOuia.tsx
+++ b/packages/patternfly-4/react-core/src/components/withOuia/withOuia.tsx
@@ -75,7 +75,12 @@ class ComponentWithOuia extends React.Component<OuiaProps, OuiaState> {
     const { isOuia, ouiaId } = this.state;
     const { component: WrappedComponent, componentProps, consumerContext } = this.props;
     return (
-      <OuiaContext.Provider value={{ isOuia, ouiaId }}>
+      <OuiaContext.Provider
+        value={{
+          isOuia: (consumerContext && consumerContext.isOuia) || isOuia,
+          ouiaId: (consumerContext && consumerContext.ouiaId) || ouiaId
+        }}
+      >
         <OuiaContext.Consumer>
           {(value: OuiaContextProps) => <WrappedComponent {...(componentProps as any)} ouiaContext={value} />}
         </OuiaContext.Consumer>


### PR DESCRIPTION
**What**:
When rendering Table the ouia context is not correctly set up. This can be fixed by using context passed from props because table components copies these context values to different context and pass them along with props.
