### PR TITLE
Broken Katacoda tutorial links

### DIFF
--- a/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartArea/examples/ChartArea.md
@@ -23,7 +23,7 @@ PatternFly React charts are based on the [Victory](https://formidable.com/open-s
 
 Learn to build an area chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
-[Start course](https://katacoda.com/patternfly/courses/charts/area-chart)
+[Start course](https://katacoda.com/patternfly/courses/react-charts/area-chart)
 
 ## Examples
 ```js title=Basic-with-right-aligned-legend

--- a/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBar/examples/ChartBar.md
@@ -21,7 +21,7 @@ PatternFly React charts are based on the [Victory](https://formidable.com/open-s
 
 Learn to build a bar chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
-[Start course](https://katacoda.com/patternfly/courses/charts/bar-chart)
+[Start course](https://katacoda.com/patternfly/courses/react-charts/bar-chart)
 
 ## Examples
 ```js title=Basic-with-right-aligned-legend

--- a/packages/patternfly-4/react-charts/src/components/ChartBullet/examples/ChartBullet.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartBullet/examples/ChartBullet.md
@@ -20,7 +20,7 @@ PatternFly React charts are based on the [Victory](https://formidable.com/open-s
 
 Learn to build a bullet chart using a Katacoda tutorial starting with a simple chart, adding qualitative ranges, primary comparative measures, a comparative warning measure, tooltips, labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
-[Start course](https://katacoda.com/patternfly/courses/charts/bullet-chart)
+[Start course](https://katacoda.com/patternfly/courses/react-charts/bullet-chart)
 
 ## Examples
 ```js title=Basic

--- a/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonut/examples/ChartDonut.md
@@ -17,7 +17,7 @@ PatternFly React charts are based on the [Victory](https://formidable.com/open-s
 
 Learn to build a donut chart using a Katacoda tutorial starting with a simple chart, adding thresholds, tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
-[Start course](https://katacoda.com/patternfly/courses/charts/donut-chart)
+[Start course](https://katacoda.com/patternfly/courses/react-charts/donut-chart)
 
 ## Examples
 ```js title=Basic

--- a/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartDonutUtilization/examples/ChartDonutUtilization.md
@@ -18,7 +18,7 @@ PatternFly React charts are based on the [Victory](https://formidable.com/open-s
 
 Learn to build a donut utilization chart using a Katacoda tutorial starting with a simple chart, adding thresholds, tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
-[Start course](https://katacoda.com/patternfly/courses/charts/donut-utilization-chart)
+[Start course](https://katacoda.com/patternfly/courses/react-charts/donut-utilization-chart)
 
 ## Donut utilization examples
 ```js title=Basic

--- a/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartLine/examples/ChartLine.md
@@ -22,7 +22,7 @@ PatternFly React charts are based on the [Victory](https://formidable.com/open-s
 
 Learn to build a line chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
-[Start course](https://katacoda.com/patternfly/courses/charts/line-chart)
+[Start course](https://katacoda.com/patternfly/courses/react-charts/line-chart)
 
 ## Examples
 ```js title=Basic-with-right-aligned-legend

--- a/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartPie/examples/ChartPie.md
@@ -15,7 +15,7 @@ PatternFly React charts are based on the [Victory](https://formidable.com/open-s
 
 Learn to build a pie chart using a Katacoda tutorial starting with a simple chart, adding tooltips, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
-[Start course](https://katacoda.com/patternfly/courses/charts/pie-chart)
+[Start course](https://katacoda.com/patternfly/courses/react-charts/pie-chart)
 
 ## Examples
 ```js title=Basic-with-right-aligned-legend

--- a/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
+++ b/packages/patternfly-4/react-charts/src/components/ChartStack/examples/ChartStack.md
@@ -21,7 +21,7 @@ PatternFly React charts are based on the [Victory](https://formidable.com/open-s
 
 Learn to build a stack chart using a Katacoda tutorial starting with a simple chart, adding multiple datasets, tooltips, axis labels, a legend, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
-[Start course](https://katacoda.com/patternfly/courses/charts/stack-chart)
+[Start course](https://katacoda.com/patternfly/courses/react-charts/stack-chart)
 
 ## Examples
 ```js title=Basic-with-right-aligned-legend

--- a/packages/patternfly-4/react-charts/src/components/Sparkline/examples/sparkline.md
+++ b/packages/patternfly-4/react-charts/src/components/Sparkline/examples/sparkline.md
@@ -22,7 +22,7 @@ PatternFly React charts are based on the [Victory](https://formidable.com/open-s
 
 Learn to build a sparkline chart using a Katacoda tutorial starting with a simple chart, adding tooltips, and concluding by changing the theme color. You'll learn how to use React chart components together to build a consistent user experience.
 
-[Start course](https://katacoda.com/patternfly/courses/charts/sparkline-chart)
+[Start course](https://katacoda.com/patternfly/courses/react-charts/sparkline-chart)
 
 ## Examples
 ```js title=Basic


### PR DESCRIPTION
The Katacoda chart tutorials have moved to a new directory. Thus, the links in the chart examples are broken.

This:
https://katacoda.com/patternfly/courses/charts/area-chart

Should be:
https://katacoda.com/patternfly/courses/react-charts/area-chart
