### PR TITLE
fix(linting): eslint for *.md file fixes

### DIFF
--- a/packages/patternfly-4/react-catalog-view-extension/README.md
+++ b/packages/patternfly-4/react-catalog-view-extension/README.md
@@ -18,7 +18,7 @@ npm install react-catalog-view-extension --save
 
 ### Usage
 
-```javascript
+```
 import { Component } from 'react-catalog-view-extension';
 ```
 

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/CatalogTile/examples/CatalogTile.md
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/CatalogTile/examples/CatalogTile.md
@@ -20,6 +20,7 @@ This package is currently an extension. Extension components do not undergo the 
 ```js title=Basic-featured-tile
 import React from 'react';
 import { CatalogTile, CatalogTileBadge } from '@patternfly/react-catalog-view-extension';
+import { CogIcon } from '@patternfly/react-icons';
 import { pfLogo2 } from './examples/pfLogo2.svg'
 
 Basic = () => (
@@ -49,6 +50,7 @@ Basic = () => (
 ```js title=Basic-without-truncated-text
 import React from 'react';
 import { CatalogTile, CatalogTileBadge } from '@patternfly/react-catalog-view-extension';
+import { CogIcon } from '@patternfly/react-icons';
 import { pfLogo2 } from './examples/pfLogo2.svg'
 
 SimpleNoTrunc = () => (
@@ -78,6 +80,7 @@ SimpleNoTrunc = () => (
 ```js title=Basic-with-footer
 import React from 'react';
 import { CatalogTile, CatalogTileBadge } from '@patternfly/react-catalog-view-extension';
+import { CogIcon, OutlinedCheckCircleIcon } from '@patternfly/react-icons';
 import { pfLogo2 } from './examples/pfLogo2.svg'
 
 SimpleFooter = () => (
@@ -111,6 +114,7 @@ SimpleFooter = () => (
 ```js title=Link-variant
 import React from 'react';
 import { CatalogTile, CatalogTileBadge } from '@patternfly/react-catalog-view-extension';
+import { CogIcon } from '@patternfly/react-icons';
 import { pfLogo2 } from './examples/pfLogo2.svg'
 
 Link = () => (
@@ -140,6 +144,7 @@ Link = () => (
 ```js title=With-multiple-icon-badges
 import React from 'react';
 import { CatalogTile, CatalogTileBadge } from '@patternfly/react-catalog-view-extension';
+import { CogIcon, OutlinedCheckCircleIcon } from '@patternfly/react-icons';
 import { pfLogo2 } from './examples/pfLogo2.svg'
 
 MultiIcon = () => (
@@ -170,7 +175,7 @@ MultiIcon = () => (
 
 ```js title=With-text-badge
 import React from 'react';
-import { CatalogTile, CatalogTileBadge } from '@patternfly/react-catalog-view-extension';
+import { CatalogTile } from '@patternfly/react-catalog-view-extension';
 import { pfLogo2 } from './examples/pfLogo2.svg'
 
 TextBadge = () => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,6 +1761,15 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.4":
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.0.tgz#1a2039a028057a2c888b668d94c98e61ea906e7f"
+  integrity sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
 "@babel/types@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.4.tgz#516570d539e44ddf308c07569c258ff94fde9193"
@@ -6006,6 +6015,14 @@ babel-plugin-transform-imports@^1.5.0:
     lodash.findkey "^4.6.0"
     lodash.kebabcase "^4.1.1"
     lodash.snakecase "^4.1.1"
+
+babel-plugin-transform-imports@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-imports/-/babel-plugin-transform-imports-2.0.0.tgz#9e5f49f751a9d34ba8f4bb988c7e48ed2419c6b6"
+  integrity sha512-65ewumYJ85QiXdcB/jmiU0y0jg6eL6CdnDqQAqQ8JMOKh1E52VPG3NJzbVKWcgovUR5GBH8IWpCXQ7I8Q3wjgw==
+  dependencies:
+    "@babel/types" "^7.4"
+    is-valid-path "^0.1.1"
 
 babel-plugin-transform-inline-consecutive-adds@^0.4.3:
   version "0.4.3"


### PR DESCRIPTION
for react-catalog-view-extension

initial cleanup of linting errors on *.md files. 

