### PR TITLE
build(package.json): Upgrade react-bootstrap to fix React deprecated lifecycle method warnings

### DIFF
--- a/packages/patternfly-3/patternfly-react-extensions/package.json
+++ b/packages/patternfly-3/patternfly-react-extensions/package.json
@@ -38,7 +38,7 @@
     "css-element-queries": "^1.0.1",
     "patternfly": "^3.59.4",
     "patternfly-react": "^2.39.6",
-    "react-bootstrap": "^0.32.1",
+    "react-bootstrap": "^0.33.0",
     "react-click-outside": "^3.0.1",
     "react-diff-view": "^1.8.1",
     "react-ellipsis-with-tooltip": "^1.0.8",

--- a/packages/patternfly-3/patternfly-react/package.json
+++ b/packages/patternfly-3/patternfly-react/package.json
@@ -30,7 +30,7 @@
     "css-element-queries": "^1.0.1",
     "lodash": "^4.17.15",
     "patternfly": "^3.59.4",
-    "react-bootstrap": "^0.32.1",
+    "react-bootstrap": "^0.33.0",
     "react-bootstrap-switch": "^15.5.3",
     "react-bootstrap-typeahead": "^3.4.1",
     "react-c3js": "^0.1.20",

--- a/packages/patternfly-3/patternfly-react/src/components/AboutModal/__snapshots__/AboutModal.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/AboutModal/__snapshots__/AboutModal.test.js.snap
@@ -4,6 +4,7 @@ exports[`AboutModal renders correctly when hidden 1`] = `null`;
 
 exports[`AboutModal renders correctly when shown 1`] = `
 <div
+  aria-hidden="true"
   role="dialog"
 >
   <div

--- a/packages/patternfly-3/patternfly-react/src/components/DropdownKebab/__snapshots__/DropdownKebab.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/DropdownKebab/__snapshots__/DropdownKebab.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Kebab dropdown renders properly 1`] = `
-<Uncontrolled(Dropdown)
+<ForwardRef
   className="dropdown-kebab-pf"
   componentClass={[Function]}
   id="myKebab"
@@ -65,5 +65,5 @@ exports[`Kebab dropdown renders properly 1`] = `
       Separated link
     </MenuItem>
   </DropdownMenu>
-</Uncontrolled(Dropdown)>
+</ForwardRef>
 `;

--- a/packages/patternfly-3/patternfly-react/src/components/InfoTip/__snapshots__/InfoTip.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/InfoTip/__snapshots__/InfoTip.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders Dropdown: dropdown is rendered 1`] = `
-<Uncontrolled(Dropdown)
+<ForwardRef
   componentClass="li"
   id="InfoTip"
   onBlur={[Function]}
@@ -11,5 +11,5 @@ exports[`renders Dropdown: dropdown is rendered 1`] = `
   open={false}
 >
   children
-</Uncontrolled(Dropdown)>
+</ForwardRef>
 `;

--- a/packages/patternfly-3/patternfly-react/src/components/Masthead/__snapshots__/Masthead.test.js.snap
+++ b/packages/patternfly-3/patternfly-react/src/components/Masthead/__snapshots__/Masthead.test.js.snap
@@ -319,7 +319,7 @@ exports[`MastheadCollapse renders properly: MastheadCollapse snapshot 1`] = `
 `;
 
 exports[`MastheadDropdown renders properly: MastheadDropdown snapshot 1`] = `
-<Uncontrolled(Dropdown)
+<ForwardRef
   className=""
   componentClass={[Function]}
   id="app-help-dropdown"
@@ -362,5 +362,5 @@ exports[`MastheadDropdown renders properly: MastheadDropdown snapshot 1`] = `
       About
     </MenuItem>
   </DropdownMenu>
-</Uncontrolled(Dropdown)>
+</ForwardRef>
 `;

