### PR TITLE
fix(ci): stop caching stale doc builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,6 @@ references:
     cypress-v{{.Environment.CACHE_VERSION}}-{{checksum "yarn.lock"}}
   build_cache_key: &build_cache_key
     build-cache-v{{.Environment.CACHE_VERSION}}-{{checksum "yarn.lock"}}
-  doc_build_cache_key: &doc_build_cache_key
-    doc-build-v{{.Environment.CACHE_VERSION}}-{{checksum "yarn.lock"}}
   doc_build_cache_paths: &doc_build_cache_paths
   - packages/patternfly-4/react-docs/.cache
   - packages/patternfly-4/react-docs/public
@@ -262,17 +260,14 @@ jobs:
     - restore_cache:
         keys:
         - *js_deps_cache_key
-    - restore_cache:
-        keys:
-        - *doc_build_cache_key
     - *install_node
     - *install_yarn
     - run:
         name: Build patternfly-react docs
         command: ~/.yarn/bin/yarn build:docs
-    - save_cache:
+    - persist_to_workspace:
+        root: ~/project
         paths: *doc_build_cache_paths
-        key: *doc_build_cache_key
   test_a11y_pf4:
     docker:
     - image: circleci/node:10-browsers
@@ -281,9 +276,6 @@ jobs:
     - restore_cache:
         keys:
         - *js_deps_cache_key
-    - restore_cache:
-        keys:
-        - *doc_build_cache_key
     - run:
         name: PF4 a11y tests
         command: yarn test:a11y || true
@@ -294,9 +286,6 @@ jobs:
     - image: circleci/node:10
     steps:
     - *attach_workspace
-    - restore_cache:
-        keys:
-        - *doc_build_cache_key
     - run:
         name: Copy to docs folder
         command: .circleci/copy-docs.sh

--- a/.circleci/copy-docs.sh
+++ b/.circleci/copy-docs.sh
@@ -4,7 +4,6 @@ mkdir -p docs
 cp -r .out docs/patternfly-3
 cp -r packages/patternfly-4/react-docs/public docs/patternfly-4
 cp .circleci/index.html docs/index.html
-cp -r packages/patternfly-4/react-integration/results/test-html-report.html docs/patternfly-4
 # These need to be at the root for CSS variables
 cp -r docs/patternfly-4/assets docs/assets
 # Use newer favicon


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Revert some of #3295 which aggressively cached our docs in order to show the Cypress coverage results. This PR stops uploading them to Surge for now.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
