### PR TITLE
chore(inputgroup): update docs to be more readable

### DIFF
--- a/packages/patternfly-4/react-core/src/components/InputGroup/examples/InputGroup.md
+++ b/packages/patternfly-4/react-core/src/components/InputGroup/examples/InputGroup.md
@@ -23,19 +23,83 @@ import {
 ## Examples
 ```js title=Basic
 import React from 'react';
-import { DollarSignIcon, AtIcon, CalendarAltIcon, SearchIcon, QuestionCircleIcon } from '@patternfly/react-icons';
+import { AtIcon, SearchIcon } from '@patternfly/react-icons';
 import {
   Button,
-  ButtonVariant,
-  TextArea,
   InputGroup,
   InputGroupText,
+  TextInput
+} from '@patternfly/react-core';
+
+class SimpleInputGroups extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <InputGroup>
+          <TextInput id="textInput6" type="email" aria-label="email input field" />
+          <InputGroupText id="email-example">@example.com</InputGroupText>
+        </InputGroup>
+        <br />
+        <InputGroup>
+          <InputGroupText id="username" aria-label="@">
+            <AtIcon />
+          </InputGroupText>
+          <TextInput isValid={false} id="textInput7" type="email" aria-label="Error state username example" />
+        </InputGroup>
+        <br />
+        <InputGroup>
+          <TextInput name="textInput11" id="textInput11" type="search" aria-label="search input example" />
+          <Button variant="control" aria-label="search button for search input">
+            <SearchIcon />
+          </Button>
+        </InputGroup>
+      </React.Fragment>
+    );
+  }
+}
+```
+
+```js title=With-textarea
+import React from 'react';
+import {
+  Button,
+  TextArea,
+  InputGroup
+} from '@patternfly/react-core';
+
+class SimpleInputGroups extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <InputGroup>
+          <TextArea name="textarea2" id="textarea2" aria-label="textarea with button" />
+          <Button id="textAreaButton2" variant="control">
+            Button
+          </Button>
+        </InputGroup>
+      </React.Fragment>
+    );
+  }
+}
+```
+
+```js title=With-dropdown
+import React from 'react';
+import {
+  Button,
+  InputGroup,
   TextInput,
   Dropdown,
   DropdownToggle,
-  DropdownItem,
-  Popover,
-  PopoverPosition
+  DropdownItem
 } from '@patternfly/react-core';
 
 class SimpleInputGroups extends React.Component {
@@ -62,33 +126,6 @@ class SimpleInputGroups extends React.Component {
     return (
       <React.Fragment>
         <InputGroup>
-          <Button id="textAreaButton1" variant={ButtonVariant.control}>
-            Button
-          </Button>
-          <TextArea name="textarea1" id="textarea1" aria-label="textarea with buttons" />
-          <Button variant={ButtonVariant.control}>Button</Button>
-        </InputGroup>
-        <br />
-        <br />
-        <InputGroup>
-          <TextArea name="textarea2" id="textarea2" aria-label="textarea with button" />
-          <Button id="textAreaButton2" variant={ButtonVariant.control}>
-            Button
-          </Button>
-        </InputGroup>
-        <br />
-        <br />
-        <InputGroup>
-          <Button id="textAreaButton3" variant={ButtonVariant.control}>
-            Button
-          </Button>
-          <Button variant={ButtonVariant.control}>Button</Button>
-          <TextArea name="textarea3" id="textarea3" aria-label="textarea with 3 buttons" />
-          <Button variant={ButtonVariant.control}>Button</Button>
-        </InputGroup>
-        <br />
-        <br />
-        <InputGroup>
           <Dropdown
             onSelect={this.onSelect}
             toggle={
@@ -110,49 +147,62 @@ class SimpleInputGroups extends React.Component {
             ]}
           />
           <TextInput id="textInput3" aria-label="input with dropdown and button" />
-          <Button id="inputDropdownButton1" variant={ButtonVariant.control}>Button</Button>
+          <Button id="inputDropdownButton1" variant="control">Button</Button>
         </InputGroup>
-        <br />
-        <br />
-        <InputGroup>
-          <InputGroupText>
-            <DollarSignIcon />
-          </InputGroupText>
-          <TextInput id="textInput5" type="number" aria-label="Dollar amount input example" />
-          <InputGroupText>.00</InputGroupText>
-        </InputGroup>
-        <br />
-        <br />
-        <InputGroup>
-          <TextInput id="textInput6" type="email" aria-label="email input field" />
-          <InputGroupText id="email-example">@example.com</InputGroupText>
-        </InputGroup>
-        <br />
-        <br />
-        <InputGroup>
-          <InputGroupText id="username" aria-label="@">
-            <AtIcon />
-          </InputGroupText>
-          <TextInput isValid={false} id="textInput7" type="email" aria-label="Error state username example" />
-        </InputGroup>
-        <br />
-        <br />
+      </React.Fragment>
+    );
+  }
+}
+```
+
+```js title=With-datepicker
+import React from 'react';
+import { CalendarAltIcon } from '@patternfly/react-icons';
+import {
+  InputGroup,
+  InputGroupText,
+  TextInput
+} from '@patternfly/react-core';
+
+class SimpleInputGroups extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <React.Fragment>
         <InputGroup>
           <InputGroupText component="label" htmlFor="textInput9">
             <CalendarAltIcon />
           </InputGroupText>
           <TextInput name="textInput9" id="textInput9" type="date" aria-label="Date input example" />
         </InputGroup>
-        <br />
-        <br />
-        <InputGroup>
-          <TextInput name="textInput11" id="textInput11" type="search" aria-label="search input example" />
-          <Button variant={ButtonVariant.control} aria-label="search button for search input">
-            <SearchIcon />
-          </Button>
-        </InputGroup>
-        <br />
-        <br />
+      </React.Fragment>
+    );
+  }
+}
+```
+
+```js title=With-popover
+import React from 'react';
+import { QuestionCircleIcon } from '@patternfly/react-icons';
+import {
+  Button,
+  InputGroup,
+  TextInput,
+  Popover,
+  PopoverPosition
+} from '@patternfly/react-core';
+
+class SimpleInputGroups extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <React.Fragment>
         <InputGroup>
           <TextInput name="textInput10" id="textInput10" type="search" aria-label="input example with popover" />
           <Popover
@@ -160,10 +210,60 @@ class SimpleInputGroups extends React.Component {
             position={PopoverPosition.top}
             bodyContent="This field is an example of input group with popover"
           >
-            <Button variant={ButtonVariant.control} aria-label="popover for input">
+            <Button variant="control" aria-label="popover for input">
               <QuestionCircleIcon />
             </Button>
           </Popover>
+        </InputGroup>
+      </React.Fragment>
+    );
+  }
+}
+```
+
+
+```js title=With-multiple-group-siblings
+import React from 'react';
+import { DollarSignIcon } from '@patternfly/react-icons';
+import {
+  Button,
+  TextArea,
+  InputGroup,
+  InputGroupText,
+  TextInput
+} from '@patternfly/react-core';
+
+class SimpleInputGroups extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <InputGroup>
+          <Button id="textAreaButton1" variant="control">
+            Button
+          </Button>
+          <TextArea name="textarea1" id="textarea1" aria-label="textarea with buttons" />
+          <Button variant="control">Button</Button>
+        </InputGroup>
+        <br />
+        <InputGroup>
+          <Button id="textAreaButton3" variant="control">
+            Button
+          </Button>
+          <Button variant="control">Button</Button>
+          <TextArea name="textarea3" id="textarea3" aria-label="textarea with 3 buttons" />
+          <Button variant="control">Button</Button>
+        </InputGroup>
+        <br />
+        <InputGroup>
+          <InputGroupText>
+            <DollarSignIcon />
+          </InputGroupText>
+          <TextInput id="textInput5" type="number" aria-label="Dollar amount input example" />
+          <InputGroupText>.00</InputGroupText>
         </InputGroup>
       </React.Fragment>
     );

--- a/packages/patternfly-4/react-core/src/layouts/Grid/examples/Grid.md
+++ b/packages/patternfly-4/react-core/src/layouts/Grid/examples/Grid.md
@@ -3,7 +3,7 @@ title: 'Grid'
 cssPrefix: 'pf-l-grid'
 section: 'layouts'
 propComponents: ['Grid', 'GridItem']
-typescript: true 
+typescript: true
 ---
 import { Grid, GridItem } from '@patternfly/react-core';
 import './grid.css';
@@ -64,7 +64,6 @@ GridWithGuttersExample = () => (
 ```js title=With-overrides
 import React from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
-import ItemControl from './ItemControl';
 
 GridWithOverridesExample = () => (
   <Grid sm={6} md={4} lg={3} xl2={1}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13117,10 +13117,10 @@ gatsby-telemetry@^1.1.49:
     stack-utils "1.0.2"
     uuid "3.3.3"
 
-gatsby-theme-patternfly-org@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/gatsby-theme-patternfly-org/-/gatsby-theme-patternfly-org-1.4.0.tgz#a59d666c166fd4c6ce5aa2b294a7fbed46d7e3c7"
-  integrity sha512-7aG0vvIg9Gwc+DtKv+2Y3b5Wlb/PM/+ISAX4sYgARyg95MyDgDAxSqMbt1tMK4hKAwXJje9vXVSVWmbjjwVX0w==
+gatsby-theme-patternfly-org@^1.4.1:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/gatsby-theme-patternfly-org/-/gatsby-theme-patternfly-org-1.4.3.tgz#7e6d9714b5191c8af1ea786ac70e844ce588025e"
+  integrity sha512-nfxmZOMT+Db4QhBWjwKLUUtsr29qJm/y5qf3D2XYf3RA/H1nEcfDOqy/WjT97N4ukFOlDOxeBNd8U3dKWoi0gw==
   dependencies:
     "@mdx-js/mdx" "^1.1.5"
     "@mdx-js/react" "^1.1.5"
@@ -13145,10 +13145,10 @@ gatsby-transformer-json@^2.2.20:
     "@babel/runtime" "^7.7.4"
     bluebird "^3.7.1"
 
-gatsby-transformer-react-docgen-typescript@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/gatsby-transformer-react-docgen-typescript/-/gatsby-transformer-react-docgen-typescript-0.2.4.tgz#f00f45cb4a9894c7f6b2a176a7c8fbe2600d3cbb"
-  integrity sha512-DxSyD5ggje1SnGyrUfZy7VzVCYfJrkEo8Mms3jsgmKh96gTk0c5cBQmKJDHtlR8/mR6tyrO64N39w271V5ONwA==
+gatsby-transformer-react-docgen-typescript@^0.2.5:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/gatsby-transformer-react-docgen-typescript/-/gatsby-transformer-react-docgen-typescript-0.2.6.tgz#9595b6b75b41a6b0df9ece4207972fb663bab198"
+  integrity sha512-8P7e5gnYz5pW0mzXGOsWjt4+NW1RFwIOOvrav3B7bJlN/C0uePcnXW9NZdeRxJ6HdcNefB6eJSXTRveegBS/8A==
   dependencies:
     react-docgen "^5.1.0"
 


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**:  This PR updates the examples page for InputGroup. It changes this page from being one large example code snippet with all variations together to grouping the examples logically into multiple example code snippets. The code snippets are now much leaner and easier on the eyes.

<img width="1030" alt="Screen Shot 2020-02-27 at 10 37 07 AM" src="https://user-images.githubusercontent.com/5942899/75459453-7516be00-594d-11ea-83af-c834effba431.png">

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Closes https://github.com/patternfly/patternfly-react/issues/3823