--- a/packages/patternfly-3/react-console/src/AccessConsoles/__snapshots__/AccessConsoles.test.js.snap
+++ b/packages/patternfly-3/react-console/src/AccessConsoles/__snapshots__/AccessConsoles.test.js.snap
@@ -44,167 +44,173 @@ exports[`AccessConsoles keeps connection when switching types 1`] = `
                 <div
                   className=""
                 >
-                  <Uncontrolled(Dropdown)
+                  <ForwardRef
                     disabled={false}
                     id="console-type-selector"
                   >
-                    <Dropdown
-                      bsClass="dropdown"
-                      componentClass={[Function]}
+                    <Uncontrolled(Dropdown)
                       disabled={false}
                       id="console-type-selector"
-                      onToggle={[Function]}
-                      open={false}
+                      innerRef={null}
                     >
-                      <ButtonGroup
-                        block={false}
-                        bsClass="btn-group"
-                        className="dropdown"
-                        justified={false}
-                        vertical={false}
+                      <Dropdown
+                        bsClass="dropdown"
+                        componentClass={[Function]}
+                        disabled={false}
+                        id="console-type-selector"
+                        onToggle={[Function]}
+                        open={false}
                       >
-                        <div
-                          className="dropdown btn-group"
+                        <ButtonGroup
+                          block={false}
+                          bsClass="btn-group"
+                          className="dropdown"
+                          justified={false}
+                          vertical={false}
                         >
-                          <DropdownToggle
-                            bsClass="dropdown-toggle"
-                            bsRole="toggle"
-                            disabled={false}
-                            id="console-type-selector"
-                            key=".0"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            open={false}
-                            useAnchor={false}
+                          <div
+                            className="dropdown btn-group"
                           >
-                            <Button
-                              active={false}
-                              aria-expanded={false}
-                              aria-haspopup={true}
-                              block={false}
-                              bsClass="btn"
-                              bsStyle="default"
-                              className="dropdown-toggle"
+                            <DropdownToggle
+                              bsClass="dropdown-toggle"
+                              bsRole="toggle"
                               disabled={false}
                               id="console-type-selector"
+                              key=".0"
                               onClick={[Function]}
                               onKeyDown={[Function]}
-                              role="button"
+                              open={false}
+                              useAnchor={false}
                             >
-                              <button
+                              <Button
+                                active={false}
                                 aria-expanded={false}
                                 aria-haspopup={true}
-                                className="dropdown-toggle btn btn-default"
+                                block={false}
+                                bsClass="btn"
+                                bsStyle="default"
+                                className="dropdown-toggle"
                                 disabled={false}
                                 id="console-type-selector"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
                                 role="button"
-                                type="button"
                               >
-                                VNC Console
-                                 
-                                <span
-                                  className="caret"
-                                />
-                              </button>
-                            </Button>
-                          </DropdownToggle>
-                          <DropdownMenu
-                            bsClass="dropdown-menu"
-                            bsRole="menu"
-                            key=".1"
-                            labelledBy="console-type-selector"
-                            onClose={[Function]}
-                            onSelect={[Function]}
-                            open={false}
-                            pullRight={false}
-                          >
-                            <RootCloseWrapper
-                              disabled={true}
-                              event="click"
-                              onRootClose={[Function]}
+                                <button
+                                  aria-expanded={false}
+                                  aria-haspopup={true}
+                                  className="dropdown-toggle btn btn-default"
+                                  disabled={false}
+                                  id="console-type-selector"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="button"
+                                  type="button"
+                                >
+                                  VNC Console
+                                   
+                                  <span
+                                    className="caret"
+                                  />
+                                </button>
+                              </Button>
+                            </DropdownToggle>
+                            <DropdownMenu
+                              bsClass="dropdown-menu"
+                              bsRole="menu"
+                              key=".1"
+                              labelledBy="console-type-selector"
+                              onClose={[Function]}
+                              onSelect={[Function]}
+                              open={false}
+                              pullRight={false}
                             >
-                              <ul
-                                aria-labelledby="console-type-selector"
-                                className="dropdown-menu"
-                                role="menu"
+                              <RootCloseWrapper
+                                disabled={true}
+                                event="click"
+                                onRootClose={[Function]}
                               >
-                                <MenuItem
-                                  bsClass="dropdown"
-                                  disabled={false}
-                                  divider={false}
-                                  eventKey="1"
-                                  header={false}
-                                  key=".0"
-                                  onClick={[Function]}
-                                  onKeyDown={[Function]}
-                                  onSelect={[Function]}
+                                <ul
+                                  aria-labelledby="console-type-selector"
+                                  className="dropdown-menu"
+                                  role="menu"
                                 >
-                                  <li
-                                    className=""
-                                    role="presentation"
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey="1"
+                                    header={false}
+                                    key=".0"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <SafeAnchor
-                                      componentClass="a"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      role="menuitem"
-                                      tabIndex="-1"
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <a
-                                        href="#"
+                                      <SafeAnchor
+                                        componentClass="a"
                                         onClick={[Function]}
                                         onKeyDown={[Function]}
                                         role="menuitem"
                                         tabIndex="-1"
                                       >
-                                        VNC Console
-                                      </a>
-                                    </SafeAnchor>
-                                  </li>
-                                </MenuItem>
-                                <MenuItem
-                                  bsClass="dropdown"
-                                  disabled={false}
-                                  divider={false}
-                                  eventKey="2"
-                                  header={false}
-                                  key=".1"
-                                  onClick={[Function]}
-                                  onKeyDown={[Function]}
-                                  onSelect={[Function]}
-                                >
-                                  <li
-                                    className=""
-                                    role="presentation"
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          VNC Console
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey="2"
+                                    header={false}
+                                    key=".1"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <SafeAnchor
-                                      componentClass="a"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      role="menuitem"
-                                      tabIndex="-1"
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <a
-                                        href="#"
+                                      <SafeAnchor
+                                        componentClass="a"
                                         onClick={[Function]}
                                         onKeyDown={[Function]}
                                         role="menuitem"
                                         tabIndex="-1"
                                       >
-                                        Serial Console
-                                      </a>
-                                    </SafeAnchor>
-                                  </li>
-                                </MenuItem>
-                              </ul>
-                            </RootCloseWrapper>
-                          </DropdownMenu>
-                        </div>
-                      </ButtonGroup>
-                    </Dropdown>
-                  </Uncontrolled(Dropdown)>
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          Serial Console
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                </ul>
+                              </RootCloseWrapper>
+                            </DropdownMenu>
+                          </div>
+                        </ButtonGroup>
+                      </Dropdown>
+                    </Uncontrolled(Dropdown)>
+                  </ForwardRef>
                   <Checkbox
                     bsClass="checkbox"
                     className="console-selector-pf-disconnect-switch"
@@ -406,165 +412,171 @@ exports[`AccessConsoles switching SerialConsole and VncConsole 1`] = `
                 <div
                   className=""
                 >
