### PR TITLE
fix(layouts): wrapped examples to fix codesandbox

### DIFF
--- a/packages/patternfly-4/react-core/src/layouts/Bullseye/examples/Bullseye.md
+++ b/packages/patternfly-4/react-core/src/layouts/Bullseye/examples/Bullseye.md
@@ -14,7 +14,9 @@ import './bullseye.css';
 import React from 'react';
 import { Bullseye } from '@patternfly/react-core';
 
-<Bullseye>
-  <div>Bullseye ◎ layout</div>
-</Bullseye>
+BasicBullseyeExample = () => (
+  <Bullseye>
+    <div>Bullseye ◎ layout</div>
+  </Bullseye>
+);
 ```

--- a/packages/patternfly-4/react-core/src/layouts/Flex/examples/Flex.md
+++ b/packages/patternfly-4/react-core/src/layouts/Flex/examples/Flex.md
@@ -15,47 +15,53 @@ import './flex.css';
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
-<Flex>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-</Flex>
+BasicFlexExample = () => (
+  <Flex>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+  </Flex>
+);
 ```
 
 ```js title=Nesting
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
-<Flex>
+NestingFlexExample = () => (
   <Flex>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
+    <Flex>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ```js title=Nested-with-items
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
-<Flex>
+NestedItemsFlexExample = () => (
   <Flex>
+    <Flex>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
     <FlexItem>Flex item</FlexItem>
     <FlexItem>Flex item</FlexItem>
+    <Flex>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <Flex>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ### Flex Spacing
@@ -63,42 +69,48 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex>
-  <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-none"]}]}>Item - none</FlexItem>
-  <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-xs"]}]}>Item - xs</FlexItem>
-  <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-sm"]}]}>Item -sm</FlexItem>
-  <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-md"]}]}>Item - md</FlexItem>
-  <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-lg"]}]}>Item - lg</FlexItem>
-  <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-xl"]}]}>Item - xl</FlexItem>
-  <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-2xl"]}]}>Item - 2xl</FlexItem>
-  <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-3xl"]}]}>Item - 3xl</FlexItem>
-</Flex>
+FlexSpacingExample = () => (
+  <Flex>
+    <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-none"]}]}>Item - none</FlexItem>
+    <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-xs"]}]}>Item - xs</FlexItem>
+    <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-sm"]}]}>Item -sm</FlexItem>
+    <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-md"]}]}>Item - md</FlexItem>
+    <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-lg"]}]}>Item - lg</FlexItem>
+    <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-xl"]}]}>Item - xl</FlexItem>
+    <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-2xl"]}]}>Item - 2xl</FlexItem>
+    <FlexItem breakpointMods={[{modifier: FlexModifiers["spacer-3xl"]}]}>Item - 3xl</FlexItem>
+  </Flex>
+);
 ```
 
 ```js title=Spacing-xl
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex breakpointMods={[{modifier: FlexModifiers["space-items-xl"]}]}>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-</Flex>
+FlexSpacingXlExample = () => (
+  <Flex breakpointMods={[{modifier: FlexModifiers["space-items-xl"]}]}>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+  </Flex>
+);
 ```
 
-```js title=Spacin-none
+```js title=Spacing-none
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex breakpointMods={[{modifier: FlexModifiers["space-items-none"]}]}>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-</Flex>
+FlexSpacingNoneExample = () => (
+  <Flex breakpointMods={[{modifier: FlexModifiers["space-items-none"]}]}>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+  </Flex>
+);
 ```
 
 ### Flex layout modifiers
@@ -107,86 +119,96 @@ import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 import React from 'react';
 import { Flex, FlexItem } from '@patternfly/react-core';
 
-<Flex className="example-border">
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-</Flex>
+FlexLayoutModifiersExample = () => (
+  <Flex className="example-border">
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+  </Flex>
+);
 ```
 
 ```js title=Inline
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex className="example-border" breakpointMods={[{modifier: FlexModifiers["inline-flex"]}]}>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-</Flex>
+FlexInlineExample = () => (
+  <Flex className="example-border" breakpointMods={[{modifier: FlexModifiers["inline-flex"]}]}>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+  </Flex>
+);
 ```
 
 ```js title=Using-canGrow
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers.grow}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
+FlexUsingCanGrowExample = () => (
   <Flex>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
+    <Flex breakpointMods={[{modifier: FlexModifiers.grow}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ```js title=Adjusting-width
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["flex-1"]}]}>
-    <FlexItem>Flex item</FlexItem>
+FlexAdjustingWidthExample = () => (
+  <Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["flex-1"]}]}>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["flex-1"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["flex-1"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["flex-1"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["flex-1"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ```js title=Specifying-column-widths
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["flex-1"]}]}>
-    <FlexItem>Flex item</FlexItem>
+FlexSpecifyingColumnWidthsExample = () => (
+  <Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["flex-1"]}]}>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["flex-2"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["flex-3"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["flex-2"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["flex-3"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ### Column layout modifiers
@@ -195,48 +217,54 @@ import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex breakpointMods={[{modifier: FlexModifiers.column}]}>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-</Flex>
+FlexColumnLayoutExample = () => (
+  <Flex breakpointMods={[{modifier: FlexModifiers.column}]}>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+  </Flex>
+);
 ```
 
 ```js title=Stacking-elements
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex breakpointMods={[{modifier: FlexModifiers.column}]}>
-  <Flex>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
+FlexStackingElementsExample = () => (
+  <Flex breakpointMods={[{modifier: FlexModifiers.column}]}>
+    <Flex>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-  <Flex>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ```js title=Nesting-elements-in-columns
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
+FlexNestingElementsInColumnsExample = () => (
+  <Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ### Responsive layout modifiers
@@ -245,34 +273,38 @@ import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers, FlexBreakpoints } from '@patternfly/react-core';
 
-<Flex breakpointMods={[{modifier: FlexModifiers["column"]}, {modifier: FlexModifiers["row"], breakpoint: FlexBreakpoints.lg}]}>
-  <Flex>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
+FlexSwitchingBetweenDirectionColumnAndRowExample = () => (
+  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}, {modifier: FlexModifiers["row"], breakpoint: FlexBreakpoints.lg}]}>
+    <Flex>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: "column"}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex breakpointMods={[{modifier: "column"}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ```js title=Controlling-width-of-text
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex breakpointMods={[{modifier: FlexModifiers["column"]}, {modifier: FlexModifiers["row"], breakpoint: FlexModifiers["lg"]}]}>
-  <Flex breakpointMods={[{modifier: FlexModifiers["flex-1"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Lorem ipsum dolor sit amet consectetur adipisicing elit. Est animi modi temporibus, alias qui obcaecati ullam dolor nam, nulla magni iste rem praesentium numquam provident amet ut nesciunt harum accusamus.</FlexItem>
+FlexControllingWidthOfTextExample = () => (
+  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}, {modifier: FlexModifiers["row"], breakpoint: FlexModifiers["lg"]}]}>
+    <Flex breakpointMods={[{modifier: FlexModifiers["flex-1"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Lorem ipsum dolor sit amet consectetur adipisicing elit. Est animi modi temporibus, alias qui obcaecati ullam dolor nam, nulla magni iste rem praesentium numquam provident amet ut nesciunt harum accusamus.</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ### Flex alignment
@@ -281,129 +313,145 @@ import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex className="example-border">
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem breakpointMods={[{modifier: FlexModifiers["align-right"]}]}>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-</Flex>
+FlexAligningRightExample = () => (
+  <Flex className="example-border">
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem breakpointMods={[{modifier: FlexModifiers["align-right"]}]}>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+  </Flex>
+);
 ```
 
 ```js title=Align-right-on-single-item
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex className="example-border">
-  <FlexItem breakpointMods={[{modifier: FlexModifiers["align-right"]}]}>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-</Flex>
+FlexAligningRightOnSingleItemExample = () => (
+  <Flex className="example-border">
+    <FlexItem breakpointMods={[{modifier: FlexModifiers["align-right"]}]}>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+  </Flex>
+);
 ```
 
 ```js title=Align-right-on-multiple-groups
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex>
+FlexAlignRightOnMultipleGroupsExample = () => (
   <Flex>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
+    <Flex>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["align-right"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["align-right"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["align-right"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["align-right"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ```js title=Align-adjacent-content
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["flex-1"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
+FlexAlignAdjacentContentExample = () => (
   <Flex>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
+    <Flex breakpointMods={[{modifier: FlexModifiers["flex-1"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-</Flex>
+);
 ```
 
 ```js title=Align-self-flex-end
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
+FlexAlignSelfFlexEndExample = () => (
+  <Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["column"]}, {modifier: FlexModifiers["align-self-flex-end"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}, {modifier: FlexModifiers["align-self-flex-end"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ```js title=Align-self-center
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
+FlexAlignSelfCenterExample = () => (
+  <Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["column"]}, {modifier: FlexModifiers["align-self-center"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}, {modifier: FlexModifiers["align-self-center"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ```js title=Align-self-baseline
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
+FlexAlignSelfBaselineExample = () => (
+  <Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["column"]}, {modifier: FlexModifiers["align-self-baseline"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}, {modifier: FlexModifiers["align-self-baseline"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ```js title=Align-self-stretch
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
+FlexAlignSelfStretchExample = () => (
+  <Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["column"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
+    <Flex breakpointMods={[{modifier: FlexModifiers["column"]}, {modifier: FlexModifiers["align-self-stretch"]}]}>
+      <FlexItem>Flex item</FlexItem>
+      <FlexItem>Flex item</FlexItem>
+    </Flex>
   </Flex>
-  <Flex breakpointMods={[{modifier: FlexModifiers["column"]}, {modifier: FlexModifiers["align-self-stretch"]}]}>
-    <FlexItem>Flex item</FlexItem>
-    <FlexItem>Flex item</FlexItem>
-  </Flex>
-</Flex>
+);
 ```
 
 ### Flex justification
@@ -412,32 +460,38 @@ import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex className="example-border" breakpointMods={[{modifier: FlexModifiers["justify-content-flex-end"]}]}>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-</Flex>
+FlexJustifyContentFlexEndExample = () => (
+  <Flex className="example-border" breakpointMods={[{modifier: FlexModifiers["justify-content-flex-end"]}]}>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+  </Flex>
+);
 ```
 
 ```js title=Justify-content-space-between
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers  } from '@patternfly/react-core';
 
-<Flex className="example-border" breakpointMods={[{modifier: FlexModifiers["justify-content-space-between"]}]}>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-</Flex>
+FlexJustifyContentSpaceBetweenExample = () => (
+  <Flex className="example-border" breakpointMods={[{modifier: FlexModifiers["justify-content-space-between"]}]}>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+  </Flex>
+);
 ```
 
 ```js title=Justify-content-flex-start
 import React from 'react';
 import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 
-<Flex className="example-border" breakpointMods={[{modifier: FlexModifiers["justify-content-flex-start"]}]}>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-  <FlexItem>Flex item</FlexItem>
-</Flex>
+FlexJustifyContentFlexStartExample = () => (
+  <Flex className="example-border" breakpointMods={[{modifier: FlexModifiers["justify-content-flex-start"]}]}>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+    <FlexItem>Flex item</FlexItem>
+  </Flex>
+);
 ```

--- a/packages/patternfly-4/react-core/src/layouts/Gallery/examples/Gallery.md
+++ b/packages/patternfly-4/react-core/src/layouts/Gallery/examples/Gallery.md
@@ -14,28 +14,32 @@ import './gallery.css';
 import React from 'react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
 
-<Gallery>
-  <GalleryItem>Gallery Item</GalleryItem>
-  <GalleryItem>Gallery Item</GalleryItem>
-  <GalleryItem>Gallery Item</GalleryItem>
-  <GalleryItem>Gallery Item</GalleryItem>
-  <GalleryItem>Gallery Item</GalleryItem>
-  <GalleryItem>Gallery Item</GalleryItem>
-  <GalleryItem>Gallery Item</GalleryItem>
-  <GalleryItem>Gallery Item</GalleryItem>
-</Gallery>
+GalleryBasicExample = () => (
+  <Gallery>
+    <GalleryItem>Gallery Item</GalleryItem>
+    <GalleryItem>Gallery Item</GalleryItem>
+    <GalleryItem>Gallery Item</GalleryItem>
+    <GalleryItem>Gallery Item</GalleryItem>
+    <GalleryItem>Gallery Item</GalleryItem>
+    <GalleryItem>Gallery Item</GalleryItem>
+    <GalleryItem>Gallery Item</GalleryItem>
+    <GalleryItem>Gallery Item</GalleryItem>
+  </Gallery>
+);
 ```
 
 ```js title=With-gutters
 import React from 'react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
 
-<Gallery gutter="md">
-  <GalleryItem>Gallery Item</GalleryItem>
-  <GalleryItem>Gallery Item</GalleryItem>
-  <GalleryItem>Gallery Item</GalleryItem>
-  <GalleryItem>Gallery Item</GalleryItem>
-  <GalleryItem>Gallery Item</GalleryItem>
-  <GalleryItem>Gallery Item</GalleryItem>
-</Gallery>
+GalleryWithGuttersExample = () => (
+  <Gallery gutter="md">
+    <GalleryItem>Gallery Item</GalleryItem>
+    <GalleryItem>Gallery Item</GalleryItem>
+    <GalleryItem>Gallery Item</GalleryItem>
+    <GalleryItem>Gallery Item</GalleryItem>
+    <GalleryItem>Gallery Item</GalleryItem>
+    <GalleryItem>Gallery Item</GalleryItem>
+  </Gallery>
+);
 ```

--- a/packages/patternfly-4/react-core/src/layouts/Grid/examples/Grid.md
+++ b/packages/patternfly-4/react-core/src/layouts/Grid/examples/Grid.md
@@ -13,48 +13,52 @@ import './grid.css';
 import React from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
 
-<Grid>
-  <GridItem span={8}>span = 8</GridItem>
-  <GridItem span={4} rowSpan={2}>
-    span = 4, rowSpan = 2
-  </GridItem>
-  <GridItem span={2} rowSpan={3}>
-    span = 2, rowSpan = 3
-  </GridItem>
-  <GridItem span={2}>span = 2</GridItem>
-  <GridItem span={4}>span = 4</GridItem>
-  <GridItem span={2}>span = 2</GridItem>
-  <GridItem span={2}>span = 2</GridItem>
-  <GridItem span={2}>span = 2</GridItem>
-  <GridItem span={4}>span = 4</GridItem>
-  <GridItem span={2}>span = 2</GridItem>
-  <GridItem span={4}>span = 4</GridItem>
-  <GridItem span={4}>span = 4</GridItem>
-</Grid>
+GridBasicExample = () => (
+  <Grid>
+    <GridItem span={8}>span = 8</GridItem>
+    <GridItem span={4} rowSpan={2}>
+      span = 4, rowSpan = 2
+    </GridItem>
+    <GridItem span={2} rowSpan={3}>
+      span = 2, rowSpan = 3
+    </GridItem>
+    <GridItem span={2}>span = 2</GridItem>
+    <GridItem span={4}>span = 4</GridItem>
+    <GridItem span={2}>span = 2</GridItem>
+    <GridItem span={2}>span = 2</GridItem>
+    <GridItem span={2}>span = 2</GridItem>
+    <GridItem span={4}>span = 4</GridItem>
+    <GridItem span={2}>span = 2</GridItem>
+    <GridItem span={4}>span = 4</GridItem>
+    <GridItem span={4}>span = 4</GridItem>
+  </Grid>
+);
 ```
 
 ```js title=With-gutters
 import React from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
 
-<Grid gutter="md">
-  <GridItem span={8}>span = 8</GridItem>
-  <GridItem span={4} rowSpan={2}>
-    span = 4, rowSpan = 2
-  </GridItem>
-  <GridItem span={2} rowSpan={3}>
-    span = 2, rowSpan = 3
-  </GridItem>
-  <GridItem span={2}>span = 2</GridItem>
-  <GridItem span={4}>span = 4</GridItem>
-  <GridItem span={2}>span = 2</GridItem>
-  <GridItem span={2}>span = 2</GridItem>
-  <GridItem span={2}>span = 2</GridItem>
-  <GridItem span={4}>span = 4</GridItem>
-  <GridItem span={2}>span = 2</GridItem>
-  <GridItem span={4}>span = 4</GridItem>
-  <GridItem span={4}>span = 4</GridItem>
-</Grid>
+GridWithGuttersExample = () => (
+  <Grid gutter="md">
+    <GridItem span={8}>span = 8</GridItem>
+    <GridItem span={4} rowSpan={2}>
+      span = 4, rowSpan = 2
+    </GridItem>
+    <GridItem span={2} rowSpan={3}>
+      span = 2, rowSpan = 3
+    </GridItem>
+    <GridItem span={2}>span = 2</GridItem>
+    <GridItem span={4}>span = 4</GridItem>
+    <GridItem span={2}>span = 2</GridItem>
+    <GridItem span={2}>span = 2</GridItem>
+    <GridItem span={2}>span = 2</GridItem>
+    <GridItem span={4}>span = 4</GridItem>
+    <GridItem span={2}>span = 2</GridItem>
+    <GridItem span={4}>span = 4</GridItem>
+    <GridItem span={4}>span = 4</GridItem>
+  </Grid>
+);
 ```
 
 ```js title=With-overrides
@@ -62,21 +66,23 @@ import React from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
 import ItemControl from './ItemControl';
 
-<Grid sm={6} md={4} lg={3} xl2={1}>
-  <GridItem span={3} rowSpan={2}>
-    span = 3 rowSpan= 2
-  </GridItem>
-  <GridItem>Grid Item</GridItem>
-  <GridItem>Grid Item</GridItem>
-  <GridItem>Grid Item</GridItem>
-  <GridItem>Grid Item</GridItem>
-  <GridItem>Grid Item</GridItem>
-  <GridItem>Grid Item</GridItem>
-  <GridItem>Grid Item</GridItem>
-  <GridItem>Grid Item</GridItem>
-  <GridItem>Grid Item</GridItem>
-  <GridItem>Grid Item</GridItem>
-  <GridItem>Grid Item</GridItem>
-</Grid>
+GridWithOverridesExample = () => (
+  <Grid sm={6} md={4} lg={3} xl2={1}>
+    <GridItem span={3} rowSpan={2}>
+      span = 3 rowSpan= 2
+    </GridItem>
+    <GridItem>Grid Item</GridItem>
+    <GridItem>Grid Item</GridItem>
+    <GridItem>Grid Item</GridItem>
+    <GridItem>Grid Item</GridItem>
+    <GridItem>Grid Item</GridItem>
+    <GridItem>Grid Item</GridItem>
+    <GridItem>Grid Item</GridItem>
+    <GridItem>Grid Item</GridItem>
+    <GridItem>Grid Item</GridItem>
+    <GridItem>Grid Item</GridItem>
+    <GridItem>Grid Item</GridItem>
+  </Grid>
+);
 ```
 

--- a/packages/patternfly-4/react-core/src/layouts/Level/examples/Level.md
+++ b/packages/patternfly-4/react-core/src/layouts/Level/examples/Level.md
@@ -16,10 +16,11 @@ import { Level, LevelItem } from '@patternfly/react-core';
 
 LevelBasicExample = () => (
   <Level>
-  <LevelItem>Level Item</LevelItem>
-  <LevelItem>Level Item</LevelItem>
-  <LevelItem>Level Item</LevelItem>
-</Level>
+    <LevelItem>Level Item</LevelItem>
+    <LevelItem>Level Item</LevelItem>
+    <LevelItem>Level Item</LevelItem>
+  </Level>
+);
 ```
 
 ```js title=With-gutters

--- a/packages/patternfly-4/react-core/src/layouts/Level/examples/Level.md
+++ b/packages/patternfly-4/react-core/src/layouts/Level/examples/Level.md
@@ -14,7 +14,8 @@ import './level.css';
 import React from 'react';
 import { Level, LevelItem } from '@patternfly/react-core';
 
-<Level>
+LevelBasicExample = () => (
+  <Level>
   <LevelItem>Level Item</LevelItem>
   <LevelItem>Level Item</LevelItem>
   <LevelItem>Level Item</LevelItem>
@@ -25,9 +26,11 @@ import { Level, LevelItem } from '@patternfly/react-core';
 import React from 'react';
 import { Level, LevelItem } from '@patternfly/react-core';
 
-<Level gutter="md">
-  <LevelItem>Level Item</LevelItem>
-  <LevelItem>Level Item</LevelItem>
-  <LevelItem>Level Item</LevelItem>
-</Level>
+LevelWithGuttersExample = () => (
+  <Level gutter="md">
+    <LevelItem>Level Item</LevelItem>
+    <LevelItem>Level Item</LevelItem>
+    <LevelItem>Level Item</LevelItem>
+  </Level>
+);
 ```

--- a/packages/patternfly-4/react-core/src/layouts/Split/examples/Split.md
+++ b/packages/patternfly-4/react-core/src/layouts/Split/examples/Split.md
@@ -14,20 +14,24 @@ import './split.css';
 import React from 'react';
 import { Split, SplitItem } from '@patternfly/react-core';
 
-<Split>
-  <SplitItem>content</SplitItem>
-  <SplitItem isFilled>pf-m-fill</SplitItem>
-  <SplitItem>content</SplitItem>
-</Split>
+SplitBasicExample = () => (
+  <Split>
+    <SplitItem>content</SplitItem>
+    <SplitItem isFilled>pf-m-fill</SplitItem>
+    <SplitItem>content</SplitItem>
+  </Split>
+);
 ```
 
 ```js title=With-gutter
 import React from 'react';
 import { Split, SplitItem } from '@patternfly/react-core';
 
-<Split gutter="md">
-  <SplitItem>content</SplitItem>
-  <SplitItem isFilled>pf-m-fill</SplitItem>
-  <SplitItem>content</SplitItem>
-</Split>
+SplitWithGutterExample = () => (
+  <Split gutter="md">
+    <SplitItem>content</SplitItem>
+    <SplitItem isFilled>pf-m-fill</SplitItem>
+    <SplitItem>content</SplitItem>
+  </Split>
+);
 ```

--- a/packages/patternfly-4/react-core/src/layouts/Stack/examples/Stack.md
+++ b/packages/patternfly-4/react-core/src/layouts/Stack/examples/Stack.md
@@ -14,20 +14,24 @@ import './stack.css';
 import React from 'react';
 import { Stack, StackItem } from '@patternfly/react-core';
 
-<Stack>
-  <StackItem>content</StackItem>
-  <StackItem isFilled>pf-m-fill</StackItem>
-  <StackItem>content</StackItem>
-</Stack>
+StackBasicExample = () => (
+  <Stack>
+    <StackItem>content</StackItem>
+    <StackItem isFilled>pf-m-fill</StackItem>
+    <StackItem>content</StackItem>
+  </Stack>
+);
 ```
 
 ```js title=With-gutter
 import React from 'react';
 import { Stack, StackItem } from '@patternfly/react-core';
 
-<Stack gutter="md">
-  <StackItem>content</StackItem>
-  <StackItem isFilled>pf-m-fill</StackItem>
-  <StackItem>content</StackItem>
-</Stack>
+StackWithGutterExample = () => (
+  <Stack gutter="md">
+    <StackItem>content</StackItem>
+    <StackItem isFilled>pf-m-fill</StackItem>
+    <StackItem>content</StackItem>
+  </Stack>
+);
 ```

--- a/packages/patternfly-4/react-core/src/layouts/Toolbar/examples/Toolbar.md
+++ b/packages/patternfly-4/react-core/src/layouts/Toolbar/examples/Toolbar.md
@@ -14,26 +14,8 @@ import './toolbar.css';
 import React from 'react';
 import { Toolbar, ToolbarGroup, ToolbarSection, ToolbarItem } from '@patternfly/react-core';
 
-<Toolbar>
-  <ToolbarGroup>
-    <ToolbarItem>Item 1</ToolbarItem>
-  </ToolbarGroup>
-  <ToolbarGroup>
-    <ToolbarItem>Item 2</ToolbarItem>
-    <ToolbarItem>Item 3</ToolbarItem>
-  </ToolbarGroup>
-  <ToolbarGroup>
-    <ToolbarItem>Item 4</ToolbarItem>
-  </ToolbarGroup>
-</Toolbar>
-```
-
-```js title=With-sections
-import React from 'react';
-import { Toolbar, ToolbarGroup, ToolbarSection, ToolbarItem } from '@patternfly/react-core';
-
-<Toolbar>
-  <ToolbarSection aria-label="First section">
+ToolbarBasicExample = () => (
+  <Toolbar>
     <ToolbarGroup>
       <ToolbarItem>Item 1</ToolbarItem>
     </ToolbarGroup>
@@ -41,16 +23,38 @@ import { Toolbar, ToolbarGroup, ToolbarSection, ToolbarItem } from '@patternfly/
       <ToolbarItem>Item 2</ToolbarItem>
       <ToolbarItem>Item 3</ToolbarItem>
     </ToolbarGroup>
-  </ToolbarSection>
-  <ToolbarSection aria-label="Second section">
     <ToolbarGroup>
       <ToolbarItem>Item 4</ToolbarItem>
-      <ToolbarItem>Item 5</ToolbarItem>
-      <ToolbarItem>Item 6</ToolbarItem>
     </ToolbarGroup>
-    <ToolbarGroup>
-      <ToolbarItem>Item 7</ToolbarItem>
-    </ToolbarGroup>
-  </ToolbarSection>
-</Toolbar>
+  </Toolbar>
+);
+```
+
+```js title=With-sections
+import React from 'react';
+import { Toolbar, ToolbarGroup, ToolbarSection, ToolbarItem } from '@patternfly/react-core';
+
+ToolbarWithSectionsExample = () => (
+  <Toolbar>
+    <ToolbarSection aria-label="First section">
+      <ToolbarGroup>
+        <ToolbarItem>Item 1</ToolbarItem>
+      </ToolbarGroup>
+      <ToolbarGroup>
+        <ToolbarItem>Item 2</ToolbarItem>
+        <ToolbarItem>Item 3</ToolbarItem>
+      </ToolbarGroup>
+    </ToolbarSection>
+    <ToolbarSection aria-label="Second section">
+      <ToolbarGroup>
+        <ToolbarItem>Item 4</ToolbarItem>
+        <ToolbarItem>Item 5</ToolbarItem>
+        <ToolbarItem>Item 6</ToolbarItem>
+      </ToolbarGroup>
+      <ToolbarGroup>
+        <ToolbarItem>Item 7</ToolbarItem>
+      </ToolbarGroup>
+    </ToolbarSection>
+  </Toolbar>
+);
 ```


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-org/issues/1681 - this PR wraps the layouts examples in a function component needed for Codesandbox to render examples correctly.


