### PR TITLE
feat(popover): allow to set popover trigger

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.test.tsx
@@ -62,3 +62,20 @@ test('popover passes along values to tippy.js', () => {
   );
   expect(view).toMatchSnapshot();
 });
+
+test('popover with custom triggers', () => {
+  const view = shallow(
+    <Popover
+      triggers={['mouseenter', 'focus']}
+      headerContent={<div>Popover Header</div>}
+      bodyContent={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Tippy Props Test</div>
+    </Popover>
+  );
+  expect(view.prop('trigger')).toBe('mouseenter focus');
+});

--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
@@ -27,6 +27,15 @@ export enum PopoverPosition {
   right = 'right'
 }
 
+export enum PopoverTriggers {
+  manual = 'manual',
+  focus = 'focus',
+  mouseenter = 'mouseenter',
+  click = 'click',
+}
+
+type Triggers = 'manual' | 'focus' | 'mouseenter' | 'click';
+
 export interface PopoverProps {
   /** Accessible label, required when header is not present */
   'aria-label'?: string;
@@ -69,6 +78,8 @@ export interface PopoverProps {
    * Instead, the consumer is responsible for closing the popover themselves by adding a callback listener for the shouldClose prop.
    */
   isVisible?: boolean;
+  /** The events which cause the popover to show. This takes effect only when isVisible is not set. **/
+  triggers?: Triggers[];
   /** Maximum width of the popover (default 18.75rem) */
   maxWidth?: string;
   /** Lifecycle function invoked when the popover has fully transitioned out. */
@@ -109,6 +120,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
     enableFlip: true,
     className: '',
     isVisible: null as boolean,
+    triggers: ['click'],
     shouldClose: (): void => null,
     'aria-label': '',
     headerContent: null as typeof PopoverHeader,
@@ -214,6 +226,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       bodyContent,
       footerContent,
       isVisible,
+      triggers,
       shouldClose,
       appendTo,
       hideOnOutsideClick,
@@ -280,7 +293,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
         appendTo={appendTo}
         content={content}
         lazy
-        trigger={handleEvents ? 'click' : 'manual'}
+        trigger={handleEvents ? triggers.join(' ') : 'manual'}
         isVisible={isVisible}
         hideOnClick={shouldHideOnClick()}
         animateFill={false}

--- a/packages/patternfly-4/react-core/src/components/Popover/examples/Popover.md
+++ b/packages/patternfly-4/react-core/src/components/Popover/examples/Popover.md
@@ -6,7 +6,7 @@ typescript: true
 propComponents: ['Popover']
 ---
 
-import { Popover, PopoverPosition, Checkbox, Button } from '@patternfly/react-core';
+import { Popover, PopoverPosition, PopoverTriggers, Checkbox, Button } from '@patternfly/react-core';
 
 ## Examples
 ```js title=Basic
@@ -144,6 +144,24 @@ HeadlessPopover = () => (
     footerContent="Popover Footer"
   >
     <Button>Toggle Popover</Button>
+  </Popover>
+);
+```
+
+```js title=Triggers
+import React from 'react';
+import { Popover, PopoverTriggers, Button } from '@patternfly/react-core';
+
+SimplePopover = () => (
+  <Popover
+    triggers={[PopoverTriggers.mouseenter, PopoverTriggers.focus]}
+    headerContent={<div>Popover Header</div>}
+    bodyContent={
+      <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.</div>
+    }
+    footerContent="Popover Footer"
+  >
+    <Button onClick={() => {alert('side effect')}}>Do something</Button>
   </Popover>
 );
 ```

--- a/packages/patternfly-4/react-core/src/components/Popover/index.ts
+++ b/packages/patternfly-4/react-core/src/components/Popover/index.ts
@@ -1,1 +1,1 @@
-export { Popover, PopoverPosition } from './Popover';
+export { Popover, PopoverPosition, PopoverTriggers } from './Popover';

--- a/packages/patternfly-4/react-integration/cypress/integration/popover.spec.ts
+++ b/packages/patternfly-4/react-integration/cypress/integration/popover.spec.ts
@@ -19,4 +19,19 @@ describe('Popover Demo Test', () => {
       });
     });
   });
+
+  it('Open and Close Focus triggered Popover', () => {
+    cy.get('div[id="popoverTriggerTarget"]').then((popoverLink: JQuery<HTMLDivElement>) => {
+      cy.get('.tippy-popper').should('not.exist');
+      cy.wrap(popoverLink).focus();
+      cy.get('.tippy-popper').should('exist');
+      cy.get('h6').contains('Popover Header');
+      cy.get('.pf-c-popover__body').contains('Popover Body');
+      cy.get('footer').contains('Popover Footer');
+      cy.get('button[aria-label="Close"]').then(closeBtn => {
+        cy.wrap(closeBtn).click();
+        cy.get('.tippy-popper').should('not.exist');
+      });
+    });
+  });
 });

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/PopoverDemo/PopoverDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/PopoverDemo/PopoverDemo.tsx
@@ -1,12 +1,24 @@
-import { Popover } from '@patternfly/react-core';
+import { Popover, PopoverTriggers } from '@patternfly/react-core';
 import React, { Component } from 'react';
+
+const PopoverTriggerDemo = ({children, headerContent, bodyContent, footerContent}) => (
+      <Popover
+        headerContent={headerContent}
+        bodyContent={bodyContent}
+        footerContent={footerContent}
+        triggers={[PopoverTriggers.focus]}
+      >
+        {children}
+      </Popover>
+)
 
 export class PopoverDemo extends Component {
   myPopoverProps = {
     headerContent: <div>Popover Header</div>,
     bodyContent: <div>Popover Body</div>,
     footerContent: 'Popover Footer',
-    children: <div id="popoverTarget">Hello</div>
+    children: <div id="popoverTarget">Hello</div>,
+    triggerDemoChildren: <div id="popoverTriggerTarget">Focus me</div>
   };
 
   componentDidMount() {
@@ -15,6 +27,7 @@ export class PopoverDemo extends Component {
 
   render() {
     return (
+      <>
       <Popover
         headerContent={this.myPopoverProps.headerContent}
         bodyContent={this.myPopoverProps.bodyContent}
@@ -22,6 +35,14 @@ export class PopoverDemo extends Component {
       >
         {this.myPopoverProps.children}
       </Popover>
+      <PopoverTriggerDemo 
+        headerContent={this.myPopoverProps.headerContent}
+        bodyContent={this.myPopoverProps.bodyContent}
+        footerContent={this.myPopoverProps.footerContent}
+      >
+        {this.myPopoverProps.triggerDemoChildren}
+      </PopoverTriggerDemo>
+      </>
     );
   }
 }


### PR DESCRIPTION
**What**:

closes #3116 

I added the `triggers` prop to modify the trigger option passed to `TippsyJS`.

**Please notice** that if you set `isVisible` this props is irrelevant since you are the one who manages when to display the popover and thus you will have to implement those triggers or catch those events and mutate the state that determines whether to display or hide the popover.

//cc @jotak 