-                  <Uncontrolled(Dropdown)
+                  <ForwardRef
                     disabled={false}
                     id="console-type-selector"
                   >
-                    <Dropdown
-                      bsClass="dropdown"
-                      componentClass={[Function]}
+                    <Uncontrolled(Dropdown)
                       disabled={false}
                       id="console-type-selector"
-                      onToggle={[Function]}
+                      innerRef={null}
                     >
-                      <ButtonGroup
-                        block={false}
-                        bsClass="btn-group"
-                        className="dropdown"
-                        justified={false}
-                        vertical={false}
+                      <Dropdown
+                        bsClass="dropdown"
+                        componentClass={[Function]}
+                        disabled={false}
+                        id="console-type-selector"
+                        onToggle={[Function]}
                       >
-                        <div
-                          className="dropdown btn-group"
+                        <ButtonGroup
+                          block={false}
+                          bsClass="btn-group"
+                          className="dropdown"
+                          justified={false}
+                          vertical={false}
                         >
-                          <DropdownToggle
-                            bsClass="dropdown-toggle"
-                            bsRole="toggle"
-                            disabled={false}
-                            id="console-type-selector"
-                            key=".0"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            open={false}
-                            useAnchor={false}
+                          <div
+                            className="dropdown btn-group"
                           >
-                            <Button
-                              active={false}
-                              aria-expanded={false}
-                              aria-haspopup={true}
-                              block={false}
-                              bsClass="btn"
-                              bsStyle="default"
-                              className="dropdown-toggle"
+                            <DropdownToggle
+                              bsClass="dropdown-toggle"
+                              bsRole="toggle"
                               disabled={false}
                               id="console-type-selector"
+                              key=".0"
                               onClick={[Function]}
                               onKeyDown={[Function]}
-                              role="button"
+                              open={false}
+                              useAnchor={false}
                             >
-                              <button
+                              <Button
+                                active={false}
                                 aria-expanded={false}
                                 aria-haspopup={true}
