### PR TITLE
Column functions are not always equal

### DIFF
--- a/packages/patternfly-4/react-table/src/components/Table/base/columns-are-equal.ts
+++ b/packages/patternfly-4/react-table/src/components/Table/base/columns-are-equal.ts
@@ -10,7 +10,7 @@ import { ColumnsType } from './types';
 export function columnsAreEqual(oldColumns: ColumnsType, newColumns: ColumnsType) {
   return isEqualWith(oldColumns, newColumns, (a, b) => {
     if (isFunction(a) && isFunction(b)) {
-      return true;
+      return a === b;
     }
 
     return undefined;


### PR DESCRIPTION
 - This is important when using [React hooks](https://reactjs.org/docs/hooks-state.html)

Fixes #3620

In my case, I'm using the Table and passing a `onCollapse` method within a React component that uses hooks.

I need the columns that are a function, but a different one, to be updated, I'm using as example `onCollapse`, but this applies to any other column.

Consider below code:

```ts

interface RowState {
    isOpen: boolean;
    // more stuff
}

export const PolicyTable: React.FunctionComponent<PolicyTableProps> = (props) => {

    const [ rowsState, setRowsState ] = React.useState<Record<string, RowState>>({});

    const onCollapse = (_event, idx: number, isOpen: boolean) => {
        const rowState = { ...rowsState[idx], isOpen };
        const newRowsState = { ...rowsState };
        newRowsState[idx] = rowState;
        setRowsState(setRowsState);
    }

    // Other props not show for simplicity
    return <Table
        onCollapse={ onCollapse }
    />
}

```

With this in place, on first render, all the rows have my initial `rowState` value.
If i click the first cell, only that cell is going to have the updated `rowState` (where it is open) and the others will have the old `rowState` (nothing open).
When clicking the second row, it will discard my modified `rowState` (because this cell doesn't have access to it) and only open what I clicked.

See below gif without the contents of this PR:

![without-pr-content](https://user-images.githubusercontent.com/3845764/73317014-52807080-41fa-11ea-9176-5fff22a16b7a.gif)

and with this PR content:

![with-pr-content](https://user-images.githubusercontent.com/3845764/73317021-590ee800-41fa-11ea-8069-15f3259848b9.gif)

