### PR TITLE
fix(Catalog Tile): Adjusted max height of header image

### DIFF
--- a/packages/patternfly-4/react-catalog-view-extension/sass/react-catalog-view-extension/_catalog-tile.scss
+++ b/packages/patternfly-4/react-catalog-view-extension/sass/react-catalog-view-extension/_catalog-tile.scss
@@ -42,7 +42,7 @@
 .catalog-tile-pf-icon {
   font-size: 40px;
   height: 40px;
-  max-width: 80px;
+  max-width: 60px;
   min-width: 40px;
 }
 

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/CatalogTile/examples/catalogTile.css
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/CatalogTile/examples/catalogTile.css
@@ -27,7 +27,7 @@
 .ws-react-c-catalogtile .catalog-tile-pf-icon {
   font-size: 40px;
   height: 40px;
-  max-width: 80px;
+  max-width: 60px;
   min-width: 40px;
 }
 .ws-react-c-catalogtile .catalog-tile-pf-badge-container {


### PR DESCRIPTION
Fixing bug where badging wraps at two lines when you have a wider wordmark. We're just shrinking down the max width of the provided image in the header here.

<img width="268" alt="Screen Shot 2020-01-30 at 1 27 38 PM" src="https://user-images.githubusercontent.com/7014965/73478610-647e2280-4364-11ea-80ef-861d085d0142.png">