-                                className="dropdown-toggle btn btn-default"
+                                block={false}
+                                bsClass="btn"
+                                bsStyle="default"
+                                className="dropdown-toggle"
                                 disabled={false}
                                 id="console-type-selector"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
                                 role="button"
-                                type="button"
                               >
-                                Select Console Type
-                                 
-                                <span
-                                  className="caret"
-                                />
-                              </button>
-                            </Button>
-                          </DropdownToggle>
-                          <DropdownMenu
-                            bsClass="dropdown-menu"
-                            bsRole="menu"
-                            key=".1"
-                            labelledBy="console-type-selector"
-                            onClose={[Function]}
-                            onSelect={[Function]}
-                            pullRight={false}
-                          >
-                            <RootCloseWrapper
-                              disabled={true}
-                              event="click"
-                              onRootClose={[Function]}
+                                <button
+                                  aria-expanded={false}
+                                  aria-haspopup={true}
+                                  className="dropdown-toggle btn btn-default"
+                                  disabled={false}
+                                  id="console-type-selector"
+                                  onClick={[Function]}
+                                  onKeyDown={[Function]}
+                                  role="button"
+                                  type="button"
+                                >
+                                  Select Console Type
+                                   
+                                  <span
+                                    className="caret"
+                                  />
+                                </button>
+                              </Button>
+                            </DropdownToggle>
+                            <DropdownMenu
+                              bsClass="dropdown-menu"
+                              bsRole="menu"
+                              key=".1"
+                              labelledBy="console-type-selector"
+                              onClose={[Function]}
+                              onSelect={[Function]}
+                              pullRight={false}
                             >
-                              <ul
-                                aria-labelledby="console-type-selector"
-                                className="dropdown-menu"
-                                role="menu"
+                              <RootCloseWrapper
+                                disabled={true}
+                                event="click"
+                                onRootClose={[Function]}
                               >
-                                <MenuItem
-                                  bsClass="dropdown"
-                                  disabled={false}
-                                  divider={false}
-                                  eventKey="1"
-                                  header={false}
-                                  key=".0"
-                                  onClick={[Function]}
-                                  onKeyDown={[Function]}
-                                  onSelect={[Function]}
+                                <ul
+                                  aria-labelledby="console-type-selector"
+                                  className="dropdown-menu"
+                                  role="menu"
                                 >
-                                  <li
-                                    className=""
-                                    role="presentation"
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey="1"
+                                    header={false}
+                                    key=".0"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <SafeAnchor
-                                      componentClass="a"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      role="menuitem"
-                                      tabIndex="-1"
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <a
-                                        href="#"
+                                      <SafeAnchor
+                                        componentClass="a"
                                         onClick={[Function]}
                                         onKeyDown={[Function]}
                                         role="menuitem"
                                         tabIndex="-1"
                                       >
-                                        VNC Console
-                                      </a>
-                                    </SafeAnchor>
-                                  </li>
-                                </MenuItem>
-                                <MenuItem
-                                  bsClass="dropdown"
-                                  disabled={false}
-                                  divider={false}
-                                  eventKey="2"
-                                  header={false}
-                                  key=".1"
-                                  onClick={[Function]}
-                                  onKeyDown={[Function]}
-                                  onSelect={[Function]}
-                                >
-                                  <li
-                                    className=""
-                                    role="presentation"
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          VNC Console
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey="2"
+                                    header={false}
+                                    key=".1"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <SafeAnchor
-                                      componentClass="a"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      role="menuitem"
-                                      tabIndex="-1"
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <a
-                                        href="#"
+                                      <SafeAnchor
+                                        componentClass="a"
                                         onClick={[Function]}
                                         onKeyDown={[Function]}
                                         role="menuitem"
                                         tabIndex="-1"
                                       >
-                                        Serial Console
-                                      </a>
-                                    </SafeAnchor>
-                                  </li>
-                                </MenuItem>
-                              </ul>
-                            </RootCloseWrapper>
-                          </DropdownMenu>
-                        </div>
-                      </ButtonGroup>
-                    </Dropdown>
-                  </Uncontrolled(Dropdown)>
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          Serial Console
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                </ul>
+                              </RootCloseWrapper>
+                            </DropdownMenu>
+                          </div>
+                        </ButtonGroup>
+                      </Dropdown>
+                    </Uncontrolled(Dropdown)>
+                  </ForwardRef>
                 </div>
               </Col>
             </div>
