### PR TITLE
Update interpolation examples to use monotoneX

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -60,7 +60,7 @@ BasicRightAlignedLegend = (
             { name: 'Cats', x: '2017', y: 8 },
             { name: 'Cats', x: '2018', y: 6 }
           ]}
-          interpolation="basis"
+          interpolation="monotoneX"
         />
         <ChartArea
           data={[
@@ -70,7 +70,7 @@ BasicRightAlignedLegend = (
             { name: 'Dogs', x: '2018', y: 5 },
             { name: 'Dogs', x: '2019', y: 6 }
           ]}
-          interpolation="basis"
+          interpolation="monotoneX"
         />
         <ChartArea
           data={[
@@ -80,7 +80,7 @@ BasicRightAlignedLegend = (
             { name: 'Birds', x: '2018', y: 2 },
             { name: 'Birds', x: '2019', y: 4 }
           ]}
-          interpolation="basis"
+          interpolation="monotoneX"
         />
       </ChartGroup>
     </Chart>
@@ -122,7 +122,7 @@ BottomAlignedLegend = (
             { name: 'Cats', x: '2017', y: 8 },
             { name: 'Cats', x: '2018', y: 6 }
           ]}
-          interpolation="basis"
+          interpolation="monotoneX"
         />
         <ChartArea
           data={[
@@ -132,7 +132,7 @@ BottomAlignedLegend = (
             { name: 'Dogs', x: '2018', y: 5 },
             { name: 'Dogs', x: '2019', y: 6 }
           ]}
-          interpolation="basis"
+          interpolation="monotoneX"
         />
         <ChartArea
           data={[
@@ -142,7 +142,7 @@ BottomAlignedLegend = (
             { name: 'Birds', x: '2018', y: 2 },
             { name: 'Birds', x: '2019', y: 4 }
           ]}
-          interpolation="basis"
+          interpolation="monotoneX"
         />
       </ChartGroup>
     </Chart>
@@ -210,7 +210,7 @@ class MultiColorChart extends React.Component {
                 { name: 'Cats', x: '2017', y: 8 },
                 { name: 'Cats', x: '2018', y: 6 }
               ]}
-              interpolation="basis"
+              interpolation="monotoneX"
             />
             <ChartArea
               data={[
@@ -220,7 +220,7 @@ class MultiColorChart extends React.Component {
                 { name: 'Dogs', x: '2018', y: 5 },
                 { name: 'Dogs', x: '2019', y: 6 }
               ]}
-              interpolation="basis"
+              interpolation="monotoneX"
             />
             <ChartArea
               data={[
@@ -230,7 +230,7 @@ class MultiColorChart extends React.Component {
                 { name: 'Birds', x: '2018', y: 2 },
                 { name: 'Birds', x: '2019', y: 4 }
               ]}
-              interpolation="basis"
+              interpolation="monotoneX"
             />
           </ChartGroup>
         </Chart>

--- a/packages/patternfly-4/react-charts/src/components/ChartLegend/examples/ChartLegend.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartLegend/examples/ChartLegend.md
@@ -463,6 +463,7 @@ class InteractiveLegendChart extends React.Component {
                 return (
                   <ChartArea
                     data={!hiddenSeries.has(index) ? s.datapoints : [{ y: null}]}
+                    interpolation="monotoneX"
                     key={'area-' + index}
                     name={'area-' + index}
                   />

--- a/packages/patternfly-4/react-charts/src/components/ChartScatter/examples/ChartScatter.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartScatter/examples/ChartScatter.md
@@ -122,7 +122,10 @@ class ScatterAreaChart extends React.Component {
             <ChartGroup>
               {this.series.map((s, idx) => {
                 return (
-                  <ChartArea key={'area-' + idx} name={'area-' + idx} data={s.datapoints} />
+                  <ChartArea 
+                    interpolation="monotoneX"
+                    key={'area-' + idx} name={'area-' + idx} data={s.datapoints} 
+                  />
                 );
               })}
             </ChartGroup>

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -345,7 +345,7 @@ class MultiColorChart extends React.Component {
                   { name: 'Cats', x: 'Friday', y: 2 },
                   { name: 'Cats', x: 'Saturday', y: 0 }
                 ]}
-                interpolation="basis"
+                interpolation="monotoneX"
               />
              <ChartArea
                data={[
@@ -357,7 +357,7 @@ class MultiColorChart extends React.Component {
                   { name: 'Birds', x: 'Friday', y: 3 },
                   { name: 'Birds', x: 'Saturday', y: 5 }
                 ]}
-                interpolation="basis"
+                interpolation="monotoneX"
               />
               <ChartArea
                 data={[
@@ -369,7 +369,7 @@ class MultiColorChart extends React.Component {
                   { name: 'Dogs', x: 'Friday', y: 8 },
                   { name: 'Dogs', x: 'Saturday', y: 12 }
                 ]}
-                interpolation="basis"
+                interpolation="monotoneX"
               />
             </ChartStack>
           </Chart>

--- a/packages/patternfly-4/react-charts/src/components/ChartTheme/examples/ChartTheme.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartTheme/examples/ChartTheme.md
@@ -166,7 +166,7 @@ MultiColorUnordered = (
               { name: 'Cats', x: '2017', y: 8 },
               { name: 'Cats', x: '2018', y: 6 }
             ]}
-            interpolation="basis"
+            interpolation="monotoneX"
           />
           <ChartArea
             data={[
@@ -176,7 +176,7 @@ MultiColorUnordered = (
               { name: 'Dogs', x: '2018', y: 5 },
               { name: 'Dogs', x: '2019', y: 6 }
             ]}
-            interpolation="basis"
+            interpolation="monotoneX"
           />
           <ChartArea
             data={[
@@ -186,7 +186,7 @@ MultiColorUnordered = (
               { name: 'Birds', x: '2018', y: 2 },
               { name: 'Birds', x: '2019', y: 4 }
             ]}
-            interpolation="basis"
+            interpolation="monotoneX"
           />
         </ChartGroup>
       </Chart>

--- a/packages/patternfly-4/react-charts/src/components/ChartThreshold/examples/ChartThreshold.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartThreshold/examples/ChartThreshold.md
@@ -119,7 +119,7 @@ class MultiColorChart extends React.Component {
                   { name: 'Cats', x: 3, y: 8 },
                   { name: 'Cats', x: 4, y: 6 }
                 ]}
-                interpolation="basis"
+                interpolation="monotoneX"
               />
               <ChartArea
                 data={[
@@ -129,7 +129,7 @@ class MultiColorChart extends React.Component {
                   { name: 'Birds', x: 4, y: 5 },
                   { name: 'Birds', x: 5, y: 6 }
                 ]}
-                interpolation="basis"
+                interpolation="monotoneX"
               />
             </ChartGroup>
             <ChartThreshold

--- a/packages/patternfly-4/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartTooltip/examples/ChartTooltip.md
@@ -52,7 +52,7 @@ VononoiContainer = (
               { name: 'Cats', x: '2017', y: 8 },
               { name: 'Cats', x: '2018', y: 6 }
             ]}
-            interpolation="basis"
+            interpolation="monotoneX"
           />
           <ChartArea
             data={[
@@ -62,7 +62,7 @@ VononoiContainer = (
               { name: 'Dogs', x: '2018', y: 5 },
               { name: 'Dogs', x: '2019', y: 6 }
             ]}
-            interpolation="basis"
+            interpolation="monotoneX"
           />
           <ChartArea
             data={[
@@ -72,7 +72,7 @@ VononoiContainer = (
               { name: 'Birds', x: '2018', y: 2 },
               { name: 'Birds', x: '2019', y: 4 }
             ]}
-            interpolation="basis"
+            interpolation="monotoneX"
           />
         </ChartGroup>
       </Chart>


### PR DESCRIPTION
Updated the ChartArea examples to use `interpolation="monotoneX"`.

Note: "The way curves are drawn creates misleading visualization" using `interpolation="basis"`.

Fixes: https://github.com/patternfly/patternfly-react/issues/3329

<img width="696" alt="Screen Shot 2019-12-03 at 11 50 50 AM" src="https://user-images.githubusercontent.com/17481322/70071321-2c0bd380-15c3-11ea-840c-72d5865b55f4.png">
