### PR TITLE
surround ouia check with a try catch

### DIFF
--- a/packages/patternfly-4/react-core/src/components/withOuia/ouia.ts
+++ b/packages/patternfly-4/react-core/src/components/withOuia/ouia.ts
@@ -1,6 +1,11 @@
-export const isOUIAEnvironment = (): boolean =>
-  (typeof window !== 'undefined' && window.localStorage.ouia && window.localStorage.ouia.toLowerCase() === 'true') ||
-  false;
+export const isOUIAEnvironment = (): boolean => {
+  try {
+    return (typeof window !== 'undefined' && window.localStorage && window.localStorage.ouia && window.localStorage.ouia.toLowerCase() === 'true') ||
+    false;
+  } catch (exception) {
+    return false;
+  }
+}
 export const generateOUIAId = (): boolean =>
   (typeof window !== 'undefined' &&
     window.localStorage['ouia-generate-id'] &&


### PR DESCRIPTION
add try/catch to the ouia check since there are some environments were simply checking for window.localStorage can throw a security exception