### PR TITLE
fix(Catalog view extension): Many styles on examples stopped working

### DIFF
--- a/packages/patternfly-4/react-catalog-view-extension/src/components/CatalogItemHeader/examples/catalogItemHeader.css
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/CatalogItemHeader/examples/catalogItemHeader.css
@@ -1,27 +1,27 @@
-.ws-react-c-catalogitemheader .text-overflow-pf {
+.ws-react-e-catalogitemheader .text-overflow-pf {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   word-wrap: normal;
 }
-.ws-react-c-catalogitemheader .catalog-item-header-pf {
+.ws-react-e-catalogitemheader .catalog-item-header-pf {
   display: flex;
   align-items: center;
 }
-.ws-react-c-catalogitemheader .catalog-item-header-pf-icon {
+.ws-react-e-catalogitemheader .catalog-item-header-pf-icon {
   font-size: 60px;
   max-height: 60px;
   width: 60px;
 }
-.ws-react-c-catalogitemheader .catalog-item-header-pf-text {
+.ws-react-e-catalogitemheader .catalog-item-header-pf-text {
   margin-left: 20px;
 }
-.ws-react-c-catalogitemheader .catalog-item-header-pf-title {
+.ws-react-e-catalogitemheader .catalog-item-header-pf-title {
   font-weight: 400;
   margin-bottom: 0;
   margin-top: 0;
 }
-.ws-react-c-catalogitemheader .catalog-item-header-pf-subtitle {
+.ws-react-e-catalogitemheader .catalog-item-header-pf-subtitle {
   color: #8b8d8f;
   font-size: small;
   margin-bottom: 0;

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/CatalogTile/examples/catalogTile.css
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/CatalogTile/examples/catalogTile.css
@@ -1,53 +1,53 @@
-.ws-react-c-catalogtile .catalog-tile-pf.featured {
+.ws-react-e-catalogtile .catalog-tile-pf.featured {
   border-top: 2px solid #39a5dc;
 }
-.ws-react-c-catalogtile .catalog-tile-pf:active, .ws-react-c-catalogtile .catalog-tile-pf:hover, .ws-react-c-catalogtile .catalog-tile-pf:focus, .ws-react-c-catalogtile .catalog-tile-pf:visited {
+.ws-react-e-catalogtile .catalog-tile-pf:active, .ws-react-e-catalogtile .catalog-tile-pf:hover, .ws-react-e-catalogtile .catalog-tile-pf:focus, .ws-react-e-catalogtile .catalog-tile-pf:visited {
   color: inherit;
   text-decoration: none;
 }
-.ws-react-c-catalogtile .catalog-tile-pf-header {
+.ws-react-e-catalogtile .catalog-tile-pf-header {
   font-size: 16px;
   font-weight: 400;
 }
-.ws-react-c-catalogtile .catalog-tile-pf-header .catalog-tile-pf-title {
+.ws-react-e-catalogtile .catalog-tile-pf-header .catalog-tile-pf-title {
   font-weight: 400;
 }
-.ws-react-c-catalogtile .catalog-tile-pf-header .catalog-tile-pf-subtitle {
+.ws-react-e-catalogtile .catalog-tile-pf-header .catalog-tile-pf-subtitle {
   color: #4D5258;
   font-size: small;
 }
-.ws-react-c-catalogtile .catalog-tile-pf-header .catalog-tile-pf-subtitle a {
+.ws-react-e-catalogtile .catalog-tile-pf-header .catalog-tile-pf-subtitle a {
   color: #0066CC;
   text-decoration: none;
 }
-.ws-react-c-catalogtile .catalog-tile-pf-header .catalog-tile-pf-subtitle a:hover {
+.ws-react-e-catalogtile .catalog-tile-pf-header .catalog-tile-pf-subtitle a:hover {
   color: #004080;
   text-decoration: underline;
 }
-.ws-react-c-catalogtile .catalog-tile-pf-icon {
+.ws-react-e-catalogtile .catalog-tile-pf-icon {
   font-size: 40px;
   height: 40px;
   max-width: 80px;
   min-width: 40px;
 }
-.ws-react-c-catalogtile .catalog-tile-pf-badge-container {
+.ws-react-e-catalogtile .catalog-tile-pf-badge-container {
   display: flex;
   flex: 1;
   justify-content: flex-end;
 }
-.ws-react-c-catalogtile .catalog-tile-pf-badge-container .catalog-tile-pf-badge {
+.ws-react-e-catalogtile .catalog-tile-pf-badge-container .catalog-tile-pf-badge {
   font-size: 16px;
   margin-left: 5px;
 }
-.ws-react-c-catalogtile .catalog-tile-pf-body .catalog-tile-pf-description span {
+.ws-react-e-catalogtile .catalog-tile-pf-body .catalog-tile-pf-description span {
   display: -webkit-box;
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
 }
-.ws-react-c-catalogtile .catalog-tile-pf-body .catalog-tile-pf-description span.has-footer {
+.ws-react-e-catalogtile .catalog-tile-pf-body .catalog-tile-pf-description span.has-footer {
   -webkit-line-clamp: 1;
 }
-.ws-react-c-catalogtile .example-ok-icon {
+.ws-react-e-catalogtile .example-ok-icon {
   color: #4CB140;
 }

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/VerticalTabs/examples/verticalTab.css
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/VerticalTabs/examples/verticalTab.css
@@ -1,16 +1,16 @@
-.ws-react-c-verticaltabs .vertical-tabs-pf {
+.ws-react-e-verticaltabs .vertical-tabs-pf {
   list-style: none;
   margin: 0 0 30px;
   padding: 0;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf .vertical-tabs-pf {
+.ws-react-e-verticaltabs .vertical-tabs-pf .vertical-tabs-pf {
   margin-bottom: 0;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf-tab {
+.ws-react-e-verticaltabs .vertical-tabs-pf-tab {
   margin-top: 4px;
   position: relative;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf-tab > a {
+.ws-react-e-verticaltabs .vertical-tabs-pf-tab > a {
   color: initial;
   display: inline-block;
   font-size: 13px;
@@ -19,50 +19,50 @@
   width: 100%;
   word-break: break-word;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf-tab > a:hover, .ws-react-c-verticaltabs .vertical-tabs-pf-tab > a:focus {
+.ws-react-e-verticaltabs .vertical-tabs-pf-tab > a:hover, .ws-react-e-verticaltabs .vertical-tabs-pf-tab > a:focus {
   color: #0088ce;
   text-decoration: none;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf-tab > a.no-wrap {
+.ws-react-e-verticaltabs .vertical-tabs-pf-tab > a.no-wrap {
   overflow-x: hidden;
   white-space: nowrap;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf-tab > a.truncate {
+.ws-react-e-verticaltabs .vertical-tabs-pf-tab > a.truncate {
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf-tab.active > a {
+.ws-react-e-verticaltabs .vertical-tabs-pf-tab.active > a {
   color: #0088ce;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf-tab.active > a::before {
+.ws-react-e-verticaltabs .vertical-tabs-pf-tab.active > a::before {
   background: #0088ce;
   content: " ";
   left: 0;
   position: absolute;
   width: 3px;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf-tab:first-of-type {
+.ws-react-e-verticaltabs .vertical-tabs-pf-tab:first-of-type {
   margin-top: 0;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf-tab > .vertical-tabs-pf > .vertical-tabs-pf-tab {
+.ws-react-e-verticaltabs .vertical-tabs-pf-tab > .vertical-tabs-pf > .vertical-tabs-pf-tab {
   position: initial;
   padding-left: 15px;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf.restrict-tabs {
+.ws-react-e-verticaltabs .vertical-tabs-pf.restrict-tabs {
   /* Show siblings of the active tab */
   /* Show the direct children of an active tab */
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf.restrict-tabs .vertical-tabs-pf-tab {
+.ws-react-e-verticaltabs .vertical-tabs-pf.restrict-tabs .vertical-tabs-pf-tab {
   display: none;
   /* Show any active tab, tab that has an active descendant, or is force shown */
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf.restrict-tabs .vertical-tabs-pf-tab.active, .ws-react-c-verticaltabs .vertical-tabs-pf.restrict-tabs .vertical-tabs-pf-tab.active-descendant, .ws-react-c-verticaltabs .vertical-tabs-pf.restrict-tabs .vertical-tabs-pf-tab.shown {
+.ws-react-e-verticaltabs .vertical-tabs-pf.restrict-tabs .vertical-tabs-pf-tab.active, .ws-react-e-verticaltabs .vertical-tabs-pf.restrict-tabs .vertical-tabs-pf-tab.active-descendant, .ws-react-e-verticaltabs .vertical-tabs-pf.restrict-tabs .vertical-tabs-pf-tab.shown {
   display: block;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf.restrict-tabs.active-tab > .vertical-tabs-pf-tab {
+.ws-react-e-verticaltabs .vertical-tabs-pf.restrict-tabs.active-tab > .vertical-tabs-pf-tab {
   display: block;
 }
-.ws-react-c-verticaltabs .vertical-tabs-pf.restrict-tabs .vertical-tabs-pf-tab.active > .vertical-tabs-pf > .vertical-tabs-pf-tab {
+.ws-react-e-verticaltabs .vertical-tabs-pf.restrict-tabs .vertical-tabs-pf-tab.active > .vertical-tabs-pf > .vertical-tabs-pf-tab {
   display: block;
 }


### PR DESCRIPTION
Many styles on examples stopped working. This change restores all styles on affected examples.

Changed classes to reflect the structure of the HTML, which appears to have changed.

Fixes #3633.