### PR TITLE
fix(version): version updated in react-core for react-icons

### DIFF
--- a/packages/patternfly-4/react-core/package.json
+++ b/packages/patternfly-4/react-core/package.json
@@ -39,7 +39,7 @@
     "develop": "yarn build:babel:esm --skip-initial-build --watch --verbose"
   },
   "dependencies": {
-    "@patternfly/react-icons": "^3.15.1",
+    "@patternfly/react-icons": "^3.15.0",
     "@patternfly/react-styles": "^3.7.2",
     "@patternfly/react-tokens": "^2.8.2",
     "emotion": "^9.2.9",


### PR DESCRIPTION
Change version for react-icons from 3.15.1 to 3.15.0 