### PR TITLE
fix(table): rename visible/hiddenOn2Xl to visible/hiddenOn_2xl

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/Table.md
+++ b/packages/patternfly-4/react-table/src/components/Table/Table.md
@@ -802,12 +802,12 @@ class HiddenVisibleBreakpointTable extends React.Component {
       columns: [
         {
           title: 'Repositories',
-          columnTransforms: [classNames(Visibility.hidden, Visibility.visibleOnMd, Visibility.hiddenOnLg, Visibility.visibleOn2Xl)]
+          columnTransforms: [classNames(Visibility.hidden, Visibility.visibleOnMd, Visibility.hiddenOnLg, Visibility.visibleOn_2xl)]
         },
         'Branches',
         {
           title: 'Pull requests',
-          columnTransforms: [classNames(Visibility.hiddenOnMd, Visibility.visibleOnLg, Visibility.hiddenOn2Xl)]
+          columnTransforms: [classNames(Visibility.hiddenOnMd, Visibility.visibleOnLg, Visibility.hiddenOn_2xl)]
         },
         'Workspaces',
         {

--- a/packages/patternfly-4/react-table/src/components/Table/utils/decorators/classNames.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/decorators/classNames.ts
@@ -8,12 +8,12 @@ export const Visibility = pickProperties(styles.modifiers, [
   'hiddenOnMd',
   'hiddenOnLg',
   'hiddenOnXl',
-  'hiddenOn2Xl',
+  'hiddenOn_2xl',
   'visibleOnSm',
   'visibleOnMd',
   'visibleOnLg',
   'visibleOnXl',
-  'visibleOn2Xl'
+  'visibleOn_2xl'
 ]);
 
 // tslint:disable-next-line:no-shadowed-variable

--- a/packages/patternfly-4/react-table/src/components/Table/utils/transformers.test.tsx
+++ b/packages/patternfly-4/react-table/src/components/Table/utils/transformers.test.tsx
@@ -1,5 +1,7 @@
 import { mount } from 'enzyme';
 import {
+  Visibility,
+  classNames,
   selectable,
   sortable,
   cellActions,
@@ -305,4 +307,12 @@ describe('Transformer functions', () => {
   test('cell height auto', () => {
     expect(cellHeightAuto()).toEqual({ className: 'pf-m-height-auto' });
   });
+  
+  describe('visibility classNames', () => {
+    Object.keys(Visibility).forEach((className => {
+      test(`${className} is defined`, () => {
+        expect(Visibility[className]).not.toBe(undefined)
+      })
+    }))
+  })
 });


### PR DESCRIPTION
**What**: Closes #3355 

Visibility doesn't have `hiddenOn2Xl` and `visibleOn2Xl` and that's why they are set to `undefined` and are not shown in the class prop.
Nevertheless, these two modifiers exist according to the [pf4 core documentations](https://pf4.patternfly.org/documentation/core/components/table#with-hiddenvisible-breakpoint-modifiers).

The problem is that the way react-style parses a modifier name is if it has a number, it will add `_` before it. Thus, `hidden-on-2xl` will be `hiddenOn_2xl` and not `hiddenOn2Xl`.

This patch fixes this and adds a test to verify it works.