### PR TITLE
fix(Select): Display pre-selected input

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Select/Select.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.tsx
@@ -83,7 +83,7 @@ export interface SelectProps
 
 export interface SelectState {
   openedOnEnter: boolean;
-  typeaheadInputValue: string;
+  typeaheadInputValue: string|null;
   typeaheadActiveChild?: HTMLElement;
   typeaheadFilteredChildren: React.ReactNode[];
   typeaheadCurrIndex: number;
@@ -122,9 +122,9 @@ class Select extends React.Component<SelectProps & InjectedOuiaProps, SelectStat
     onFilter: null
   } as Partial<SelectProps & InjectedOuiaProps>;
 
-  state = {
+  state: SelectState = {
     openedOnEnter: false,
-    typeaheadInputValue: '',
+    typeaheadInputValue: null,
     typeaheadActiveChild: null as HTMLElement,
     typeaheadFilteredChildren: React.Children.toArray(this.props.children),
     typeaheadCurrIndex: -1,
@@ -215,7 +215,7 @@ class Select extends React.Component<SelectProps & InjectedOuiaProps, SelectStat
   clearSelection = (e: React.MouseEvent) => {
     e.stopPropagation();
     this.setState({
-      typeaheadInputValue: '',
+      typeaheadInputValue: null,
       typeaheadActiveChild: null,
       typeaheadFilteredChildren: React.Children.toArray(this.props.children),
       typeaheadCurrIndex: -1

--- a/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -8997,7 +8997,7 @@ exports[`typeahead select renders selected successfully 1`] = `
                       id="select-typeahead"
                       placeholder=""
                       type="text"
-                      value=""
+                      value="Mr"
                     />
                   </div>
                   <button
@@ -9140,7 +9140,7 @@ exports[`typeahead select renders selected successfully 1`] = `
                 onFocus={[Function]}
                 placeholder=""
                 type="text"
-                value=""
+                value="Mr"
               />
             </div>
             <button


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #3304

Defaults `typeaheadInputValue` to null and sets it accordingly when clearing selections as well

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
