### PR TITLE
improvement(Select): Add showOnlySelectionCount property to Select component

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Select/Select.tsx
+++ b/packages/patternfly-4/react-core/src/components/Select/Select.tsx
@@ -77,6 +77,8 @@ export interface SelectProps
   width?: string | number;
   /** Max height of the select container as a number of px or string percentage */
   maxHeight?: string | number;
+  /** If true, only show count of selections rather than selected values. Default to false. */
+  showOnlySelectionCount?: boolean;
   /** Icon element to render inside the select toggle */
   toggleIcon?: React.ReactElement;
   /** Custom content to render in the select menu.  If this prop is defined, the variant prop will be ignored and the select will render with a single select toggle */
@@ -120,6 +122,7 @@ class Select extends React.Component<SelectProps & InjectedOuiaProps, SelectStat
     width: '',
     onClear: (_e: React.MouseEvent) => undefined as void,
     onCreateOption: (_newOptionValue: string) => undefined as void,
+    showOnlySelectionCount: false,
     toggleIcon: null as React.ReactElement,
     onFilter: null,
     customContent: null
@@ -356,6 +359,7 @@ class Select extends React.Component<SelectProps & InjectedOuiaProps, SelectStat
       ouiaId,
       createText,
       noResultsFoundText,
+      showOnlySelectionCount,
       ...props
     } = this.props;
     const { openedOnEnter, typeaheadInputValue, typeaheadActiveChild } = this.state;
@@ -370,7 +374,7 @@ class Select extends React.Component<SelectProps & InjectedOuiaProps, SelectStat
       }
     }
     let selectedChips = null;
