### PR TITLE
chore(table): fix types for table transforms

### DIFF
--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableActionsDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableActionsDemo.tsx
@@ -5,14 +5,20 @@ import {
   TableBody,
   TableProps,
   headerCol,
+  ICell,
   IRow,
   IRowData,
   IExtra,
-  IAction,
+  IActions,
   ISeparator
 } from '@patternfly/react-table';
 
-export class TableActionsDemo extends React.Component<TableProps, { columns: any; rows: IRow[] }> {
+interface TableState {
+  columns: (ICell | string)[];
+  rows: IRow[];
+}
+
+export class TableActionsDemo extends React.Component<TableProps, TableState> {
   constructor(props: TableProps) {
     super(props);
     this.state = {
@@ -47,7 +53,7 @@ export class TableActionsDemo extends React.Component<TableProps, { columns: any
       return null;
     }
 
-    const thirdAction =
+    const thirdAction: IActions =
       rowData.type === 'blue'
         ? [
             {
@@ -59,7 +65,7 @@ export class TableActionsDemo extends React.Component<TableProps, { columns: any
               onClick: (event, rowId, rowData, extra) =>
                 // tslint:disable-next-line:no-console
                 console.log(`clicked on Third action, on row ${rowId} of type ${rowData.type}`)
-            } as IAction
+            }
           ]
         : [];
 
@@ -70,19 +76,19 @@ export class TableActionsDemo extends React.Component<TableProps, { columns: any
         onClick: (event, rowId, rowData, extra) =>
           // tslint:disable-next-line:no-console
           console.log(`clicked on Some action, on row ${rowId} of type ${rowData.type}`)
-      } as IAction,
+      },
       {
         title: 'Another action',
         // tslint:disable-next-line:no-shadowed-variable
         onClick: (event, rowId, rowData, extra) =>
           // tslint:disable-next-line:no-console
           console.log(`clicked on Another action, on row ${rowId} of type ${rowData.type}`)
-      } as IAction,
+      },
       ...thirdAction
-    ];
+    ] as IActions;
   }
 
