### PR TITLE
fix(select): fix group select options in single variant

### DIFF
--- a/packages/react-core/src/components/Select/Select.tsx
+++ b/packages/react-core/src/components/Select/Select.tsx
@@ -292,8 +292,15 @@ class Select extends React.Component<SelectProps & InjectedOuiaProps, SelectStat
       return;
     }
 
-    const { children } = this.props;
-    const item = children.filter(child => child.props.value.toString() === value.toString())[0];
+    const { children, isGrouped } = this.props;
+    let item = children.filter(
+      child => child.props.value !== undefined && child.props.value.toString() === value.toString()
+    )[0];
+    if (isGrouped) {
+      item = children
+        .reduce((acc, curr) => [...acc, ...React.Children.toArray(curr.props.children)], [])
+        .filter(child => child.props.value.toString() === value.toString())[0];
+    }
     if (item) {
       if (item && item.props.children) {
         if (type === 'node') {
@@ -536,6 +543,7 @@ class Select extends React.Component<SelectProps & InjectedOuiaProps, SelectStat
           {variant === SelectVariant.single && isExpanded && !customContent && (
             <SelectMenu
               {...props}
+              isGrouped={isGrouped}
               selected={selections}
               openedOnEnter={openedOnEnter}
               aria-label={ariaLabel}

--- a/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-core/src/components/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -4080,13 +4080,11 @@ exports[`select renders select groups successfully 1`] = `
                 >
                   <div
                     class="pf-c-select__menu-group"
-                    id="-0"
-                    index="0"
                   >
                     <div
                       aria-hidden="true"
                       class="pf-c-select__menu-group-title"
-                      id=""
+                      id="group-1"
                     >
                       group 1
                     </div>
@@ -4095,6 +4093,7 @@ exports[`select renders select groups successfully 1`] = `
                     >
                       <button
                         class="pf-c-select__menu-item"
+                        id="Mr-0"
                         role="option"
                         type="button"
                       >
@@ -4106,6 +4105,7 @@ exports[`select renders select groups successfully 1`] = `
                     >
                       <button
                         class="pf-c-select__menu-item"
+                        id="Mrs-1"
                         role="option"
                         type="button"
                       >
@@ -4117,6 +4117,7 @@ exports[`select renders select groups successfully 1`] = `
                     >
                       <button
                         class="pf-c-select__menu-item"
+                        id="Ms-2"
                         role="option"
                         type="button"
                       >
@@ -4128,6 +4129,7 @@ exports[`select renders select groups successfully 1`] = `
                     >
                       <button
                         class="pf-c-select__menu-item"
+                        id="Other-3"
                         role="option"
                         type="button"
                       >
@@ -4137,13 +4139,11 @@ exports[`select renders select groups successfully 1`] = `
                   </div>
                   <div
                     class="pf-c-select__menu-group"
-                    id="-1"
-                    index="1"
                   >
                     <div
                       aria-hidden="true"
                       class="pf-c-select__menu-group-title"
-                      id=""
+                      id="group-2"
                     >
                       group 2
                     </div>
@@ -4152,6 +4152,7 @@ exports[`select renders select groups successfully 1`] = `
                     >
                       <button
                         class="pf-c-select__menu-item"
+                        id="Mr-4"
                         role="option"
                         type="button"
                       >
@@ -4163,6 +4164,7 @@ exports[`select renders select groups successfully 1`] = `
                     >
                       <button
                         class="pf-c-select__menu-item"
+                        id="Mrs-5"
                         role="option"
                         type="button"
                       >
@@ -4174,6 +4176,7 @@ exports[`select renders select groups successfully 1`] = `
                     >
                       <button
                         class="pf-c-select__menu-item"
+                        id="Ms-6"
                         role="option"
                         type="button"
                       >
@@ -4185,6 +4188,7 @@ exports[`select renders select groups successfully 1`] = `
                     >
                       <button
                         class="pf-c-select__menu-item"
+                        id="Other-7"
                         role="option"
                         type="button"
                       >
@@ -4253,7 +4257,7 @@ exports[`select renders select groups successfully 1`] = `
           className=""
           isCustomContent={false}
           isExpanded={false}
-          isGrouped={false}
+          isGrouped={true}
           keyHandler={[Function]}
           maxHeight=""
           openedOnEnter={false}
@@ -4265,32 +4269,24 @@ exports[`select renders select groups successfully 1`] = `
             role="listbox"
           >
             <SelectGroup
-              id="-0"
-              index={0}
-              isSelected={false}
               key=".0"
-              keyHandler={[Function]}
               label="group 1"
-              sendRef={[Function]}
+              titleId="group-1"
             >
               <div
                 className="pf-c-select__menu-group"
-                id="-0"
-                index={0}
-                isSelected={false}
-                keyHandler={[Function]}
-                sendRef={[Function]}
               >
                 <div
                   aria-hidden={true}
                   className="pf-c-select__menu-group-title"
-                  id=""
+                  id="group-1"
                 >
                   group 1
                 </div>
                 <SelectOption
                   className=""
                   component="button"
+                  id="Mr-0"
                   index={0}
                   isChecked={false}
                   isDisabled={false}
@@ -4309,6 +4305,7 @@ exports[`select renders select groups successfully 1`] = `
                     <button
                       aria-selected={null}
                       className="pf-c-select__menu-item"
+                      id="Mr-0"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
@@ -4321,7 +4318,8 @@ exports[`select renders select groups successfully 1`] = `
                 <SelectOption
                   className=""
                   component="button"
-                  index={0}
+                  id="Mrs-1"
+                  index={1}
                   isChecked={false}
                   isDisabled={false}
                   isFocused={false}
@@ -4339,6 +4337,7 @@ exports[`select renders select groups successfully 1`] = `
                     <button
                       aria-selected={null}
                       className="pf-c-select__menu-item"
+                      id="Mrs-1"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
@@ -4351,7 +4350,8 @@ exports[`select renders select groups successfully 1`] = `
                 <SelectOption
                   className=""
                   component="button"
-                  index={0}
+                  id="Ms-2"
+                  index={2}
                   isChecked={false}
                   isDisabled={false}
                   isFocused={false}
@@ -4369,6 +4369,7 @@ exports[`select renders select groups successfully 1`] = `
                     <button
                       aria-selected={null}
                       className="pf-c-select__menu-item"
+                      id="Ms-2"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
@@ -4381,7 +4382,8 @@ exports[`select renders select groups successfully 1`] = `
                 <SelectOption
                   className=""
                   component="button"
-                  index={0}
+                  id="Other-3"
+                  index={3}
                   isChecked={false}
                   isDisabled={false}
                   isFocused={false}
@@ -4399,6 +4401,7 @@ exports[`select renders select groups successfully 1`] = `
                     <button
                       aria-selected={null}
                       className="pf-c-select__menu-item"
+                      id="Other-3"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
@@ -4411,33 +4414,25 @@ exports[`select renders select groups successfully 1`] = `
               </div>
             </SelectGroup>
             <SelectGroup
-              id="-1"
-              index={1}
-              isSelected={false}
               key=".1"
-              keyHandler={[Function]}
               label="group 2"
-              sendRef={[Function]}
+              titleId="group-2"
             >
               <div
                 className="pf-c-select__menu-group"
-                id="-1"
-                index={1}
-                isSelected={false}
-                keyHandler={[Function]}
-                sendRef={[Function]}
               >
                 <div
                   aria-hidden={true}
                   className="pf-c-select__menu-group-title"
-                  id=""
+                  id="group-2"
                 >
                   group 2
                 </div>
                 <SelectOption
                   className=""
                   component="button"
-                  index={0}
+                  id="Mr-4"
+                  index={4}
                   isChecked={false}
                   isDisabled={false}
                   isFocused={false}
@@ -4455,6 +4450,7 @@ exports[`select renders select groups successfully 1`] = `
                     <button
                       aria-selected={null}
                       className="pf-c-select__menu-item"
+                      id="Mr-4"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
@@ -4467,7 +4463,8 @@ exports[`select renders select groups successfully 1`] = `
                 <SelectOption
                   className=""
                   component="button"
-                  index={0}
+                  id="Mrs-5"
+                  index={5}
                   isChecked={false}
                   isDisabled={false}
                   isFocused={false}
@@ -4485,6 +4482,7 @@ exports[`select renders select groups successfully 1`] = `
                     <button
                       aria-selected={null}
                       className="pf-c-select__menu-item"
+                      id="Mrs-5"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
@@ -4497,7 +4495,8 @@ exports[`select renders select groups successfully 1`] = `
                 <SelectOption
                   className=""
                   component="button"
-                  index={0}
+                  id="Ms-6"
+                  index={6}
                   isChecked={false}
                   isDisabled={false}
                   isFocused={false}
@@ -4515,6 +4514,7 @@ exports[`select renders select groups successfully 1`] = `
                     <button
                       aria-selected={null}
                       className="pf-c-select__menu-item"
+                      id="Ms-6"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"
@@ -4527,7 +4527,8 @@ exports[`select renders select groups successfully 1`] = `
                 <SelectOption
                   className=""
                   component="button"
-                  index={0}
+                  id="Other-7"
+                  index={7}
                   isChecked={false}
                   isDisabled={false}
                   isFocused={false}
@@ -4545,6 +4546,7 @@ exports[`select renders select groups successfully 1`] = `
                     <button
                       aria-selected={null}
                       className="pf-c-select__menu-item"
+                      id="Other-7"
                       onClick={[Function]}
                       onKeyDown={[Function]}
                       role="option"

--- a/packages/react-core/src/components/Select/examples/Select.md
+++ b/packages/react-core/src/components/Select/examples/Select.md
@@ -144,6 +144,79 @@ class SingleSelectInput extends React.Component {
 }
 ```
 
+```js title=Grouped-single
+import React from 'react';
+import { Select, SelectOption, SelectVariant, SelectGroup } from '@patternfly/react-core';
+
+class GroupedSingleSelectInput extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false,
+      selected: null
+    };
+
+    this.onToggle = isExpanded => {
+      this.setState({
+        isExpanded
+      });
+    };
+
+    this.onSelect = (event, selection) => {
+      this.setState({
+        selected: selection,
+        isExpanded: false
+      })
+    };
+
+    this.clearSelection = () => {
+      this.setState({
+        selected: null
+      });
+    };
+
+    this.options = [
+      <SelectGroup label="Status" key="group1">
+        <SelectOption key={0} value="Running" />
+        <SelectOption key={1} value="Stopped" />
+        <SelectOption key={2} value="Down" />
+        <SelectOption key={3} value="Degraded" />
+        <SelectOption key={4} value="Needs Maintenence" />
+      </SelectGroup>,
+      <SelectGroup label="Vendor Names" key="group2">
+        <SelectOption key={5} value="Dell" />
+        <SelectOption key={6} value="Samsung" isDisabled />
+        <SelectOption key={7} value="Hewlett-Packard" />
+      </SelectGroup>
+    ];
+  }
+
+  render() {
+    const { isExpanded, selected } = this.state;
+    const titleId = 'grouped-single-select-id';
+    return (
+      <div>
+        <span id={titleId} hidden>
+          Grouped Checkbox Title
+        </span>
+        <Select
+          variant={SelectVariant.single}
+          onToggle={this.onToggle}
+          onSelect={this.onSelect}
+          selections={selected}
+          isExpanded={isExpanded}
+          placeholderText="Filter by status/vendor"
+          ariaLabelledBy={titleId}
+          isGrouped
+        >
+          {this.options}
+        </Select>
+      </div>
+    );
+  }
+}
+```
+
 ```js title=Checkbox-input
 import React from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';


### PR DESCRIPTION
**What**: Closes #3780 

When running the tests in `Select.test.tsx` we get an error message saying children element doesn't have `sendRef` and `isSelected` in its props.

I tracked what tests cause this error message which led me to this particular test:
https://github.com/patternfly/patternfly-react/blob/692ea8492d70c7d231535f4663c565f1519da6cf/packages/patternfly-4/react-core/src/components/Select/__tests__/Select.test.tsx#L125-L130


After reading the `Select.tsx` code, I noticed that `isGrouped` is not passed to `SelectMenu` when variant is `single` -- which I fixed.
In addition, I had to add a case when `isGrouped` is true when displaying the selected value in the select box because the selected option is a grand child of the Select component.

Unfortunately, this change causes the DOM to look differently which forced me to update the snapshots.
