### PR TITLE
Added page titles for react docs & react icons pages

### DIFF
--- a/packages/patternfly-4/react-docs/src/pages/icons.js
+++ b/packages/patternfly-4/react-docs/src/pages/icons.js
@@ -42,7 +42,7 @@ const iconsPage = ({ location }) => {
   };
 
   return (
-    <SideNavLayout location={location} context="react">
+    <SideNavLayout location={location} context="react" pageTitle="React icons">
       <PageSection className="ws-section">
         <Title size="md" className="ws-framework-title">
           React

--- a/packages/patternfly-4/react-docs/src/pages/index.js
+++ b/packages/patternfly-4/react-docs/src/pages/index.js
@@ -24,7 +24,7 @@ const IndexPage = ({ data, location }) => {
   const prInfo = data.allEnvVars.edges.filter(({ node }) => node.name === 'PR_INFO')[0].node;
 
   return (
-    <SideNavLayout location={location} context="react">
+    <SideNavLayout location={location} context="react" pageTitle="React docs">
       <div style={containerStyle}>
         <PageSection style={centerStyle}>
           <div style={{ flex: 'none', textAlign: 'center' }}>


### PR DESCRIPTION
**What**: Towards https://github.com/patternfly/patternfly-org/pull/1705 - this PR adds page titles to React Docs and React Icons pages rather than browser tab simply displaying "PatternFly 4" for both pages.
