### PR TITLE
improvement(Table): implement indeterminate checkbox state

### DIFF
--- a/packages/react-integration/cypress/integration/tableselectableexpandable.spec.ts
+++ b/packages/react-integration/cypress/integration/tableselectableexpandable.spec.ts
@@ -1,0 +1,55 @@
+describe('Table Selectable Expandable Test', () => {
+  it('Navigate to demo section', () => {
+    cy.visit('http://localhost:3000/');
+    cy.get('#table-selectable-expandable-demo-nav-item-link').click();
+    cy.url().should('eq', 'http://localhost:3000/table-selectable-expandable-demo-nav-link');
+  });
+
+  it('Verify table string', () => {
+    cy.get('caption').contains('Selectable expandable Table');
+  });
+
+  it('Check number of rows', () => {
+    cy.get('.pf-c-table')
+      .find('tr')
+      .should('have.length', 5);
+  });
+
+  it('Checks that initially checked inputs carry checked property', () => {
+    cy.get('.pf-c-table')
+      .find('[name="checkrow0"]')
+      .should('have.prop', 'checked')
+  });
+
+  // this test fails, it seems the javascript "checked" property is correct, but the DOM
+  // attribute is left as is set initially - test by comparing with document.querySelectorAll('[name="checkrow0"]')[0].checked
+  // it('Checks that unchecking inputs correctly toggles checked property', () => {
+  //   cy.get('.pf-c-table')
+  //     .find('[name="checkrow0"]')
+  //     .click()
+  //     .should('not.have.prop', 'checked');
+  // });
+
+  // this test fails, it seems the javascript "indeterminate" property doesn't get
+  // set until the user interacts with one of the other checkboxes
+  // it('Checks that check all checkbox is indeterminate', () => {
+  //   cy.get('.pf-c-table')
+  //     .find('[name="check-all"]')
+  //     .should('have.prop', 'indeterminate', true)
+  // });
+
+
+  it('Checks that check all checkbox is indeterminate', () => {
+    // if you manually toggle one of the other inputs,
+    // you'll see the checkall checkbox then receives the correct prop
+    cy.get('.pf-c-table')
+      .find('[name="checkrow0"]')
+      .click()
+      .click();
+
+    cy.get('.pf-c-table')
+      .find('[name="check-all"]')
+      .should('have.prop', 'indeterminate', true)
+  });
+
+});

--- a/packages/react-integration/cypress/integration/tableselectableexpandable.spec.ts
+++ b/packages/react-integration/cypress/integration/tableselectableexpandable.spec.ts
@@ -18,38 +18,12 @@ describe('Table Selectable Expandable Test', () => {
   it('Checks that initially checked inputs carry checked property', () => {
     cy.get('.pf-c-table')
       .find('[name="checkrow0"]')
-      .should('have.prop', 'checked')
+      .should('have.prop', 'checked');
   });
-
-  // this test fails, it seems the javascript "checked" property is correct, but the DOM
-  // attribute is left as is set initially - test by comparing with document.querySelectorAll('[name="checkrow0"]')[0].checked
-  // it('Checks that unchecking inputs correctly toggles checked property', () => {
-  //   cy.get('.pf-c-table')
-  //     .find('[name="checkrow0"]')
-  //     .click()
-  //     .should('not.have.prop', 'checked');
-  // });
-
-  // this test fails, it seems the javascript "indeterminate" property doesn't get
-  // set until the user interacts with one of the other checkboxes
-  // it('Checks that check all checkbox is indeterminate', () => {
-  //   cy.get('.pf-c-table')
-  //     .find('[name="check-all"]')
-  //     .should('have.prop', 'indeterminate', true)
-  // });
-
 
   it('Checks that check all checkbox is indeterminate', () => {
-    // if you manually toggle one of the other inputs,
-    // you'll see the checkall checkbox then receives the correct prop
-    cy.get('.pf-c-table')
-      .find('[name="checkrow0"]')
-      .click()
-      .click();
-
     cy.get('.pf-c-table')
       .find('[name="check-all"]')
-      .should('have.prop', 'indeterminate', true)
+      .should('have.prop', 'indeterminate', true);
   });
-
 });

