### PR TITLE
fix(react-catalog-view-extension): fix checbox margin on filter side panel

### DIFF
--- a/packages/patternfly-4/react-catalog-view-extension/sass/react-catalog-view-extension/_filter-side-panel.scss
+++ b/packages/patternfly-4/react-catalog-view-extension/sass/react-catalog-view-extension/_filter-side-panel.scss
@@ -36,8 +36,8 @@
     margin-top: 0;
   }
 
-  .checkbox {
-    margin: 0;
+  .pf-c-check__input {
+    margin-left: 0 !important;
   }
 
   .item-icon {

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/examples/filterSidePanel.css
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/examples/filterSidePanel.css
@@ -37,8 +37,8 @@
   margin-top: 0;
 }
 
-.filter-panel-pf-category-item .checkbox {
-  margin: 0;
+.filter-panel-pf-category-item .pf-c-check__input {
+  margin-left: 0px;
 }
 
 .filter-panel-pf-category-item .item-icon {


### PR DESCRIPTION

provide a 0px left margin for cb in filter side panel (overrides the -20px defaulted in console)

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**:

<!-- Are there any upstream issues or separate issues you need to reference? -->

**Additional issues**:

<!-- feel free to add additional comments -->
