### PR TITLE
fix(react-catalog-extension): fix @types errors when using the extension

### DIFF
--- a/packages/patternfly-4/react-catalog-view-extension/package.json
+++ b/packages/patternfly-4/react-catalog-view-extension/package.json
@@ -64,6 +64,8 @@
     "@babel/plugin-transform-typescript": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
+    "@types/react": "^16.4.0",
+    "@types/react-dom": "^16.4.0",
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-plugin-typescript-to-proptypes": "^0.17.1",
     "node-sass": "^4.12.0",


### PR DESCRIPTION

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: errors occur when using the extension due to @types/react...specify versions in package.json


<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
