### PR TITLE
feat(Alert): change default alert variant to default

### DIFF
--- a/packages/react-core/src/components/Alert/Alert.tsx
+++ b/packages/react-core/src/components/Alert/Alert.tsx
@@ -36,7 +36,7 @@ export interface AlertProps extends Omit<React.HTMLProps<HTMLDivElement>, 'actio
 }
 
 export const Alert: React.FunctionComponent<AlertProps & OUIAProps> = ({
-  variant = AlertVariant.info,
+  variant = AlertVariant.default,
   isInline = false,
   isLiveRegion = false,
   variantLabel = `${capitalize(variant)} alert:`,

--- a/packages/react-core/src/components/Alert/__tests__/Alert.test.tsx
+++ b/packages/react-core/src/components/Alert/__tests__/Alert.test.tsx
@@ -5,14 +5,14 @@ import { Alert, AlertVariant } from '../Alert';
 import { AlertActionLink } from '../AlertActionLink';
 import { AlertActionCloseButton } from '../AlertActionCloseButton';
 
-test('default Alert variant is info', () => {
+test('default Alert variant is default', () => {
   const view = mount(<Alert title="this is a test">Alert testing</Alert>);
   expect(
     view
       .find('Alert')
       .childAt(0)
       .prop('className')
-  ).toContain('pf-m-info');
+  ).toContain('pf-c-alert');
 });
 
 Object.values(AlertVariant).forEach(variant => {

--- a/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
+++ b/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
@@ -265,14 +265,10 @@ exports[`alertgroup closes when alerts are closed 1`] = `
               aria-atomic="false"
               aria-label="Default Alert"
               aria-live="polite"
-<<<<<<< HEAD
-              class="pf-c-alert pf-m-info"
+              class="pf-c-alert"
               data-ouia-component-id="2"
               data-ouia-component-type="PF4/Alert"
               data-ouia-safe="true"
-=======
-              class="pf-c-alert"
->>>>>>> feat(Alert): change default alert variant to default
             >
               <div
                 class="pf-c-alert__icon"
@@ -348,14 +344,10 @@ exports[`alertgroup closes when alerts are closed 1`] = `
               aria-atomic="false"
               aria-label="Default Alert"
               aria-live="polite"
-<<<<<<< HEAD
-              class="pf-c-alert pf-m-info"
+              class="pf-c-alert"
               data-ouia-component-id="2"
               data-ouia-component-type="PF4/Alert"
               data-ouia-safe="true"
-=======
-              class="pf-c-alert"
->>>>>>> feat(Alert): change default alert variant to default
             >
               <div
                 class="pf-c-alert__icon"
@@ -440,21 +432,20 @@ exports[`alertgroup closes when alerts are closed 1`] = `
           >
             <div
               aria-atomic="false"
-              aria-label="Info Alert"
+              aria-label="Default Alert"
               aria-live="polite"
-              className="pf-c-alert pf-m-info"
+              className="pf-c-alert"
               data-ouia-component-id={2}
               data-ouia-component-type="PF4/Alert"
               data-ouia-safe={true}
             >
               <AlertIcon
-                variant="info"
+                variant="default"
               >
                 <div
-<<<<<<< HEAD
                   className="pf-c-alert__icon"
                 >
-                  <InfoCircleIcon
+                  <BellIcon
                     color="currentColor"
                     noVerticalAlign={false}
                     size="sm"
@@ -471,15 +462,15 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                           "verticalAlign": "-0.125em",
                         }
                       }
-                      viewBox="0 0 512 512"
+                      viewBox="0 0 448 512"
                       width="1em"
                     >
                       <path
-                        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                        d="M224 512c35.32 0 63.97-28.65 63.97-64H160.03c0 35.35 28.65 64 63.97 64zm215.39-149.71c-19.32-20.76-55.47-51.99-55.47-154.29 0-77.7-54.48-139.9-127.94-155.16V32c0-17.67-14.32-32-31.98-32s-31.98 14.33-31.98 32v20.84C118.56 68.1 64.08 130.3 64.08 208c0 102.3-36.15 133.53-55.47 154.29-6 6.45-8.66 14.16-8.61 21.71.11 16.4 12.98 32 32.1 32h383.8c19.12 0 32-15.6 32.1-32 .05-7.55-2.61-15.27-8.61-21.71z"
                         transform=""
                       />
                     </svg>
-                  </InfoCircleIcon>
+                  </BellIcon>
                 </div>
               </AlertIcon>
               <h4
@@ -488,7 +479,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                 <span
                   className="pf-u-screen-reader"
                 >
-                  Info alert:
+                  Default alert:
                 </span>
                 Test Alert
               </h4>
@@ -499,21 +490,12 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                   aria-label="Close"
                   onClose={[MockFunction]}
                   title="Test Alert"
-                  variantLabel="Info alert:"
+                  variantLabel="Default alert:"
                 >
                   <Button
                     aria-label="Close"
                     onClick={[MockFunction]}
                     variant="plain"
-=======
-                  aria-atomic="false"
-                  aria-label="Default Alert"
-                  aria-live="polite"
-                  className="pf-c-alert"
-                >
-                  <AlertIcon
-                    variant="default"
->>>>>>> feat(Alert): change default alert variant to default
                   >
                     <button
                       aria-disabled={null}
@@ -527,11 +509,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                       tabIndex={null}
                       type="button"
                     >
-<<<<<<< HEAD
                       <TimesIcon
-=======
-                      <BellIcon
->>>>>>> feat(Alert): change default alert variant to default
                         color="currentColor"
                         noVerticalAlign={false}
                         size="sm"
@@ -548,7 +526,6 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                               "verticalAlign": "-0.125em",
                             }
                           }
-<<<<<<< HEAD
                           viewBox="0 0 352 512"
                           width="1em"
                         >
@@ -564,121 +541,6 @@ exports[`alertgroup closes when alerts are closed 1`] = `
               </div>
             </div>
           </Alert>
-=======
-                          viewBox="0 0 448 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M224 512c35.32 0 63.97-28.65 63.97-64H160.03c0 35.35 28.65 64 63.97 64zm215.39-149.71c-19.32-20.76-55.47-51.99-55.47-154.29 0-77.7-54.48-139.9-127.94-155.16V32c0-17.67-14.32-32-31.98-32s-31.98 14.33-31.98 32v20.84C118.56 68.1 64.08 130.3 64.08 208c0 102.3-36.15 133.53-55.47 154.29-6 6.45-8.66 14.16-8.61 21.71.11 16.4 12.98 32 32.1 32h383.8c19.12 0 32-15.6 32.1-32 .05-7.55-2.61-15.27-8.61-21.71z"
-                            transform=""
-                          />
-                        </svg>
-                      </BellIcon>
-                    </div>
-                  </AlertIcon>
-                  <h4
-                    className="pf-c-alert__title"
-                  >
-                    <span
-                      className="pf-u-screen-reader"
-                    >
-                      Default alert:
-                    </span>
-                    Test Alert
-                  </h4>
-                  <div
-                    className="pf-c-alert__action"
-                  >
-                    <AlertActionCloseButton
-                      aria-label="Close"
-                      onClose={[MockFunction]}
-                      title="Test Alert"
-                      variantLabel="Default alert:"
-                    >
-                      <Component
-                        aria-label="Close"
-                        onClick={[MockFunction]}
-                        variant="plain"
-                      >
-                        <ComponentWithOuia
-                          component={[Function]}
-                          componentProps={
-                            Object {
-                              "aria-label": "Close",
-                              "children": <TimesIcon
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                size="sm"
-                                title={null}
-                              />,
-                              "onClick": [MockFunction],
-                              "variant": "plain",
-                            }
-                          }
-                          consumerContext={
-                            Object {
-                              "isOuia": false,
-                              "ouiaId": null,
-                            }
-                          }
-                        >
-                          <Button
-                            aria-label="Close"
-                            onClick={[MockFunction]}
-                            ouiaContext={
-                              Object {
-                                "isOuia": false,
-                                "ouiaId": null,
-                              }
-                            }
-                            variant="plain"
-                          >
-                            <button
-                              aria-disabled={null}
-                              aria-label="Close"
-                              className="pf-c-button pf-m-plain"
-                              disabled={false}
-                              onClick={[MockFunction]}
-                              tabIndex={null}
-                              type="button"
-                            >
-                              <TimesIcon
-                                color="currentColor"
-                                noVerticalAlign={false}
-                                size="sm"
-                                title={null}
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  aria-labelledby={null}
-                                  fill="currentColor"
-                                  height="1em"
-                                  role="img"
-                                  style={
-                                    Object {
-                                      "verticalAlign": "-0.125em",
-                                    }
-                                  }
-                                  viewBox="0 0 352 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                                    transform=""
-                                  />
-                                </svg>
-                              </TimesIcon>
-                            </button>
-                          </Button>
-                        </ComponentWithOuia>
-                      </Component>
-                    </AlertActionCloseButton>
-                  </div>
-                </div>
-              </Alert>
-            </ComponentWithOuia>
-          </Component>
->>>>>>> feat(Alert): change default alert variant to default
         </li>
       </ul>
     </AlertGroupInline>

--- a/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
+++ b/packages/react-core/src/components/AlertGroup/__tests__/__snapshots__/AlertGroup.test.tsx.snap
@@ -263,12 +263,16 @@ exports[`alertgroup closes when alerts are closed 1`] = `
           <li>
             <div
               aria-atomic="false"
-              aria-label="Info Alert"
+              aria-label="Default Alert"
               aria-live="polite"
+<<<<<<< HEAD
               class="pf-c-alert pf-m-info"
               data-ouia-component-id="2"
               data-ouia-component-type="PF4/Alert"
               data-ouia-safe="true"
+=======
+              class="pf-c-alert"
+>>>>>>> feat(Alert): change default alert variant to default
             >
               <div
                 class="pf-c-alert__icon"
@@ -279,11 +283,11 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                   height="1em"
                   role="img"
                   style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
+                  viewBox="0 0 448 512"
                   width="1em"
                 >
                   <path
-                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                    d="M224 512c35.32 0 63.97-28.65 63.97-64H160.03c0 35.35 28.65 64 63.97 64zm215.39-149.71c-19.32-20.76-55.47-51.99-55.47-154.29 0-77.7-54.48-139.9-127.94-155.16V32c0-17.67-14.32-32-31.98-32s-31.98 14.33-31.98 32v20.84C118.56 68.1 64.08 130.3 64.08 208c0 102.3-36.15 133.53-55.47 154.29-6 6.45-8.66 14.16-8.61 21.71.11 16.4 12.98 32 32.1 32h383.8c19.12 0 32-15.6 32.1-32 .05-7.55-2.61-15.27-8.61-21.71z"
                     transform=""
                   />
                 </svg>
@@ -294,7 +298,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                 <span
                   class="pf-u-screen-reader"
                 >
-                  Info alert:
+                  Default alert:
                 </span>
                 Test Alert
               </h4>
@@ -342,12 +346,16 @@ exports[`alertgroup closes when alerts are closed 1`] = `
           <li>
             <div
               aria-atomic="false"
-              aria-label="Info Alert"
+              aria-label="Default Alert"
               aria-live="polite"
+<<<<<<< HEAD
               class="pf-c-alert pf-m-info"
               data-ouia-component-id="2"
               data-ouia-component-type="PF4/Alert"
               data-ouia-safe="true"
+=======
+              class="pf-c-alert"
+>>>>>>> feat(Alert): change default alert variant to default
             >
               <div
                 class="pf-c-alert__icon"
@@ -358,11 +366,11 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                   height="1em"
                   role="img"
                   style="vertical-align: -0.125em;"
-                  viewBox="0 0 512 512"
+                  viewBox="0 0 448 512"
                   width="1em"
                 >
                   <path
-                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+                    d="M224 512c35.32 0 63.97-28.65 63.97-64H160.03c0 35.35 28.65 64 63.97 64zm215.39-149.71c-19.32-20.76-55.47-51.99-55.47-154.29 0-77.7-54.48-139.9-127.94-155.16V32c0-17.67-14.32-32-31.98-32s-31.98 14.33-31.98 32v20.84C118.56 68.1 64.08 130.3 64.08 208c0 102.3-36.15 133.53-55.47 154.29-6 6.45-8.66 14.16-8.61 21.71.11 16.4 12.98 32 32.1 32h383.8c19.12 0 32-15.6 32.1-32 .05-7.55-2.61-15.27-8.61-21.71z"
                     transform=""
                   />
                 </svg>
@@ -373,7 +381,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                 <span
                   class="pf-u-screen-reader"
                 >
-                  Info alert:
+                  Default alert:
                 </span>
                 Test Alert
               </h4>
@@ -443,6 +451,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                 variant="info"
               >
                 <div
+<<<<<<< HEAD
                   className="pf-c-alert__icon"
                 >
                   <InfoCircleIcon
@@ -496,6 +505,15 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                     aria-label="Close"
                     onClick={[MockFunction]}
                     variant="plain"
+=======
+                  aria-atomic="false"
+                  aria-label="Default Alert"
+                  aria-live="polite"
+                  className="pf-c-alert"
+                >
+                  <AlertIcon
+                    variant="default"
+>>>>>>> feat(Alert): change default alert variant to default
                   >
                     <button
                       aria-disabled={null}
@@ -509,7 +527,11 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                       tabIndex={null}
                       type="button"
                     >
+<<<<<<< HEAD
                       <TimesIcon
+=======
+                      <BellIcon
+>>>>>>> feat(Alert): change default alert variant to default
                         color="currentColor"
                         noVerticalAlign={false}
                         size="sm"
@@ -526,6 +548,7 @@ exports[`alertgroup closes when alerts are closed 1`] = `
                               "verticalAlign": "-0.125em",
                             }
                           }
+<<<<<<< HEAD
                           viewBox="0 0 352 512"
                           width="1em"
                         >
@@ -541,6 +564,121 @@ exports[`alertgroup closes when alerts are closed 1`] = `
               </div>
             </div>
           </Alert>
+=======
+                          viewBox="0 0 448 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M224 512c35.32 0 63.97-28.65 63.97-64H160.03c0 35.35 28.65 64 63.97 64zm215.39-149.71c-19.32-20.76-55.47-51.99-55.47-154.29 0-77.7-54.48-139.9-127.94-155.16V32c0-17.67-14.32-32-31.98-32s-31.98 14.33-31.98 32v20.84C118.56 68.1 64.08 130.3 64.08 208c0 102.3-36.15 133.53-55.47 154.29-6 6.45-8.66 14.16-8.61 21.71.11 16.4 12.98 32 32.1 32h383.8c19.12 0 32-15.6 32.1-32 .05-7.55-2.61-15.27-8.61-21.71z"
+                            transform=""
+                          />
+                        </svg>
+                      </BellIcon>
+                    </div>
+                  </AlertIcon>
+                  <h4
+                    className="pf-c-alert__title"
+                  >
+                    <span
+                      className="pf-u-screen-reader"
+                    >
+                      Default alert:
+                    </span>
+                    Test Alert
+                  </h4>
+                  <div
+                    className="pf-c-alert__action"
+                  >
+                    <AlertActionCloseButton
+                      aria-label="Close"
+                      onClose={[MockFunction]}
+                      title="Test Alert"
+                      variantLabel="Default alert:"
+                    >
+                      <Component
+                        aria-label="Close"
+                        onClick={[MockFunction]}
+                        variant="plain"
+                      >
+                        <ComponentWithOuia
+                          component={[Function]}
+                          componentProps={
+                            Object {
+                              "aria-label": "Close",
+                              "children": <TimesIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="sm"
+                                title={null}
+                              />,
+                              "onClick": [MockFunction],
+                              "variant": "plain",
+                            }
+                          }
+                          consumerContext={
+                            Object {
+                              "isOuia": false,
+                              "ouiaId": null,
+                            }
+                          }
+                        >
+                          <Button
+                            aria-label="Close"
+                            onClick={[MockFunction]}
+                            ouiaContext={
+                              Object {
+                                "isOuia": false,
+                                "ouiaId": null,
+                              }
+                            }
+                            variant="plain"
+                          >
+                            <button
+                              aria-disabled={null}
+                              aria-label="Close"
+                              className="pf-c-button pf-m-plain"
+                              disabled={false}
+                              onClick={[MockFunction]}
+                              tabIndex={null}
+                              type="button"
+                            >
+                              <TimesIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="sm"
+                                title={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  aria-labelledby={null}
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "verticalAlign": "-0.125em",
+                                    }
+                                  }
+                                  viewBox="0 0 352 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                    transform=""
+                                  />
+                                </svg>
+                              </TimesIcon>
+                            </button>
+                          </Button>
+                        </ComponentWithOuia>
+                      </Component>
+                    </AlertActionCloseButton>
+                  </div>
+                </div>
+              </Alert>
+            </ComponentWithOuia>
+          </Component>
+>>>>>>> feat(Alert): change default alert variant to default
         </li>
       </ul>
     </AlertGroupInline>

--- a/packages/react-integration/demo-app-ts/src/components/demos/AlertDemo/AlertDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/AlertDemo/AlertDemo.tsx
@@ -44,7 +44,7 @@ export class AlertDemo extends React.Component<null, AlertDemoState> {
             Info alert description. <a href="#">This is a link.</a>
           </Alert>
         )}
-        <Alert id="default-alert" variant="default" title="Default alert title" isInline>
+        <Alert id="default-alert" title="Default alert title" isInline>
           Info alert description
         </Alert>
       </React.Fragment>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #2646

@tlabaj `default` cannot be removed from the `variant` property union because it is now set to be the default value. Should the `variant` property accept a string instead of the specific "default" string, or should it remain accepting "default"?

## Breaking changes
1. Changes the default of the `variant` property to `default` instead of `info`. To maintain current default behavior, set the `variant` property to `info`.