### PR TITLE
chore(emptyState): remove debug message from tests

### DIFF
--- a/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/EmptyState/EmptyState.test.tsx
@@ -78,7 +78,6 @@ describe('EmptyState', () => {
         id="empty-state-icon"
       />
     );
-    console.log(view.debug());
     expect(view.find('div').props().className).toBe('pf-c-empty-state__icon custom-empty-state-icon');
     expect(view.find('AddressBookIcon').length).toBe(1);
   });


### PR DESCRIPTION
**What**:

small nitpick - removing unnecessary debug log in the empty state tests (that I added and forgot to remove :scream: )

issue: #3165 
closes #3165