### PR TITLE
feat(Popover): add min-width override property

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
@@ -70,6 +70,8 @@ export interface PopoverProps {
    * Instead, the consumer is responsible for closing the popover themselves by adding a callback listener for the shouldClose prop.
    */
   isVisible?: boolean;
+  /** Minimum width of the popover (default 6.25rem) */
+  minWidth?: string;
   /** Maximum width of the popover (default 18.75rem) */
   maxWidth?: string;
   /** Lifecycle function invoked when the popover has fully transitioned out. */
@@ -167,6 +169,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
   }
 
   storeTippyInstance = (tip: TippyInstance) => {
+    if(this.props.minWidth) tip.popperChildren.tooltip.style.minWidth = this.props.minWidth;
     tip.popperChildren.tooltip.classList.add(styles.popover);
     this.tip = tip;
   };
@@ -236,6 +239,7 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
       onShown,
       onMount,
       zIndex,
+      minWidth,
       maxWidth,
       closeBtnAriaLabel,
       distance,

--- a/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
+++ b/packages/patternfly-4/react-core/src/components/Popover/Popover.tsx
@@ -169,7 +169,9 @@ export class Popover extends React.Component<PopoverProps, PopoverState> {
   }
 
   storeTippyInstance = (tip: TippyInstance) => {
-    if(this.props.minWidth) tip.popperChildren.tooltip.style.minWidth = this.props.minWidth;
+    if (this.props.minWidth) {
+      tip.popperChildren.tooltip.style.minWidth = this.props.minWidth;
+    }
     tip.popperChildren.tooltip.classList.add(styles.popover);
     this.tip = tip;
   };

--- a/packages/patternfly-4/react-core/src/components/Popover/__tests__/Popover.test.tsx
+++ b/packages/patternfly-4/react-core/src/components/Popover/__tests__/Popover.test.tsx
@@ -21,6 +21,26 @@ test('popover renders close-button, header and body', () => {
   expect(view).toMatchSnapshot();
 });
 
+test('popover can have a custom minimum width', () => {
+  const view = shallow(
+    <Popover
+      position="top"
+      isVisible
+      minWidth="600px"
+      hideOnOutsideClick
+      headerContent={<div>Popover Header</div>}
+      bodyContent={
+        <div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam id feugiat augue, nec fringilla turpis.
+        </div>
+      }
+    >
+      <div>Toggle Popover</div>
+    </Popover>
+  );
+  expect(view).toMatchSnapshot();
+});
+
 test('popover can specify position as object value', () => {
   const view = shallow(
     <Popover

--- a/packages/patternfly-4/react-core/src/components/Popover/__tests__/__snapshots__/Popover.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/Popover/__tests__/__snapshots__/Popover.test.tsx.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`popover can have a custom minimum width 1`] = `
+<PopoverBase
+  appendTo={[Function]}
+  arrow={true}
+  boundary="window"
+  content={<React.Fragment />}
+  distance={25}
+  flip={true}
+  flipBehavior={
+    Array [
+      "top",
+      "right",
+      "bottom",
+      "left",
+      "top",
+      "right",
+      "bottom",
+    ]
+  }
+  hideOnClick={false}
+  interactive={true}
+  interactiveBorder={0}
+  isVisible={true}
+  lazy={true}
+  maxWidth="calc(2rem + 18.75rem)"
+  onCreate={[Function]}
+  onHidden={[Function]}
+  onHide={[Function]}
+  onMount={[Function]}
+  onShow={[Function]}
+  onShown={[Function]}
+  placement="top"
+  popperOptions={
+    Object {
+      "modifiers": Object {
+        "hide": Object {
+          "enabled": true,
+        },
+        "preventOverflow": Object {
+          "enabled": true,
+        },
+      },
+    }
+  }
+  theme="pf-popover"
+  trigger="manual"
+  zIndex={9999}
+>
+  <div>
+    Toggle Popover
+  </div>
+</PopoverBase>
+`;
+
 exports[`popover can specify position as object value 1`] = `
 <PopoverBase
   appendTo={[Function]}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #3192 . Adds in an optional `midWidth` property that will override the default and allow a custom minimum width on the popover.

Update: the default min-width property will be adjusted to match max-width, making both examples match. This PR could still be added in if we want to allow users to customize the width of a popover.
