### PR TITLE
fix react-docs version

### DIFF
--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@patternfly/react-docs",
   "description": "PatternFly React Docs",
-  "version": "4.20.24",
+  "version": "4.20.25",
   "author": "Red Hat",
   "license": "MIT",
   "private": true,


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Publishing on master is broken because we published react-docs from our `v4` branch. This should fix it!

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