-    if (variant === SelectVariant.typeaheadMulti) {
+    if (variant === SelectVariant.typeaheadMulti && !showOnlySelectionCount) {
       selectedChips = (
         <ChipGroup>
           {selections &&
@@ -484,6 +488,11 @@ class Select extends React.Component<SelectProps & InjectedOuiaProps, SelectStat
                 <div className={css(styles.selectToggleWrapper)}>
                   {toggleIcon && <span className={css(styles.selectToggleIcon)}>{toggleIcon}</span>}
                   {selections && (Array.isArray(selections) && selections.length > 0) && selectedChips}
+                  {selections && showOnlySelectionCount && (Array.isArray(selections) && selections.length > 0) && (
+                    <div className={css(styles.selectToggleBadge)}>
+                      <span className={css(badgeStyles.badge, badgeStyles.modifiers.read)}>{selections.length}</span>
+                    </div>
+                  )}
                   <input
                     className={css(formStyles.formControl, styles.selectToggleTypeahead)}
                     aria-activedescendant={typeaheadActiveChild && typeaheadActiveChild.id}

--- a/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -141,6 +141,7 @@ exports[`checkbox select renders checkbox select groups successfully - old class
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="checkbox"
@@ -916,6 +917,7 @@ exports[`checkbox select renders checkbox select groups successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="checkbox"
@@ -1639,6 +1641,7 @@ exports[`checkbox select renders closed successfully - old classes 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="checkbox"
@@ -1868,6 +1871,7 @@ exports[`checkbox select renders closed successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="checkbox"
@@ -2083,6 +2087,7 @@ exports[`checkbox select renders expanded successfully - old classes 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="checkbox"
@@ -2540,6 +2545,7 @@ exports[`checkbox select renders expanded successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="checkbox"
@@ -3020,6 +3026,7 @@ exports[`checkbox select renders expanded successfully with custom objects 1`] =
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="checkbox"
@@ -3468,6 +3475,7 @@ exports[`select custom select filter filters properly 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="typeahead"
@@ -3948,6 +3956,7 @@ exports[`select renders select groups successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="single"
@@ -4609,6 +4618,7 @@ exports[`select renders up drection successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="single"
@@ -4842,6 +4852,7 @@ exports[`select single select renders closed successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="single"
@@ -5077,6 +5088,7 @@ exports[`select single select renders disabled successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="single"
@@ -5313,6 +5325,7 @@ exports[`select single select renders expanded successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="single"
@@ -5755,6 +5768,7 @@ exports[`select single select renders expanded successfully with custom objects 
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="single"
@@ -6104,6 +6118,7 @@ exports[`select with custom content renders closed successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="single"
@@ -6274,6 +6289,7 @@ exports[`select with custom content renders expanded successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="single"
@@ -6567,6 +6583,7 @@ exports[`typeahead multi select renders closed successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="typeaheadmulti"
@@ -6606,6 +6623,7 @@ exports[`typeahead multi select renders closed successfully 1`] = `
                   <div
                     class="pf-c-select__toggle-wrapper"
                   >
+                    
                     
                     <input
                       aria-label=""
@@ -6826,6 +6844,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="typeaheadmulti"
@@ -6865,6 +6884,7 @@ exports[`typeahead multi select renders expanded successfully 1`] = `
                   <div
                     class="pf-c-select__toggle-wrapper"
                   >
+                    
                     
                     <input
                       aria-label=""
@@ -7300,6 +7320,7 @@ exports[`typeahead multi select renders selected successfully 1`] = `
           "Mrs",
         ]
       }
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="typeaheadmulti"
@@ -8305,6 +8326,7 @@ exports[`typeahead multi select test onChange 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="typeahead"
@@ -8629,6 +8651,7 @@ exports[`typeahead select renders closed successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="typeahead"
@@ -8887,6 +8910,7 @@ exports[`typeahead select renders expanded successfully 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="typeahead"
@@ -9347,6 +9371,7 @@ exports[`typeahead select renders selected successfully 1`] = `
       }
       placeholderText=""
       selections="Mr"
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="typeahead"
@@ -9903,6 +9928,7 @@ exports[`typeahead select test creatable option 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="typeahead"
@@ -10237,6 +10263,7 @@ exports[`typeahead select test onChange 1`] = `
       }
       placeholderText=""
       selections=""
+      showOnlySelectionCount={false}
       toggleIcon={null}
       toggleId={null}
       variant="typeahead"

--- a/packages/patternfly-4/react-core/src/components/Select/examples/Select.md
+++ b/packages/patternfly-4/react-core/src/components/Select/examples/Select.md
@@ -537,7 +537,8 @@ class MultiTypeaheadSelectInput extends React.Component {
       isExpanded: false,
       selected: [],
       isCreatable: false,
-      hasOnCreateOption: false
+      hasOnCreateOption: false,
+      showOnlySelectionCount: false
     };
 
     this.onCreateOption = newValue => {
@@ -585,10 +586,16 @@ class MultiTypeaheadSelectInput extends React.Component {
         hasOnCreateOption: checked
       });
     };
+
+    this.toggleShowOnlyCount = checked => {
+      this.setState({
+        showOnlySelectionCount: checked
+      });
+    };
   }
 
   render() {
-    const { isExpanded, selected, isCreatable, hasOnCreateOption } = this.state;
+    const { isExpanded, selected, isCreatable, hasOnCreateOption, showOnlySelectionCount } = this.state;
     const titleId = 'multi-typeahead-select-id';
 
     return (
@@ -608,6 +615,7 @@ class MultiTypeaheadSelectInput extends React.Component {
           placeholderText="Select a state"
           isCreatable={isCreatable}
           onCreateOption={(hasOnCreateOption && this.onCreateOption) || undefined}
+          showOnlySelectionCount={showOnlySelectionCount}
         >
           {this.state.options.map((option, index) => (
             <SelectOption isDisabled={option.disabled} key={index} value={option.value} />
@@ -628,6 +636,14 @@ class MultiTypeaheadSelectInput extends React.Component {
           aria-label="toggle new checkbox"
           id="toggle-new-typeahead-multi"
           name="toggle-new-typeahead-multi"
+        />
+        <Checkbox
+          label="showOnlySelectionCount"
+          isChecked={this.state.showOnlySelectionCount}
+          onChange={this.toggleShowOnlyCount}
+          aria-label="toggle show only selection count checkbox"
+          id="toggle-show-only-selection-count-multi"
+          name="toggle-show-selection-count-multi"
         />
       </div>
     );

--- a/packages/patternfly-4/react-core/src/experimental/components/DataToolbar/__snapshots__/DataToolbar.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/experimental/components/DataToolbar/__snapshots__/DataToolbar.test.tsx.snap
@@ -229,6 +229,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                               }
                               placeholderText=""
                               selections="Running"
+                              showOnlySelectionCount={false}
                               toggleIcon={null}
                               toggleId={null}
                               variant="single"
@@ -935,6 +936,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                               }
                               placeholderText=""
                               selections="Low"
+                              showOnlySelectionCount={false}
                               toggleIcon={null}
                               toggleId={null}
                               variant="single"
@@ -2366,6 +2368,7 @@ exports[`data toolbar DataToolbarToggleGroup 1`] = `
                             }
                             placeholderText=""
                             selections="Running"
+                            showOnlySelectionCount={false}
                             toggleIcon={null}
                             toggleId={null}
                             variant="single"
@@ -2580,6 +2583,7 @@ exports[`data toolbar DataToolbarToggleGroup 1`] = `
                             }
                             placeholderText=""
                             selections="Low"
+                            showOnlySelectionCount={false}
                             toggleIcon={null}
                             toggleId={null}
                             variant="single"


### PR DESCRIPTION
Add showOnlySelectionCount property to Select component to display only the selection count rather than all selected values.

<img width="853" alt="Screen Shot 2020-01-06 at 10 10 34 PM" src="https://user-images.githubusercontent.com/35978579/71867461-2f214480-30d8-11ea-86d5-4850b929e875.png">
<img width="849" alt="Screen Shot 2020-01-06 at 10 10 45 PM" src="https://user-images.githubusercontent.com/35978579/71867462-2f214480-30d8-11ea-8929-c2ada17105d3.png">



<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #https://github.com/patternfly/patternfly-react/issues/3456<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
