### PR TITLE
feat(DataList): add selectable variant

### DIFF
--- a/packages/patternfly-4/react-core/src/components/DataList/DataList.test.js
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataList.test.js
@@ -184,4 +184,9 @@ describe('DataList', () => {
     );
     expect(view).toMatchSnapshot();
   });
+
+  test('Selectable DataList', () => {
+    const view = shallow(<DataListContent aria-label="Primary Content Details" isSelectable> test</DataListContent>);
+    expect(view).toMatchSnapshot();
+  });
 });

--- a/packages/patternfly-4/react-core/src/components/DataList/DataList.tsx
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataList.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { isUndefined } from 'lodash';
+
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/DataList/data-list';
 
@@ -9,15 +11,51 @@ export interface DataListProps extends React.HTMLProps<HTMLUListElement> {
   className?: string;
   /* Adds accessible text to the DataList list */
   'aria-label': string;
+  /* Optional callback to make DataList selectable, fired when DataListItem selected */
+  onSelectDataListItem?: (id:string) => void;
+  /* Id of DataList item currently selected */
+  selectedDataListItemId?: string;
 }
 
-export const DataList: React.FunctionComponent<DataListProps> = ({
-  children = null,
-  className = '',
-  'aria-label': ariaLabel,
-  ...props
-}: DataListProps) => (
-  <ul className={css(styles.dataList, className)} aria-label={ariaLabel} {...props}>
-    {children}
-  </ul>
-);
+interface DataListContextProps {
+  isSelectable: boolean;
+  selectedDataListItemId: string;
+  updateSelectedDataListItem: (id: string) => void;
+}
+
+export const DataListContext = React.createContext<Partial<DataListContextProps>>({
+  isSelectable: false,
+});
+
+export class DataList extends React.Component<DataListProps> {
+
+  constructor(props: DataListProps) {
+    super(props);
+    this.state = {
+      selectedDataListItemId: props.selectedDataListItemId
+    }
+  }
+
+  updateSelectedDataListItem = (id: string) => {
+    this.props.onSelectDataListItem(id);
+  };
+
+  render() {
+    const { children, className, 'aria-label': ariaLabel, selectedDataListItemId, onSelectDataListItem, ...props } = this.props;
+    const isSelectable = !isUndefined(onSelectDataListItem);
+
+    return (
+      <DataListContext.Provider
+        value={{
+          isSelectable: isSelectable,
+          selectedDataListItemId,
+          updateSelectedDataListItem: this.updateSelectedDataListItem
+        }}
+      >
+        <ul className={css(styles.dataList, className)} aria-label={ariaLabel} {...props}>
+          {children}
+        </ul>
+      </DataListContext.Provider>
+    );
+  }
+}

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListCheck.tsx
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListCheck.tsx
@@ -22,7 +22,7 @@ export interface DataListCheckProps extends Omit<React.HTMLProps<HTMLInputElemen
 
 export const DataListCheck: React.FunctionComponent<DataListCheckProps> = ({
   className = '',
-  onChange,
+  onChange = (checked: boolean, event: React.FormEvent<HTMLInputElement>) => {},
   isValid = true,
   isDisabled = false,
   isChecked = null,

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListItem.tsx
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListItem.tsx
@@ -41,7 +41,18 @@ export class DataListItem extends React.Component<DataListItemProps> {
     const { children, className, isExpanded, 'aria-labelledby': ariaLabelledBy, id, ...props } = this.props;
     const { isSelectable, selectedDataListItemId, updateSelectedDataListItem } = this.context;
 
-    const selectDataListItem = () => {
+    const selectDataListItem = (event: React.MouseEvent) => {
+      let target: any = event.target;
+      while (event.currentTarget !== target) {
+        if (("onclick" in target && target["onclick"]) ||
+          target["parentNode"]["classList"].contains(styles.dataListItemAction) ||
+          target["parentNode"]["classList"].contains(styles.dataListItemControl)) {
+          // check other event handlers are not present.
+          return;
+        } else {
+          target = target["parentNode"];
+        }
+      }
       updateSelectedDataListItem(id);
     };
 

--- a/packages/patternfly-4/react-core/src/components/DataList/__snapshots__/DataList.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/DataList/__snapshots__/DataList.test.js.snap
@@ -103,6 +103,7 @@ exports[`DataList Item 1`] = `
 <li
   aria-labelledby="item-1"
   className="pf-c-data-list__item data-list-item-custom"
+  id=""
 />
 `;
 
@@ -110,21 +111,58 @@ exports[`DataList Item default 1`] = `
 <li
   aria-labelledby="item-1"
   className="pf-c-data-list__item"
+  id=""
 />
 `;
 
 exports[`DataList List 1`] = `
-<ul
-  aria-label="this is a simple list"
-  className="pf-c-data-list data-list-custom"
-/>
+<ContextProvider
+  value={
+    Object {
+      "isSelectable": false,
+      "selectedDataListItemId": undefined,
+      "updateSelectedDataListItem": [Function],
+    }
+  }
+>
+  <ul
+    aria-label="this is a simple list"
+    className="pf-c-data-list data-list-custom"
+  />
+</ContextProvider>
 `;
 
 exports[`DataList List default 1`] = `
-<ul
-  aria-label="this is a simple list"
-  className="pf-c-data-list"
-/>
+<ContextProvider
+  value={
+    Object {
+      "isSelectable": false,
+      "selectedDataListItemId": undefined,
+      "updateSelectedDataListItem": [Function],
+    }
+  }
+>
+  <ul
+    aria-label="this is a simple list"
+    className="pf-c-data-list"
+  />
+</ContextProvider>
+`;
+
+exports[`DataList Selectable DataList 1`] = `
+<section
+  aria-label="Primary Content Details"
+  className="pf-c-data-list__expandable-content"
+  hidden={false}
+  id=""
+  isSelectable={true}
+>
+  <div
+    className="pf-c-data-list__expandable-content-body"
+  >
+     test
+  </div>
+</section>
 `;
 
 exports[`DataList item row default 1`] = `

--- a/packages/patternfly-4/react-core/src/components/DataList/examples/DataList.md
+++ b/packages/patternfly-4/react-core/src/components/DataList/examples/DataList.md
@@ -822,3 +822,134 @@ class ModifiersDataList extends React.Component {
   }
 }
 ```
+```js title=Selectable-rows
+import React from 'react';
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  KebabToggle,
+  DataList,
+  DataListItem,
+  DataListCell,
+  DataListItemRow,
+  DataListCheck,
+  DataListItemCells,
+  DataListAction
+} from '@patternfly/react-core';
+
+class SelectableDataList extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { 
+      isOpen1: false,
+      isOpen2: false,
+      selectedDataListItemId: ''
+    };
+
+    this.onToggle1 = isOpen1  => {
+      this.setState({ isOpen1 });
+    };
+    
+    this.onToggle2 = isOpen2  => {
+      this.setState({ isOpen2 });
+    };
+
+    this.onSelect1 = event => {
+      this.setState(prevState => ({
+        isOpen1: !prevState.isOpen1
+      }));
+    };
+    
+    this.onSelect2 = event => {
+      this.setState(prevState => ({
+        isOpen2: !prevState.isOpen2
+      }));
+    };
+    
+    this.onSelectDataListItem = (id) => {
+      this.setState({ selectedDataListItemId: id });
+    }
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <DataList aria-label="selectable data list example " selectedDataListItemId={this.state.selectedDataListItemId} onSelectDataListItem={this.onSelectDataListItem}>
+          {!this.state.isDeleted && (
+            <DataListItem aria-labelledby="selectable-action-item1" id="item1">
+              <DataListItemRow>
+                <DataListItemCells
+                  dataListCells={[
+                    <DataListCell key="primary content">
+                      <span id="selectable-action-item1">Single actionable Primary content</span>
+                    </DataListCell>,
+                    <DataListCell key="secondary content">Single actionable Secondary content</DataListCell>
+                  ]}
+                />
+                <DataListAction
+                  aria-labelledby="selectable-action-item1 selectable-action-action1"
+                  id="selectable-action-action1"
+                  aria-label="Actions"
+                >
+                  <Dropdown
+                    isPlain
+                    position={DropdownPosition.right}
+                    isOpen={this.state.isOpen1}
+                    onSelect={this.onSelect1}
+                    toggle={<KebabToggle onToggle={this.onToggle1} />}
+                    dropdownItems={[
+                      <DropdownItem key="link">Link</DropdownItem>,
+                      <DropdownItem key="action" component="button">
+                        Action
+                      </DropdownItem>,
+                      <DropdownItem key="disabled link" isDisabled>
+                        Disabled Link
+                      </DropdownItem>
+                    ]}
+                  />
+                </DataListAction>
+              </DataListItemRow>
+            </DataListItem>
+          )}
+          <DataListItem aria-labelledby="selectable-actions-item2" id="item2">
+            <DataListItemRow>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="primary content">
+                    <span id="selectable-actions-item2">Selectable actions Primary content</span>
+                  </DataListCell>,
+                  <DataListCell key="secondary content">Selectable actions Secondary content</DataListCell>
+                ]}
+              />
+              <DataListAction
+                aria-labelledby="selectable-actions-item2 selectable-actions-action2"
+                id="selectable-actions-action2"
+                aria-label="Actions"
+              >
+                <Dropdown
+                  isPlain
+                  position={DropdownPosition.right}
+                  isOpen={this.state.isOpen2}
+                  onSelect={this.onSelect2}
+                  toggle={<KebabToggle onToggle={this.onToggle2} />}
+                  dropdownItems={[
+                    <DropdownItem key="link">Link</DropdownItem>,
+                    <DropdownItem key="action" component="button">
+                      Action
+                    </DropdownItem>,
+                    <DropdownItem key="disabled link" isDisabled>
+                      Disabled Link
+                    </DropdownItem>
+                  ]}
+                />
+              </DataListAction>
+            </DataListItemRow>
+          </DataListItem>
+        </DataList>
+      </React.Fragment>
+    );
+  }
+}
+```

--- a/packages/patternfly-4/react-integration/cypress/integration/datalist.spec.ts
+++ b/packages/patternfly-4/react-integration/cypress/integration/datalist.spec.ts
@@ -14,4 +14,20 @@ describe('Data List Demo Test', () => {
     cy.get('#simple-item3').contains('Secondary content (pf-m-no-fill)');
     cy.get('#simple-item4').contains('Secondary content (pf-m-align-right pf-m-no-fill)');
   });
+
+  it('Verify rows selectable', () => {
+    cy.get("#row1.pf-m-selectable").should('be.visible');
+    cy.get("#row2.pf-m-selectable").should('be.visible');
+
+    cy.get("#row1.pf-m-selected").should('not.be.visible');
+    cy.get("#row2.pf-m-selected").should('not.be.visible');
+
+    cy.get("#row1").click();
+    cy.get("#row1.pf-m-selected").should('be.visible');
+    cy.get("#row2.pf-m-selected").should('not.be.visible');
+
+    cy.get("#row2").click();
+    cy.get("#row1.pf-m-selected").should('not.be.visible');
+    cy.get("#row2.pf-m-selected").should('be.visible');
+  });
 });

--- a/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDemo.tsx
+++ b/packages/patternfly-4/react-integration/demo-app-ts/src/components/demos/DataListDemo/DataListDemo.tsx
@@ -1,11 +1,32 @@
 import React from 'react';
-import { DataList, DataListItem, DataListItemRow, DataListItemCells, DataListCell } from '@patternfly/react-core';
+import { DataList, DataListProps, DataListItem, DataListItemRow, DataListItemCells, DataListCell } from '@patternfly/react-core';
 
-export class DataListDemo extends React.Component {
+interface DataListState {
+  selectedDataListItemId: string;
+}
+
+
+export class DataListDemo extends React.Component<DataListProps, DataListState> {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedDataListItemId: ''
+    };
+  }
+
+  onSelectDataListItem = (id) => {
+    this.setState({ selectedDataListItemId: id });
+  };
+
   render() {
     return (
-      <DataList aria-label="Simple data list example">
-        <DataListItem aria-labelledby="simple-item1">
+      <DataList
+        aria-label="Simple data list example"
+        selectedDataListItemId={this.state.selectedDataListItemId}
+        onSelectDataListItem={this.onSelectDataListItem}
+      >
+        <DataListItem aria-labelledby="simple-item1" id="row1">
           <DataListItemRow>
             <DataListItemCells
               dataListCells={[
@@ -19,7 +40,7 @@ export class DataListDemo extends React.Component {
             />
           </DataListItemRow>
         </DataListItem>
-        <DataListItem aria-labelledby="simple-item2">
+        <DataListItem aria-labelledby="simple-item2" id="row2">
           <DataListItemRow>
             <DataListItemCells
               dataListCells={[


### PR DESCRIPTION
addresses #3233 

I have not figured out a clean way to prevent clicking the kebab (or interacting with components which have their own event handlers) from also selecting a DataListItem row. Events keep propagating up to parent components. I'd love any help people are willing to give... (@evwilkin @jschuler).

Is it possible the interaction as is would be acceptable for merging before code freeze monday? I could open an issue to figure out the last part? @mcarrano @mcoker 