### PR TITLE
added console warning to Drawer beta component

### DIFF
--- a/packages/patternfly-4/react-core/src/components/Drawer/Drawer.tsx
+++ b/packages/patternfly-4/react-core/src/components/Drawer/Drawer.tsx
@@ -13,22 +13,35 @@ export interface DrawerProps extends React.HTMLProps<HTMLDivElement> {
   isInline?: boolean;
 }
 
-export const Drawer: React.SFC<DrawerProps> = ({
-  className = '',
-  children,
-  isExpanded = false,
-  isInline = false,
-  ...props
-}: DrawerProps) => (
-  <div
-    {...props}
-    className={css(
-      styles.drawer,
-      isExpanded && styles.modifiers.expanded,
-      isInline && styles.modifiers.inline,
-      className
-    )}
-  >
-    {children}
-  </div>
-);
+export class Drawer extends React.Component<DrawerProps> {
+  static hasWarnBeta = false;
+  constructor(props: DrawerProps) {
+    super(props);
+  }
+
+  componentDidMount() {
+    if (!Drawer.hasWarnBeta && process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn('This component is in beta and subject to change.');
+      Drawer.hasWarnBeta = true;
+    }
+  }
+
+  render() {
+    const { className = '', children, isExpanded = false, isInline = false, ...props } = this.props;
+
+    return (
+      <div
+        {...props}
+        className={css(
+          styles.drawer,
+          isExpanded && styles.modifiers.expanded,
+          isInline && styles.modifiers.inline,
+          className
+        )}
+      >
+        {children}
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Towards #3624 - this PR adds a console warning for the Drawer beta component, similar to existing implementations in the DataToolbar and SimpleList components.