### PR TITLE
Empty state width

### DIFF
--- a/packages/react-core/src/components/EmptyState/EmptyState.tsx
+++ b/packages/react-core/src/components/EmptyState/EmptyState.tsx
@@ -20,7 +20,7 @@ export interface EmptyStateProps extends React.HTMLProps<HTMLDivElement> {
 export const EmptyState: React.FunctionComponent<EmptyStateProps> = ({
   children,
   className = '',
-  variant = EmptyStateVariant.large,
+  variant = EmptyStateVariant.full,
   ...props
 }: EmptyStateProps) => (
   <div

--- a/packages/react-core/src/components/EmptyState/EmptyState.tsx
+++ b/packages/react-core/src/components/EmptyState/EmptyState.tsx
@@ -3,8 +3,8 @@ import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/EmptyState/empty-state';
 
 export enum EmptyStateVariant {
-  large = 'large',
-  small = 'small',
+  lg = 'lg',
+  sm = 'sm',
   full = 'full'
 }
 
@@ -14,7 +14,7 @@ export interface EmptyStateProps extends React.HTMLProps<HTMLDivElement> {
   /** Content rendered inside the EmptyState */
   children: React.ReactNode;
   /** Modifies EmptyState max-width */
-  variant?: 'small' | 'large' | 'full';
+  variant?: 'sm' | 'lg' | 'full';
 }
 
 export const EmptyState: React.FunctionComponent<EmptyStateProps> = ({
@@ -26,8 +26,8 @@ export const EmptyState: React.FunctionComponent<EmptyStateProps> = ({
   <div
     className={css(
       styles.emptyState,
-      variant === 'large' && styles.modifiers.lg,
-      variant === 'small' && styles.modifiers.sm,
+      variant === 'lg' && styles.modifiers.lg,
+      variant === 'sm' && styles.modifiers.sm,
       className
     )}
     {...props}

--- a/packages/react-core/src/components/EmptyState/__tests__/EmptyState.test.tsx
+++ b/packages/react-core/src/components/EmptyState/__tests__/EmptyState.test.tsx
@@ -31,10 +31,10 @@ describe('EmptyState', () => {
     expect(view).toMatchSnapshot();
   });
 
-  test('Main variant regular', () => {
+  test('Main variant large', () => {
     const view = shallow(
-      <EmptyState variant={EmptyStateVariant.full}>
-        <Title size={BaseSizes.md}>EmptyState full</Title>
+      <EmptyState variant={EmptyStateVariant.lg}>
+        <Title size={BaseSizes.md}>EmptyState large</Title>
       </EmptyState>
     );
     expect(view).toMatchSnapshot();
@@ -42,7 +42,7 @@ describe('EmptyState', () => {
 
   test('Main variant small', () => {
     const view = shallow(
-      <EmptyState variant={EmptyStateVariant.small}>
+      <EmptyState variant={EmptyStateVariant.sm}>
         <Title size={BaseSizes.md}>EmptyState small</Title>
       </EmptyState>
     );

--- a/packages/react-core/src/components/EmptyState/__tests__/Generated/__snapshots__/EmptyState.test.tsx.snap
+++ b/packages/react-core/src/components/EmptyState/__tests__/Generated/__snapshots__/EmptyState.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EmptyState should match snapshot (auto-generated) 1`] = `
 <div
-  className="pf-c-empty-state pf-m-sm ''"
+  className="pf-c-empty-state ''"
 >
   <div>
     ReactNode

--- a/packages/react-core/src/components/EmptyState/__tests__/__snapshots__/EmptyState.test.tsx.snap
+++ b/packages/react-core/src/components/EmptyState/__tests__/__snapshots__/EmptyState.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`EmptyState Main 1`] = `
 <div
-  className="pf-c-empty-state pf-m-lg"
+  className="pf-c-empty-state"
 >
   <Title
     headingLevel="h5"

--- a/packages/react-core/src/components/EmptyState/__tests__/__snapshots__/EmptyState.test.tsx.snap
+++ b/packages/react-core/src/components/EmptyState/__tests__/__snapshots__/EmptyState.test.tsx.snap
@@ -29,14 +29,14 @@ exports[`EmptyState Main 1`] = `
 </div>
 `;
 
-exports[`EmptyState Main variant regular 1`] = `
+exports[`EmptyState Main variant large 1`] = `
 <div
-  className="pf-c-empty-state"
+  className="pf-c-empty-state pf-m-lg"
 >
   <Title
     size="md"
   >
-    EmptyState full
+    EmptyState large
   </Title>
 </div>
 `;

--- a/packages/react-core/src/components/EmptyState/examples/EmptyState.md
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyState.md
@@ -68,7 +68,7 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 
 SimpleEmptyState = () => (
-  <EmptyState variant={EmptyStateVariant.small}>
+  <EmptyState variant={EmptyStateVariant.sm}>
     <EmptyStateIcon icon={CubesIcon} />
     <Title headingLevel="h5" size="lg">
       Empty State
@@ -104,7 +104,7 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 
 SimpleEmptyState = () => (
-  <EmptyState variant={EmptyStateVariant.large}>
+  <EmptyState variant={EmptyStateVariant.lg}>
     <EmptyStateIcon icon={CubesIcon} />
     <Title headingLevel="h5" size="lg">
       Empty State

--- a/packages/react-core/src/components/EmptyState/examples/EmptyState.md
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyState.md
@@ -32,7 +32,7 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 
 SimpleEmptyState = () => (
-  <EmptyState variant={EmptyStateVariant.full}>
+  <EmptyState>
     <EmptyStateIcon icon={CubesIcon} />
     <Title headingLevel="h5" size="lg">
       Empty State

--- a/packages/react-integration/demo-app-ts/src/components/demos/EmptyStateDemo/EmptyStateDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/EmptyStateDemo/EmptyStateDemo.tsx
@@ -33,7 +33,7 @@ export class EmptyStateDemo extends Component {
         </EmptyStateSecondaryActions>
       </React.Fragment>
     ),
-    variant: EmptyStateVariant.large
+    variant: EmptyStateVariant.lg
   };
   mySmallEmptyStateProps: EmptyStateProps = {
     children: (
@@ -57,7 +57,7 @@ export class EmptyStateDemo extends Component {
         </EmptyStateSecondaryActions>
       </React.Fragment>
     ),
-    variant: EmptyStateVariant.small
+    variant: EmptyStateVariant.sm
   };
   myFullEmptyStateProps: EmptyStateProps = {
     children: (

--- a/packages/react-integration/demo-app-ts/src/components/demos/EmptyStateDemo/EmptyStateDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/EmptyStateDemo/EmptyStateDemo.tsx
@@ -32,7 +32,8 @@ export class EmptyStateDemo extends Component {
           <Button variant="link">Action area</Button>
         </EmptyStateSecondaryActions>
       </React.Fragment>
-    )
+    ),
+    variant: EmptyStateVariant.large
   };
   mySmallEmptyStateProps: EmptyStateProps = {
     children: (
@@ -79,8 +80,7 @@ export class EmptyStateDemo extends Component {
           <Button variant="link">Action area</Button>
         </EmptyStateSecondaryActions>
       </React.Fragment>
-    ),
-    variant: EmptyStateVariant.full
+    )
   };
 
   componentDidMount() {
@@ -90,9 +90,9 @@ export class EmptyStateDemo extends Component {
   render() {
     return (
       <React.Fragment>
-        <EmptyState>{this.myLargeEmptyStateProps.children}</EmptyState>
+        <EmptyState variant={this.myLargeEmptyStateProps.variant}>{this.myLargeEmptyStateProps.children}</EmptyState>
         <EmptyState variant={this.mySmallEmptyStateProps.variant}>{this.mySmallEmptyStateProps.children}</EmptyState>
-        <EmptyState variant={this.myFullEmptyStateProps.variant}>{this.myFullEmptyStateProps.children}</EmptyState>
+        <EmptyState>{this.myFullEmptyStateProps.children}</EmptyState>
       </React.Fragment>
     );
   }

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEmptyStateDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableEmptyStateDemo.tsx
@@ -27,7 +27,7 @@ export class EmptyStateTable extends React.Component<TableProps, { columns: (ICe
           heightAuto: true,
           props: { colSpan: '8' },
           title: (
-            <EmptyState variant={EmptyStateVariant.small}>
+            <EmptyState variant={EmptyStateVariant.sm}>
               <EmptyStateIcon icon={CubesIcon} />
               <Title headingLevel="h5" size="lg">
                 Empty State


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
Change the default width to full instead of large.  updated the variant name to be more consistent with other components.  Note: The variant `full` was not changed to allow for flexibility of other sizes being added that are larger than `xl`.
**What**: Closes #3221 #3873 


## Breaking changes
1. Changes the default width to `full` instead of `large`.  To maintain the previous default behaviour, set the `variant` prop to large. e.g `<EmptyState variant={EmptyStateVariant.large}> ...</EmptyState>` 
2. Variant `small` has been updated to `sm`
3. Variant `large` has been updated to `lg`