@@ -774,7 +786,7 @@ exports[`AccessConsoles with SerialConsole and VncConsole as children 1`] = `
         bsClass="col"
         componentClass="div"
       >
-        <Uncontrolled(Dropdown)
+        <ForwardRef
           disabled={false}
           id="console-type-selector"
         >
@@ -812,7 +824,7 @@ exports[`AccessConsoles with SerialConsole and VncConsole as children 1`] = `
               Serial Console
             </MenuItem>
           </DropdownMenu>
-        </Uncontrolled(Dropdown)>
+        </ForwardRef>
       </Col>
     </FormGroup>
   </Form>
@@ -850,7 +862,7 @@ exports[`AccessConsoles with SerialConsole as a single child 1`] = `
         bsClass="col"
         componentClass="div"
       >
-        <Uncontrolled(Dropdown)
+        <ForwardRef
           disabled={false}
           id="console-type-selector"
         >
@@ -878,7 +890,7 @@ exports[`AccessConsoles with SerialConsole as a single child 1`] = `
               Serial Console
             </MenuItem>
           </DropdownMenu>
-        </Uncontrolled(Dropdown)>
+        </ForwardRef>
       </Col>
     </FormGroup>
   </Form>
@@ -916,7 +928,7 @@ exports[`AccessConsoles with VncConsole as a single child 1`] = `
         bsClass="col"
         componentClass="div"
       >
-        <Uncontrolled(Dropdown)
+        <ForwardRef
           disabled={false}
           id="console-type-selector"
         >
@@ -944,7 +956,7 @@ exports[`AccessConsoles with VncConsole as a single child 1`] = `
               VNC Console
             </MenuItem>
           </DropdownMenu>
-        </Uncontrolled(Dropdown)>
+        </ForwardRef>
       </Col>
     </FormGroup>
   </Form>
