### PR TITLE
fix(DonutChart): Put back secondary title when showing percentage

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Chart/DonutChart.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Chart/DonutChart.js
@@ -32,6 +32,7 @@ const setDonutTitle = obj => {
   switch (type) {
     case 'percent':
       primary = precision ? `${truncateNum(percentage, precision)}%` : `${Math.round(percentage)}%`;
+      [secondary] = columns[iMax];
       break;
     case 'max':
       primary = Math.round(columns[iMax][1]).toString();


### PR DESCRIPTION
<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
When using a percentage-type donut chart, there used to be primary title (the percentage) and secondary title, which indicated what the percentage actually means. This secondary title is not being shown anymore. I believe it was accidentally droped in https://github.com/patternfly/patternfly-react/pull/2375

<!-- What changes are being made? (What issue is being addressed here?) -->

**What**: Add back the secondary title for percentage-type donut charts.

<!-- Are there any upstream issues or separate issues you need to reference? -->
Issue #3323 