### PR TITLE
fix(DataToolbar): hide Clear all filters button if no event handler provided

### DIFF
--- a/packages/patternfly-4/react-core/src/experimental/components/DataToolbar/DataToolbar.tsx
+++ b/packages/patternfly-4/react-core/src/experimental/components/DataToolbar/DataToolbar.tsx
@@ -106,7 +106,7 @@ export class DataToolbar extends React.Component<DataToolbarProps, DataToolbarSt
 
     const isToggleManaged = this.isToggleManaged();
     const numberOfFilters = this.getNumberOfFilters();
-    const showClearFiltersButton = numberOfFilters > 0;
+    const showClearFiltersButton = clearAllFilters && numberOfFilters > 0;
 
     return (
       <div className={css(styles.dataToolbar, className)} id={id} {...props}>

--- a/packages/patternfly-4/react-core/src/experimental/components/DataToolbar/__snapshots__/DataToolbar.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/experimental/components/DataToolbar/__snapshots__/DataToolbar.test.tsx.snap
@@ -2018,7 +2018,6 @@ exports[`data toolbar DataToolbarItemsAndGroups 1`] = `
       collapseListedFiltersBreakpoint="lg"
       isExpanded={false}
       numberOfFilters={0}
-      showClearFiltersButton={false}
     >
       <div
         className="pf-c-data-toolbar__content pf-m-hidden"
@@ -2123,7 +2122,6 @@ exports[`data toolbar DataToolbarOneContent 1`] = `
       collapseListedFiltersBreakpoint="lg"
       isExpanded={false}
       numberOfFilters={0}
-      showClearFiltersButton={false}
     >
       <div
         className="pf-c-data-toolbar__content pf-m-hidden"
@@ -2771,7 +2769,6 @@ exports[`data toolbar DataToolbarToggleGroup 1`] = `
       collapseListedFiltersBreakpoint="lg"
       isExpanded={false}
       numberOfFilters={0}
-      showClearFiltersButton={false}
     >
       <div
         className="pf-c-data-toolbar__content pf-m-hidden"
@@ -2928,7 +2925,6 @@ exports[`data toolbar DataToolbarTwoContent 1`] = `
       collapseListedFiltersBreakpoint="lg"
       isExpanded={false}
       numberOfFilters={0}
-      showClearFiltersButton={false}
     >
       <div
         className="pf-c-data-toolbar__content pf-m-hidden"


### PR DESCRIPTION
Fixes issue #3400 found while testing Katacoda tutorial.