@@ -1004,131 +1016,137 @@ exports[`AccessConsoles with preselected SerialConsole 1`] = `
                 <div
                   className=""
                 >
-                  <Uncontrolled(Dropdown)
+                  <ForwardRef
                     disabled={false}
                     id="console-type-selector"
                   >
-                    <Dropdown
-                      bsClass="dropdown"
-                      componentClass={[Function]}
+                    <Uncontrolled(Dropdown)
                       disabled={false}
                       id="console-type-selector"
-                      onToggle={[Function]}
+                      innerRef={null}
                     >
-                      <ButtonGroup
-                        block={false}
-                        bsClass="btn-group"
-                        className="dropdown"
-                        justified={false}
-                        vertical={false}
+                      <Dropdown
+                        bsClass="dropdown"
+                        componentClass={[Function]}
+                        disabled={false}
+                        id="console-type-selector"
+                        onToggle={[Function]}
                       >
-                        <div
-                          className="dropdown btn-group"
+                        <ButtonGroup
+                          block={false}
+                          bsClass="btn-group"
+                          className="dropdown"
+                          justified={false}
+                          vertical={false}
                         >
-                          <DropdownToggle
-                            bsClass="dropdown-toggle"
-                            bsRole="toggle"
-                            disabled={false}
-                            id="console-type-selector"
-                            key=".0"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            open={false}
-                            useAnchor={false}
+                          <div
+                            className="dropdown btn-group"
                           >
-                            <Button
-                              active={false}
-                              aria-expanded={false}
-                              aria-haspopup={true}
-                              block={false}
-                              bsClass="btn"
-                              bsStyle="default"
-                              className="dropdown-toggle"
+                            <DropdownToggle
+                              bsClass="dropdown-toggle"
+                              bsRole="toggle"
                               disabled={false}
                               id="console-type-selector"
+                              key=".0"
                               onClick={[Function]}
                               onKeyDown={[Function]}
-                              role="button"
+                              open={false}
+                              useAnchor={false}
                             >
-                              <button
+                              <Button
+                                active={false}
                                 aria-expanded={false}
                                 aria-haspopup={true}
-                                className="dropdown-toggle btn btn-default"
+                                block={false}
+                                bsClass="btn"
+                                bsStyle="default"
+                                className="dropdown-toggle"
                                 disabled={false}
                                 id="console-type-selector"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
                                 role="button"
-                                type="button"
                               >
-                                Serial Console
-                                 
-                                <span
-                                  className="caret"
-                                />
-                              </button>
-                            </Button>
-                          </DropdownToggle>
-                          <DropdownMenu
-                            bsClass="dropdown-menu"
-                            bsRole="menu"
-                            key=".1"
-                            labelledBy="console-type-selector"
-                            onClose={[Function]}
-                            onSelect={[Function]}
-                            pullRight={false}
-                          >
-                            <RootCloseWrapper
-                              disabled={true}
-                              event="click"
-                              onRootClose={[Function]}
-                            >
-                              <ul
-                                aria-labelledby="console-type-selector"
-                                className="dropdown-menu"
-                                role="menu"
-                              >
-                                <MenuItem
-                                  bsClass="dropdown"
+                                <button
+                                  aria-expanded={false}
+                                  aria-haspopup={true}
+                                  className="dropdown-toggle btn btn-default"
                                   disabled={false}
-                                  divider={false}
-                                  eventKey="2"
-                                  header={false}
-                                  key=".1"
+                                  id="console-type-selector"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
-                                  onSelect={[Function]}
+                                  role="button"
+                                  type="button"
                                 >
-                                  <li
-                                    className=""
-                                    role="presentation"
+                                  Serial Console
+                                   
+                                  <span
+                                    className="caret"
+                                  />
+                                </button>
+                              </Button>
+                            </DropdownToggle>
+                            <DropdownMenu
+                              bsClass="dropdown-menu"
+                              bsRole="menu"
+                              key=".1"
+                              labelledBy="console-type-selector"
+                              onClose={[Function]}
+                              onSelect={[Function]}
+                              pullRight={false}
+                            >
+                              <RootCloseWrapper
+                                disabled={true}
+                                event="click"
+                                onRootClose={[Function]}
+                              >
+                                <ul
+                                  aria-labelledby="console-type-selector"
+                                  className="dropdown-menu"
+                                  role="menu"
+                                >
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    eventKey="2"
+                                    header={false}
+                                    key=".1"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <SafeAnchor
-                                      componentClass="a"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      role="menuitem"
-                                      tabIndex="-1"
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <a
-                                        href="#"
+                                      <SafeAnchor
+                                        componentClass="a"
                                         onClick={[Function]}
                                         onKeyDown={[Function]}
                                         role="menuitem"
                                         tabIndex="-1"
                                       >
-                                        Serial Console
-                                      </a>
-                                    </SafeAnchor>
-                                  </li>
-                                </MenuItem>
-                              </ul>
-                            </RootCloseWrapper>
-                          </DropdownMenu>
-                        </div>
-                      </ButtonGroup>
-                    </Dropdown>
-                  </Uncontrolled(Dropdown)>
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          Serial Console
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                </ul>
+                              </RootCloseWrapper>
+                            </DropdownMenu>
+                          </div>
+                        </ButtonGroup>
+                      </Dropdown>
+                    </Uncontrolled(Dropdown)>
+                  </ForwardRef>
                   <Checkbox
                     bsClass="checkbox"
                     className="console-selector-pf-disconnect-switch"
@@ -1218,7 +1236,7 @@ exports[`AccessConsoles with wrapped SerialConsole as a child 1`] = `
         bsClass="col"
         componentClass="div"
       >
-        <Uncontrolled(Dropdown)
+        <ForwardRef
           disabled={false}
           id="console-type-selector"
         >
