### PR TITLE
add GDPR banner to all pages

### DIFF
--- a/packages/patternfly-4/react-docs/src/pages/icons.js
+++ b/packages/patternfly-4/react-docs/src/pages/icons.js
@@ -42,7 +42,7 @@ const iconsPage = ({ location }) => {
   };
 
   return (
-    <SideNavLayout location={location} context="react" pageTitle="React icons">
+    <SideNavLayout location={location} context="react" showGdprBanner={true} pageTitle="React icons">
       <PageSection className="ws-section">
         <Title size="md" className="ws-framework-title">
           React

--- a/packages/patternfly-4/react-docs/src/pages/index.js
+++ b/packages/patternfly-4/react-docs/src/pages/index.js
@@ -24,7 +24,7 @@ const IndexPage = ({ data, location }) => {
   const prInfo = data.allEnvVars.edges.filter(({ node }) => node.name === 'PR_INFO')[0].node;
 
   return (
-    <SideNavLayout location={location} context="react" pageTitle="React docs">
+    <SideNavLayout location={location} context="react" showGdprBanner={true} pageTitle="React docs">
       <div style={containerStyle}>
         <PageSection style={centerStyle}>
           <div style={{ flex: 'none', textAlign: 'center' }}>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Towards https://github.com/patternfly/patternfly-org/pull/1645 - this PR in addition to https://github.com/patternfly/patternfly-org/pull/1703 add a banner to all site pages for GDPR compliance.  This specifically sets the `showGdprBanner` prop on the `SideNavLayout` component to enable the banner.