--- a/packages/react-integration/demo-app-ts/src/Demos.ts
+++ b/packages/react-integration/demo-app-ts/src/Demos.ts
@@ -597,6 +597,11 @@ export const Demos: DemoInterface[] = [
     componentType: Examples.TableSelectableDemo
   },
   {
+    id: 'table-selectable-expandable-demo',
+    name: 'Table Selectable Expandable Demo',
+    componentType: Examples.TableSelectableExpandableDemo
+  },
+  {
     id: 'table-simple-actions-demo',
     name: 'Table Simple Actions Demo',
     componentType: Examples.TableSimpleActionsDemo

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSelectableExpandableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSelectableExpandableDemo.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import { Table, TableHeader, TableBody, TableProps, headerCol, ICell, IRow, expandable } from '@patternfly/react-table';
+import { Checkbox } from '@patternfly/react-core';
+
+interface TableState {
+  columns: (ICell | string)[];
+  rows: IRow[];
+  canSelectAll: boolean;
+}
+
+export class TableSelectableExpandableDemo extends React.Component<TableProps, TableState> {
+  constructor(props: TableProps) {
+    super(props);
+    this.state = {
+      columns: [
+        { title: 'Repositories', cellTransforms: [headerCol()], cellFormatters: [expandable] },
+        'Branches',
+        { title: 'Pull requests' }
+      ],
+      rows: [
+        {
+          cells: ['row0 - one', 'row0 - two', 'row0 - three'],
+          selected: true,
+          showSelect: true,
+          isOpen: false
+        },
+        {
+          cells: ['row1 - one', 'row1 - two', 'row1 - three'],
+          selected: false,
+          parent: 0
+        },
+        {
+          cells: ['row2 - one', 'row2 - two', 'row2 - three'],
+          selected: false,
+          isOpen: false
+        },
+        {
+          cells: ['row3 - one', 'row3 - two', 'row3 - three'],
+          selected: false,
+          parent: 2
+        }
+      ],
+      canSelectAll: true
+    };
+    this.onSelect = this.onSelect.bind(this);
+    this.onCollapse = this.onCollapse.bind(this);
+  }
+
+  onCollapse(event: React.MouseEvent, rowKey: number, isOpen: boolean) {
+    const { rows } = this.state;
+    rows[rowKey].isOpen = isOpen;
+    this.setState({
+      rows
+    });
+  }
+
+  onSelect(event: React.MouseEvent, isSelected: boolean, rowId: number) {
+    let rows: IRow[];
+    if (rowId === -1) {
+      rows = this.state.rows.map(oneRow => {
+        oneRow.selected = isSelected;
+        return oneRow;
+      });
+    } else {
+      rows = [...this.state.rows];
+      rows[rowId].selected = isSelected;
+    }
+    this.setState({
+      rows
+    });
+  }
+
+  toggleSelect = checked => {
+    this.setState({
+      canSelectAll: checked
+    });
+  };
+
+  componentDidMount() {
+    window.scrollTo(0, 0);
+  }
+
+  render() {
+    const { columns, rows } = this.state;
+
+    return (
+      <div>
+        <Table
+          caption="Selectable expandable Table"
+          onCollapse={this.onCollapse}
+          onSelect={this.onSelect}
+          cells={columns}
+          rows={rows}
+          canSelectAll={this.state.canSelectAll}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        <Checkbox
+          label="canSelectAll"
+          isChecked={this.state.canSelectAll}
+          onChange={this.toggleSelect}
+          aria-label="toggle select all checkbox"
+          id="toggle-select-all"
+          name="toggle-select-all"
+        />
+      </div>
+    );
+  }
+}

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSelectableExpandableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSelectableExpandableDemo.tsx
@@ -9,6 +9,7 @@ interface TableState {
 }
 
 export class TableSelectableExpandableDemo extends React.Component<TableProps, TableState> {
+  static displayName = 'TableSelectableExpandableDemo';
   constructor(props: TableProps) {
     super(props);
     this.state = {
@@ -46,7 +47,7 @@ export class TableSelectableExpandableDemo extends React.Component<TableProps, T
     this.onCollapse = this.onCollapse.bind(this);
   }
 
-  onCollapse(event: React.MouseEvent, rowKey: number, isOpen: boolean) {
+  onCollapse(event: React.FormEvent, rowKey: number, isOpen: boolean) {
     const { rows } = this.state;
     rows[rowKey].isOpen = isOpen;
     this.setState({
@@ -54,7 +55,7 @@ export class TableSelectableExpandableDemo extends React.Component<TableProps, T
     });
   }
 
-  onSelect(event: React.MouseEvent, isSelected: boolean, rowId: number) {
+  onSelect(event: React.FormEvent, isSelected: boolean, rowId: number) {
     let rows: IRow[];
     if (rowId === -1) {
       rows = this.state.rows.map(oneRow => {
@@ -70,7 +71,7 @@ export class TableSelectableExpandableDemo extends React.Component<TableProps, T
     });
   }
 
-  toggleSelect = checked => {
+  toggleSelect = (checked: boolean) => {
     this.setState({
       canSelectAll: checked
     });

--- a/packages/react-integration/demo-app-ts/src/components/demos/index.ts
+++ b/packages/react-integration/demo-app-ts/src/components/demos/index.ts
@@ -115,6 +115,7 @@ export * from './TableDemo/TableHeadersWrappableDemo';
 export * from './TableDemo/TableRowWrapperDemo';
 export * from './TableDemo/TableRowClickDemo';
 export * from './TableDemo/TableSelectableDemo';
+export * from './TableDemo/TableSelectableExpandableDemo';
 export * from './TableDemo/TableSimpleActionsDemo';
 export * from './TableDemo/TableSimpleDemo';
 export * from './TableDemo/TableSortableDemo';

--- a/packages/react-table/src/components/Table/SelectColumn.tsx
+++ b/packages/react-table/src/components/Table/SelectColumn.tsx
@@ -1,22 +1,46 @@
 import * as React from 'react';
+import { SelectedRowsAmount } from './Table';
 
 export interface SelectColumnProps {
   name?: string;
+  'data-selectedrowsamount'?: SelectedRowsAmount;
   children?: React.ReactNode;
   className?: string;
   onSelect?: (event: React.FormEvent<HTMLInputElement>) => void;
 }
 
-export const SelectColumn: React.FunctionComponent<SelectColumnProps> = ({
-  children = null as React.ReactNode,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  className,
-  onSelect = null as (event: React.FormEvent<HTMLInputElement>) => void,
-  ...props
-}: SelectColumnProps) => (
-  <React.Fragment>
-    <input {...props} type="checkbox" onChange={onSelect} />
-    {children}
-  </React.Fragment>
-);
-SelectColumn.displayName = 'SelectColumn';
+export class SelectColumn extends React.Component<SelectColumnProps> {
+  static displayName = 'SelectColumn';
+  static defaultProps: SelectColumnProps = {
+    children: null as React.ReactNode,
+    onSelect: null as (event: React.FormEvent<HTMLInputElement>) => void
+  };
+
+  ref: React.RefObject<HTMLInputElement> = React.createRef();
+
+  setCheckStatus() {
+    if (this.props.name === 'check-all') {
+      this.ref.current.indeterminate = this.props['data-selectedrowsamount'] === SelectedRowsAmount.some;
+      this.ref.current.checked = this.props['data-selectedrowsamount'] === SelectedRowsAmount.all;
+    }
+  }
+
+  componentDidMount() {
+    this.setCheckStatus();
+  }
+
+  componentDidUpdate() {
+    this.setCheckStatus();
+  }
+
+  render() {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { children, onSelect, className, ...props } = this.props;
+    return (
+      <React.Fragment>
+        <input {...props} type="checkbox" onChange={onSelect} ref={this.ref} />
+        {children}
+      </React.Fragment>
+    );
+  }
+}

--- a/packages/react-table/src/components/Table/Table.test.tsx
+++ b/packages/react-table/src/components/Table/Table.test.tsx
@@ -22,7 +22,8 @@ import {
   truncate,
   breakWord,
   fitContent,
-  ICell
+  ICell,
+  SelectedRowsAmount
 } from './index';
 import { rows, columns, editableRows, editableColumns, actions } from '../../test-helpers/data-sets';
 import { ColumnsType } from './base';
@@ -278,7 +279,7 @@ test('Selectable table with selected expandable row', () => {
     </Table>
   );
 
-  expect(view.find('input[name="check-all"]').prop('checked')).toEqual(true);
+  expect(view.find('input[name="check-all"]').prop('data-selectedrowsamount')).toEqual(SelectedRowsAmount.all);
 });
 
 test('Empty state table', () => {

--- a/packages/react-table/src/components/Table/Table.tsx
+++ b/packages/react-table/src/components/Table/Table.tsx
@@ -31,6 +31,12 @@ export enum TableVariant {
   compact = 'compact'
 }
 
+export enum SelectedRowsAmount {
+  all = 'all',
+  some = 'some',
+  none = 'none'
+}
+
 export type RowEditType = 'save' | 'cancel' | 'edit';
 
 export interface RowErrors {
@@ -103,7 +109,7 @@ export interface IColumn {
     contentId?: string;
     dropdownPosition?: DropdownPosition;
     dropdownDirection?: DropdownDirection;
-    allRowsSelected?: boolean;
+    selectedRowsAmount?: SelectedRowsAmount;
   };
 }
 
@@ -333,11 +339,17 @@ export class Table extends React.Component<TableProps & OUIAProps, {}> {
 
   isSelected = (row: IRow) => row.selected === true;
 
-  areAllRowsSelected = (rows: IRow[]) => {
+  howManyRowsSelected = (rows: IRow[]) => {
     if (rows === undefined || rows.length === 0) {
-      return false;
+      return SelectedRowsAmount.none;
     }
-    return rows.every(row => this.isSelected(row) || (row.hasOwnProperty('parent') && !row.showSelect));
+    const selectableRows = rows.filter(row => !(row.hasOwnProperty('parent') && !row.showSelect));
+    const count = selectableRows.filter(row => this.isSelected(row)).length;
+    return count === 0
+      ? SelectedRowsAmount.none
+      : count === selectableRows.length
+      ? SelectedRowsAmount.all
+      : SelectedRowsAmount.some;
   };
 
   componentDidMount() {
@@ -394,7 +406,7 @@ export class Table extends React.Component<TableProps & OUIAProps, {}> {
       onSort,
       onSelect,
       canSelectAll,
-      allRowsSelected: onSelect ? this.areAllRowsSelected(rows as IRow[]) : false,
+      selectedRowsAmount: onSelect ? this.howManyRowsSelected(rows as IRow[]) : SelectedRowsAmount.none,
       actions,
       actionResolver,
       areActionsDisabled,

--- a/packages/react-table/src/components/Table/utils/decorators/selectable.tsx
+++ b/packages/react-table/src/components/Table/utils/decorators/selectable.tsx
@@ -10,7 +10,7 @@ export const selectable: ITransform = (
   { rowIndex, columnIndex, rowData, column, property }: IExtra
 ) => {
   const {
-    extraParams: { onSelect, allRowsSelected, rowLabeledBy = 'simple-node' }
+    extraParams: { onSelect, selectedRowsAmount, rowLabeledBy = 'simple-node' }
   } = column;
   const extraData = {
     rowIndex,
@@ -42,8 +42,8 @@ export const selectable: ITransform = (
           'aria-labelledby': rowLabeledBy + rowIndex
         }
       : {
-          checked: allRowsSelected,
-          'aria-label': 'Select all rows'
+          'aria-label': 'Select all rows',
+          'data-selectedrowsamount': selectedRowsAmount
         }),
     ...(rowData &&
       rowData.disableCheckbox && {

--- a/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
+++ b/packages/react-virtualized-extension/src/components/Virtualized/__snapshots__/VirtualizedTable.test.tsx.snap
@@ -138,7 +138,6 @@ exports[`Actions virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": [Function],
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": [Function],
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -152,6 +151,7 @@ exports[`Actions virtualized table 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -182,7 +182,6 @@ exports[`Actions virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": [Function],
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": [Function],
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -196,6 +195,7 @@ exports[`Actions virtualized table 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -225,7 +225,6 @@ exports[`Actions virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": [Function],
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": [Function],
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -239,6 +238,7 @@ exports[`Actions virtualized table 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -268,7 +268,6 @@ exports[`Actions virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": [Function],
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": [Function],
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -282,6 +281,7 @@ exports[`Actions virtualized table 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -311,7 +311,6 @@ exports[`Actions virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": [Function],
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": [Function],
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -325,6 +324,7 @@ exports[`Actions virtualized table 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -355,7 +355,6 @@ exports[`Actions virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": [Function],
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": [Function],
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -369,6 +368,7 @@ exports[`Actions virtualized table 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -438,7 +438,6 @@ exports[`Actions virtualized table 1`] = `
                     "extraParams": Object {
                       "actionResolver": [Function],
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": [Function],
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -452,6 +451,7 @@ exports[`Actions virtualized table 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -482,7 +482,6 @@ exports[`Actions virtualized table 1`] = `
                     "extraParams": Object {
                       "actionResolver": [Function],
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": [Function],
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -496,6 +495,7 @@ exports[`Actions virtualized table 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -525,7 +525,6 @@ exports[`Actions virtualized table 1`] = `
                     "extraParams": Object {
                       "actionResolver": [Function],
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": [Function],
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -539,6 +538,7 @@ exports[`Actions virtualized table 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -568,7 +568,6 @@ exports[`Actions virtualized table 1`] = `
                     "extraParams": Object {
                       "actionResolver": [Function],
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": [Function],
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -582,6 +581,7 @@ exports[`Actions virtualized table 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -611,7 +611,6 @@ exports[`Actions virtualized table 1`] = `
                     "extraParams": Object {
                       "actionResolver": [Function],
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": [Function],
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -625,6 +624,7 @@ exports[`Actions virtualized table 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -655,7 +655,6 @@ exports[`Actions virtualized table 1`] = `
                     "extraParams": Object {
                       "actionResolver": [Function],
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": [Function],
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -669,6 +668,7 @@ exports[`Actions virtualized table 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -732,7 +732,6 @@ exports[`Actions virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": [Function],
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": [Function],
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -746,6 +745,7 @@ exports[`Actions virtualized table 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -776,7 +776,6 @@ exports[`Actions virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": [Function],
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": [Function],
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -790,6 +789,7 @@ exports[`Actions virtualized table 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -819,7 +819,6 @@ exports[`Actions virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": [Function],
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": [Function],
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -833,6 +832,7 @@ exports[`Actions virtualized table 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -862,7 +862,6 @@ exports[`Actions virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": [Function],
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": [Function],
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -876,6 +875,7 @@ exports[`Actions virtualized table 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -905,7 +905,6 @@ exports[`Actions virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": [Function],
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": [Function],
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -919,6 +918,7 @@ exports[`Actions virtualized table 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -949,7 +949,6 @@ exports[`Actions virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": [Function],
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": [Function],
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -963,6 +962,7 @@ exports[`Actions virtualized table 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -1283,7 +1283,6 @@ exports[`Selectable virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -1297,6 +1296,7 @@ exports[`Selectable virtualized table 1`] = `
             "onSelect": [Function],
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -1327,7 +1327,6 @@ exports[`Selectable virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -1341,6 +1340,7 @@ exports[`Selectable virtualized table 1`] = `
             "onSelect": [Function],
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -1371,7 +1371,6 @@ exports[`Selectable virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -1385,6 +1384,7 @@ exports[`Selectable virtualized table 1`] = `
             "onSelect": [Function],
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -1414,7 +1414,6 @@ exports[`Selectable virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -1428,6 +1427,7 @@ exports[`Selectable virtualized table 1`] = `
             "onSelect": [Function],
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -1457,7 +1457,6 @@ exports[`Selectable virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -1471,6 +1470,7 @@ exports[`Selectable virtualized table 1`] = `
             "onSelect": [Function],
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -1500,7 +1500,6 @@ exports[`Selectable virtualized table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -1514,6 +1513,7 @@ exports[`Selectable virtualized table 1`] = `
             "onSelect": [Function],
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -1583,7 +1583,6 @@ exports[`Selectable virtualized table 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -1597,6 +1596,7 @@ exports[`Selectable virtualized table 1`] = `
                       "onSelect": [Function],
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -1627,7 +1627,6 @@ exports[`Selectable virtualized table 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -1641,6 +1640,7 @@ exports[`Selectable virtualized table 1`] = `
                       "onSelect": [Function],
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -1671,7 +1671,6 @@ exports[`Selectable virtualized table 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -1685,6 +1684,7 @@ exports[`Selectable virtualized table 1`] = `
                       "onSelect": [Function],
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -1714,7 +1714,6 @@ exports[`Selectable virtualized table 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -1728,6 +1727,7 @@ exports[`Selectable virtualized table 1`] = `
                       "onSelect": [Function],
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -1757,7 +1757,6 @@ exports[`Selectable virtualized table 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -1771,6 +1770,7 @@ exports[`Selectable virtualized table 1`] = `
                       "onSelect": [Function],
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -1800,7 +1800,6 @@ exports[`Selectable virtualized table 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -1814,6 +1813,7 @@ exports[`Selectable virtualized table 1`] = `
                       "onSelect": [Function],
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -1877,7 +1877,6 @@ exports[`Selectable virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -1891,6 +1890,7 @@ exports[`Selectable virtualized table 1`] = `
                           "onSelect": [Function],
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -1921,7 +1921,6 @@ exports[`Selectable virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -1935,6 +1934,7 @@ exports[`Selectable virtualized table 1`] = `
                           "onSelect": [Function],
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -1965,7 +1965,6 @@ exports[`Selectable virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -1979,6 +1978,7 @@ exports[`Selectable virtualized table 1`] = `
                           "onSelect": [Function],
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -2008,7 +2008,6 @@ exports[`Selectable virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -2022,6 +2021,7 @@ exports[`Selectable virtualized table 1`] = `
                           "onSelect": [Function],
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -2051,7 +2051,6 @@ exports[`Selectable virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -2065,6 +2064,7 @@ exports[`Selectable virtualized table 1`] = `
                           "onSelect": [Function],
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -2094,7 +2094,6 @@ exports[`Selectable virtualized table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -2108,6 +2107,7 @@ exports[`Selectable virtualized table 1`] = `
                           "onSelect": [Function],
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -2146,13 +2146,13 @@ exports[`Selectable virtualized table 1`] = `
                       >
                         <SelectColumn
                           aria-label="Select all rows"
-                          checked={false}
+                          data-selectedrowsamount="none"
                           name="check-all"
                           onSelect={[Function]}
                         >
                           <input
                             aria-label="Select all rows"
-                            checked={false}
+                            data-selectedrowsamount="none"
                             name="check-all"
                             onChange={[Function]}
                             type="checkbox"
@@ -2493,7 +2493,6 @@ exports[`Simple Actions table 1`] = `
                 "title": "Third action",
               },
             ],
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -2507,6 +2506,7 @@ exports[`Simple Actions table 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -2556,7 +2556,6 @@ exports[`Simple Actions table 1`] = `
                 "title": "Third action",
               },
             ],
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -2570,6 +2569,7 @@ exports[`Simple Actions table 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -2618,7 +2618,6 @@ exports[`Simple Actions table 1`] = `
                 "title": "Third action",
               },
             ],
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -2632,6 +2631,7 @@ exports[`Simple Actions table 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -2680,7 +2680,6 @@ exports[`Simple Actions table 1`] = `
                 "title": "Third action",
               },
             ],
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -2694,6 +2693,7 @@ exports[`Simple Actions table 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -2742,7 +2742,6 @@ exports[`Simple Actions table 1`] = `
                 "title": "Third action",
               },
             ],
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -2756,6 +2755,7 @@ exports[`Simple Actions table 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -2805,7 +2805,6 @@ exports[`Simple Actions table 1`] = `
                 "title": "Third action",
               },
             ],
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -2819,6 +2818,7 @@ exports[`Simple Actions table 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -2907,7 +2907,6 @@ exports[`Simple Actions table 1`] = `
                           "title": "Third action",
                         },
                       ],
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -2921,6 +2920,7 @@ exports[`Simple Actions table 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -2970,7 +2970,6 @@ exports[`Simple Actions table 1`] = `
                           "title": "Third action",
                         },
                       ],
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -2984,6 +2983,7 @@ exports[`Simple Actions table 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -3032,7 +3032,6 @@ exports[`Simple Actions table 1`] = `
                           "title": "Third action",
                         },
                       ],
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -3046,6 +3045,7 @@ exports[`Simple Actions table 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -3094,7 +3094,6 @@ exports[`Simple Actions table 1`] = `
                           "title": "Third action",
                         },
                       ],
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -3108,6 +3107,7 @@ exports[`Simple Actions table 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -3156,7 +3156,6 @@ exports[`Simple Actions table 1`] = `
                           "title": "Third action",
                         },
                       ],
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -3170,6 +3169,7 @@ exports[`Simple Actions table 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -3219,7 +3219,6 @@ exports[`Simple Actions table 1`] = `
                           "title": "Third action",
                         },
                       ],
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -3233,6 +3232,7 @@ exports[`Simple Actions table 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -3315,7 +3315,6 @@ exports[`Simple Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -3329,6 +3328,7 @@ exports[`Simple Actions table 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -3378,7 +3378,6 @@ exports[`Simple Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -3392,6 +3391,7 @@ exports[`Simple Actions table 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -3440,7 +3440,6 @@ exports[`Simple Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -3454,6 +3453,7 @@ exports[`Simple Actions table 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -3502,7 +3502,6 @@ exports[`Simple Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -3516,6 +3515,7 @@ exports[`Simple Actions table 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -3564,7 +3564,6 @@ exports[`Simple Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -3578,6 +3577,7 @@ exports[`Simple Actions table 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -3627,7 +3627,6 @@ exports[`Simple Actions table 1`] = `
                               "title": "Third action",
                             },
                           ],
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -3641,6 +3640,7 @@ exports[`Simple Actions table 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -3956,7 +3956,6 @@ exports[`Simple virtualized table aria-label 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -3970,6 +3969,7 @@ exports[`Simple virtualized table aria-label 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -3999,7 +3999,6 @@ exports[`Simple virtualized table aria-label 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -4013,6 +4012,7 @@ exports[`Simple virtualized table aria-label 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -4042,7 +4042,6 @@ exports[`Simple virtualized table aria-label 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -4056,6 +4055,7 @@ exports[`Simple virtualized table aria-label 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -4085,7 +4085,6 @@ exports[`Simple virtualized table aria-label 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -4099,6 +4098,7 @@ exports[`Simple virtualized table aria-label 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -4128,7 +4128,6 @@ exports[`Simple virtualized table aria-label 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -4142,6 +4141,7 @@ exports[`Simple virtualized table aria-label 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -4210,7 +4210,6 @@ exports[`Simple virtualized table aria-label 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -4224,6 +4223,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -4253,7 +4253,6 @@ exports[`Simple virtualized table aria-label 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -4267,6 +4266,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -4296,7 +4296,6 @@ exports[`Simple virtualized table aria-label 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -4310,6 +4309,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -4339,7 +4339,6 @@ exports[`Simple virtualized table aria-label 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -4353,6 +4352,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -4382,7 +4382,6 @@ exports[`Simple virtualized table aria-label 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -4396,6 +4395,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -4458,7 +4458,6 @@ exports[`Simple virtualized table aria-label 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -4472,6 +4471,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -4501,7 +4501,6 @@ exports[`Simple virtualized table aria-label 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -4515,6 +4514,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -4544,7 +4544,6 @@ exports[`Simple virtualized table aria-label 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -4558,6 +4557,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -4587,7 +4587,6 @@ exports[`Simple virtualized table aria-label 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -4601,6 +4600,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -4630,7 +4630,6 @@ exports[`Simple virtualized table aria-label 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -4644,6 +4643,7 @@ exports[`Simple virtualized table aria-label 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -4890,7 +4890,6 @@ exports[`Simple virtualized table className 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -4904,6 +4903,7 @@ exports[`Simple virtualized table className 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -4933,7 +4933,6 @@ exports[`Simple virtualized table className 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -4947,6 +4946,7 @@ exports[`Simple virtualized table className 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -4976,7 +4976,6 @@ exports[`Simple virtualized table className 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -4990,6 +4989,7 @@ exports[`Simple virtualized table className 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -5019,7 +5019,6 @@ exports[`Simple virtualized table className 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -5033,6 +5032,7 @@ exports[`Simple virtualized table className 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -5062,7 +5062,6 @@ exports[`Simple virtualized table className 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -5076,6 +5075,7 @@ exports[`Simple virtualized table className 1`] = `
             "onSelect": undefined,
             "onSort": undefined,
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": undefined,
           },
           "header": Object {
@@ -5144,7 +5144,6 @@ exports[`Simple virtualized table className 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -5158,6 +5157,7 @@ exports[`Simple virtualized table className 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -5187,7 +5187,6 @@ exports[`Simple virtualized table className 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -5201,6 +5200,7 @@ exports[`Simple virtualized table className 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -5230,7 +5230,6 @@ exports[`Simple virtualized table className 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -5244,6 +5243,7 @@ exports[`Simple virtualized table className 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -5273,7 +5273,6 @@ exports[`Simple virtualized table className 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -5287,6 +5286,7 @@ exports[`Simple virtualized table className 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -5316,7 +5316,6 @@ exports[`Simple virtualized table className 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -5330,6 +5329,7 @@ exports[`Simple virtualized table className 1`] = `
                       "onSelect": undefined,
                       "onSort": undefined,
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": undefined,
                     },
                     "header": Object {
@@ -5392,7 +5392,6 @@ exports[`Simple virtualized table className 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -5406,6 +5405,7 @@ exports[`Simple virtualized table className 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -5435,7 +5435,6 @@ exports[`Simple virtualized table className 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -5449,6 +5448,7 @@ exports[`Simple virtualized table className 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -5478,7 +5478,6 @@ exports[`Simple virtualized table className 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -5492,6 +5491,7 @@ exports[`Simple virtualized table className 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -5521,7 +5521,6 @@ exports[`Simple virtualized table className 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -5535,6 +5534,7 @@ exports[`Simple virtualized table className 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -5564,7 +5564,6 @@ exports[`Simple virtualized table className 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -5578,6 +5577,7 @@ exports[`Simple virtualized table className 1`] = `
                           "onSelect": undefined,
                           "onSort": undefined,
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": undefined,
                         },
                         "header": Object {
@@ -5829,7 +5829,6 @@ exports[`Sortable Virtualized Table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -5843,6 +5842,7 @@ exports[`Sortable Virtualized Table 1`] = `
             "onSelect": undefined,
             "onSort": [Function],
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": Object {},
           },
           "header": Object {
@@ -5873,7 +5873,6 @@ exports[`Sortable Virtualized Table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -5887,6 +5886,7 @@ exports[`Sortable Virtualized Table 1`] = `
             "onSelect": undefined,
             "onSort": [Function],
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": Object {},
           },
           "header": Object {
@@ -5916,7 +5916,6 @@ exports[`Sortable Virtualized Table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -5930,6 +5929,7 @@ exports[`Sortable Virtualized Table 1`] = `
             "onSelect": undefined,
             "onSort": [Function],
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": Object {},
           },
           "header": Object {
@@ -5959,7 +5959,6 @@ exports[`Sortable Virtualized Table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -5973,6 +5972,7 @@ exports[`Sortable Virtualized Table 1`] = `
             "onSelect": undefined,
             "onSort": [Function],
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": Object {},
           },
           "header": Object {
@@ -6002,7 +6002,6 @@ exports[`Sortable Virtualized Table 1`] = `
           "extraParams": Object {
             "actionResolver": undefined,
             "actions": undefined,
-            "allRowsSelected": false,
             "areActionsDisabled": undefined,
             "canSelectAll": true,
             "contentId": "expanded-content",
@@ -6016,6 +6015,7 @@ exports[`Sortable Virtualized Table 1`] = `
             "onSelect": undefined,
             "onSort": [Function],
             "rowLabeledBy": "simple-node",
+            "selectedRowsAmount": "none",
             "sortBy": Object {},
           },
           "header": Object {
@@ -6084,7 +6084,6 @@ exports[`Sortable Virtualized Table 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -6098,6 +6097,7 @@ exports[`Sortable Virtualized Table 1`] = `
                       "onSelect": undefined,
                       "onSort": [Function],
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": Object {},
                     },
                     "header": Object {
@@ -6128,7 +6128,6 @@ exports[`Sortable Virtualized Table 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -6142,6 +6141,7 @@ exports[`Sortable Virtualized Table 1`] = `
                       "onSelect": undefined,
                       "onSort": [Function],
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": Object {},
                     },
                     "header": Object {
@@ -6171,7 +6171,6 @@ exports[`Sortable Virtualized Table 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -6185,6 +6184,7 @@ exports[`Sortable Virtualized Table 1`] = `
                       "onSelect": undefined,
                       "onSort": [Function],
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": Object {},
                     },
                     "header": Object {
@@ -6214,7 +6214,6 @@ exports[`Sortable Virtualized Table 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -6228,6 +6227,7 @@ exports[`Sortable Virtualized Table 1`] = `
                       "onSelect": undefined,
                       "onSort": [Function],
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": Object {},
                     },
                     "header": Object {
@@ -6257,7 +6257,6 @@ exports[`Sortable Virtualized Table 1`] = `
                     "extraParams": Object {
                       "actionResolver": undefined,
                       "actions": undefined,
-                      "allRowsSelected": false,
                       "areActionsDisabled": undefined,
                       "canSelectAll": true,
                       "contentId": "expanded-content",
@@ -6271,6 +6270,7 @@ exports[`Sortable Virtualized Table 1`] = `
                       "onSelect": undefined,
                       "onSort": [Function],
                       "rowLabeledBy": "simple-node",
+                      "selectedRowsAmount": "none",
                       "sortBy": Object {},
                     },
                     "header": Object {
@@ -6333,7 +6333,6 @@ exports[`Sortable Virtualized Table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -6347,6 +6346,7 @@ exports[`Sortable Virtualized Table 1`] = `
                           "onSelect": undefined,
                           "onSort": [Function],
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": Object {},
                         },
                         "header": Object {
@@ -6377,7 +6377,6 @@ exports[`Sortable Virtualized Table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -6391,6 +6390,7 @@ exports[`Sortable Virtualized Table 1`] = `
                           "onSelect": undefined,
                           "onSort": [Function],
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": Object {},
                         },
                         "header": Object {
@@ -6420,7 +6420,6 @@ exports[`Sortable Virtualized Table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -6434,6 +6433,7 @@ exports[`Sortable Virtualized Table 1`] = `
                           "onSelect": undefined,
                           "onSort": [Function],
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": Object {},
                         },
                         "header": Object {
@@ -6463,7 +6463,6 @@ exports[`Sortable Virtualized Table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -6477,6 +6476,7 @@ exports[`Sortable Virtualized Table 1`] = `
                           "onSelect": undefined,
                           "onSort": [Function],
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": Object {},
                         },
                         "header": Object {
@@ -6506,7 +6506,6 @@ exports[`Sortable Virtualized Table 1`] = `
                         "extraParams": Object {
                           "actionResolver": undefined,
                           "actions": undefined,
-                          "allRowsSelected": false,
                           "areActionsDisabled": undefined,
                           "canSelectAll": true,
                           "contentId": "expanded-content",
@@ -6520,6 +6519,7 @@ exports[`Sortable Virtualized Table 1`] = `
                           "onSelect": undefined,
                           "onSort": [Function],
                           "rowLabeledBy": "simple-node",
+                          "selectedRowsAmount": "none",
                           "sortBy": Object {},
                         },
                         "header": Object {


### PR DESCRIPTION
**What**: Closes #3648

Added indeterminate state; this cannot be achieved simply through HTML attributes, hence the use of hooks. Left in the `allRowsSelected` prop in case it's used somewhere but it's made redundant with this change.

(Kinda new to React, please correct me if I went against conventions)