### PR TITLE
fix(DataList): properly assign selectable and selected classes

### DIFF
--- a/packages/patternfly-4/react-core/src/components/DataList/DataList.tsx
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataList.tsx
@@ -31,8 +31,8 @@ export const DataList: React.FunctionComponent<DataListProps> = ({
     children = null,
     className = '',
     'aria-label': ariaLabel,
-    onSelectDataListItem = (id:string) => {},
     selectedDataListItemId = '',
+    onSelectDataListItem,
     ...props
   }: DataListProps) => {
   const isSelectable = !isUndefined(onSelectDataListItem);

--- a/packages/patternfly-4/react-core/src/components/DataList/DataListItem.tsx
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListItem.tsx
@@ -64,7 +64,7 @@ export const DataListItem: React.FunctionComponent<DataListItemProps> = ({
               styles.dataListItem,
               isExpanded && styles.modifiers.expanded,
               isSelectable && styles.modifiers.selectable,
-              selectedDataListItemId === id && styles.modifiers.selected,
+              selectedDataListItemId && selectedDataListItemId === id && styles.modifiers.selected,
               className)}
             aria-labelledby={ariaLabelledBy}
             {...(isSelectable && { tabIndex: 0, onClick: selectDataListItem, onKeyDown: onKeyDown })}

--- a/packages/patternfly-4/react-core/src/components/DataList/__snapshots__/DataList.test.js.snap
+++ b/packages/patternfly-4/react-core/src/components/DataList/__snapshots__/DataList.test.js.snap
@@ -115,7 +115,7 @@ exports[`DataList List 1`] = `
 <ContextProvider
   value={
     Object {
-      "isSelectable": true,
+      "isSelectable": false,
       "selectedDataListItemId": "",
       "updateSelectedDataListItem": [Function],
     }
@@ -132,7 +132,7 @@ exports[`DataList List default 1`] = `
 <ContextProvider
   value={
     Object {
-      "isSelectable": true,
+      "isSelectable": false,
       "selectedDataListItemId": "",
       "updateSelectedDataListItem": [Function],
     }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
Closes #3446

### Changes
- removed default prop of onSelectDataListItem
  - `isSelectable` was always true
- added check to `selectedDataListItemId`
  - was always true which cause `styles.modifiers.selected` to be always assigned

![data-list-ok](https://user-images.githubusercontent.com/22619452/71661222-d7887f00-2d4d-11ea-9b40-2e1b4126756e.gif)

