### PR TITLE
Remove listing of icons while under construction

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,6 +11,7 @@ exemptLabels:
   - pinned
   - security
   - accessibility
+  - "breaking change :boom:"
 
 # Label to use when marking as stale
 staleLabel: wontfix

--- a/packages/patternfly-4/react-docs/src/pages/icons.js
+++ b/packages/patternfly-4/react-docs/src/pages/icons.js
@@ -39,8 +39,8 @@ export default ({ location }) => {
       <PageSection className="ws-section">
         <Title size="md" className="ws-framework-title">React</Title>
         <Title size="4xl">Icons</Title>
-        <Text>These are all Patternfly React Icons.</Text>
-        <Text>Learn how you can use them in the <a href="https://github.com/patternfly/patternfly-react/tree/master/packages/react-icons">react-icons docs</a></Text>
+        <Text>These are all of the icons available for use in PatternFly React. For recommended icon usage, see our <a href="https://www.patternfly.org/v4/design-guidelines/styles/icons">icon usage guidelines</a>.</Text>
+        <Text>Learn how you can use them in the <a href="https://github.com/patternfly/patternfly-react/tree/master/packages/react-icons">react-icons docs</a>.</Text>
         <Grid>
           {allIcons.map(([id, Icon]) => (
             <GridItem key={id} style={cellStyle} sm={6} md={4} lg={2}>


### PR DESCRIPTION
Removes listing of icons that we should not be fully supporting while the design team works out the correct approach.  These were prematurely added.

Fixes: https://github.com/patternfly/patternfly-react/issues/3484