### PR TITLE
Changed ouia variable name in localStorage in order to comply with spec

### DIFF
--- a/packages/patternfly-4/react-core/src/components/withOuia/ouia.ts
+++ b/packages/patternfly-4/react-core/src/components/withOuia/ouia.ts
@@ -1,6 +1,6 @@
 export const isOUIAEnvironment = (): boolean => {
   try {
-    return (typeof window !== 'undefined' && window.localStorage && window.localStorage.ouia && window.localStorage.ouia.toLowerCase() === 'true') ||
+    return (typeof window !== 'undefined' && window.localStorage && window.localStorage.getItem("ouia:enabled") && window.localStorage["ouia:enabled"].toLowerCase() === 'true') ||
     false;
   } catch (exception) {
     return false;


### PR DESCRIPTION
According to OUIA spec:

> If OUIA attributes are not enabled by default there SHOULD be an HTML local storage variable ouia:enabled, to enable the usage of these attributes. Such action MAY incur a page restart.

This PR makes localStorage ouia related item to comply with the spec.

Fixes  #3625 