### PR TITLE
react-console: Fix homepage URL

### DIFF
--- a/packages/patternfly-3/react-console/package.json
+++ b/packages/patternfly-3/react-console/package.json
@@ -22,7 +22,7 @@
   "bugs": {
     "url": "https://github.com/patternfly/patternfly-react/issues"
   },
-  "homepage": "https://github.com/patternfly/patternfly-react/blob/master/src/console/README.md",
+  "homepage": "https://github.com/patternfly/patternfly-react/blob/master/packages/patternfly-3/react-console/README.md",
   "scripts": {
     "build": "yarn build:sass && yarn build:less && yarn build:babel",
     "build:babel": "concurrently \"yarn build:babel:cjs\" \"yarn build:babel:esm\"",


### PR DESCRIPTION
**What**: Update the react-console pacakage's homepage to the currently correct location.

Previously, the URL pointed to a broken link (probably before the monorepo reorganization).
