### PR TITLE
feat(radio): allow radios to be "inoperable"

### DIFF
--- a/packages/react-core/src/components/Card/examples/Card.md
+++ b/packages/react-core/src/components/Card/examples/Card.md
@@ -7,7 +7,7 @@ propComponents: ['Card', 'CardHeadMain', 'CardHeader', 'CardBody', 'CardFooter']
 ---
 
 import { Brand, Card, CardActions, CardHead, CardHeadMain, CardHeader, CardBody, CardFooter, Checkbox, DropdownActions } from '@patternfly/react-core';
-import pfLogo from './pfLogo.svg'; 
+import pfLogo from './pfLogo.svg';
 
 ## Examples
 ```js title=Basic
@@ -24,9 +24,9 @@ SimpleCard = () => (
 ```
 
 ```js title=With-image-and-actions
-import React from 'react'; 
-import { Brand, Card, CardHead, CardHeadMain, CardActions, CardHeader, CardBody, CardFooter, Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownPosition, DropdownDirection, KebabToggle, } from '@patternfly/react-core'; 
-import pfLogo from './pfLogo.svg'; 
+import React from 'react';
+import { Brand, Card, CardHead, CardHeadMain, CardActions, CardHeader, CardBody, CardFooter, Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownPosition, DropdownDirection, KebabToggle, } from '@patternfly/react-core';
+import pfLogo from './pfLogo.svg';
 
 class KebabDropdown extends React.Component {
   constructor(props) {
@@ -46,11 +46,11 @@ class KebabDropdown extends React.Component {
       });
     };
     this.onClick = (checked, event) => {
-      const target = event.target; 
-      const value = target.type === 'checkbox' ? target.checked : target.value; 
-      const name = target.name; 
-      this.setState({ [name]: value }); 
-    }; 
+      const target = event.target;
+      const value = target.type === 'checkbox' ? target.checked : target.value;
+      const name = target.name;
+      this.setState({ [name]: value });
+    };
   }
 
   render() {
@@ -88,7 +88,7 @@ class KebabDropdown extends React.Component {
               position={'right'}
             />
             <input
-              type="checkbox" 
+              type="checkbox"
               isChecked={this.state.check1}
               onChange={this.onClick}
               aria-label="card checkbox example"
@@ -107,15 +107,15 @@ class KebabDropdown extends React.Component {
 ```
 
 ```js title=Card-header-in-card-head
- import React from 'react'; 
-import { Card, CardHead, CardActions, CardHeader, CardBody, CardFooter, Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownPosition, DropdownDirection, KebabToggle } from '@patternfly/react-core'; 
+ import React from 'react';
+import { Card, CardHead, CardActions, CardHeader, CardBody, CardFooter, Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownPosition, DropdownDirection, KebabToggle } from '@patternfly/react-core';
 
 class KebabDropdown extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       isOpen: false,
-      check1: false
+      check2: false
     };
     this.onToggle = isOpen => {
       this.setState({
@@ -128,11 +128,11 @@ class KebabDropdown extends React.Component {
       });
     };
     this.onClick = (checked, event) => {
-      const target = event.target; 
-      const value = target.type === 'checkbox' ? target.checked : target.value; 
-      const name = target.name; 
-      this.setState({ [name]: value }); 
-    }; 
+      const target = event.target;
+      const value = target.type === 'checkbox' ? target.checked : target.value;
+      const name = target.name;
+      this.setState({ [name]: value });
+    };
   }
 
   render() {
@@ -167,12 +167,12 @@ class KebabDropdown extends React.Component {
               position={'right'}
             />
             <input
-              type="checkbox" 
-              isChecked={this.state.check1}
+              type="checkbox"
+              isChecked={this.state.check2}
               onChange={this.onClick}
               aria-label="card checkbox example"
-              id="check-1"
-              name="check1"
+              id="check-2"
+              name="check2"
             />
           </CardActions>
         <CardHeader>This is a really really really really really really really really really really long header</CardHeader>
@@ -186,15 +186,15 @@ class KebabDropdown extends React.Component {
 ```
 
 ```js title=Only-actions-in-card-head-(no-header/footer)
- import React from 'react'; 
-import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownPosition, DropdownDirection, KebabToggle, Card, CardHead, CardActions, CardHeader, CardBody } from '@patternfly/react-core'; 
+ import React from 'react';
+import { Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownPosition, DropdownDirection, KebabToggle, Card, CardHead, CardActions, CardHeader, CardBody } from '@patternfly/react-core';
 
 class KebabDropdown extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       isOpen: false,
-      check1: false
+      check3: false
     };
     this.onToggle = isOpen => {
       this.setState({
@@ -207,11 +207,11 @@ class KebabDropdown extends React.Component {
       });
     };
     this.onClick = (checked, event) => {
-      const target = event.target; 
-      const value = target.type === 'checkbox' ? target.checked : target.value; 
-      const name = target.name; 
-      this.setState({ [name]: value }); 
-    }; 
+      const target = event.target;
+      const value = target.type === 'checkbox' ? target.checked : target.value;
+      const name = target.name;
+      this.setState({ [name]: value });
+    };
   }
 
   render() {
@@ -246,12 +246,12 @@ class KebabDropdown extends React.Component {
               position={'right'}
             />
             <input
-              type="checkbox" 
-              isChecked={this.state.check1}
+              type="checkbox"
+              isChecked={this.state.check3}
               onChange={this.onClick}
               aria-label="card checkbox example"
-              id="check-1"
-              name="check1"
+              id="check-3"
+              name="check3"
             />
           </CardActions>
         </CardHead>
@@ -272,7 +272,7 @@ ImageCard = () => (
       <CardHeadMain>
         <Brand src={pfLogo} alt="PatternFly logo" style={{ height: '50px' }}/>
       </CardHeadMain>
-    </CardHead> 
+    </CardHead>
     <CardHeader>Header</CardHeader>
     <CardBody>Body</CardBody>
     <CardFooter>Footer</CardFooter>
@@ -373,7 +373,7 @@ HoverableCard = () => (
 
 ```js title=Selectable-and-selected
 import React from 'react';
