### PR TITLE
fix(Slider): Add limit for lowest possible value of slider

### DIFF
--- a/packages/patternfly-3/patternfly-react/src/components/Slider/Slider.js
+++ b/packages/patternfly-3/patternfly-react/src/components/Slider/Slider.js
@@ -24,7 +24,8 @@ class Slider extends React.Component {
   }
 
   onSlide = value => {
-    this.setState({ value }, () => this.props.onSlide(value));
+    const newValue = value < this.props.min ? this.props.min : value;
+    this.setState({ value: newValue }, () => this.props.onSlide(newValue));
   };
 
   onInputChange = event => {


### PR DESCRIPTION
When using the arrow keys to control the slider, it was possible to go below the set minimum value
on the slider. (-1 for a minimum of 0, 0 for a minimum of 1, and so on.) I added a minimum value check for the slider value.

Fixes #3187.
