### PR TITLE
fix(linting): turning on errors for Markdown code block linting. We a…

### DIFF
--- a/.eslintrc_md.json
+++ b/.eslintrc_md.json
@@ -12,13 +12,13 @@
     }
   },
   "rules": {
-    "eol-last": 1,
-    "spaced-comment": 1,
+    "eol-last": 2,
+    "spaced-comment": 2,
     "no-unused-vars": 0,
-    "no-this-before-super": 1,
+    "no-this-before-super": 2,
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
-    "react/no-unknown-property": 1,
-    "react/jsx-no-undef": 1
+    "react/no-unknown-property": 2,
+    "react/jsx-no-undef": 2
   }
 }


### PR DESCRIPTION
…re now ahead of the game.

By upping our rules from warning to error will cause build failures if any of the rules fail for code blocks inside Markdown files. This is important as it will keep our Demos and examples in a usable state.


