### PR TITLE
build(patternfly-3): enable releasing patternfly 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,13 +59,13 @@ workflows:
     - lint_pf3:
         requires:
         - build_pf3
-    # - deploy_prerelease:
-    #     requires:
-    #     - test_jest_pf3
-    #     - build_docs_pf3
-    #     filters:
-    #       branches:
-    #         only: master
+    - deploy_prerelease:
+        requires:
+        - test_jest_pf3
+        - build_docs_pf3
+        filters:
+          branches:
+            only: patternfly-3
 jobs:
   build_pf3:
     docker:


### PR DESCRIPTION
I temporarily disabled releasing PF3 to prevent conflicts with master's PF3. Now that PF3 is out of master, we can reenable releasing for PF3.