### PR TITLE
fix(datalist): make data list action children optional

### DIFF
--- a/packages/patternfly-4/react-core/src/components/DataList/DataListAction.tsx
+++ b/packages/patternfly-4/react-core/src/components/DataList/DataListAction.tsx
@@ -38,7 +38,7 @@ export const DataListActionVisibility: IDataListActionVisibility = Object.keys(v
 
 export interface DataListActionProps extends Omit<React.HTMLProps<HTMLDivElement>, 'children'> {
   /** Content rendered as DataList Action  (e.g <Button> or <Dropdown>) */
-  children: React.ReactNode;
+  children?: React.ReactNode;
   /** Additional classes added to the DataList Action */
   className?: string;
   /** Identify the DataList toggle number */


### PR DESCRIPTION
**What**: Closes #3751 

Set the children props to be optional: `children?: ...`