### PR TITLE
[PF3] Update CustomModalDialog to match changes to original react-bootstrap ModalDialog

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Modal/InnerComponents/CustomModalDialog.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Modal/InnerComponents/CustomModalDialog.js
@@ -1,6 +1,7 @@
 /**
  * CustomModalDialog creates custom ReactBootstrap ModalDialog
- * https://github.com/react-bootstrap/react-bootstrap/blob/master/src/ModalDialog.js
+ * https://github.com/react-bootstrap/react-bootstrap/blob/bs3-dev/src/ModalDialog.js
+ * Up-to-date with the original as of https://github.com/react-bootstrap/react-bootstrap/commit/87a9a97f8670f3a02436f8f520caf36f88e4bdab
  *
  * This extends ModalDialog and adds contentClassName prop for setting
  * `modal-content` div's class
@@ -26,7 +27,7 @@ const Size = {
 // eslint-disable-next-line react/prefer-stateless-function
 class CustomModalDialog extends React.Component {
   render() {
-    const { dialogClassName, contentClassName, className, style, children, ...props } = this.props;
+    const { dialogClassName, contentClassName, className, style, children, onMouseDownDialog, ...props } = this.props;
     const [bsProps, elementProps] = splitBsProps(props);
 
     const bsClassName = prefix(bsProps);
@@ -47,7 +48,8 @@ class CustomModalDialog extends React.Component {
         style={modalStyle}
         className={classNames(className, bsClassName)}
       >
-        <div className={classNames(dialogClassName, dialogClasses)}>
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+        <div className={classNames(dialogClassName, dialogClasses)} onMouseDown={onMouseDownDialog}>
           <div className={classNames(prefix(bsProps, 'content'), contentClassName)} role="document">
             {children}
           </div>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #3364 

As detailed in [my comment here](https://github.com/patternfly/patternfly-react/issues/3364#issuecomment-565645973), since upgrading react-bootstrap in https://github.com/patternfly/patternfly-react/pull/3249 we have had a warning appear when rendering a `<Modal>`. This is happening because we created `CustomModalDialog` based on the react-bootstrap `ModalDialog` in order to introduce a custom prop, and react-bootstrap has since made a change requiring updates to their original `ModalDialog`.

Our `CustomModalDialog` was introduced in https://github.com/patternfly/patternfly-react/commit/9b0f3d9aff2646309bc3e2708d01186c041c10c7 (Nov 13, 2017). Looking at [the history of react-bootstrap's original `ModalDialog`](https://github.com/react-bootstrap/react-bootstrap/commits/bs3-dev/src/ModalDialog.js), we can see that the only real (non-code-style) change they made since we copied it was [this one](https://github.com/react-bootstrap/react-bootstrap/commit/87a9a97f8670f3a02436f8f520caf36f88e4bdab#diff-e62f630dfbeeba1084a3724f9d4dbf98) which introduces the `onMouseDownDialog` prop. This PR simply replicates that change in our `CustomModalDialog`.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: This should also unblock the resolution of https://github.com/ManageIQ/manageiq-v2v/issues/1037

cc @laviro @martinpovolny @himdel