### PR TITLE
allow string literals to be used for FlexItem modifiers

### DIFF
--- a/packages/patternfly-4/react-core/src/layouts/Flex/Flex.test.tsx
+++ b/packages/patternfly-4/react-core/src/layouts/Flex/Flex.test.tsx
@@ -52,3 +52,13 @@ describe('flex item modifiers', () => {
     })
   })
 });
+
+test('flex modifier as string literal', () => {
+  const view = mount(<Flex breakpointMods={[{ modifier: 'flex-1', breakpoint: 'sm' }]} />)
+  expect(view.find('div').prop('className')).not.toMatch(/undefined/)
+});
+
+test('flex item modifier as string literal', () => {
+  const view = mount(<FlexItem breakpointMods={[{ modifier: 'flex-1', breakpoint: 'sm' }]} />)
+  expect(view.find('div').prop('className')).not.toMatch(/undefined/)
+});

--- a/packages/patternfly-4/react-core/src/layouts/Flex/FlexUtils.tsx
+++ b/packages/patternfly-4/react-core/src/layouts/Flex/FlexUtils.tsx
@@ -108,5 +108,5 @@ export interface FlexItemBreakpointMod {
   /** The attribute to modify  */
   modifier: keyof typeof FlexItemModifiers;
   /** The breakpoint at which to apply the modifier */
-  breakpoint?: FlexBreakpoints;
+  breakpoint?: keyof typeof FlexBreakpoints;
 }


### PR DESCRIPTION
FlexItem gave TS errors when string literals were used, e.g. `breakpoint: 'sm'`. It was working fine when used with the enum `breakpoint: FlexBreakpoints.xl`

Closes: #3547 