@@ -1246,7 +1264,7 @@ exports[`AccessConsoles with wrapped SerialConsole as a child 1`] = `
               Serial Console
             </MenuItem>
           </DropdownMenu>
-        </Uncontrolled(Dropdown)>
+        </ForwardRef>
       </Col>
     </FormGroup>
   </Form>

--- a/packages/patternfly-4/react-catalog-view-extension/package.json
+++ b/packages/patternfly-4/react-catalog-view-extension/package.json
@@ -48,7 +48,7 @@
     "css-element-queries": "^1.0.1",
     "patternfly": "^3.59.4",
     "patternfly-react": "^2.39.4",
-    "react-bootstrap": "^0.32.1",
+    "react-bootstrap": "^0.33.0",
     "react-click-outside": "^3.0.1",
     "react-diff-view": "^1.8.1",
     "react-ellipsis-with-tooltip": "^1.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3354,6 +3354,14 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/react@^16.9.11":
+  version "16.9.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.11.tgz#70e0b7ad79058a7842f25ccf2999807076ada120"
+  integrity sha512-UBT4GZ3PokTXSWmdgC/GeCGEJXE5ofWyibCcecRLUVN2ZBpXQGVgQGtG2foS7CrTKFKlQVVswLvf7Js6XA/CVQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@types/retry@^0.12.0":
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
@@ -19073,9 +19081,10 @@ react-bootstrap-typeahead@^3.4.1:
     react-popper "^1.0.0"
     warning "^4.0.1"
 
-react-bootstrap@^0.32.1:
-  version "0.32.4"
-  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.32.4.tgz#8efc4cbfc4807215d75b7639bee0d324c8d740d1"
+react-bootstrap@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.33.0.tgz#db0004ae6c5b4822921c23448ff214de0e300d2e"
+  integrity sha512-UcxxaczDIPEsY+O4EqCIIEPDjxvLqqfUfXhQO+yzhk0yXzR0Y7+6xqBW01sy3gN717GUXhrkpwZiyn9uFX1s0A==
   dependencies:
     "@babel/runtime-corejs2" "^7.0.0"
     classnames "^2.2.5"
@@ -19084,10 +19093,10 @@ react-bootstrap@^0.32.1:
     keycode "^2.2.0"
     prop-types "^15.6.1"
     prop-types-extra "^1.0.1"
-    react-overlays "^0.8.0"
+    react-overlays "^0.9.0"
     react-prop-types "^0.4.0"
     react-transition-group "^2.0.0"
-    uncontrollable "^5.0.0"
+    uncontrollable "^7.0.2"
     warning "^3.0.0"
 
 react-c3js@^0.1.20:
@@ -19402,7 +19411,7 @@ react-motion@^0.5.2:
     prop-types "^15.5.8"
     raf "^3.1.0"
 
-react-overlays@^0.8.0, react-overlays@^0.8.1:
+react-overlays@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.8.3.tgz#fad65eea5b24301cca192a169f5dddb0b20d3ac5"
   dependencies:
@@ -19411,6 +19420,18 @@ react-overlays@^0.8.0, react-overlays@^0.8.1:
     prop-types "^15.5.10"
     prop-types-extra "^1.0.1"
     react-transition-group "^2.2.0"
+    warning "^3.0.0"
+
+react-overlays@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.9.0.tgz#729a485ab890463da2470d2fdd0ee9e0988c8e02"
+  integrity sha512-qosfsydfV85q9JDy8APCRaWV2sibj66NLrgm3OdbJxiZImtllNO9fjWdNWZL3nWLuC3ISRfSkMPUX8dXEYmbPw==
+  dependencies:
+    classnames "^2.2.5"
+    dom-helpers "^3.2.1"
+    prop-types "^15.5.10"
+    prop-types-extra "^1.0.1"
+    react-transition-group "^2.2.1"
     warning "^3.0.0"
 
 react-popper-tooltip@^2.8.3:
@@ -22698,11 +22719,15 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
 
-uncontrollable@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-5.1.0.tgz#7e9a1c50ea24e3c78b625e52d21ff3f758c7bd59"
+uncontrollable@^7.0.2:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-7.1.0.tgz#de2a4e8a2edca06024c81228a54503d23bb83e51"
+  integrity sha512-ie1drnxEKHREeGehl+26HvnCkwhTxxwFGt4FpoBvjmv8qyljIkCHpYVYAwYroTQyXFgEbDc4zoZKtr/EAN9eJw==
   dependencies:
+    "@babel/runtime" "^7.6.3"
+    "@types/react" "^16.9.11"
     invariant "^2.2.4"
+    react-lifecycles-compat "^3.0.4"
 
 underscore.string@^3.3.5:
   version "3.3.5"


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

Fixes #3010 
In order to prevent React's warnings about deprecated lifecycle methods, and allow consumers who use Patternfly 3 components to eventually upgrade to React 17, I am upgrading our version of react-bootstrap to take their fixes for https://github.com/react-bootstrap/react-bootstrap/issues/4398.

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

Once released, this will unblock https://github.com/ManageIQ/manageiq-v2v/issues/1037.

<!-- feel free to add additional comments -->

We should do a once-over to make sure all affected PF3 components are still behaving as expected, especially since some of the snapshots changed.