### PR TITLE
fix(Catalog tile): Reduce padding between badge and logo

### DIFF
--- a/packages/patternfly-4/react-catalog-view-extension/sass/react-catalog-view-extension/_catalog-tile.scss
+++ b/packages/patternfly-4/react-catalog-view-extension/sass/react-catalog-view-extension/_catalog-tile.scss
@@ -10,6 +10,10 @@
     color: inherit;
     text-decoration: none;
   }
+
+  .pf-c-card__actions {
+    padding-left: 5px;
+  }
 }
 
 .catalog-tile-pf-header {

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/CatalogTile/examples/catalogTile.css
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/CatalogTile/examples/catalogTile.css
@@ -24,6 +24,9 @@
   color: #004080;
   text-decoration: underline;
 }
+.ws-react-e-catalogtile .pf-c-card__actions {
+  padding-left: 5px;
+}
 .ws-react-e-catalogtile .catalog-tile-pf-icon {
   font-size: 40px;
   height: 40px;
@@ -34,6 +37,7 @@
   display: flex;
   flex: 1;
   justify-content: flex-end;
+  margin-left: 10px;
 }
 .ws-react-e-catalogtile .catalog-tile-pf-badge-container .catalog-tile-pf-badge {
   font-size: 16px;


### PR DESCRIPTION
Reducing padding between the badge and logo to avoid text wrapping on relatively short badges in OpenShift.