-import { Card, CardHead, CardActions, CardHeader, CardBody, Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownPosition, DropdownDirection, KebabToggle, } from '@patternfly/react-core'; 
+import { Card, CardHead, CardActions, CardHeader, CardBody, Dropdown, DropdownToggle, DropdownItem, DropdownSeparator, DropdownPosition, DropdownDirection, KebabToggle, } from '@patternfly/react-core';
 
 class SelectableCard extends React.Component {
   constructor(props) {
@@ -397,7 +397,7 @@ class SelectableCard extends React.Component {
       this.setState({
         selected: newSelected
       })
-    }; 
+    };
     this.onToggle = (isOpen, event) => {
       event.stopPropagation()
       this.setState({

--- a/packages/react-core/src/components/Radio/__tests__/Generated/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react-core/src/components/Radio/__tests__/Generated/__snapshots__/Radio.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Radio should match snapshot (auto-generated) 1`] = `
 <label
   className="pf-c-radio ''"
   htmlFor="string"
+  tabIndex={null}
 >
   <span
     className="pf-c-radio__label"
@@ -13,6 +14,7 @@ exports[`Radio should match snapshot (auto-generated) 1`] = `
     </div>
   </span>
   <input
+    aria-disabled={null}
     aria-invalid={false}
     checked={true}
     className="pf-c-radio__input"
@@ -20,6 +22,7 @@ exports[`Radio should match snapshot (auto-generated) 1`] = `
     id="string"
     name="string"
     onChange={[Function]}
+    tabIndex={null}
     type="radio"
   />
   <div

--- a/packages/react-core/src/components/Radio/__tests__/Radio.test.tsx
+++ b/packages/react-core/src/components/Radio/__tests__/Radio.test.tsx
@@ -22,6 +22,13 @@ describe('Radio check component', () => {
     expect(view).toMatchSnapshot();
   });
 
+  test('isInoperable', () => {
+    const view = shallow(
+      <Radio id="inoperable-check" isInoperable aria-label="check" name="inoperable-check" />
+    );
+    expect(view).toMatchSnapshot();
+  });
+
   test('isLabelBeforeButton', () => {
     const view = shallow(<Radio id="check" isLabelBeforeButton label="Radio label" aria-label="check" name="check" />);
     expect(view).toMatchSnapshot();

--- a/packages/react-core/src/components/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react-core/src/components/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -3,8 +3,10 @@
 exports[`Radio check component controlled 1`] = `
 <div
   className="pf-c-radio"
+  tabIndex={null}
 >
   <input
+    aria-disabled={null}
     aria-invalid={false}
     aria-label="check"
     checked={true}
@@ -13,6 +15,7 @@ exports[`Radio check component controlled 1`] = `
     id="check"
     name="check"
     onChange={[Function]}
+    tabIndex={null}
     type="radio"
   />
 </div>
@@ -21,8 +24,10 @@ exports[`Radio check component controlled 1`] = `
 exports[`Radio check component isDisabled 1`] = `
 <div
   className="pf-c-radio"
+  tabIndex={null}
 >
   <input
+    aria-disabled={null}
     aria-invalid={false}
     aria-label="check"
     className="pf-c-radio__input"
@@ -30,6 +35,29 @@ exports[`Radio check component isDisabled 1`] = `
     id="check"
     name="check"
     onChange={[Function]}
+    tabIndex={null}
+    type="radio"
+  />
+</div>
+`;
+
+exports[`Radio check component isInoperable 1`] = `
+<div
+  className="pf-c-radio pf-m-inoperable"
+  tabIndex={0}
+>
+  <input
+    aria-disabled={true}
+    aria-invalid={false}
+    aria-label="check"
+    className="pf-c-radio__input pf-m-inoperable"
+    disabled={false}
+    id="inoperable-check"
+    name="inoperable-check"
+    onChange={[Function]}
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    tabIndex={-1}
     type="radio"
   />
 </div>
@@ -38,6 +66,7 @@ exports[`Radio check component isDisabled 1`] = `
 exports[`Radio check component isLabelBeforeButton 1`] = `
 <div
   className="pf-c-radio"
+  tabIndex={null}
 >
   <label
     className="pf-c-radio__label"
@@ -46,12 +75,14 @@ exports[`Radio check component isLabelBeforeButton 1`] = `
     Radio label
   </label>
   <input
+    aria-disabled={null}
     aria-invalid={false}
     className="pf-c-radio__input"
     disabled={false}
     id="check"
     name="check"
     onChange={[Function]}
+    tabIndex={null}
     type="radio"
   />
 </div>
@@ -61,14 +92,17 @@ exports[`Radio check component isLabelWrapped 1`] = `
 <label
   className="pf-c-radio"
   htmlFor="check"
+  tabIndex={null}
 >
   <input
+    aria-disabled={null}
     aria-invalid={false}
     className="pf-c-radio__input"
     disabled={false}
     id="check"
     name="check"
     onChange={[Function]}
+    tabIndex={null}
     type="radio"
   />
   <span
@@ -82,8 +116,10 @@ exports[`Radio check component isLabelWrapped 1`] = `
 exports[`Radio check component label is function 1`] = `
 <div
   className="pf-c-radio"
+  tabIndex={null}
 >
   <input
+    aria-disabled={null}
     aria-invalid={false}
     checked={true}
     className="pf-c-radio__input"
@@ -91,6 +127,7 @@ exports[`Radio check component label is function 1`] = `
     id="check"
     name="check"
     onChange={[Function]}
+    tabIndex={null}
     type="radio"
   />
   <label
@@ -107,8 +144,10 @@ exports[`Radio check component label is function 1`] = `
 exports[`Radio check component label is node 1`] = `
 <div
   className="pf-c-radio"
+  tabIndex={null}
 >
   <input
+    aria-disabled={null}
     aria-invalid={false}
     checked={true}
     className="pf-c-radio__input"
@@ -116,6 +155,7 @@ exports[`Radio check component label is node 1`] = `
     id="check"
     name="check"
     onChange={[Function]}
+    tabIndex={null}
     type="radio"
   />
   <label
@@ -132,8 +172,10 @@ exports[`Radio check component label is node 1`] = `
 exports[`Radio check component label is string 1`] = `
 <div
   className="pf-c-radio"
+  tabIndex={null}
 >
   <input
+    aria-disabled={null}
     aria-invalid={false}
     checked={true}
     className="pf-c-radio__input"
@@ -141,6 +183,7 @@ exports[`Radio check component label is string 1`] = `
     id="check"
     name="check"
     onChange={[Function]}
+    tabIndex={null}
     type="radio"
   />
   <label
@@ -155,8 +198,10 @@ exports[`Radio check component label is string 1`] = `
 exports[`Radio check component passing HTML attribute 1`] = `
 <div
   className="pf-c-radio"
+  tabIndex={null}
 >
   <input
+    aria-disabled={null}
     aria-invalid={false}
     aria-labelledby="labelId"
     checked={true}
@@ -165,6 +210,7 @@ exports[`Radio check component passing HTML attribute 1`] = `
     id="check"
     name="check"
     onChange={[Function]}
+    tabIndex={null}
     type="radio"
   />
   <label
@@ -179,8 +225,10 @@ exports[`Radio check component passing HTML attribute 1`] = `
 exports[`Radio check component passing class 1`] = `
 <div
   className="pf-c-radio class-123"
+  tabIndex={null}
 >
   <input
+    aria-disabled={null}
     aria-invalid={false}
     checked={true}
     className="pf-c-radio__input"
@@ -188,6 +236,7 @@ exports[`Radio check component passing class 1`] = `
     id="check"
     name="check"
     onChange={[Function]}
+    tabIndex={null}
     type="radio"
   />
   <label
@@ -202,8 +251,10 @@ exports[`Radio check component passing class 1`] = `
 exports[`Radio check component uncontrolled 1`] = `
 <div
   className="pf-c-radio"
+  tabIndex={null}
 >
   <input
+    aria-disabled={null}
     aria-invalid={false}
     aria-label="check"
     className="pf-c-radio__input"
@@ -211,6 +262,7 @@ exports[`Radio check component uncontrolled 1`] = `
     id="check"
     name="check"
     onChange={[Function]}
+    tabIndex={null}
     type="radio"
   />
 </div>

--- a/packages/react-core/src/components/Radio/examples/Radio.md
+++ b/packages/react-core/src/components/Radio/examples/Radio.md
@@ -5,7 +5,7 @@ cssPrefix: 'pf-c-radio'
 typescript: true
 propComponents: ['Radio']
 ---
-import { Radio } from '@patternfly/react-core';
+import { Radio, Tooltip } from '@patternfly/react-core';
 
 ## Examples
 ```js title=Controlled
@@ -75,6 +75,15 @@ LabelWrapsInputRadio = () => (
 );
 ```
 
+```js title=With-description
+import React from 'react';
+import { Radio } from '@patternfly/react-core';
+
+WithDescriptionRadio = () => (
+  <Radio id="radio-with-description" label="Radio with description example" description="Description" name="radio-5" />
+);
+```
+
 ```js title=Disabled
 import React from 'react';
 import { Radio } from '@patternfly/react-core';
@@ -87,11 +96,22 @@ DisabledRadio = () => (
 );
 ```
 
-```js title=With-description
+```js title=Inoperable-with-wrapping-tooltip
 import React from 'react';
-import { Radio } from '@patternfly/react-core';
+import { Radio, Tooltip } from '@patternfly/react-core';
 
-DisabledRadio = () => (
-  <Radio id="radio-with-description" label="Radio with description example" description="Description" />
+InoperableRadioWithTooltip = () => (
+  <Tooltip content={<div>Radio <strong>component</strong> tooltip content</div>}>
+    <Radio isInoperable id="radio-inoperable-tooltip-label-wrapped" label="Option 1" description="This Radio is inoperable that's nested within a containing Tooltip component" name="radio-7" />
+  </Tooltip>
+);
+```
+
+```js title=Inoperable-with-nested-tooltip
+import React from 'react';
+import { Radio, Tooltip } from '@patternfly/react-core';
+
+InoperableRadioWithInputTooltip = () => (
+    <Radio tooltip={{component: Tooltip, props: {children: null, content: <div>Radio <strong>input</strong> tooltip content</div>, position: 'left'}}} isInoperable id="radio-inoperable-input-tooltip" label="Option 1" description="This Radio is inoperable with a nested tooltip" name="radio-8" />
 );
 ```

--- a/packages/react-core/src/components/Tabs/Tab.tsx
+++ b/packages/react-core/src/components/Tabs/Tab.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Omit } from '../../helpers/typeUtils';
 
 export interface TabProps extends Omit<React.HTMLProps<HTMLAnchorElement | HTMLButtonElement>, 'title'> {
   /** content rendered inside the Tab content area. */

--- a/packages/react-core/src/components/Wizard/Wizard.tsx
+++ b/packages/react-core/src/components/Wizard/Wizard.tsx
@@ -490,6 +490,7 @@ export class Wizard extends React.Component<WizardProps, WizardState> {
             />
           )}
           <WizardToggle
+            stepButtonAriaHidden={isInPage || null}
             isNavOpen={this.state.isNavOpen}
             onNavToggle={isNavOpen => this.setState({ isNavOpen })}
             nav={nav}

--- a/packages/react-core/src/components/Wizard/WizardToggle.tsx
+++ b/packages/react-core/src/components/Wizard/WizardToggle.tsx
@@ -21,6 +21,8 @@ export interface WizardToggleProps {
   isNavOpen: boolean;
   /** Callback function for when the nav is toggled */
   onNavToggle: (isOpen: boolean) => void;
+  /** If the steps button is aria-hidden */
+  stepButtonAriaHidden?: boolean;
 }
 
 export const WizardToggle: React.FunctionComponent<WizardToggleProps> = ({
@@ -30,7 +32,8 @@ export const WizardToggle: React.FunctionComponent<WizardToggleProps> = ({
   steps,
   activeStep,
   children,
-  hasBodyPadding = true
+  hasBodyPadding = true,
+  stepButtonAriaHidden,
 }: WizardToggleProps) => {
   let activeStepIndex;
   let activeStepName;
@@ -54,6 +57,7 @@ export const WizardToggle: React.FunctionComponent<WizardToggleProps> = ({
   return (
     <>
       <button
+        aria-hidden={stepButtonAriaHidden}
         onClick={() => onNavToggle(!isNavOpen)}
         className={css(styles.wizardToggle, isNavOpen && 'pf-m-expanded')}
         aria-expanded={isNavOpen}

--- a/packages/react-core/src/components/Wizard/WizardToggle.tsx
+++ b/packages/react-core/src/components/Wizard/WizardToggle.tsx
@@ -33,7 +33,7 @@ export const WizardToggle: React.FunctionComponent<WizardToggleProps> = ({
   activeStep,
   children,
   hasBodyPadding = true,
-  stepButtonAriaHidden,
+  stepButtonAriaHidden
 }: WizardToggleProps) => {
   let activeStepIndex;
   let activeStepName;

--- a/packages/react-core/src/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/react-core/src/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
@@ -62,6 +62,7 @@ exports[`Wizard should match snapshot 1`] = `
                 isNavOpen={false}
                 nav={[Function]}
                 onNavToggle={[Function]}
+                stepButtonAriaHidden={null}
                 steps={
                   Array [
                     Object {

--- a/packages/react-core/src/helpers/typeUtils.ts
+++ b/packages/react-core/src/helpers/typeUtils.ts
@@ -1,3 +1,8 @@
+export type OneOf<T, K extends keyof T> = T[K];
+
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
 // Gathers all the required keys from an interface/type T
 export type RequiredKeys<T> = {
   [K in keyof T]-?: ({} extends { [P in K]: T[K] } ? never : K);

--- a/packages/react-integration/cypress/integration/radio.spec.ts
+++ b/packages/react-integration/cypress/integration/radio.spec.ts
@@ -23,4 +23,146 @@ describe('Radio Demo Test', () => {
     cy.get('#radio-6').should('not.be.checked');
     cy.get('#radio-6').should('be.disabled');
   });
+
+  // Inoperable radio example 1
+  it('Verify inoperable radio can receive focus and has correct classes/attributes', () => {
+    cy.get('#ts-demo-app-page-id').within(() => {
+      cy.get('div.pf-c-radio:nth-of-type(8)').click();
+      cy.focused()
+        .should('have.class', 'pf-m-inoperable')
+        .and('have.attr', 'tabindex', '0');
+      cy.get('div.pf-c-radio:nth-of-type(8)').focus();
+      cy.focused().should('have.class', 'pf-m-inoperable');
+    });
+  });
+
+  // Inoperable radio example 1
+  it('Verify inoperable radio supresses events', () => {
+    cy.get('#ts-demo-app-page-id').within(() => {
+      cy.get('div.pf-c-radio:nth-of-type(8)').click();
+      cy.get('div.pf-c-radio:nth-of-type(8)')
+        .find('.pf-c-radio__input')
+        .click();
+      cy.get('div.pf-c-radio:nth-of-type(8)')
+        .find('.pf-c-radio__input')
+        .focus();
+      cy.get('div.pf-c-radio:nth-of-type(8)')
+        .find('.pf-c-radio__input')
+        .type('{enter}');
+      cy.get('div.pf-c-radio:nth-of-type(8)')
+        .find('.pf-c-radio__label')
+        .click();
+      cy.url().should('eq', 'http://localhost:3000/radio-demo-nav-link'); // shouldn't have navigated anywhere
+    });
+  });
+
+  // Inoperable radio example 2
+  it('Verify inoperable radio can show tooltip on focus', () => {
+    cy.get('#ts-demo-app-page-id').within(() => {
+      cy.get('div.pf-c-radio:nth-of-type(9)')
+        .focus()
+        .should('have.attr', 'aria-describedby', 'tippy-1');
+    });
+    cy.get('.tippy-popper').should('be.visible');
+  });
+
+  // Inoperable radio example 3
+  it('Verify inoperable label wrapped radio can receive focus and has correct classes/attributes', () => {
+    cy.get('#ts-demo-app-page-id').within(() => {
+      cy.get('label.pf-c-radio:nth-of-type(1)').click();
+      cy.focused().should('have.class', 'pf-m-inoperable');
+      cy.get('label.pf-c-radio:nth-of-type(1)').focus();
+      cy.focused().should('have.class', 'pf-m-inoperable');
+    });
+  });
+
+  // Inoperable radio example 3
+  it('Verify inoperable label wrapped radio supresses events', () => {
+    cy.get('#ts-demo-app-page-id').within(() => {
+      cy.get('label.pf-c-radio:nth-of-type(1)').click();
+      cy.get('label.pf-c-radio:nth-of-type(1)')
+        .find('.pf-c-radio__input')
+        .click();
+      cy.get('label.pf-c-radio:nth-of-type(1)')
+        .find('.pf-c-radio__input')
+        .focus();
+      cy.get('label.pf-c-radio:nth-of-type(1)')
+        .find('.pf-c-radio__input')
+        .type('{enter}');
+      cy.get('label.pf-c-radio:nth-of-type(1)')
+        .find('.pf-c-radio__label')
+        .click();
+      cy.url().should('eq', 'http://localhost:3000/radio-demo-nav-link'); // shouldn't have navigated anywhere
+    });
+  });
+
+  // Inoperable radio example 4
+  it('Verify inoperable label wrapped shows tooltip on focus', () => {
+    cy.get('#ts-demo-app-page-id').within(() => {
+      cy.get('label.pf-c-radio:nth-of-type(2)')
+        .focus()
+        .should('have.attr', 'aria-describedby', 'tippy-2');
+    });
+    cy.get('.tippy-popper').should('be.visible');
+  });
+
+  // Inoperable radio example 5
+  it('Verify inoperable label wrapped radio with nested tooltip can receive focus and has correct classes/attributes', () => {
+    cy.get('#ts-demo-app-page-id').within(() => {
+      cy.get('label.pf-c-radio:nth-of-type(3)').click();
+      cy.focused()
+        .should('have.class', 'pf-m-inoperable')
+        .and('have.id', 'inoperable-radio-5');
+      cy.get('#inoperable-radio-5')
+        .focus()
+        .should('have.attr', 'aria-describedby', 'tippy-3')
+        .and('have.class', 'pf-m-inoperable');
+    });
+    cy.get('.tippy-popper').should('be.visible');
+  });
+
+  // Inoperable radio example 6
+  it('Verify inoperable radio with nested tooltip can receive focus and has correct classes/attributes', () => {
+    cy.get('#ts-demo-app-page-id').within(() => {
+      cy.get('#inoperable-radio-6')
+        .focus()
+        .should('have.class', 'pf-m-inoperable')
+        .and('have.attr', 'aria-describedby', 'tippy-4');
+    });
+    cy.get('.tippy-popper').should('be.visible');
+  });
+
+  // Inoperable radio example 7
+  it('Verify inoperable radio with nested tooltip properly sets explicit tabindex values', () => {
+    cy.get('#ts-demo-app-page-id').within(() => {
+      cy.get('#inoperable-radio-7').should('have.attr', 'tabindex', '6');
+      cy.get('label.pf-c-radio:nth-of-type(4)').click();
+      cy.focused().should('have.attr', 'tabindex', '6');
+    });
+  });
+
+  // Inoperable radio example 8
+  it('Verify inoperable radio wrapped in Tooltip properly sets explicit tabindex values', () => {
+    cy.get('#ts-demo-app-page-id').within(() => {
+      cy.get('div.pf-c-radio:nth-of-type(11)')
+        .focus()
+        .should('have.attr', 'tabindex', '3');
+    });
+  });
+
+  // Inoperable radio example 8
+  it('Verify inoperable radio wrapped in Tooltip avoids unnecessary tabstops', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    cy.get('body').tab();
+    cy.focused().should('have.attr', 'tabindex', '3');
+
+    /* eslint-disable @typescript-eslint/ban-ts-ignore */
+    cy.get('body')
+      // @ts-ignore
+      .tab()
+      .tab();
+    /* eslint-enable @typescript-eslint/ban-ts-ignore */
+    cy.focused().should('have.attr', 'tabindex', '6');
+  });
 });

--- a/packages/react-integration/cypress/support/index.js
+++ b/packages/react-integration/cypress/support/index.js
@@ -12,6 +12,7 @@
 // You can read more here:
 // https://on.cypress.io/configuration
 // ***********************************************************
+import 'cypress-plugin-tab';
 
 // Import commands.js using ES2015 syntax:
 import './commands';

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -6,7 +6,7 @@ interface DemoInterface {
   /** The name of the demo */
   name: string;
   /** Demo component associated with the demo  */
-  componentType: any;
+  componentType: React.ComponentType;
 }
 /** Add the name of the demo and it's component here to have them show up in the demo app */
 export const Demos: DemoInterface[] = [

--- a/packages/react-integration/demo-app-ts/src/components/demos/RadioDemo/RadioDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/RadioDemo/RadioDemo.tsx
@@ -1,4 +1,4 @@
-import { Radio, RadioProps } from '@patternfly/react-core';
+import { Radio, RadioProps, Tooltip } from '@patternfly/react-core';
 import React, { Component } from 'react';
 export class RadioDemo extends Component {
   state = {
@@ -55,6 +55,9 @@ export class RadioDemo extends Component {
     ),
     name: 'disabled-2'
   };
+  interactiveEventHandler = () => {
+    window.location.href = 'https://github.com/patternfly/patternfly-react';
+  };
 
   componentDidMount() {
     window.scrollTo(0, 0);
@@ -108,6 +111,119 @@ export class RadioDemo extends Component {
           name={this.myUncheckedDescriptionRadioProps.name}
           description={this.myUncheckedDescriptionRadioProps.description}
         />
+
+        <Radio
+          id="inoperable-radio-1"
+          name="inoperable-1"
+          description="A basic inoperable radio input"
+          isInoperable
+          label="Inoperable radio example 1"
+          onChange={this.interactiveEventHandler}
+          onClick={this.interactiveEventHandler}
+          onKeyPress={this.interactiveEventHandler}
+        />
+
+        <Tooltip content="This tooltip content wraps the entire component">
+          <Radio
+            id="inoperable-radio-2"
+            name="inoperable-2"
+            isInoperable
+            label="Inoperable radio example 2"
+            description="This radio is inoperable and is encased within a Tooltip component"
+            onChange={this.interactiveEventHandler}
+            onClick={this.interactiveEventHandler}
+            onKeyPress={this.interactiveEventHandler}
+          />
+        </Tooltip>
+
+        <Radio
+          id="inoperable-radio-3"
+          name="inoperable-3"
+          isInoperable
+          label="Inoperable radio example 3"
+          onChange={this.interactiveEventHandler}
+          onClick={this.interactiveEventHandler}
+          onKeyPress={this.interactiveEventHandler}
+          description="This radio is inoperable and label wrapped"
+          isLabelWrapped
+        />
+
+        <Tooltip content="This tooltip content wraps the entire component">
+          <Radio
+            id="inoperable-radio-4"
+            name="inoperable-4"
+            isInoperable
+            isLabelWrapped
+            label="Inoperable radio example 4"
+            description="This radio is inoperable and label wrapped and is encased within a Tooltip component"
+            onChange={this.interactiveEventHandler}
+            onClick={this.interactiveEventHandler}
+            onKeyPress={this.interactiveEventHandler}
+          />
+        </Tooltip>
+
+        <Radio
+          id="inoperable-radio-5"
+          name="inoperable-5"
+          isLabelWrapped
+          isInoperable
+          tooltip={{
+            component: Tooltip,
+            props: {
+              children: null,
+              content: 'This tooltip content wraps only the radio input element',
+              position: 'left'
+            }
+          }}
+          label="Inoperable radio example 5"
+          description="This Radio is inoperable and label wrapped with a nested tooltip"
+        />
+
+        <Radio
+          id="inoperable-radio-6"
+          name="inoperable-6"
+          isInoperable
+          tooltip={{
+            component: Tooltip,
+            props: {
+              children: null,
+              content: 'This tooltip content wraps only the radio input element',
+              position: 'left'
+            }
+          }}
+          label="Inoperable radio example 6"
+          description="This Radio is inoperable with a nested tooltip"
+        />
+
+        <Radio
+          id="inoperable-radio-7"
+          name="inoperable-7"
+          isInoperable
+          isLabelWrapped
+          tabIndex={6}
+          tooltip={{
+            component: Tooltip,
+            props: {
+              children: null,
+              content:
+                'This tooltip content wraps only the radio input element and is explicitly focused as the second element of the page',
+              position: 'left'
+            }
+          }}
+          label="Inoperable radio example 7"
+          description="This Radio is inoperable and label wrapped with positive tabindex"
+        />
+
+        <Tooltip content="This tooltip content wraps the entire Radio component and is explicitly focused as the first element of the page">
+          <Radio
+            id="inoperable-radio-8"
+            name="inoperable-8"
+            isInoperable
+            tabIndex={3}
+            label="Inoperable radio example 8"
+            description="This Radio is inoperable with positive tabindex"
+          />
+        </Tooltip>
       </React.Fragment>
     );
   }

--- a/packages/react-integration/package.json
+++ b/packages/react-integration/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^4.0.3",
     "cypress": "^3.8.2",
+    "cypress-plugin-tab": "^1.0.5",
     "jasmine-xml2html-converter": "^0.0.2",
     "junit-merge": "^2.0.0",
     "local-web-server": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4746,6 +4746,14 @@ ajv@^6.0.1, ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.3, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ally.js@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/ally.js/-/ally.js-1.4.1.tgz#9fb7e6ba58efac4ee9131cb29aa9ee3b540bcf1e"
+  integrity sha1-n7fmuljvrE7pExyymqnuO1QLzx4=
+  dependencies:
+    css.escape "^1.5.0"
+    platform "1.3.3"
+
 alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
@@ -8121,6 +8129,11 @@ css-what@2.1, css-what@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
 
+css.escape@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
 css@^2.2.3:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
@@ -8259,6 +8272,13 @@ cycle@1.0.x:
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
+
+cypress-plugin-tab@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz#a40714148104004bb05ed62b1bf46bb544f8eb4a"
+  integrity sha512-QtTJcifOVwwbeMP3hsOzQOKf3EqKsLyjtg9ZAGlYDntrCRXrsQhe4ZQGIthRMRLKpnP6/tTk6G0gJ2sZUfRliQ==
+  dependencies:
+    ally.js "^1.4.1"
 
 cypress@^3.8.2:
   version "3.8.2"
@@ -17896,6 +17916,11 @@ pkginfo@0.3.x:
 pkginfo@0.x.x:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
+
+platform@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.3.tgz#646c77011899870b6a0903e75e997e8e51da7461"
+  integrity sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE=
 
 plop@^2.0.0:
   version "2.5.2"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: This PR introduces a new prop `isInoperable`. When provided as a prop, radios are set into a partially enabled state. This way, users can still attach tooltips when the radios are not fully available for whatever reason. Click, change, and keypress events are suppressed when this prop is present so effectively the only thing you can do is focus the element and view the tooltip.

Closes # https://github.com/patternfly/patternfly-react/issues/3791

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Steps toward closing https://github.com/patternfly/patternfly-react/issues/1894