-  areActionsDisabled(rowData, { rowIndex }) {
+  areActionsDisabled(rowData: IRowData, { rowIndex }: IExtra) {
     return rowIndex === 3;
   }
 

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableBreakpointModifiersDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableBreakpointModifiersDemo.tsx
@@ -6,10 +6,16 @@ import {
   TableProps,
   classNames,
   Visibility,
+  ICell,
   IRow
 } from '@patternfly/react-table';
 
-export class TableBreakpointModifersDemo extends React.Component<TableProps, { columns: any; rows: IRow[] }> {
+interface TableState {
+  columns: (ICell | string)[];
+  rows: IRow[];
+}
+
+export class TableBreakpointModifersDemo extends React.Component<TableProps, TableState> {
   constructor(props: TableProps) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCollapsibleDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCollapsibleDemo.tsx
@@ -5,10 +5,16 @@ import {
   TableBody,
   TableProps,
   expandable,
+  ICell,
   IRow
 } from '@patternfly/react-table';
 
-export class TableCollapsibleDemo extends React.Component<TableProps, { columns: any; rows: IRow[] }> {
+interface TableState {
+  columns: (ICell | string)[];
+  rows: IRow[];
+}
+
+export class TableCollapsibleDemo extends React.Component<TableProps, TableState> {
   constructor(props: TableProps) {
     super(props);
     this.state = {
@@ -60,7 +66,7 @@ export class TableCollapsibleDemo extends React.Component<TableProps, { columns:
     this.onCollapse = this.onCollapse.bind(this);
   }
 
-  onCollapse(event, rowKey, isOpen) {
+  onCollapse(event: React.MouseEvent, rowKey: number, isOpen: boolean) {
     const { rows } = this.state;
     /**
      * Please do not use rowKey as row index for more complex tables.

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompactBorderlessRowsDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompactBorderlessRowsDemo.tsx
@@ -5,10 +5,16 @@ import {
   TableBody,
   TableProps,
   TableVariant,
+  ICell,
   IRow
 } from '@patternfly/react-table';
 
-export class TableCompactBorderlessRowsDemo extends React.Component<TableProps, { columns: any; rows: IRow[] }> {
+interface TableState {
+  columns: (ICell | string)[];
+  rows: IRow[];
+}
+
+export class TableCompactBorderlessRowsDemo extends React.Component<TableProps, TableState> {
   constructor(props: TableProps) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompactDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompactDemo.tsx
@@ -5,10 +5,16 @@ import {
   TableBody,
   TableProps,
   TableVariant,
+  ICell,
   IRow
 } from '@patternfly/react-table';
 
-export class TableCompactDemo extends React.Component<TableProps, { columns: any; rows: IRow[] }> {
+interface TableState {
+  columns: (ICell | string)[];
+  rows: IRow[];
+}
+
+export class TableCompactDemo extends React.Component<TableProps, TableState> {
   constructor(props: TableProps) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompactExpandableDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompactExpandableDemo.tsx
@@ -59,7 +59,7 @@ export class TableCompactExpandableDemo extends React.Component<TableProps, { co
     this.onCollapse = this.onCollapse.bind(this);
   }
 
-  onCollapse(event, rowKey, isOpen) {
+  onCollapse(event: React.MouseEvent, rowKey: number, isOpen: boolean) {
     const { rows } = this.state;
     /**
      * Please do not use rowKey as row index for more complex tables.

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompoundExpandableDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableCompoundExpandableDemo.tsx
@@ -1,11 +1,24 @@
 import * as React from 'react';
-import { Table, TableHeader, TableBody, TableProps, compoundExpand, IRow, IRowCell } from '@patternfly/react-table';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableProps,
+  compoundExpand,
+  IRow,
+  ICell
+} from '@patternfly/react-table';
 
 import { CodeBranchIcon, CodeIcon, CubeIcon } from '@patternfly/react-icons';
 
 import { DemoSortableTable } from './TableSortableForCompoundExpandableDemo';
 
-export class TableCompoundExpandableDemo extends React.Component<TableProps, { columns: any; rows: any[] }> {
+interface TableState {
+  columns: (ICell | string)[];
+  rows: IRow[];
+}
+
+export class TableCompoundExpandableDemo extends React.Component<TableProps, TableState> {
   constructor(props: TableProps) {
     super(props);
     this.state = {
@@ -186,23 +199,30 @@ export class TableCompoundExpandableDemo extends React.Component<TableProps, { c
     this.onExpand = this.onExpand.bind(this);
   }
 
-  onExpand(event, rowIndex, colIndex, isOpen, rowData, extraData) {
-    const { rows } = this.state;
+  onExpand(
+    event: React.MouseEvent,
+    rowIndex: number,
+    colIndex: number,
+    isOpen: boolean
+    ) {
+    const newRows = Array.from(this.state.rows);
+    const rowCells = newRows[rowIndex].cells;
+
     if (!isOpen) {
       // set all other expanded cells false in this row if we are expanding
-      rows[rowIndex].cells.forEach(cell => {
+      (rowCells as ICell[]).forEach(cell => {
         if (cell.props) {
           cell.props.isOpen = false;
         }
       });
-      rows[rowIndex].cells[colIndex].props.isOpen = true;
-      rows[rowIndex].isOpen = true;
+      (rowCells as ICell[])[colIndex].props.isOpen = true;
+      newRows[rowIndex].isOpen = true;
     } else {
-      rows[rowIndex].cells[colIndex].props.isOpen = false;
-      rows[rowIndex].isOpen = rows[rowIndex].cells.some(cell => cell.props && cell.props.isOpen);
+      (rowCells as ICell[])[colIndex].props.isOpen = false;
+      newRows[rowIndex].isOpen = (rowCells as ICell[]).some(cell => cell.props && cell.props.isOpen);
     }
     this.setState({
-      rows
+      rows: newRows
     });
   }
 

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableFirstCellAsHeaderDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableFirstCellAsHeaderDemo.tsx
@@ -10,10 +10,16 @@ import {
   TableVariant,
   expandable,
   cellWidth,
+  ICell,
   IRow
 } from '@patternfly/react-table';
 
-export class TableFirstCellAsHeaderDemo extends React.Component<TableProps, { columns: any; rows: IRow[] }> {
+interface TableState {
+  columns: (ICell | string)[];
+  rows: IRow[];
+}
+
+export class TableFirstCellAsHeaderDemo extends React.Component<TableProps, TableState> {
   constructor(props: TableProps) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableHeadersWrappableDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableHeadersWrappableDemo.tsx
@@ -1,7 +1,20 @@
 import * as React from 'react';
-import { Table, TableHeader, TableBody, TableProps, wrappable, IRow } from '@patternfly/react-table';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableProps,
+  wrappable,
+  ICell,
+  IRow
+} from '@patternfly/react-table';
 
-export class TableHeadersWrappableDemo extends React.Component<TableProps, { columns: any; rows: IRow[] }> {
+interface TableState {
+  rows: IRow[];
+  columns: (ICell | string)[];
+}
+
+export class TableHeadersWrappableDemo extends React.Component<TableProps, TableState> {
   constructor(props: TableProps) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableRowWrapperDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableRowWrapperDemo.tsx
@@ -3,19 +3,23 @@ import {
   Table,
   TableHeader,
   TableBody,
-  RowWrapperProps
+  RowWrapperProps,
+  TableProps,
+  ICell,
+  IRow
 } from '@patternfly/react-table';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 
 interface ITableRowWrapperDemoState {
-  rows: any;
-  columns: any;
+  rows: IRow[];
+  columns: (ICell | string)[];
 }
 
-export class TableRowWrapperDemo extends React.Component<any, ITableRowWrapperDemoState> {
+export class TableRowWrapperDemo extends React.Component<TableProps, ITableRowWrapperDemoState> {
   customRowWrapper: (props: RowWrapperProps) => JSX.Element;
-  constructor(props: any) {
+  constructor(props: TableProps) {
+
     super(props);
     this.state = {
       columns: [

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSelectableDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSelectableDemo.tsx
@@ -1,11 +1,23 @@
 import * as React from 'react';
-import { Table, TableHeader, TableBody, TableProps, headerCol, IRow } from '@patternfly/react-table';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableProps,
+  headerCol,
+  ICell,
+  IRow,
+  selectable
+} from '@patternfly/react-table';
 import { Checkbox } from '@patternfly/react-core';
 
-export class TableSelectableDemo extends React.Component<
-  TableProps,
-  { columns: any; rows: IRow[]; canSelectAll: boolean }
-> {
+interface TableState {
+  columns: (ICell | string)[];
+  rows: IRow[];
+  canSelectAll: boolean;
+}
+
+export class TableSelectableDemo extends React.Component<TableProps, TableState> {
   constructor(props: TableProps) {
     super(props);
     this.state = {
@@ -35,8 +47,8 @@ export class TableSelectableDemo extends React.Component<
     this.onSelect = this.onSelect.bind(this);
   }
 
-  onSelect(event, isSelected, rowId) {
-    let rows;
+  onSelect(event: React.MouseEvent, isSelected: boolean, rowId: number) {
+    let rows: IRow[];
     if (rowId === -1) {
       rows = this.state.rows.map(oneRow => {
         oneRow.selected = isSelected;

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSimpleActionsDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSimpleActionsDemo.tsx
@@ -5,10 +5,18 @@ import {
   TableBody,
   TableProps,
   headerCol,
-  IRow
+  ICell,
+  IRow,
+  IActions
 } from '@patternfly/react-table';
 
-export class TableSimpleActionsDemo extends React.Component<TableProps, { columns: any; rows: IRow[]; actions: any }> {
+interface ITableState {
+  columns: (ICell | string)[];
+  rows: IRow[];
+  actions: IActions;
+}
+
+export class TableSimpleActionsDemo extends React.Component<TableProps, ITableState> {
   constructor(props: TableProps) {
     super(props);
     this.state = {
@@ -41,7 +49,8 @@ export class TableSimpleActionsDemo extends React.Component<TableProps, { column
           onClick: (event, rowId, rowData, extra) => console.log('clicked on Another action, on row: ', rowId)
         },
         {
-          isSeparator: true
+          isSeparator: true,
+          onClick: null
         },
         {
           title: 'Third action',

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSimpleDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSimpleDemo.tsx
@@ -5,10 +5,11 @@ import {
   TableBody,
   TableProps,
   textCenter,
+  ICell,
   IRow
 } from '@patternfly/react-table';
 
-export class TableSimpleDemo extends React.Component<TableProps, { columns: any; rows: IRow[] }> {
+export class TableSimpleDemo extends React.Component<TableProps, { columns: (ICell | string)[]; rows: IRow[] }> {
   constructor(props: TableProps) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSortableDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSortableDemo.tsx
@@ -6,11 +6,12 @@ import {
   TableProps,
   sortable,
   SortByDirection,
+  ICell,
   IRow,
   ISortBy
 } from '@patternfly/react-table';
 
-export class TableSortableDemo extends React.Component<TableProps, { columns: any; rows: IRow[]; sortBy: ISortBy }> {
+export class TableSortableDemo extends React.Component<TableProps, { columns: (ICell | string)[]; rows: IRow[]; sortBy: ISortBy }> {
   constructor(props: TableProps) {
     super(props);
     this.state = {
@@ -27,7 +28,7 @@ export class TableSortableDemo extends React.Component<TableProps, { columns: an
     this.onSort = this.onSort.bind(this);
   }
 
-  onSort(_event, index, direction) {
+  onSort(_event: React.MouseEvent, index: number, direction: SortByDirection) {
     const sortedRows = this.state.rows.sort((a, b) => (a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0));
     this.setState({
       sortBy: {

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSortableForCompoundExpandableDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSortableForCompoundExpandableDemo.tsx
@@ -7,14 +7,15 @@ import {
   TableVariant,
   sortable,
   SortByDirection,
+  ICell,
   IRow,
   ISortBy
 } from '@patternfly/react-table';
 
 export interface DemoSortableTableProps {
-  firstColumnRows?: any[];
-  columns?: any;
-  rows?: IRow[];
+  firstColumnRows?: string[];
+  columns?: (ICell | string)[];
+  rows?: (IRow | string[])[];
   sortBy?: ISortBy;
   id?: string;
 }
@@ -32,7 +33,7 @@ export class DemoSortableTable extends React.Component<DemoSortableTableProps> {
     sortBy: {}
   };
 
-  onSort = (_event, index, direction) => {
+  onSort = (_event: React.MouseEvent, index: number, direction: SortByDirection) => {
     const sortedRows = this.state.rows.sort((a, b) => {
       if (a[index] < b[index]) {
         return -1;

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableWidthModifiersDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/TableDemo/TableWidthModifiersDemo.tsx
@@ -5,10 +5,11 @@ import {
   TableBody,
   TableProps,
   cellWidth,
+  ICell,
   IRow
 } from '@patternfly/react-table';
 
-export class TableWidthModifiersDemo extends React.Component<TableProps, { columns: any; rows: IRow[] }> {
+export class TableWidthModifiersDemo extends React.Component<TableProps, { columns: (ICell | string)[]; rows: IRow[] }> {
   constructor(props: TableProps) {
     super(props);
     this.state = {

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -23,7 +23,6 @@ export * from './ChipGroupDemo/ChipGroupDemo';
 export * from './ContextSelectorDemo/ContextSelectorDemo';
 export * from './ClipboardCopyDemo/ClipboardCopyDemo';
 export * from './ClipboardCopyDemo/ClipboardCopyExpandedDemo';
-export * from './ContextSelectorDemo/ContextSelectorDemo';
 export * from './DataListDemo/DataListDemo';
 export * from './DataToolbarDemo/DataToolbarDemo';
 export * from './DividerDemo/DividerDemo';

--- a/packages/patternfly-4/react-table/package.json
+++ b/packages/patternfly-4/react-table/package.json
@@ -47,6 +47,7 @@
     "build:babel:cjs": "babel --source-maps --extensions '.js,.ts,.tsx' src --out-dir dist/js --presets=@babel/env",
     "build:babel:esm": "babel --source-maps --extensions '.js,.ts,.tsx' src --out-dir dist/esm",
     "build:babel:umd": "babel --source-maps --extensions '.js' dist/esm --out-dir dist/umd --plugins=transform-es2015-modules-umd",
+    "watch:types": "tsc -w -p tsconfig.gen-dts.json",
     "build:types": "tsc -p tsconfig.gen-dts.json",
     "clean": "rimraf dist",
     "develop": "yarn build:babel:esm --skip-initial-build --watch --verbose --source-maps"

--- a/packages/patternfly-4/react-table/src/components/Table/Table.test.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.test.tsx
@@ -11,7 +11,11 @@ import {
   sortable,
   expandable,
   compoundExpand,
-  IRow
+  IRow,
+  OnCollapse,
+  OnExpand,
+  OnSelect,
+  OnSort
 } from './index';
 import { rows, columns, actions } from '../../test-helpers/data-sets';
 import { ColumnsType } from './base';
@@ -48,8 +52,8 @@ describe('Simple table', () => {
 });
 
 test('Sortable table', () => {
-  const onSortCall = () => undefined as any;
-  columns[0] = { ...columns[0], transforms: [sortable] };
+  const onSortCall: OnSort = () => undefined;
+  columns[0] = { ...(columns[0] as object), transforms: [sortable] };
   const view = mount(
     <Table aria-label="Aria labeled" onSort={onSortCall} sortBy={{}} cells={columns} rows={rows}>
       <TableHeader />
@@ -134,7 +138,7 @@ test('Actions table', () => {
 });
 
 test('Cell header table', () => {
-  columns[0] = { ...columns[0], cellTransforms: [headerCol] };
+  columns[0] = { ...(columns[0] as object), cellTransforms: [headerCol('test-headercol-')] };
   const view = mount(
     <Table aria-label="Aria labeled" cells={columns} rows={rows}>
       <TableHeader />
@@ -149,8 +153,8 @@ test('Collapsible table', () => {
   rows[1] = { ...rows[1], parent: 0 };
   rows[3] = { ...rows[3], isOpen: false };
   rows[4] = { ...rows[4], parent: 3 };
-  columns[0] = { ...columns[0], cellFormatters: [expandable] };
-  const onCollapse = () => undefined as any;
+  columns[0] = { ...(columns[0] as object), cellFormatters: [expandable] };
+  const onCollapse: OnCollapse = () => undefined;
   const view = mount(
     <Table aria-label="Aria labeled" onCollapse={onCollapse} cells={columns} rows={rows}>
       <TableHeader />
@@ -171,7 +175,7 @@ test('Compound Expandable table', () => {
     { isOpen: false, cells: [{ title: '3', props: { isOpen: false } }, { title: '4', props: { isOpen: false } }] },
     { parent: 2, compoundParent: 0, cells: [{ title: 'expanded', props: { colSpan: 2 } }] }
   ];
-  const onExpand = () => undefined as any;
+  const onExpand: OnExpand = () => undefined;
   const view = mount(
     <Table aria-label="Aria labeled" onExpand={onExpand} cells={compoundColumns} rows={compoundRows}>
       <TableHeader />
@@ -185,7 +189,7 @@ test('Collapsible nested table', () => {
   rows[0] = { ...rows[0], isOpen: false };
   rows[1] = { ...rows[1], parent: 0, isOpen: true };
   rows[2] = { ...rows[2], parent: 1 };
-  const onCollapse = () => undefined as any;
+  const onCollapse: OnCollapse = () => undefined;
   const view = mount(
     <Table aria-label="Aria labeled" onCollapse={onCollapse} cells={columns} rows={rows}>
       <TableHeader />
@@ -196,7 +200,7 @@ test('Collapsible nested table', () => {
 });
 
 test('Selectable table', () => {
-  const onSelect = () => undefined as any;
+  const onSelect: OnSelect = () => undefined;
   const view = mount(
     <Table aria-label="Aria labeled" onSelect={onSelect} cells={columns} rows={rows}>
       <TableHeader />
@@ -207,9 +211,9 @@ test('Selectable table', () => {
 });
 
 test('Header width table', () => {
-  columns[0] = { ...columns[0], transforms: [cellWidth(10)] };
-  columns[2] = { ...columns[2], transforms: [cellWidth(30)] };
-  columns[4] = { ...columns[4], transforms: [cellWidth('max')] };
+  columns[0] = { ...(columns[0] as object), transforms: [cellWidth(10)] };
+  columns[2] = { ...(columns[2] as object), transforms: [cellWidth(30)] };
+  columns[4] = { ...(columns[4] as object), transforms: [cellWidth('max')] };
   const view = mount(
     <Table aria-label="Aria labeled" cells={columns} rows={rows}>
       <TableHeader />
@@ -232,7 +236,7 @@ test('Selectable table with selected expandable row', () => {
         parent: 0
       }
     ],
-    onSelect: (f: any) => f
+    onSelect: (e: React.MouseEvent) => e
   };
 
   const view = mount(

--- a/packages/patternfly-4/react-table/src/components/Table/Table.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.tsx
@@ -58,7 +58,7 @@ export enum SortByDirection {
   desc = 'desc'
 }
 
-export interface IHeaderRow extends ColumnType {}
+export interface IHeaderRow extends ColumnType { }
 
 export interface IRowData extends IRow {
   disableActions?: boolean;
@@ -91,7 +91,7 @@ export interface IExtraColumnData {
   property?: string;
 }
 
-export interface IExtraData extends IExtraColumnData, IExtraRowData {}
+export interface IExtraData extends IExtraColumnData, IExtraRowData { }
 
 export interface IExtra extends IExtraData {
   rowData?: IRowData;
@@ -128,33 +128,39 @@ export interface IDecorator extends React.HTMLProps<HTMLElement> {
   children?: React.ReactNode;
 }
 
-export type ITransforms = ((
-  label?: IFormatterValueType,
-  rowData?: IRowData,
-  columnIndex?: number,
-  column?: IColumn,
-  property?: string,
-  rowIndex?: number,
-  rowKey?: RowKeyType
-) => { className: string; 'aria-sort': string; children: React.ReactNode })[];
+export type decoratorReturnType = {
+  className?: string;
+  'aria-sort'?: string;
+  children?: React.ReactNode;
+  textCenter?: boolean;
+  component?: string;
+  isVisible?: boolean;
+  title?: string | React.ReactNode;
+  props?: any;
+  scope?: string;
+  parentId?: number;
+  colSpan?: number;
+  id?: React.ReactText;
+}
 
-export type IFormatters = ((
+export type ITransform = ((
+  label?: IFormatterValueType,
+  extra?: IExtra
+) => decoratorReturnType
+);
+
+export type IFormatter = ((
   data?: IFormatterValueType,
-  rowData?: IRowData,
-  columnIndex?: number,
-  column?: IColumn,
-  property?: string,
-  rowIndex?: number,
-  rowKey?: RowKeyType
-) => formatterValueType)[];
+  extra?: IExtra
+) => formatterValueType & decoratorReturnType);
 
 export interface ICell {
   title?: string | React.ReactNode;
-  transforms?: ITransforms;
-  cellTransforms?: ITransforms;
-  columnTransforms?: ITransforms;
-  formatters?: IFormatters;
-  cellFormatters?: IFormatters;
+  transforms?: ITransform[];
+  cellTransforms?: ITransform[];
+  columnTransforms?: ITransform[];
+  formatters?: IFormatter[];
+  cellFormatters?: IFormatter[];
   props?: any;
   data?: any;
   header?: any;

--- a/packages/patternfly-4/react-table/src/components/Table/base/types.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/base/types.tsx
@@ -17,6 +17,7 @@ export interface CellType {
 
 // Columns Types
 export type ColumnsType = ColumnType[] | any[];
+
 export interface ColumnType {
   property?: string;
   cell?: CellType;

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/cellActions.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/cellActions.tsx
@@ -10,7 +10,8 @@ import {
   IExtra,
   IExtraData,
   IFormatterValueType,
-  IRowData
+  IRowData,
+  ITransform
 } from '../../Table';
 
 const resolveOrDefault = (
@@ -24,7 +25,7 @@ export const cellActions = (
   actions: IActions,
   actionResolver: IActionsResolver,
   areActionsDisabled: IAreActionsDisabled
-) => (
+): ITransform => (
   label: IFormatterValueType,
   {
     rowData,

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/cellHeightAuto.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/cellHeightAuto.ts
@@ -1,7 +1,8 @@
 import { css, getModifier } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
+import { ITransform } from '../../Table';
 
-export const cellHeightAuto = () => {
+export const cellHeightAuto: ITransform = () => {
   console.warn('cellHeightAuto:', 'is deprecated. Use heightAuto instead. Read more here: https://github.com/patternfly/patternfly-react/issues/3132')
   return {
     className: css(getModifier(styles, 'heightAuto'))

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/cellWidth.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/cellWidth.ts
@@ -1,6 +1,7 @@
 import { css, getModifier } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
+import { ITransform } from '../../Table';
 
-export const cellWidth = (width: number | string) => () => ({
+export const cellWidth = (width: number | string): ITransform => () => ({
   className: css(getModifier(styles, `width_${width}`))
 });

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/classNames.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/classNames.ts
@@ -1,5 +1,6 @@
 import { css, pickProperties } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
+import { ITransform } from '../../Table';
 
 export const Visibility = pickProperties(styles.modifiers, [
   'hidden',
@@ -16,6 +17,6 @@ export const Visibility = pickProperties(styles.modifiers, [
 ]);
 
 // tslint:disable-next-line:no-shadowed-variable
-export const classNames = (...classNames: string[]) => () => ({
+export const classNames = (...classNames: string[]): ITransform => () => ({
   className: css(...classNames)
 });

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/collapsible.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/collapsible.tsx
@@ -3,9 +3,9 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import { CollapseColumn } from '../../CollapseColumn';
 import { ExpandableRowContent } from '../../ExpandableRowContent';
-import { IExtra, IFormatterValueType } from '../../Table';
+import { IExtra, IFormatterValueType, IFormatter, decoratorReturnType } from '../../Table';
 
-export const collapsible = (
+export const collapsible: IFormatter = (
   value: IFormatterValueType,
   { rowIndex, columnIndex, rowData, column, property }: IExtra
 ) => {
@@ -40,7 +40,7 @@ export const collapsible = (
   };
 };
 
-export const expandable = (value: IFormatterValueType, { rowData }: IExtra) =>
+export const expandable: IFormatter = (value: IFormatterValueType, { rowData }: IExtra) =>
   rowData.hasOwnProperty('parent') ? <ExpandableRowContent>{value}</ExpandableRowContent> : value;
 
 export const expandedRow = (colSpan: number) => {
@@ -53,7 +53,7 @@ export const expandedRow = (colSpan: number) => {
         extraParams: { contentId = 'expanded-content' }
       }
     }: IExtra
-  ) =>
+  ): decoratorReturnType =>
     rowData.hasOwnProperty('parent') && {
       // todo: rewrite this logic, it is not type safe
       colSpan: colSpan + (!!rowData.fullWidth as any),

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/compoundExpand.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/compoundExpand.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import { Button } from '@patternfly/react-core';
 import styles from '@patternfly/react-styles/css/components/Table/table';
-import { IExtra, IFormatterValueType } from '../../Table';
+import { IExtra, IFormatterValueType, ITransform } from '../../Table';
 
-export const compoundExpand = (
+export const compoundExpand: ITransform = (
   value: IFormatterValueType,
   { rowIndex, columnIndex, rowData, column, property }: IExtra
 ) => {

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/headerCol.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/headerCol.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { IExtra, IFormatterValueType } from '../../Table';
+import { IExtra, IFormatterValueType, ITransform } from '../../Table';
 
 export const headerCol = (id: string = 'simple-node') => {
   // tslint:disable-next-line:no-shadowed-variable
-  const headerCol = (value: IFormatterValueType, { rowIndex }: IExtra = {}) => {
+  const headerCol: ITransform = (value: IFormatterValueType, { rowIndex }: IExtra = {}) => {
     const result = typeof value === 'object' ? value.title : value;
     return {
       component: 'th',

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/selectable.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/selectable.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
-import { IExtra, IFormatterValueType } from '../../Table';
+import { IExtra, IRowData, IFormatterValueType, ITransform } from '../../Table';
 import { SelectColumn } from '../../SelectColumn';
 
-export const selectable = (
+export const selectable: ITransform = (
   label: IFormatterValueType,
   { rowIndex, columnIndex, rowData, column, property }: IExtra
 ) => {

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/sortable.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/sortable.tsx
@@ -3,7 +3,6 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
 import { SortByDirection, IExtra, IFormatterValueType, ITransform } from '../../Table';
-import { ExtraParamsType } from '../../base/types';
 import { SortColumn } from '../../SortColumn';
 
 export const sortable: ITransform = (label: IFormatterValueType, { columnIndex, column, property }: IExtra) => {

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/sortable.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/sortable.tsx
@@ -2,13 +2,15 @@ import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import buttonStyles from '@patternfly/react-styles/css/components/Button/button';
-import { SortByDirection, IExtra, IFormatterValueType } from '../../Table';
+import { SortByDirection, IExtra, IFormatterValueType, ITransform } from '../../Table';
+import { ExtraParamsType } from '../../base/types';
 import { SortColumn } from '../../SortColumn';
 
-export const sortable = (label: IFormatterValueType, { columnIndex, column, property }: IExtra) => {
+export const sortable: ITransform = (label: IFormatterValueType, { columnIndex, column, property }: IExtra) => {
   const {
     extraParams: { sortBy, onSort }
   } = column;
+
   const extraData = {
     columnIndex,
     column,
@@ -17,7 +19,7 @@ export const sortable = (label: IFormatterValueType, { columnIndex, column, prop
 
   const isSortedBy = sortBy && columnIndex === sortBy.index;
   function sortClicked(event: React.MouseEvent) {
-    let reversedDirection;
+    let reversedDirection: SortByDirection;
     if (!isSortedBy) {
       reversedDirection = SortByDirection.asc;
     } else {

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/textCenter.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/textCenter.ts
@@ -1,1 +1,2 @@
-export const textCenter = () => ({ textCenter: true });
+import { ITransform } from '../../Table';
+export const textCenter: ITransform = () => ({ textCenter: true });

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/wrappable.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/wrappable.ts
@@ -1,6 +1,7 @@
 import { css, getModifier } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
+import { ITransform } from '../../Table';
 
-export const wrappable = () => ({
+export const wrappable: ITransform = () => ({
   className: css(getModifier(styles, 'wrap'))
 });

--- a/packages/patternfly-4/react-table/src/components/Table/utils/formatters.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/formatters.tsx
@@ -1,5 +1,5 @@
-import { IFormatterValueType } from '../Table';
+import { IFormatterValueType, IFormatter } from '../Table';
 
-const defaultTitle = (data: IFormatterValueType) => (data && data.hasOwnProperty('title') ? data.title : data);
+const defaultTitle: IFormatter = (data: IFormatterValueType) => (data && data.hasOwnProperty('title') ? data.title : data);
 
 export { defaultTitle };

--- a/packages/patternfly-4/react-table/src/components/Table/utils/transformers.test.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/transformers.test.tsx
@@ -62,7 +62,7 @@ const testCellActions = ({
   if (!actions || actions.length === 0) {
     expect(returnedData.children).toBeUndefined();
   } else {
-    const view = mount(returnedData.children);
+    const view = mount(returnedData.children as React.ReactElement<any>);
     view
       .find('.pf-c-dropdown button')
       .first()
@@ -80,7 +80,7 @@ describe('Transformer functions', () => {
       };
       const returnedData = selectable('', { column, rowData: {} } as IExtra);
       expect(returnedData).toMatchObject({ className: 'pf-c-table__check' });
-      const view = mount(returnedData.children);
+      const view = mount(returnedData.children as React.ReactElement<any>);
       view.find('input').simulate('change');
       expect(onSelect.mock.calls).toHaveLength(1);
       expect(onSelect.mock.results[0].value).toMatchObject({ rowId: -1, selected: false });
@@ -93,7 +93,7 @@ describe('Transformer functions', () => {
       };
       const returnedData = selectable('', { column, rowIndex: 0, rowData: { selected: true } } as IExtra);
       expect(returnedData).toMatchObject({ className: 'pf-c-table__check' });
-      const view = mount(returnedData.children);
+      const view = mount(returnedData.children as React.ReactElement<any>);
       view.find('input').simulate('change');
       expect(onSelect.mock.calls).toHaveLength(1);
       expect(onSelect.mock.results[0].value).toMatchObject({ rowId: 0, selected: false });
@@ -106,7 +106,7 @@ describe('Transformer functions', () => {
       };
       const returnedData = selectable('', { column, rowIndex: 0, rowData: { selected: false } } as IExtra);
       expect(returnedData).toMatchSnapshot();
-      const view = mount(returnedData.children);
+      const view = mount(returnedData.children as React.ReactElement<any>);
       view.find('input').simulate('change');
       expect(onSelect.mock.calls).toHaveLength(1);
       expect(onSelect.mock.results[0].value).toMatchObject({ rowId: 0, selected: true });
@@ -119,7 +119,7 @@ describe('Transformer functions', () => {
       const column = { extraParams: { sortBy: {}, onSort } };
       const returnedData = sortable('', { column, columnIndex: 0 });
       expect(returnedData).toMatchObject({ className: 'pf-c-table__sort' });
-      const view = mount(returnedData.children);
+      const view = mount(returnedData.children as React.ReactElement<any>);
       view.find('button').simulate('click');
       expect(onSort.mock.calls).toHaveLength(1);
     });
@@ -129,7 +129,7 @@ describe('Transformer functions', () => {
       const column = { extraParams: { sortBy: { index: 0, direction: 'asc' }, onSort } };
       const returnedData = sortable('', { column, columnIndex: 0 } as IExtra);
       expect(returnedData).toMatchSnapshot();
-      const view = mount(returnedData.children);
+      const view = mount(returnedData.children as React.ReactElement<any>);
       view.find('button').simulate('click');
       expect(onSort.mock.calls).toHaveLength(1);
     });
@@ -139,19 +139,19 @@ describe('Transformer functions', () => {
       const column = { extraParams: { sortBy: { index: 0, direction: 'desc' }, onSort } };
       const returnedData = sortable('', { column, columnIndex: 0 } as IExtra);
       expect(returnedData).toMatchObject({ className: 'pf-c-table__sort pf-m-selected' });
-      const view = mount(returnedData.children);
+      const view = mount(returnedData.children as React.ReactElement<any>);
       view.find('button').simulate('click');
       expect(onSort.mock.calls).toHaveLength(1);
     });
   });
 
   test('simpleCellActions', () => {
-    const actions = [
+    const actions: IActions = [
       {
         title: 'Some',
         onClick: jest.fn()
       }
-    ] as IActions;
+    ];
 
     const actionConfigs = [
       {
@@ -206,7 +206,7 @@ describe('Transformer functions', () => {
     };
     const returnedData = collapsible('', { rowIndex: 0, rowData, column });
     expect(returnedData).toMatchObject({ className: 'pf-c-table__toggle' });
-    const view = mount(returnedData.children);
+    const view = mount(returnedData.children as React.ReactElement<any>);
     view.find('button').simulate('click');
     expect(onCollapse.mock.calls).toHaveLength(1);
   });
@@ -277,7 +277,7 @@ describe('Transformer functions', () => {
   test('headerCol', () => {
     const returned = headerCol('some-id')('value', { rowIndex: 0 });
     expect(returned).toMatchObject({ component: 'th' });
-    const view = mount(returned.children);
+    const view = mount(returned.children as React.ReactElement<any>);
     expect(view.find('#some-id0')).toHaveLength(1);
   });
 

--- a/packages/patternfly-4/react-table/src/components/Table/utils/transformers.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/transformers.tsx
@@ -10,26 +10,26 @@ export { compoundExpand } from './decorators/compoundExpand';
 export { headerCol } from './decorators/headerCol';
 export { classNames, Visibility } from './decorators/classNames';
 
-import { IFormatterValueType, IExtra } from '../Table';
+import { IFormatterValueType, IExtra, ITransform } from '../Table';
 
-const emptyTD = () => ({
+const emptyTD: ITransform = () => ({
   scope: '',
   component: 'td'
 });
 
-const scopeColTransformer = () => ({
+const scopeColTransformer: ITransform = () => ({
   scope: 'col'
 });
 
-const emptyCol = (label: IFormatterValueType) => ({
+const emptyCol: ITransform = (label: IFormatterValueType) => ({
   ...(label ? {} : { scope: '' })
 });
 
-const parentId = (_value: IFormatterValueType, { rowData }: IExtra) => ({
+const parentId: ITransform = (_value: IFormatterValueType, { rowData }: IExtra) => ({
   parentId: rowData.parent
 });
 
-const mapProps = (_label: IFormatterValueType, { property, rowData }: IExtra) => ({
+const mapProps: ITransform = (_label: IFormatterValueType, { property, rowData }: IExtra) => ({
   ...(rowData[property] && rowData[property].props)
 });
 

--- a/packages/patternfly-4/react-table/src/test-helpers/data-helpers.tsx
+++ b/packages/patternfly-4/react-table/src/test-helpers/data-helpers.tsx
@@ -1,13 +1,13 @@
 import { IRow } from '../components/Table/Table';
 
-export const buildExpandableRows = (relationships: any = {}, openIndexes: Number[] = [], rowCount: number = 10) => {
-  const rows = [];
+export const buildExpandableRows = (relationships: any = {}, openIndexes: number[] = [], rowCount: number = 10) => {
+  const rows: IRow[] = [];
   for (let i = 0; i < rowCount; i++) {
-    const row = {
+    const row: IRow = {
       data: {
         mockData: 'mock'
       }
-    } as IRow;
+    };
 
     if (openIndexes.indexOf(i) >= 0) {
       row.isOpen = true;

--- a/packages/patternfly-4/react-table/src/test-helpers/data-sets.tsx
+++ b/packages/patternfly-4/react-table/src/test-helpers/data-sets.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
 import * as React from 'react';
+import { IRow, ICell, IActions } from '../components/Table/Table';
 
-export const columns: any = [
+export const columns: (ICell | string)[] = [
   { title: 'Header cell' },
   'Branches',
   { title: 'Pull requests' },
@@ -11,7 +12,7 @@ export const columns: any = [
   }
 ];
 
-export const rows: any = [
+export const rows: IRow[] = [
   {
     cells: ['one', 'two', 'three', 'four', 'five']
   },
@@ -41,25 +42,26 @@ export const rows: any = [
   }
 ];
 
-export const actions: any = [
+export const actions: IActions = [
   {
     title: 'Some action',
-    onClick: ({ event }: { event: React.MouseEvent<HTMLAnchorElement, MouseEvent> }, { rowId }: { rowId: number }) =>
+    onClick: (event: React.MouseEvent, rowId: number) =>
       // tslint:disable-next-line:no-console
       console.log('clicked on Some action, on row: ', rowId)
   },
   {
     title: <div>Another action</div>,
-    onClick: ({ event }: { event: React.MouseEvent<HTMLAnchorElement, MouseEvent> }, { rowId }: { rowId: number }) =>
+    onClick: (event: React.MouseEvent, rowId: number) =>
       // tslint:disable-next-line:no-console
       console.log('clicked on Another action, on row: ', rowId)
   },
   {
-    isSeparator: true
+    isSeparator: true,
+    onClick: null
   },
   {
     title: 'Third action',
-    onClick: ({ event }: { event: React.MouseEvent<HTMLAnchorElement, MouseEvent> }, { rowId }: { rowId: number }) =>
+    onClick: (event: React.MouseEvent, rowId: number) =>
       // tslint:disable-next-line:no-console
       console.log('clicked on Third action, on row: ', rowId)
   }

--- a/packages/patternfly-4/react-virtualized-extension/src/components/Virtualized/VirtualizedTable.test.tsx
+++ b/packages/patternfly-4/react-virtualized-extension/src/components/Virtualized/VirtualizedTable.test.tsx
@@ -23,7 +23,7 @@ const measurementCache = new CellMeasurerCache({
 });
 
 describe('Simple virtualized table', () => {
-  const rowRenderer = ( index: number , isVisible: any ) => {
+  const rowRenderer = ( index: number , isVisible: boolean ) => {
     const text = rows[index].cells[0];
 
     const className = clsx({
@@ -73,7 +73,7 @@ describe('Simple virtualized table', () => {
 });
 
 test('Sortable Virtualized Table', () => {
-  const rowRenderer = ( index: number , isVisible: any ) => {
+  const rowRenderer = ( index: number , isVisible: boolean ) => {
     const text = rows[index].cells[0];
 
     const className = clsx({
@@ -82,7 +82,7 @@ test('Sortable Virtualized Table', () => {
   };
 
   const onSortCall = () => undefined as any;
-  columns[0] = { ...columns[0], transforms: [sortable] };
+  columns[0] = { ...(columns[0] as object), transforms: [sortable] };
   const view = mount(
     <Table aria-label="Aria labeled" onSort={onSortCall} sortBy={{}} cells={columns} rows={rows}>
       <TableHeader />
@@ -102,7 +102,7 @@ test('Sortable Virtualized Table', () => {
 });
 
 test('Simple Actions table', () => {
-  const rowRenderer = ( index: number , isVisible: any ) => {
+  const rowRenderer = ( index: number , isVisible: boolean ) => {
     const text = rows[index].cells[0];
 
     const className = clsx({
@@ -139,7 +139,7 @@ test('Simple Actions table', () => {
 });
 
 test('Actions virtualized table', () => {
-  const rowRenderer = ( index: number , isVisible: any ) => { 
+  const rowRenderer = ( index: number , isVisible: boolean ) => {
     const text = rows[index].cells[0];
 
     const className = clsx({
@@ -174,7 +174,7 @@ test('Actions virtualized table', () => {
 });
 
 test('Selectable virtualized table', () => {
-  const rowRenderer = ( index: number , isVisible: any ) => { 
+  const rowRenderer = ( index: number , isVisible: boolean ) => {
     const text = rows[index].cells[0];
 
     const className = clsx({

--- a/packages/patternfly-4/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
+++ b/packages/patternfly-4/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
@@ -2700,6 +2700,7 @@ exports[`Simple Actions table 1`] = `
       },
       Object {
         "isSeparator": true,
+        "onClick": null,
       },
       Object {
         "onClick": [Function],
@@ -2839,6 +2840,7 @@ exports[`Simple Actions table 1`] = `
           },
           Object {
             "isSeparator": true,
+            "onClick": null,
           },
           Object {
             "onClick": [Function],
@@ -2978,6 +2980,7 @@ exports[`Simple Actions table 1`] = `
           },
           Object {
             "isSeparator": true,
+            "onClick": null,
           },
           Object {
             "onClick": [Function],
@@ -3147,6 +3150,7 @@ exports[`Simple Actions table 1`] = `
                   },
                   Object {
                     "isSeparator": true,
+                    "onClick": null,
                   },
                   Object {
                     "onClick": [Function],
@@ -3208,6 +3212,7 @@ exports[`Simple Actions table 1`] = `
                   },
                   Object {
                     "isSeparator": true,
+                    "onClick": null,
                   },
                   Object {
                     "onClick": [Function],
@@ -3268,6 +3273,7 @@ exports[`Simple Actions table 1`] = `
                   },
                   Object {
                     "isSeparator": true,
+                    "onClick": null,
                   },
                   Object {
                     "onClick": [Function],
@@ -3328,6 +3334,7 @@ exports[`Simple Actions table 1`] = `
                   },
                   Object {
                     "isSeparator": true,
+                    "onClick": null,
                   },
                   Object {
                     "onClick": [Function],
@@ -3388,6 +3395,7 @@ exports[`Simple Actions table 1`] = `
                   },
                   Object {
                     "isSeparator": true,
+                    "onClick": null,
                   },
                   Object {
                     "onClick": [Function],
@@ -3449,6 +3457,7 @@ exports[`Simple Actions table 1`] = `
                   },
                   Object {
                     "isSeparator": true,
+                    "onClick": null,
                   },
                   Object {
                     "onClick": [Function],
@@ -3543,6 +3552,7 @@ exports[`Simple Actions table 1`] = `
                             },
                             Object {
                               "isSeparator": true,
+                              "onClick": null,
                             },
                             Object {
                               "onClick": [Function],
@@ -3604,6 +3614,7 @@ exports[`Simple Actions table 1`] = `
                             },
                             Object {
                               "isSeparator": true,
+                              "onClick": null,
                             },
                             Object {
                               "onClick": [Function],
@@ -3664,6 +3675,7 @@ exports[`Simple Actions table 1`] = `
                             },
                             Object {
                               "isSeparator": true,
+                              "onClick": null,
                             },
                             Object {
                               "onClick": [Function],
@@ -3724,6 +3736,7 @@ exports[`Simple Actions table 1`] = `
                             },
                             Object {
                               "isSeparator": true,
+                              "onClick": null,
                             },
                             Object {
                               "onClick": [Function],
@@ -3784,6 +3797,7 @@ exports[`Simple Actions table 1`] = `
                             },
                             Object {
                               "isSeparator": true,
+                              "onClick": null,
                             },
                             Object {
                               "onClick": [Function],
@@ -3845,6 +3859,7 @@ exports[`Simple Actions table 1`] = `
                             },
                             Object {
                               "isSeparator": true,
+                              "onClick": null,
                             },
                             Object {
                               "onClick": [Function],
@@ -3939,6 +3954,7 @@ exports[`Simple Actions table 1`] = `
                                 },
                                 Object {
                                   "isSeparator": true,
+                                  "onClick": null,
                                 },
                                 Object {
                                   "onClick": [Function],
@@ -4000,6 +4016,7 @@ exports[`Simple Actions table 1`] = `
                                 },
                                 Object {
                                   "isSeparator": true,
+                                  "onClick": null,
                                 },
                                 Object {
                                   "onClick": [Function],
@@ -4060,6 +4077,7 @@ exports[`Simple Actions table 1`] = `
                                 },
                                 Object {
                                   "isSeparator": true,
+                                  "onClick": null,
                                 },
                                 Object {
                                   "onClick": [Function],
@@ -4120,6 +4138,7 @@ exports[`Simple Actions table 1`] = `
                                 },
                                 Object {
                                   "isSeparator": true,
+                                  "onClick": null,
                                 },
                                 Object {
                                   "onClick": [Function],
@@ -4180,6 +4199,7 @@ exports[`Simple Actions table 1`] = `
                                 },
                                 Object {
                                   "isSeparator": true,
+                                  "onClick": null,
                                 },
                                 Object {
                                   "onClick": [Function],
@@ -4241,6 +4261,7 @@ exports[`Simple Actions table 1`] = `
                                 },
                                 Object {
                                   "isSeparator": true,
+                                  "onClick": null,
                                 },
                                 Object {
                                   "onClick": [Function],


### PR DESCRIPTION
**What**: This PR updates the types used around the existing table decorators (transforms & formatters) so that consumers can specify the standard `(ICell | string)[]` type for table column definitions in TypeScript based apps. It also makes use of the existing types throughout a lot of the table related code, and modifies a few types slightly for consistency.

It should also help clear the `strictFunctionTypes` errors for Table.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**: https://github.com/patternfly/patternfly-react/issues/3148 and https://github.com/patternfly/patternfly-react/issues/3172 and https://github.com/patternfly/patternfly-react/issues/3224

