### PR TITLE
Breaking modal variant

### DIFF
--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -43,13 +43,13 @@ export interface ModalProps extends React.HTMLProps<HTMLDivElement> {
   /** Description of the modal */
   description?: React.ReactNode;
   /** Variant of the modal */
-  variant?: 'large' | 'medium' | 'small';
+  variant?: 'small' | 'large' | 'default';
 }
 
 export enum ModalVariant {
+  small = 'small',
   large = 'large',
-  medium = 'medium',
-  small = 'small'
+  default = 'default'
 }
 
 interface ModalState {
@@ -69,7 +69,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
     actions: [] as any[],
     isFooterLeftAligned: false,
     onClose: () => undefined as any,
-    variant: 'medium',
+    variant: 'default',
     appendTo: (typeof document !== 'undefined' && document.body) || null
   };
 

--- a/packages/react-core/src/components/Modal/Modal.tsx
+++ b/packages/react-core/src/components/Modal/Modal.tsx
@@ -36,16 +36,20 @@ export interface ModalProps extends React.HTMLProps<HTMLDivElement> {
   onClose?: () => void;
   /** Default width of the Modal. */
   width?: number | string;
-  /** Creates a large version of the Modal */
-  isLarge?: boolean;
-  /** Creates a small version of the Modal */
-  isSmall?: boolean;
   /** The parent container to append the modal to. Defaults to document.body */
   appendTo?: HTMLElement | (() => HTMLElement);
   /** Flag to disable focus trap */
   disableFocusTrap?: boolean;
   /** Description of the modal */
   description?: React.ReactNode;
+  /** Variant of the modal */
+  variant?: 'large' | 'medium' | 'small';
+}
+
+export enum ModalVariant {
+  large = 'large',
+  medium = 'medium',
+  small = 'small'
 }
 
 interface ModalState {
@@ -65,8 +69,7 @@ export class Modal extends React.Component<ModalProps, ModalState> {
     actions: [] as any[],
     isFooterLeftAligned: false,
     onClose: () => undefined as any,
-    isLarge: false,
-    isSmall: false,
+    variant: 'medium',
     appendTo: (typeof document !== 'undefined' && document.body) || null
   };
 

--- a/packages/react-core/src/components/Modal/ModalBox.tsx
+++ b/packages/react-core/src/components/Modal/ModalBox.tsx
@@ -7,10 +7,8 @@ export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
   children: React.ReactNode;
   /** Additional classes added to the ModalBox */
   className?: string;
-  /** Creates a large version of the ModalBox */
-  isLarge?: boolean;
-  /** Creates a small version of the ModalBox. */
-  isSmall?: boolean;
+  /** Variant of the modal */
+  variant?: 'large' | 'medium' | 'small';
   /** String to use for Modal Box aria-label */
   title: string;
   /** Id to use for Modal Box description */
@@ -20,8 +18,7 @@ export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
 export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
   children,
   className = '',
-  isLarge = false,
-  isSmall = false,
+  variant = 'medium',
   title,
   id,
   ...props
@@ -32,7 +29,12 @@ export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
     aria-label={title}
     aria-describedby={id}
     aria-modal="true"
-    className={css(styles.modalBox, className, isLarge && styles.modifiers.lg, isSmall && styles.modifiers.sm)}
+    className={css(
+      styles.modalBox,
+      className,
+      variant === 'large' && styles.modifiers.lg,
+      variant === 'small' && styles.modifiers.sm
+    )}
   >
     {children}
   </div>

--- a/packages/react-core/src/components/Modal/ModalBox.tsx
+++ b/packages/react-core/src/components/Modal/ModalBox.tsx
@@ -8,7 +8,7 @@ export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
   /** Additional classes added to the ModalBox */
   className?: string;
   /** Variant of the modal */
-  variant?: 'large' | 'medium' | 'small';
+  variant?: 'small' | 'large' | 'default';
   /** String to use for Modal Box aria-label */
   title: string;
   /** Id to use for Modal Box description */
@@ -18,7 +18,7 @@ export interface ModalBoxProps extends React.HTMLProps<HTMLDivElement> {
 export const ModalBox: React.FunctionComponent<ModalBoxProps> = ({
   children,
   className = '',
-  variant = 'medium',
+  variant = 'default',
   title,
   id,
   ...props

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -23,7 +23,7 @@ export interface ModalContentProps {
   /** Additional classes added to the button */
   className?: string;
   /** Variant of the modal */
-  variant?: 'large' | 'medium' | 'small';
+  variant?: 'small' | 'large' | 'default';
   /** Flag to show the modal */
   isOpen?: boolean;
   /** Complex header (more than just text), supersedes title for header content */
@@ -67,7 +67,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   actions = [],
   isFooterLeftAligned = false,
   onClose = () => undefined as any,
-  variant = 'medium',
+  variant = 'default',
   width = -1,
   modalBoxAriaDescribedById = '',
   id = '',

--- a/packages/react-core/src/components/Modal/ModalContent.tsx
+++ b/packages/react-core/src/components/Modal/ModalContent.tsx
@@ -22,10 +22,8 @@ export interface ModalContentProps {
   children: React.ReactNode;
   /** Additional classes added to the button */
   className?: string;
-  /** Creates a large version of the Modal */
-  isLarge?: boolean;
-  /** Creates a small version of the Modal */
-  isSmall?: boolean;
+  /** Variant of the modal */
+  variant?: 'large' | 'medium' | 'small';
   /** Flag to show the modal */
   isOpen?: boolean;
   /** Complex header (more than just text), supersedes title for header content */
@@ -69,8 +67,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
   actions = [],
   isFooterLeftAligned = false,
   onClose = () => undefined as any,
-  isLarge = false,
-  isSmall = false,
+  variant = 'medium',
   width = -1,
   modalBoxAriaDescribedById = '',
   id = '',
@@ -97,8 +94,7 @@ export const ModalContent: React.FunctionComponent<ModalContentProps> = ({
     <ModalBox
       style={boxStyle}
       className={className}
-      isLarge={isLarge}
-      isSmall={isSmall}
+      variant={variant}
       title={title}
       id={modalBoxAriaDescribedById || id}
     >

--- a/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/Modal.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Modal should match snapshot (auto-generated) 1`] = `
     onClose={[Function]}
     showClose={true}
     title="string"
-    variant="medium"
+    variant="default"
     width={1}
   >
     <div>

--- a/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/Modal.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`Modal should match snapshot (auto-generated) 1`] = `
     onClose={[Function]}
     showClose={true}
     title="string"
+    variant="medium"
     width={1}
   >
     <div>

--- a/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/ModalBox.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/Generated/__snapshots__/ModalBox.test.tsx.snap
@@ -6,6 +6,8 @@ exports[`ModalBox should match snapshot (auto-generated) 1`] = `
   aria-label="string"
   aria-modal="true"
   className="pf-c-modal-box ''"
+  isLarge={false}
+  isSmall={false}
   role="dialog"
 >
   <div>

--- a/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalBox.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalBox.test.tsx.snap
@@ -17,7 +17,8 @@ exports[`ModalBox Test isLarge 1`] = `
   aria-describedby="boxId"
   aria-label="Test Modal Box"
   aria-modal="true"
-  className="pf-c-modal-box pf-m-lg"
+  className="pf-c-modal-box"
+  isLarge={true}
   role="dialog"
 >
   This is a ModalBox
@@ -29,7 +30,8 @@ exports[`ModalBox Test isSmall 1`] = `
   aria-describedby="boxId"
   aria-label="Test Modal Box"
   aria-modal="true"
-  className="pf-c-modal-box pf-m-sm"
+  className="pf-c-modal-box"
+  isSmall={true}
   role="dialog"
 >
   This is a ModalBox

--- a/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Modal Content Test description 1`] = `
       id="id"
       style={Object {}}
       title="Test Modal Content title"
-      variant="medium"
+      variant="default"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -63,7 +63,7 @@ exports[`Modal Content Test isOpen 1`] = `
       id="id"
       style={Object {}}
       title="Test Modal Content title"
-      variant="medium"
+      variant="default"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -104,7 +104,7 @@ exports[`Modal Content Test only body 1`] = `
       id="id"
       style={Object {}}
       title="Test Modal Content title"
-      variant="medium"
+      variant="default"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -145,7 +145,7 @@ exports[`Modal Content Test with footer 1`] = `
       id="id"
       style={Object {}}
       title="Test Modal Content title"
-      variant="medium"
+      variant="default"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -191,7 +191,7 @@ exports[`Modal Content Test with onclose 1`] = `
       id="id"
       style={Object {}}
       title="Test Modal Content title"
-      variant="medium"
+      variant="default"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -238,7 +238,7 @@ exports[`Modal Content test without footer 1`] = `
       id="id"
       style={Object {}}
       title="Test Modal Content title"
-      variant="medium"
+      variant="default"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -279,7 +279,7 @@ exports[`Modal Test with custom footer 1`] = `
       id="id"
       style={Object {}}
       title="Test Modal Custom Footer"
-      variant="medium"
+      variant="default"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -330,7 +330,7 @@ exports[`Modal Test with custom header 1`] = `
       id="id"
       style={Object {}}
       title="test-custom-header-modal"
-      variant="medium"
+      variant="default"
     >
       <ModalBoxCloseButton
         onClose={[Function]}

--- a/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
@@ -143,10 +143,9 @@ exports[`Modal Content Test with footer 1`] = `
     <ModalBox
       className=""
       id="id"
-      isLarge={false}
-      isSmall={false}
       style={Object {}}
       title="Test Modal Content title"
+      variant="medium"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -160,7 +159,6 @@ exports[`Modal Content Test with footer 1`] = `
       </ModalBoxHeader>
       <ModalBoxBody
         id="id"
-        isLarge={true}
       >
         This is a ModalBox header
       </ModalBoxBody>
@@ -207,6 +205,7 @@ exports[`Modal Content Test with onclose 1`] = `
       </ModalBoxHeader>
       <ModalBoxBody
         id="id"
+        isLarge={true}
       >
         This is a ModalBox header
       </ModalBoxBody>
@@ -253,7 +252,6 @@ exports[`Modal Content test without footer 1`] = `
       </ModalBoxHeader>
       <ModalBoxBody
         id="id"
-        isLarge={true}
       >
         This is a ModalBox header
       </ModalBoxBody>
@@ -295,6 +293,7 @@ exports[`Modal Test with custom footer 1`] = `
       </ModalBoxHeader>
       <ModalBoxBody
         id="id"
+        isLarge={true}
       >
         This is a ModalBox header
       </ModalBoxBody>

--- a/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
+++ b/packages/react-core/src/components/Modal/__tests__/__snapshots__/ModalContent.test.tsx.snap
@@ -17,10 +17,9 @@ exports[`Modal Content Test description 1`] = `
     <ModalBox
       className=""
       id="id"
-      isLarge={false}
-      isSmall={false}
       style={Object {}}
       title="Test Modal Content title"
+      variant="medium"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -62,10 +61,9 @@ exports[`Modal Content Test isOpen 1`] = `
     <ModalBox
       className=""
       id="id"
-      isLarge={false}
-      isSmall={false}
       style={Object {}}
       title="Test Modal Content title"
+      variant="medium"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -104,10 +102,9 @@ exports[`Modal Content Test only body 1`] = `
     <ModalBox
       className=""
       id="id"
-      isLarge={false}
-      isSmall={false}
       style={Object {}}
       title="Test Modal Content title"
+      variant="medium"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -163,6 +160,7 @@ exports[`Modal Content Test with footer 1`] = `
       </ModalBoxHeader>
       <ModalBoxBody
         id="id"
+        isLarge={true}
       >
         This is a ModalBox header
       </ModalBoxBody>
@@ -193,10 +191,9 @@ exports[`Modal Content Test with onclose 1`] = `
     <ModalBox
       className=""
       id="id"
-      isLarge={true}
-      isSmall={false}
       style={Object {}}
       title="Test Modal Content title"
+      variant="medium"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -240,10 +237,9 @@ exports[`Modal Content test without footer 1`] = `
     <ModalBox
       className=""
       id="id"
-      isLarge={false}
-      isSmall={false}
       style={Object {}}
       title="Test Modal Content title"
+      variant="medium"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -257,6 +253,7 @@ exports[`Modal Content test without footer 1`] = `
       </ModalBoxHeader>
       <ModalBoxBody
         id="id"
+        isLarge={true}
       >
         This is a ModalBox header
       </ModalBoxBody>
@@ -282,10 +279,9 @@ exports[`Modal Test with custom footer 1`] = `
     <ModalBox
       className=""
       id="id"
-      isLarge={true}
-      isSmall={false}
       style={Object {}}
       title="Test Modal Custom Footer"
+      variant="medium"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -333,10 +329,9 @@ exports[`Modal Test with custom header 1`] = `
     <ModalBox
       className=""
       id="id"
-      isLarge={true}
-      isSmall={false}
       style={Object {}}
       title="test-custom-header-modal"
+      variant="medium"
     >
       <ModalBoxCloseButton
         onClose={[Function]}
@@ -352,6 +347,7 @@ exports[`Modal Test with custom header 1`] = `
       </div>
       <ModalBoxBody
         id="id"
+        isLarge={true}
       >
         This is a ModalBox header
       </ModalBoxBody>

--- a/packages/react-core/src/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/components/Modal/examples/Modal.md
@@ -8,7 +8,7 @@ propComponents:
 optIn: In a future breaking-change release, the modal footer buttons will default to be left aligned. You can opt into this now by setting the Modal isFooterLeftAligned prop to true.
 ---
 
-import { Modal, Button, BaseSizes, TitleLevel } from '@patternfly/react-core';
+import { Modal, ModalVariant, Button, BaseSizes, TitleLevel } from '@patternfly/react-core';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 
 ## Examples
@@ -118,7 +118,7 @@ class SimpleModal extends React.Component {
 
 ```js title=Small
 import React from 'react';
-import { Modal, Button } from '@patternfly/react-core';
+import { Modal, ModalVariant, Button } from '@patternfly/react-core';
 
 class SmallModal extends React.Component {
   constructor(props) {
@@ -142,7 +142,7 @@ class SmallModal extends React.Component {
           Show Small Modal
         </Button>
         <Modal
-          isSmall
+          variant={ModalVariant.small}
           title="Modal Header"
           isOpen={isModalOpen}
           onClose={this.handleModalToggle}
@@ -170,7 +170,7 @@ class SmallModal extends React.Component {
 
 ```js title=Large
 import React from 'react';
-import { Modal, Button } from '@patternfly/react-core';
+import { Modal, ModalVariant, Button } from '@patternfly/react-core';
 
 class LargeModal extends React.Component {
   constructor(props) {
@@ -194,7 +194,7 @@ class LargeModal extends React.Component {
           Show Large Modal
         </Button>
         <Modal
-          isLarge
+          size={ModalVariant.large}
           title="Modal Header"
           isOpen={isModalOpen}
           onClose={this.handleModalToggle}
@@ -274,7 +274,7 @@ class WidthModal extends React.Component {
 
 ```js title=Custom-header-and-footer
 import React from 'react';
-import { Modal, Button, BaseSizes, Title, TitleLevel } from '@patternfly/react-core';
+import { Modal, ModalVariant, Button, BaseSizes, Title, TitleLevel } from '@patternfly/react-core';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 
 class CustomHeaderFooter extends React.Component {
@@ -315,7 +315,7 @@ class CustomHeaderFooter extends React.Component {
           Show Custom Header/Footer Modal
         </Button>
         <Modal
-          isLarge
+          variant={ModalVariant.large}
           isOpen={isModalOpen}
           header={header}
           title="custom header example"
@@ -342,7 +342,7 @@ class CustomHeaderFooter extends React.Component {
 
 ```js title=No-header
 import React from 'react';
-import { Modal, Button } from '@patternfly/react-core';
+import { Modal, ModalVariant, Button } from '@patternfly/react-core';
 
 class NoHeader extends React.Component {
   constructor(props) {
@@ -367,7 +367,7 @@ class NoHeader extends React.Component {
           Show No Header Modal
         </Button>
         <Modal
-          isLarge
+          variant={ModalVariant.large}
           isOpen={isModalOpen}
           hideTitle={true}
           title="no header example"

--- a/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Button, Title, TitleLevel, BaseSizes } from '@patternfly/react-core';
+import { Modal, ModalVariant, Button, Title, TitleLevel, BaseSizes } from '@patternfly/react-core';
 import WarningTriangleIcon from '@patternfly/react-icons/dist/js/icons/warning-triangle-icon';
 
 interface ModalDemoState {
@@ -130,7 +130,7 @@ export class ModalDemo extends React.Component<React.HTMLProps<HTMLDivElement>, 
 
     return (
       <Modal
-        isSmall
+        variant={ModalVariant.small}
         title="Modal Header"
         isOpen={isSmallModalOpen}
         onClose={this.handleSmallModalToggle}
@@ -157,7 +157,7 @@ export class ModalDemo extends React.Component<React.HTMLProps<HTMLDivElement>, 
 
     return (
       <Modal
-        isLarge
+        variant={ModalVariant.large}
         title="Modal Header"
         isOpen={isLargeModalOpen}
         onClose={this.handleLargeModalToggle}
@@ -229,7 +229,7 @@ export class ModalDemo extends React.Component<React.HTMLProps<HTMLDivElement>, 
 
     return (
       <Modal
-        isLarge
+        variant={ModalVariant.large}
         isOpen={isCustomHeaderFooterModalOpen}
         header={header}
         title="custom header example"
@@ -255,7 +255,7 @@ export class ModalDemo extends React.Component<React.HTMLProps<HTMLDivElement>, 
 
     return (
       <Modal
-        isLarge
+        variant={ModalVariant.large}
         title="Modal Header"
         isOpen={isNoHeaderModalOpen}
         hideTitle


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #3900

## Breaking changes
1. Collapses the `isLarge` and `isSmall` properties into a single `variant` property. To maintain the current behavior, set the `variant` property to `large` or `small`, or use the newly added `ModalVariant` enum as `ModalVariant.large` or `ModalVariant.small`.