### PR TITLE
Use direct paths to react-icons in prod build

### DIFF
--- a/packages/patternfly-4/react-core/.babelrc
+++ b/packages/patternfly-4/react-core/.babelrc
@@ -1,3 +1,0 @@
-{
-  "extends": "../.babelrc"
-}

--- a/packages/patternfly-4/react-core/babel.config.js
+++ b/packages/patternfly-4/react-core/babel.config.js
@@ -1,0 +1,31 @@
+const envDistMapping = {
+  cjs: 'js',
+  esm: 'esm',
+  umd: 'umd'
+}
+
+const createIconsTransformPlugin = (env) => [
+  "transform-imports",
+  {
+    "@patternfly/react-icons": {
+      transform: (importName, matches) =>
+        `@patternfly/react-icons/dist/${envDistMapping[env]}/icons/${importName.split(/(?=[A-Z])/).join('-').toLowerCase()}`,
+      preventFullImport: true
+    }
+  }
+]
+
+module.exports = {
+  extends: '../.babelrc',
+  env: {
+    cjs: {
+      plugins: [createIconsTransformPlugin('cjs')]
+    },
+    esm: {
+      plugins: [createIconsTransformPlugin('esm')]
+    },
+    umd: {
+      plugins: [createIconsTransformPlugin('umd')]
+    }
+  }
+}

--- a/packages/patternfly-4/react-core/package.json
+++ b/packages/patternfly-4/react-core/package.json
@@ -31,9 +31,9 @@
   "scripts": {
     "build": "yarn build:babel && yarn build:types && node ./scripts/copyTS.js && node ./scripts/copyStyles.js",
     "build:babel": "concurrently \"yarn build:babel:esm && yarn build:babel:umd\" \"yarn build:babel:cjs\"",
-    "build:babel:cjs": "babel --source-maps --extensions \".js,.ts,.tsx\" src --out-dir dist/js --presets=@babel/env",
-    "build:babel:esm": "babel --source-maps --extensions \".js,.ts,.tsx\" src --out-dir dist/esm",
-    "build:babel:umd": "babel --source-maps --extensions \".js\" dist/esm --out-dir dist/umd --plugins=transform-es2015-modules-umd",
+    "build:babel:cjs": "BABEL_ENV=cjs babel --source-maps --extensions \".js,.ts,.tsx\" src --out-dir dist/js --presets=@babel/env",
+    "build:babel:esm": "BABEL_ENV=esm babel --source-maps --extensions \".js,.ts,.tsx\" src --out-dir dist/esm",
+    "build:babel:umd": "BABEL_ENV=umd babel --source-maps --extensions \".js\" dist/esm --out-dir dist/umd --plugins=transform-es2015-modules-umd",
     "build:types": "tsc -p tsconfig.gen-dts.json",
     "clean": "rimraf dist",
     "develop": "yarn build:babel:esm --skip-initial-build --watch --verbose"
@@ -62,6 +62,7 @@
     "@types/react": "^16.4.0",
     "@types/react-dom": "^16.4.0",
     "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+    "babel-plugin-transform-imports": "^2.0.0",
     "babel-plugin-typescript-to-proptypes": "^0.17.1",
     "css": "^2.2.3",
     "fs-extra": "^6.0.1",


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Addresses #3268

Added transform-imports for react-core to use direct paths to react-icons dependencies. This change marginally improves build sizes of libraries which depends on a library that is also using react-core package icons and then is consumed by some app.

Bundle size of an app using just PF4 Modal from a third-party library was reduced from 513kB to 27Kb 

Right now, if you use any component with an icon from react-icons (Modal for example), it sometimes bundles all react-icons even if not used.

A reproducible example can be found here: https://github.com/Hyperkid123/pf-core-icons-deps

Detailed info can be found in #3268 


