### PR TITLE
docs(patternfly-4/react-docs/.../icons.js): Added a link to icons docs

### DIFF
--- a/packages/patternfly-4/react-docs/src/pages/icons.js
+++ b/packages/patternfly-4/react-docs/src/pages/icons.js
@@ -40,6 +40,7 @@ export default ({ location }) => {
         <Title size="md" className="ws-framework-title">React</Title>
         <Title size="4xl">Icons</Title>
         <Text>These are all Patternfly React Icons.</Text>
+        <Text>Learn how you can use them in the <a href="https://github.com/patternfly/patternfly-react/tree/master/packages/react-icons">react-icons docs</a></Text>
         <Grid>
           {allIcons.map(([id, Icon]) => (
             <GridItem key={id} style={cellStyle} sm={6} md={4} lg={2}>

--- a/packages/react-icons/README.md
+++ b/packages/react-icons/README.md
@@ -11,7 +11,7 @@ import { TimesIcon } from '@patternfly/react-icons';
 const closeIcon = <TimesIcon />;
 ```
 
-For a list of the available icons please refer to the [PatternFly React Docs](https://patternfly-react.surge.sh/patternfly-4/icons/Icons/)
+For a list of the available icons please refer to the [PatternFly React Docs](https://patternfly-react.surge.sh/patternfly-4/icons/)
 
 Every icon component has the following props:
 


### PR DESCRIPTION
 Added a link in the react docs icon page to react-icons docs as it is unclear how to use the icons that are shown.
And fixed the link in the react icons docs
Fixes https://github.com/patternfly/patternfly-react/issues/3459