### PR TITLE
fix(title): remove problematic default headingLevel

### DIFF
--- a/packages/react-core/src/components/EmptyState/__tests__/EmptyState.test.tsx
+++ b/packages/react-core/src/components/EmptyState/__tests__/EmptyState.test.tsx
@@ -7,8 +7,7 @@ import { EmptyStateSecondaryActions } from '../EmptyStateSecondaryActions';
 import { EmptyStateIcon } from '../EmptyStateIcon';
 import { EmptyStatePrimary } from '../EmptyStatePrimary';
 import { Button } from '../../Button';
-import { Title } from '../../Title';
-import { BaseSizes } from '../../../styles/sizes';
+import { Title, TitleSizes } from '../../Title';
 
 describe('EmptyState', () => {
   test('Main', () => {
@@ -34,7 +33,7 @@ describe('EmptyState', () => {
   test('Main variant large', () => {
     const view = shallow(
       <EmptyState variant={EmptyStateVariant.lg}>
-        <Title headingLevel="h3" size={BaseSizes.md}>EmptyState large</Title>
+        <Title headingLevel="h3" size={TitleSizes.md}>EmptyState large</Title>
       </EmptyState>
     );
     expect(view).toMatchSnapshot();
@@ -43,7 +42,7 @@ describe('EmptyState', () => {
   test('Main variant small', () => {
     const view = shallow(
       <EmptyState variant={EmptyStateVariant.sm}>
-        <Title headingLevel="h3" size={BaseSizes.md}>EmptyState small</Title>
+        <Title headingLevel="h3" size={TitleSizes.md}>EmptyState small</Title>
       </EmptyState>
     );
     expect(view).toMatchSnapshot();

--- a/packages/react-core/src/components/EmptyState/__tests__/EmptyState.test.tsx
+++ b/packages/react-core/src/components/EmptyState/__tests__/EmptyState.test.tsx
@@ -34,7 +34,7 @@ describe('EmptyState', () => {
   test('Main variant large', () => {
     const view = shallow(
       <EmptyState variant={EmptyStateVariant.lg}>
-        <Title size={BaseSizes.md}>EmptyState large</Title>
+        <Title headingLevel="h3" size={BaseSizes.md}>EmptyState large</Title>
       </EmptyState>
     );
     expect(view).toMatchSnapshot();
@@ -43,7 +43,7 @@ describe('EmptyState', () => {
   test('Main variant small', () => {
     const view = shallow(
       <EmptyState variant={EmptyStateVariant.sm}>
-        <Title size={BaseSizes.md}>EmptyState small</Title>
+        <Title headingLevel="h3" size={BaseSizes.md}>EmptyState small</Title>
       </EmptyState>
     );
     expect(view).toMatchSnapshot();

--- a/packages/react-core/src/components/EmptyState/__tests__/Generated/EmptyState.test.tsx
+++ b/packages/react-core/src/components/EmptyState/__tests__/Generated/EmptyState.test.tsx
@@ -8,6 +8,6 @@ import { EmptyState } from '../../EmptyState';
 import {} from '../..';
 
 it('EmptyState should match snapshot (auto-generated)', () => {
-  const view = shallow(<EmptyState className={"''"} children={<div>ReactNode</div>} variant={'small'} />);
+  const view = shallow(<EmptyState className={"''"} children={<div>ReactNode</div>} variant={'sm'} />);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/components/EmptyState/__tests__/Generated/__snapshots__/EmptyState.test.tsx.snap
+++ b/packages/react-core/src/components/EmptyState/__tests__/Generated/__snapshots__/EmptyState.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EmptyState should match snapshot (auto-generated) 1`] = `
 <div
-  className="pf-c-empty-state ''"
+  className="pf-c-empty-state pf-m-sm ''"
 >
   <div>
     ReactNode

--- a/packages/react-core/src/components/EmptyState/__tests__/__snapshots__/EmptyState.test.tsx.snap
+++ b/packages/react-core/src/components/EmptyState/__tests__/__snapshots__/EmptyState.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`EmptyState Main variant large 1`] = `
   className="pf-c-empty-state pf-m-lg"
 >
   <Title
+    headingLevel="h3"
     size="md"
   >
     EmptyState large
@@ -46,6 +47,7 @@ exports[`EmptyState Main variant small 1`] = `
   className="pf-c-empty-state pf-m-sm"
 >
   <Title
+    headingLevel="h3"
     size="md"
   >
     EmptyState small

--- a/packages/react-core/src/components/EmptyState/examples/EmptyState.md
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyState.md
@@ -150,7 +150,7 @@ EmptyStateSpinner = () => {
   return (
     <EmptyState>
       <EmptyStateIcon variant="container" component={Spinner} />
-      <Title size="lg">
+      <Title size="lg" headingLevel="h5">
         Loading
       </Title>
     </EmptyState>
@@ -177,7 +177,7 @@ NoMatchEmptyState = () => {
   return (
     <EmptyState>
       <EmptyStateIcon icon={SearchIcon} />
-      <Title size="lg">
+      <Title size="lg" headingLevel="h5">
         No results found
       </Title>
       <EmptyStateBody>

--- a/packages/react-core/src/components/EmptyState/examples/EmptyState.md
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyState.md
@@ -34,7 +34,7 @@ import { CubesIcon } from '@patternfly/react-icons';
 SimpleEmptyState = () => (
   <EmptyState variant={EmptyStateVariant.sm}>
     <EmptyStateIcon icon={CubesIcon} />
-    <Title headingLevel="h5" size="lg">
+    <Title headingLevel="h4" size="lg">
       Empty State
     </Title>
     <EmptyStateBody>
@@ -70,7 +70,7 @@ import { CubesIcon } from '@patternfly/react-icons';
 SimpleEmptyState = () => (
   <EmptyState variant={EmptyStateVariant.lg}>
     <EmptyStateIcon icon={CubesIcon} />
-    <Title headingLevel="h5" size="lg">
+    <Title headingLevel="h4" size="lg">
       Empty State
     </Title>
     <EmptyStateBody>
@@ -106,7 +106,7 @@ import { CubesIcon } from '@patternfly/react-icons';
 SimpleEmptyState = () => (
   <EmptyState>
     <EmptyStateIcon icon={CubesIcon} />
-    <Title headingLevel="h5" size="lg">
+    <Title headingLevel="h4" size="lg">
       Empty State
     </Title>
     <EmptyStateBody>
@@ -150,7 +150,7 @@ EmptyStateSpinner = () => {
   return (
     <EmptyState>
       <EmptyStateIcon variant="container" component={Spinner} />
-      <Title size="lg" headingLevel="h5">
+      <Title size="lg" headingLevel="h4">
         Loading
       </Title>
     </EmptyState>
@@ -177,7 +177,7 @@ NoMatchEmptyState = () => {
   return (
     <EmptyState>
       <EmptyStateIcon icon={SearchIcon} />
-      <Title size="lg" headingLevel="h5">
+      <Title size="lg" headingLevel="h4">
         No results found
       </Title>
       <EmptyStateBody>

--- a/packages/react-core/src/components/LoginPage/LoginMainHeader.tsx
+++ b/packages/react-core/src/components/LoginPage/LoginMainHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Title, TitleLevel } from '../Title';
+import { Title, TitleSizes } from '../Title';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Login/login';
 
@@ -23,7 +23,7 @@ export const LoginMainHeader: React.FunctionComponent<LoginMainHeaderProps> = ({
 }: LoginMainHeaderProps) => (
   <header className={css(styles.loginMainHeader, className)} {...props}>
     {title && (
-      <Title headingLevel={TitleLevel.h2} size="3xl">
+      <Title headingLevel="h2" size={TitleSizes['3xl']}>
         {title}
       </Title>
     )}

--- a/packages/react-core/src/components/Modal/ModalBoxHeader.tsx
+++ b/packages/react-core/src/components/Modal/ModalBoxHeader.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Title, TitleLevel } from '../Title';
+import { Title, TitleSizes } from '../Title';
 
 export interface ModalBoxHeaderProps {
   /** Content rendered inside the Header */
@@ -17,12 +17,12 @@ export const ModalBoxHeader: React.FunctionComponent<ModalBoxHeaderProps> = ({
   children = null,
   className = '',
   hideTitle = false,
-  headingLevel = TitleLevel.h1,
+  headingLevel = 'h1',
   ...props
 }: ModalBoxHeaderProps) =>
   hideTitle ? null : (
     <React.Fragment>
-      <Title size="2xl" headingLevel={headingLevel} className={className} {...props}>
+      <Title size={TitleSizes['2xl']} headingLevel={headingLevel} className={className} {...props}>
         {children}
       </Title>
     </React.Fragment>

--- a/packages/react-core/src/components/Modal/__tests__/ModalBoxHeader.test.tsx
+++ b/packages/react-core/src/components/Modal/__tests__/ModalBoxHeader.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
-import { TitleLevel } from '../../Title';
 import { ModalBoxHeader } from '../ModalBoxHeader';
 
 test('ModalBoxHeader Test', () => {
@@ -10,7 +9,7 @@ test('ModalBoxHeader Test', () => {
 });
 
 test('ModalBoxHeader Test with H3', () => {
-  const view = shallow(<ModalBoxHeader headingLevel={TitleLevel.h3}>This is a ModalBox header</ModalBoxHeader>);
+  const view = shallow(<ModalBoxHeader headingLevel="h3">This is a ModalBox header</ModalBoxHeader>);
   expect(view).toMatchSnapshot();
 });
 

--- a/packages/react-core/src/components/Modal/examples/Modal.md
+++ b/packages/react-core/src/components/Modal/examples/Modal.md
@@ -8,7 +8,7 @@ propComponents:
 optIn: In a future breaking-change release, the modal footer buttons will default to be left aligned. You can opt into this now by setting the Modal isFooterLeftAligned prop to true.
 ---
 
-import { Modal, ModalVariant, Button, BaseSizes, TitleLevel } from '@patternfly/react-core';
+import { Modal, ModalVariant, TitleSizes, Button, Title } from '@patternfly/react-core';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 
 ## Examples
@@ -274,7 +274,7 @@ class WidthModal extends React.Component {
 
 ```js title=Custom-header-and-footer
 import React from 'react';
-import { Modal, ModalVariant, Button, BaseSizes, Title, TitleLevel } from '@patternfly/react-core';
+import { Modal, ModalVariant, Button, Title } from '@patternfly/react-core';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 
 class CustomHeaderFooter extends React.Component {
@@ -295,7 +295,7 @@ class CustomHeaderFooter extends React.Component {
 
     const header = (
       <React.Fragment>
-        <Title headingLevel={TitleLevel.h1} size={BaseSizes['2xl']}>
+        <Title headingLevel="h1" size={TitleSizes['2xl']}>
           Custom Modal Header/Footer
         </Title>
         <p className="pf-u-pt-sm">Allows for custom content in the header and/or footer by passing components.</p>
@@ -303,7 +303,7 @@ class CustomHeaderFooter extends React.Component {
     );
 
     const footer = (
-      <Title headingLevel={TitleLevel.h4} size={BaseSizes.sm}>
+      <Title headingLevel="h4" size={TitleSizes.sm}>
         <WarningTriangleIcon />
         <span className="pf-u-pl-sm">Custom modal footer.</span>
       </Title>

--- a/packages/react-core/src/components/Popover/PopoverHeader.tsx
+++ b/packages/react-core/src/components/Popover/PopoverHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Title, TitleSize } from '../Title';
+import { Title, TitleSizes } from '../Title';
 import { Omit } from '../../helpers/typeUtils';
 
 export const PopoverHeader: React.FunctionComponent<PopoverHeaderProps> = ({
@@ -7,7 +7,7 @@ export const PopoverHeader: React.FunctionComponent<PopoverHeaderProps> = ({
   id,
   ...props
 }: PopoverHeaderProps) => (
-  <Title headingLevel="h6" size={TitleSize.xl} id={id} {...props}>
+  <Title headingLevel="h6" size={TitleSizes.xl} id={id} {...props}>
     {children}
   </Title>
 );

--- a/packages/react-core/src/components/Title/Title.tsx
+++ b/packages/react-core/src/components/Title/Title.tsx
@@ -2,39 +2,37 @@ import * as React from 'react';
 import { css } from '@patternfly/react-styles';
 import { Omit } from '../../helpers/typeUtils';
 import styles from '@patternfly/react-styles/css/components/Title/title';
-import { BaseSizes } from '../../styles/sizes';
 
-export enum TitleLevel {
-  h1 = 'h1',
-  h2 = 'h2',
-  h3 = 'h3',
-  h4 = 'h4',
-  h5 = 'h5',
-  h6 = 'h6'
+export enum TitleSizes {
+  md = 'md',
+  lg = 'lg',
+  xl = 'xl',
+  '2xl' = '2xl',
+  '3xl' = '3xl',
+  '4xl' = '4xl'
 }
 
+type Size = 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
+
 export interface TitleProps extends Omit<React.HTMLProps<HTMLHeadingElement>, 'size' | 'className'> {
-  /** the size of the Title  */
-  size: BaseSizes | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
-  /** content rendered inside the Title */
+  /** The size of the Title  */
+  size: Size;
+  /** Content rendered inside the Title */
   children?: React.ReactNode;
   /** Additional classes added to the Title */
   className?: string;
-  /** the heading level to use */
-  headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  /** The heading level to use */
+  headingLevel: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
 
 export const Title: React.FunctionComponent<TitleProps> = ({
   size,
   className = '',
   children = '',
-  headingLevel: HeadingLevel = 'h1',
+  headingLevel: HeadingLevel,
   ...props
 }: TitleProps) => (
-  <HeadingLevel
-    {...props}
-    className={css(styles.title, styles.modifiers[size as 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl'], className)}
-  >
+  <HeadingLevel {...props} className={css(styles.title, styles.modifiers[size as Size], className)}>
     {children}
   </HeadingLevel>
 );

--- a/packages/react-core/src/components/Title/__tests__/Title.test.tsx
+++ b/packages/react-core/src/components/Title/__tests__/Title.test.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { Title, TitleSize, TitleLevel } from '..';
+import { Title, TitleSizes } from '..';
 
-Object.values(TitleSize).forEach(size => {
+Object.values(TitleSizes).forEach(size => {
   test(`${size} Title`, () => {
     const view = shallow(
-      <Title size={size} headingLevel={TitleLevel.h1}>
+      <Title size={size} headingLevel="h1">
         {size} Title
       </Title>
     );
@@ -15,7 +15,7 @@ Object.values(TitleSize).forEach(size => {
 
 test('Heading level can be set using a string value', () => {
   const view = shallow(
-    <Title size="lg" headingLevel={TitleLevel.h3}>
+    <Title size="lg" headingLevel="h3">
       H3 Heading
     </Title>
   );

--- a/packages/react-core/src/components/Title/__tests__/__snapshots__/Title.test.tsx.snap
+++ b/packages/react-core/src/components/Title/__tests__/__snapshots__/Title.test.tsx.snap
@@ -45,29 +45,11 @@ exports[`md Title 1`] = `
 </h1>
 `;
 
-exports[`sm Title 1`] = `
-<h1
-  className="pf-c-title"
->
-  sm
-   Title
-</h1>
-`;
-
 exports[`xl Title 1`] = `
 <h1
   className="pf-c-title pf-m-xl"
 >
   xl
-   Title
-</h1>
-`;
-
-exports[`xs Title 1`] = `
-<h1
-  className="pf-c-title"
->
-  xs
    Title
 </h1>
 `;

--- a/packages/react-core/src/components/Title/examples/Title.md
+++ b/packages/react-core/src/components/Title/examples/Title.md
@@ -6,7 +6,7 @@ typescript: true
 propComponents: ['Title']
 ---
 
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 
 ## Examples
 ```js title=Sizes
@@ -14,19 +14,19 @@ import React from 'react';
 import { Title } from '@patternfly/react-core';
 
 <React.Fragment>
-  <Title headingLevel="h1" size="4xl">
+  <Title headingLevel="h1" size={TitleSizes['4xl']}>
     4xl Title
   </Title>
   <Title headingLevel="h2" size="3xl">
     3xl Title
   </Title>
-  <Title headingLevel="h3" size="2xl">
+  <Title headingLevel="h3" size={TitleSizes['2xl']}>
     2xl Title
   </Title>
   <Title headingLevel="h4" size="xl">
     xl Title
   </Title>
-  <Title headingLevel="h5" size="lg">
+  <Title headingLevel="h5" size={TitleSizes.lg}>
     lg Title
   </Title>
   <Title headingLevel="h6" size="md">

--- a/packages/react-core/src/components/Title/index.ts
+++ b/packages/react-core/src/components/Title/index.ts
@@ -1,2 +1,1 @@
 export * from './Title';
-export { BaseSizes as TitleSize } from '../../styles/sizes';

--- a/packages/react-core/src/components/Wizard/WizardHeader.tsx
+++ b/packages/react-core/src/components/Wizard/WizardHeader.tsx
@@ -32,7 +32,7 @@ export const WizardHeader: React.FunctionComponent<WizardHeaderProps> = ({
     <Button variant="plain" className={css(styles.wizardClose)} aria-label={closeButtonAriaLabel} onClick={onClose}>
       <TimesIcon aria-hidden="true" />
     </Button>
-    <Title size="3xl" className={css(styles.wizardTitle)} aria-label={title} id={titleId}>
+    <Title headingLevel="h2" size="3xl" className={css(styles.wizardTitle)} aria-label={title} id={titleId}>
       {title || <>&nbsp;</>}
     </Title>
     {description && (

--- a/packages/react-core/src/components/Wizard/__tests__/Generated/__snapshots__/WizardHeader.test.tsx.snap
+++ b/packages/react-core/src/components/Wizard/__tests__/Generated/__snapshots__/WizardHeader.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`WizardHeader should match snapshot (auto-generated) 1`] = `
   <Title
     aria-label="string"
     className="pf-c-wizard__title"
+    headingLevel="h2"
     id="string"
     size="3xl"
   >

--- a/packages/react-core/src/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
+++ b/packages/react-core/src/components/Wizard/__tests__/__snapshots__/Wizard.test.tsx.snap
@@ -177,13 +177,13 @@ exports[`Wizard should match snapshot 1`] = `
                     />
                   </svg>
                 </button>
-                <h1
+                <h2
                   aria-label="Wizard title"
                   class="pf-c-title pf-m-3xl pf-c-wizard__title"
                   id="pf-wizard-title-0"
                 >
                   Wizard title
-                </h1>
+                </h2>
                 <p
                   class="pf-c-wizard__description"
                   id="pf-wizard-description-0"
@@ -400,13 +400,13 @@ exports[`Wizard should match snapshot 1`] = `
                     />
                   </svg>
                 </button>
-                <h1
+                <h2
                   aria-label="Wizard title"
                   class="pf-c-title pf-m-3xl pf-c-wizard__title"
                   id="pf-wizard-title-0"
                 >
                   Wizard title
-                </h1>
+                </h2>
                 <p
                   class="pf-c-wizard__description"
                   id="pf-wizard-description-0"

--- a/packages/react-core/src/components/Wizard/examples/Wizard.md
+++ b/packages/react-core/src/components/Wizard/examples/Wizard.md
@@ -10,7 +10,7 @@ import { Button, Wizard, WizardFooter, WizardContextConsumer, Alert } from '@pat
 import FinishedStep from './FinishedStep';
 import SampleForm from './SampleForm';
 
-### Examples
+## Examples
 ```js title=Basic
 import React from 'react';
 import { Button, Wizard } from '@patternfly/react-core';
@@ -360,8 +360,8 @@ class ValidateButtonPressWizard extends React.Component {
     const steps = [
       { name: 'Step 1', component: <p>Step 1</p> },
       { name: 'Step 2', component: <p>Step 2</p> },
-      { 
-        name: 'Final Step', 
+      {
+        name: 'Final Step',
         component: (
           <>
             {stepsValid === 1 && <div style={{padding: '15px 0'}}><Alert variant="warning" title="Validation failed, please try again" /></div>}
@@ -449,19 +449,19 @@ class ProgressiveWizard extends React.Component {
     this.onGoToStep = ({ id, name }, { prevId, prevName }) => {
       // Remove steps after the currently clicked step
       if (name === 'Get Started') {
-        this.setState({ 
+        this.setState({
           showReviewStep: false,
           showOptionsStep: false,
           showCreateStep: false,
           showUpdateStep: false
         });
       } else if (name === 'Create Options' || name === 'Update Options') {
-        this.setState({ 
+        this.setState({
           showReviewStep: false,
           showOptionsStep: false
         });
       } else if (name.indexOf('Substep') > -1) {
-        this.setState({ 
+        this.setState({
           showReviewStep: false
         });
       }
@@ -469,7 +469,7 @@ class ProgressiveWizard extends React.Component {
     this.getNextStep = (activeStep, callback) => {
       if (activeStep.name === 'Get Started') {
         if (this.state.getStartedStepRadio === 'Create') {
-          this.setState({ 
+          this.setState({
             showCreateStep: true,
             showUpdateStep: false,
             showOptionsStep: false,
@@ -478,7 +478,7 @@ class ProgressiveWizard extends React.Component {
             callback();
           });
         } else {
-          this.setState({ 
+          this.setState({
             showCreateStep: false,
             showUpdateStep: true,
             showOptionsStep: false,
@@ -488,15 +488,15 @@ class ProgressiveWizard extends React.Component {
           });
         }
       } else if (activeStep.name === 'Create Options' || activeStep.name === 'Update Options') {
-        this.setState({ 
+        this.setState({
           showOptionsStep: true,
           showReviewStep: false
         }, () => {
           callback();
         });
       } else if (activeStep.name === 'Substep 3') {
-        this.setState({ 
-          showReviewStep: true 
+        this.setState({
+          showReviewStep: true
         }, () => {
           callback();
         });
@@ -506,25 +506,25 @@ class ProgressiveWizard extends React.Component {
     };
     this.getPreviousStep = (activeStep, callback) => {
       if (activeStep.name === 'Review') {
-        this.setState({ 
+        this.setState({
           showReviewStep: false
         }, () => {
           callback();
         });
       } else if (activeStep.name === 'Substep 1') {
-        this.setState({ 
+        this.setState({
           showOptionsStep: false
         }, () => {
           callback();
         });
       } else if (activeStep.name === 'Create Options') {
-        this.setState({ 
+        this.setState({
           showCreateStep: false
         }, () => {
           callback();
         });
       } else if (activeStep.name === 'Update Options') {
-        this.setState({ 
+        this.setState({
           showUpdateStep: false
         }, () => {
           callback();
@@ -536,11 +536,11 @@ class ProgressiveWizard extends React.Component {
   }
 
   render() {
-    const { 
-      isOpen, 
-      stepsValid, 
-      getStartedStepRadio, 
-      createStepRadio, 
+    const {
+      isOpen,
+      stepsValid,
+      getStartedStepRadio,
+      createStepRadio,
       updateStepRadio,
       showCreateStep,
       showUpdateStep,
@@ -548,8 +548,8 @@ class ProgressiveWizard extends React.Component {
       showReviewStep
     } = this.state;
 
-    const getStartedStep = { 
-      name: 'Get Started', 
+    const getStartedStep = {
+      name: 'Get Started',
       component: (
         <div>
           <Radio
@@ -637,7 +637,7 @@ class ProgressiveWizard extends React.Component {
         }
       ]
     };
-    
+
     const reviewStep = {
       name: 'Review',
       component: (
@@ -648,7 +648,7 @@ class ProgressiveWizard extends React.Component {
       )
     };
 
-    const steps = [ 
+    const steps = [
       getStartedStep,
       ...(showCreateStep ? [createStep] : []),
       ...(showUpdateStep ? [updateStep] : []),

--- a/packages/react-core/src/demos/BulkSelectTable.md
+++ b/packages/react-core/src/demos/BulkSelectTable.md
@@ -215,7 +215,7 @@ class BulkSelectTableDemo extends React.Component {
         )}
         {loading && (
           <div className="pf-l-bullseye">
-            <Title size="3xl">Please wait while loading data</Title>
+            <Title headingLevel="h2" size="3xl">Please wait while loading data</Title>
           </div>
         )}
         {this.renderPagination()}

--- a/packages/react-core/src/demos/FilterTableDemo.md
+++ b/packages/react-core/src/demos/FilterTableDemo.md
@@ -381,7 +381,7 @@ class FilterTableDemo extends React.Component {
         )}
         {loading && (
           <center>
-            <Title size="3xl">Please wait while loading data</Title>
+            <Title headingLevel="h2" size="3xl">Please wait while loading data</Title>
           </center>
         )}
       </React.Fragment>

--- a/packages/react-docs/package.json
+++ b/packages/react-docs/package.json
@@ -31,7 +31,7 @@
     "@patternfly/react-virtualized-extension": "^4.0.14",
     "gatsby": "2.19.12",
     "gatsby-cli": "2.8.29",
-    "gatsby-theme-patternfly-org": "^1.4.1",
+    "gatsby-theme-patternfly-org": "^1.4.9",
     "gatsby-transformer-react-docgen-typescript": "^0.2.5",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",

--- a/packages/react-docs/src/pages/icons.js
+++ b/packages/react-docs/src/pages/icons.js
@@ -44,7 +44,7 @@ const iconsPage = ({ location }) => {
   return (
     <SideNavLayout location={location} context="react" showGdprBanner={true} pageTitle="React icons">
       <PageSection className="ws-section">
-        <Title size="md" className="ws-framework-title">
+        <Title headingLevel="h1" size="md" className="ws-framework-title">
           React
         </Title>
         <Title headingLevel="h2" size="4xl">

--- a/packages/react-docs/src/pages/index.js
+++ b/packages/react-docs/src/pages/index.js
@@ -28,8 +28,12 @@ const IndexPage = ({ data, location }) => {
       <div style={containerStyle}>
         <PageSection style={centerStyle}>
           <div style={{ flex: 'none', textAlign: 'center' }}>
-            <Title size="4xl">PatternFly 4 React Docs</Title>
-            <Title size="2xl">{prInfo.num ? <a href={prInfo.url}>PR #{prInfo.num}</a> : 'Hi people!'}</Title>
+            <Title size="4xl" headingLevel="h1">
+              PatternFly 4 React Docs
+            </Title>
+            <Title size="2xl" headingLevel="h2">
+              {prInfo.num ? <a href={prInfo.url}>PR #{prInfo.num}</a> : 'Hi people!'}
+            </Title>
             <p>Welcome to Patternfly 4 React docs.</p>
             <p>Now go build something great.</p>
           </div>

--- a/packages/react-integration/demo-app-ts/src/components/AppHeader/AppHeader.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/AppHeader/AppHeader.tsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { Avatar, Brand, PageHeader } from '@patternfly/react-core';
 import { AppToolbar } from '../AppToolbar/AppToolbar';
-const imgBrand = '../../assets/images/imgBrand.svg';
-const imgAvatar = '../../assets/images/imgAvatar.svg';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import imgBrand from '../../assets/images/imgBrand.svg';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import imgAvatar from '../../assets/images/imgAvatar.svg';
 
 const showNavToogle: boolean = false;
 

--- a/packages/react-integration/demo-app-ts/src/components/demos/DropdownDemo/DropdownDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DropdownDemo/DropdownDemo.tsx
@@ -133,7 +133,9 @@ export class DropdownDemo extends React.Component<{}, DropdownState> {
 
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Dropdown</Title>
+        <Title size="2xl" headingLevel="h2">
+          Dropdown
+        </Title>
         <Dropdown
           id="dropdown"
           onSelect={this.onSelect}
@@ -186,7 +188,9 @@ export class DropdownDemo extends React.Component<{}, DropdownState> {
 
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Action Dropdown</Title>
+        <Title size="2xl" headingLevel="h2">
+          Action Dropdown
+        </Title>
         <Dropdown
           id="action-dropdown"
           onSelect={this.onActionSelect}

--- a/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/ModalDemo/ModalDemo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, ModalVariant, Button, Title, TitleLevel, BaseSizes } from '@patternfly/react-core';
+import { Modal, ModalVariant, Button, Title, TitleSizes } from '@patternfly/react-core';
 import WarningTriangleIcon from '@patternfly/react-icons/dist/js/icons/warning-triangle-icon';
 
 interface ModalDemoState {
@@ -211,7 +211,7 @@ export class ModalDemo extends React.Component<React.HTMLProps<HTMLDivElement>, 
 
     const header = (
       <React.Fragment>
-        <Title id="customHeaderTitle" headingLevel={TitleLevel.h1} size={BaseSizes['2xl']}>
+        <Title id="customHeaderTitle" headingLevel="h1" size={TitleSizes['2xl']}>
           Custom Modal Header/Footer
         </Title>
         <p id="customHeaderDescription" className="pf-u-pt-sm">
@@ -221,7 +221,7 @@ export class ModalDemo extends React.Component<React.HTMLProps<HTMLDivElement>, 
     );
 
     const footer = (
-      <Title id="customFooterTitle" headingLevel={TitleLevel.h4} size={BaseSizes.sm}>
+      <Title id="customFooterTitle" headingLevel="h4" size={TitleSizes.md}>
         <WarningTriangleIcon />
         <span className="pf-u-pl-sm">Custom modal footer.</span>
       </Title>

--- a/packages/react-integration/demo-app-ts/src/components/demos/NavDemo/NavDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/NavDemo/NavDemo.tsx
@@ -57,7 +57,9 @@ export class NavDemo extends Component {
     const { defaultActiveItem } = this.state;
     return (
       <StackItem isFilled>
-        <Title size="2xl">Default Nav</Title>
+        <Title headingLevel="h2" size="2xl">
+          Default Nav
+        </Title>
         <div className="example" style={{ border: '1px solid rgb(114, 118, 123)', backgroundColor: '#fff' }}>
           <Nav onSelect={this.onDefaultSelect} id="nav-primary-default">
             <NavList>
@@ -120,7 +122,9 @@ export class NavDemo extends Component {
     const { expandableActiveGroup, expandableActiveItem, expandableClickedGroup, expandableClickedItem } = this.state;
     return (
       <StackItem isFilled>
-        <Title size="2xl">Expandable Nav</Title>
+        <Title headingLevel="h2" size="2xl">
+          Expandable Nav
+        </Title>
         <div className="example" style={{ border: '1px solid rgb(114, 118, 123)', backgroundColor: '#fff' }}>
           <Nav onSelect={this.onExpandableSelect} id="nav-primary-expandable">
             <NavList>
@@ -238,7 +242,9 @@ export class NavDemo extends Component {
 
     return (
       <StackItem isFilled>
-        <Title size="2xl">Horizontal Nav</Title>
+        <Title headingLevel="h2" size="2xl">
+          Horizontal Nav
+        </Title>
         <div style={{ backgroundColor: '#292e34', padding: '1rem' }}>
           <Nav onSelect={this.onHorizontalSelect} id="nav-primary-horizontal">
             <NavList variant={NavVariants.horizontal}>

--- a/packages/react-integration/demo-app-ts/src/components/demos/PaginationDemo/PaginationDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/PaginationDemo/PaginationDemo.tsx
@@ -54,7 +54,9 @@ export class PaginationDemo extends React.Component<React.HTMLProps<HTMLDivEleme
   renderPagination() {
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Pagination</Title>
+        <Title headingLevel="h2" size="2xl">
+          Pagination
+        </Title>
         <React.Fragment>
           <Pagination
             itemCount={523}
@@ -94,7 +96,9 @@ export class PaginationDemo extends React.Component<React.HTMLProps<HTMLDivEleme
   renderDisabled() {
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Disabled state</Title>
+        <Title headingLevel="h2" size="2xl">
+          Disabled state
+        </Title>
         <React.Fragment>
           <Pagination
             itemCount={523}

--- a/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
@@ -383,7 +383,9 @@ export class SelectDemo extends Component<SelectDemoState> {
     const titleId = 'title-id';
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Single Select</Title>
+        <Title headingLevel="h2" size="2xl">
+          Single Select
+        </Title>
         <div>
           <span id={titleId} hidden>
             Title
@@ -427,7 +429,9 @@ export class SelectDemo extends Component<SelectDemoState> {
     const titleId = 'title-id';
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Disabled Single Select</Title>
+        <Title headingLevel="h2" size="2xl">
+          Disabled Single Select
+        </Title>
         <div>
           <span id={titleId} hidden>
             Title
@@ -462,7 +466,9 @@ export class SelectDemo extends Component<SelectDemoState> {
     const titleId = 'title-id';
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Custom Single Select</Title>
+        <Title headingLevel="h2" size="2xl">
+          Custom Single Select
+        </Title>
         <div>
           <span id={titleId} hidden>
             Title
@@ -516,7 +522,9 @@ export class SelectDemo extends Component<SelectDemoState> {
     const titleId = 'checkbox-select-id';
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Checkbox Select</Title>
+        <Title headingLevel="h2" size="2xl">
+          Checkbox Select
+        </Title>
         <div>
           <span id={titleId} hidden>
             Checkbox Title
@@ -550,7 +558,9 @@ export class SelectDemo extends Component<SelectDemoState> {
     const titleId = 'typeahead-select-id';
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Typeahead Select</Title>
+        <Title headingLevel="h2" size="2xl">
+          Typeahead Select
+        </Title>
         <div>
           <span id={titleId} hidden>
             Select a state
@@ -602,7 +612,9 @@ export class SelectDemo extends Component<SelectDemoState> {
 
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Typeahead Multi Select</Title>
+        <Title headingLevel="h2" size="2xl">
+          Typeahead Multi Select
+        </Title>
         <div>
           <span id={titleId} hidden>
             Select a state
@@ -634,7 +646,9 @@ export class SelectDemo extends Component<SelectDemoState> {
 
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Custom Data Typeahead Multi Select</Title>
+        <Title headingLevel="h2" size="2xl">
+          Custom Data Typeahead Multi Select
+        </Title>
         <div>
           <span id={titleId} hidden>
             Select a state
@@ -666,7 +680,9 @@ export class SelectDemo extends Component<SelectDemoState> {
 
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Custom Typeahead Multi Select</Title>
+        <Title headingLevel="h2" size="2xl">
+          Custom Typeahead Multi Select
+        </Title>
         <div>
           <span id={titleId} hidden>
             Select a state
@@ -704,7 +720,9 @@ export class SelectDemo extends Component<SelectDemoState> {
 
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Custom Typeahead Plain Multi Select</Title>
+        <Title headingLevel="h2" size="2xl">
+          Custom Typeahead Plain Multi Select
+        </Title>
         <div>
           <span id={titleId} hidden>
             Select a state
@@ -742,7 +760,9 @@ export class SelectDemo extends Component<SelectDemoState> {
     const titleId = 'custom-content-title-id';
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Custom Content Select</Title>
+        <Title headingLevel="h2" size="2xl">
+          Custom Content Select
+        </Title>
         <div id="custom-content-select-id">
           <span id={titleId} hidden>
             Title
@@ -767,7 +787,9 @@ export class SelectDemo extends Component<SelectDemoState> {
     const titleId = 'typeahead-select-form-id';
     return (
       <StackItem isFilled={false}>
-        <Title size="2xl">Typeahead inside a form</Title>
+        <Title headingLevel="h2" size="2xl">
+          Typeahead inside a form
+        </Title>
         <Form
           onSubmit={e => {
             window.location.href = '/404';

--- a/packages/react-integration/demo-app-ts/src/components/demos/TitleDemo/TitleDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TitleDemo/TitleDemo.tsx
@@ -1,9 +1,9 @@
-import { Title, TitleLevel, TitleProps } from '@patternfly/react-core';
+import { Title, TitleProps, TitleSizes } from '@patternfly/react-core';
 import React, { Component } from 'react';
 
 const myProps: TitleProps = {
   size: 'md',
-  headingLevel: TitleLevel.h1
+  headingLevel: 'h1'
 };
 
 export class TitleDemo extends Component {
@@ -16,6 +16,9 @@ export class TitleDemo extends Component {
       <React.Fragment>
         <Title size={myProps.size} headingLevel={myProps.headingLevel}>
           Integration Demo App
+        </Title>
+        <Title size={TitleSizes.md} headingLevel="h2">
+          Setting title size using TitleSizes
         </Title>
       </React.Fragment>
     );

--- a/packages/react-topology/src/components/TopologyView/examples/ItemDetails.js
+++ b/packages/react-topology/src/components/TopologyView/examples/ItemDetails.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Title, TitleLevel } from '@patternfly/react-core/dist/js/components/Title/Title';
-import { BaseSizes } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core/dist/js/components/Title/Title';
 import { TopologySideBar } from '@patternfly/react-topology';
 
 export class ItemDetails extends React.Component {
@@ -10,7 +9,7 @@ export class ItemDetails extends React.Component {
 
     const header = (
       <div className="pf-u-m-lg">
-        <Title headingLevel={TitleLevel.h1} size={BaseSizes['2xl']}>
+        <Title headingLevel="h1" size={TitleSizes['2xl']}>
           Item Details
         </Title>
         <p>Short description of the selected item.</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10575,9 +10575,10 @@ gatsby-telemetry@^1.1.49:
     stack-utils "1.0.2"
     uuid "3.3.3"
 
-gatsby-theme-patternfly-org@^1.4.1:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/gatsby-theme-patternfly-org/-/gatsby-theme-patternfly-org-1.4.3.tgz#7e6d9714b5191c8af1ea786ac70e844ce588025e"
+gatsby-theme-patternfly-org@^1.4.9:
+  version "1.4.9"
+  resolved "https://registry.yarnpkg.com/gatsby-theme-patternfly-org/-/gatsby-theme-patternfly-org-1.4.9.tgz#016366bd314fc59dab9b3c285925bc6c9dd02b79"
+  integrity sha512-/pxrtxpUo8iQAKzM7gFGtjHM3G/wJdh59UWGAObdLDo9g09W1AagEXj65aprLZmWezhsTmu3JkETE4zlK+ofUQ==
   dependencies:
     "@mdx-js/mdx" "^1.1.5"
     "@mdx-js/react" "^1.1.5"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: This PR makes the `headingLevel` prop required, replace TitleSize with TitleSizes, and also removes TitleLevel enum as these values are not expected to change.

Closes # https://github.com/patternfly/patternfly-react/issues/1439

## Breaking changes
1. **Title**: Removes enum `TitleSize`. The enum `TitleSizes` should be used instead.
2. **Title**: Removes valid values `xs` and `sm` for `size` prop. Use size `md` instead.
3. **Title**: Removes enum `TitleLevel`. Use one of the string values 'h1', 'h2', 'h3', 'h4', 'h5', or 'h6' instead.
4. **Title**: `headingLevel` is now a required prop. Update any existing usage of `Title` to supply a string value for headingLevel of h1-h6.
5. **Title**: Removes default value `h1` for `headingLevel` prop. Use one of the string values 'h1', 'h2', 'h3', 'h4', 'h5', or 'h6' explicitly.
