### PR TITLE
Update gatsby-browser.js

### DIFF
--- a/packages/patternfly-4/react-docs/gatsby-browser.js
+++ b/packages/patternfly-4/react-docs/gatsby-browser.js
@@ -1,6 +1,14 @@
 import '@patternfly/patternfly/patternfly.css';
 // Utilities
 import '@patternfly/patternfly/patternfly-addons.css';
+// React-specific CSS
+import '@patternfly/react-styles/src/css/components/Table/inline-edit.css';
+import '@patternfly/react-styles/src/css/components/Tooltip/tippy.css';
+import '@patternfly/react-styles/src/css/components/Tooltip/tippy-overrides.css';
+import '@patternfly/react-styles/src/css/components/Topology/topology-controlbar.css';
+import '@patternfly/react-styles/src/css/components/Topology/topology-side-bar.css';
+import '@patternfly/react-styles/src/css/components/Topology/topology-view.css';
+import '@patternfly/react-styles/src/css/layouts/Toolbar/toolbar.css';
 // Experimental components
 import '@patternfly/patternfly/components/DataToolbar/data-toolbar.css';
 import '@patternfly/patternfly/components/Divider/divider.css';


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Import styles that are present on Org but not in React. Closes #3311 .

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Preview link: https://patternfly-react-pr-redallen-extension-styles.surge.sh/patternfly-4/documentation/react/components/topology
