### PR TITLE
Remove width attr from BackgroundImage filter element

### DIFF
--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.tsx
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.tsx
@@ -78,7 +78,7 @@ export const BackgroundImage: React.FunctionComponent<BackgroundImageProps> = ({
   return (
     <div className={css(styles.backgroundImage, bgStyles.bgOverrides, className)} {...props}>
       <svg xmlns="http://www.w3.org/2000/svg" className="pf-c-background-image__filter" width="0" height="0">
-        <filter id="image_overlay" width="">
+        <filter id="image_overlay" width="120%">
           <feColorMatrix
             type="matrix"
             values="1 0 0 0 0

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.tsx
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/BackgroundImage.tsx
@@ -78,7 +78,7 @@ export const BackgroundImage: React.FunctionComponent<BackgroundImageProps> = ({
   return (
     <div className={css(styles.backgroundImage, bgStyles.bgOverrides, className)} {...props}>
       <svg xmlns="http://www.w3.org/2000/svg" className="pf-c-background-image__filter" width="0" height="0">
-        <filter id="image_overlay" width="120%">
+        <filter id="image_overlay">
           <feColorMatrix
             type="matrix"
             values="1 0 0 0 0

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/__tests__/Generated/__snapshots__/BackgroundImage.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/__tests__/Generated/__snapshots__/BackgroundImage.test.tsx.snap
@@ -12,7 +12,6 @@ exports[`BackgroundImage should match snapshot (auto-generated) 1`] = `
   >
     <filter
       id="image_overlay"
-      width="120%"
     >
       <feColorMatrix
         type="matrix"

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/__tests__/Generated/__snapshots__/BackgroundImage.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/__tests__/Generated/__snapshots__/BackgroundImage.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`BackgroundImage should match snapshot (auto-generated) 1`] = `
   >
     <filter
       id="image_overlay"
-      width=""
+      width="120%"
     >
       <feColorMatrix
         type="matrix"

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/__tests__/__snapshots__/BackgroundImage.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/__tests__/__snapshots__/BackgroundImage.test.tsx.snap
@@ -12,7 +12,6 @@ exports[`BackgroundImage 1`] = `
   >
     <filter
       id="image_overlay"
-      width="120%"
     >
       <feColorMatrix
         type="matrix"
@@ -56,7 +55,6 @@ exports[`BackgroundImage 2`] = `
   >
     <filter
       id="image_overlay"
-      width="120%"
     >
       <feColorMatrix
         type="matrix"
@@ -100,7 +98,6 @@ exports[`allows passing in a single string as the image src 1`] = `
   >
     <filter
       id="image_overlay"
-      width="120%"
     >
       <feColorMatrix
         type="matrix"

--- a/packages/patternfly-4/react-core/src/components/BackgroundImage/__tests__/__snapshots__/BackgroundImage.test.tsx.snap
+++ b/packages/patternfly-4/react-core/src/components/BackgroundImage/__tests__/__snapshots__/BackgroundImage.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`BackgroundImage 1`] = `
   >
     <filter
       id="image_overlay"
-      width=""
+      width="120%"
     >
       <feColorMatrix
         type="matrix"
@@ -56,7 +56,7 @@ exports[`BackgroundImage 2`] = `
   >
     <filter
       id="image_overlay"
-      width=""
+      width="120%"
     >
       <feColorMatrix
         type="matrix"
@@ -100,7 +100,7 @@ exports[`allows passing in a single string as the image src 1`] = `
   >
     <filter
       id="image_overlay"
-      width=""
+      width="120%"
     >
       <feColorMatrix
         type="matrix"


### PR DESCRIPTION
This PR removes the `width` attribute for the filter element in BackgroundImage. Looks like it could also be set to the default value of 120%, but omitting it also seems to work so taking that route. Should help clear console errors when using this component.

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/3250


