### PR TITLE
chore(demo-app-ts): increase strict checks for react-integration

### DIFF
--- a/packages/patternfly-4/react-integration/demo-app-ts/tsconfig.json
+++ b/packages/patternfly-4/react-integration/demo-app-ts/tsconfig.json
@@ -17,8 +17,14 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "preserve",
-    "strict": false,
-    "strictPropertyInitialization": false
+    "strict": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": false,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "strictFunctionTypes": false,
   },
   "include": [
     "src"


### PR DESCRIPTION
**What**: This PR raises the strict checks used in react-integration package to the maximum degree possible before breaking anything. This should help prevent new issues from being introduced while we chip away at bringing the code into compliance with `strictNullChecks`, `strictFunctionTypes`, `noImplicitAny`, and `strictPropertyInitialization` compiler options.

It's a safe step toward solving https://github.com/patternfly/patternfly-react/issues/3223
