### PR TITLE
fix(Tabs): update tabs with nav examples + add Tab component to props docs

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tab.tsx
@@ -18,6 +18,4 @@ export interface TabProps extends Omit<React.HTMLProps<HTMLAnchorElement | HTMLB
   tabContentRef?: React.RefObject<any>;
 }
 
-export const Tab: React.FunctionComponent<TabProps> = ({ className = '' }: TabProps) => {
-  return null;
-};
+export const Tab: React.FunctionComponent<TabProps> = ({ className = '' }: TabProps) => null;

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tab.tsx
@@ -18,5 +18,6 @@ export interface TabProps extends Omit<React.HTMLProps<HTMLAnchorElement | HTMLB
   tabContentRef?: React.RefObject<any>;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const Tab: React.FunctionComponent<TabProps> = ({ className = '' }: TabProps) => null;
+export const Tab: React.FunctionComponent<TabProps> = ({ className = '' }: TabProps) => {
+  return <React.Fragment />;
+};

--- a/packages/patternfly-4/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/patternfly-4/react-core/src/components/Tabs/Tab.tsx
@@ -19,5 +19,5 @@ export interface TabProps extends Omit<React.HTMLProps<HTMLAnchorElement | HTMLB
 }
 
 export const Tab: React.FunctionComponent<TabProps> = ({ className = '' }: TabProps) => {
-  return <React.Fragment />;
+  return null;
 };

--- a/packages/patternfly-4/react-core/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should not render anything 1`] = `""`;
+exports[`should not render anything 1`] = `<Fragment />`;

--- a/packages/patternfly-4/react-core/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Tabs/__tests__/__snapshots__/Tab.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should not render anything 1`] = `<Fragment />`;
+exports[`should not render anything 1`] = `""`;

--- a/packages/patternfly-4/react-core/src/components/Tabs/examples/Tabs.md
+++ b/packages/patternfly-4/react-core/src/components/Tabs/examples/Tabs.md
@@ -2,7 +2,7 @@
 title: 'Tabs'
 section: components
 cssPrefix: 'pf-c-tabs'
-propComponents: ['Tabs']
+propComponents: ['Tabs', 'Tab']
 typescript: true
 ---
 import { Tabs, Tab, TabsVariant, TabContent } from '@patternfly/react-core';
@@ -380,7 +380,7 @@ class SecondaryTabsNavVariant extends React.Component {
         aria-label="Local"
         variant={TabsVariant.nav}
       >
-        <Tab eventKey={0} title="Tab item 1">
+        <Tab eventKey={0} title="Tab item 1" href="#">
           <Tabs
             activeKey={this.state.activeTabKey2}
             isSecondary
@@ -388,21 +388,21 @@ class SecondaryTabsNavVariant extends React.Component {
             aria-label="Local secondary"
             variant={TabsVariant.nav}
           >
-            <Tab eventKey={10} title="Secondary tab item 1">
+            <Tab eventKey={10} title="Secondary tab item 1" href="#">
               Secondary tab item 1 item section
             </Tab>
-            <Tab eventKey={11} title="Secondary tab item 2">
+            <Tab eventKey={11} title="Secondary tab item 2" href="#">
               Secondary tab item 2 section
             </Tab>
-            <Tab eventKey={12} title="Secondary tab item 3">
+            <Tab eventKey={12} title="Secondary tab item 3" href="#">
               Secondary tab item 3 section
             </Tab>
           </Tabs>
         </Tab>
-        <Tab eventKey={1} title="Tab item 2">
+        <Tab eventKey={1} title="Tab item 2" href="#">
           Tab 2 section
         </Tab>
-        <Tab eventKey={2} title="Tab item 3">
+        <Tab eventKey={2} title="Tab item 3" href="#">
           Tab 3 section
         </Tab>
       </Tabs>
@@ -438,13 +438,13 @@ class TabsNavVariant extends React.Component {
         aria-label="Local"
         variant={TabsVariant.nav}
       >
-        <Tab eventKey={0} title="Tab item 1">
+        <Tab eventKey={0} title="Tab item 1" href="#">
           Tab 1 section
         </Tab>
-        <Tab eventKey={1} title="Tab item 2">
+        <Tab eventKey={1} title="Tab item 2" href="#">
           Tab 2 section
         </Tab>
-        <Tab eventKey={2} title="Tab item 3">
+        <Tab eventKey={2} title="Tab item 3" href="#">
           Tab 3 section
         </Tab>
       </Tabs>


### PR DESCRIPTION
Addresses issue #2607 

Issue (#3454) opened to address the fact that props descriptions are missing (from all docs it seems).

Note: Tab component cannot return null, or the gatsby parser does not recognize that Tab.tsx returns a component to build the props documentation for Tab. Possible alternative solution could be updating our gatsby-transformer-react-docgen-typescript plugin.
