### PR TITLE
chore(prop-types): remove a few usages

### DIFF
--- a/packages/react-core/src/helpers/componentShape.js
+++ b/packages/react-core/src/helpers/componentShape.js
@@ -1,3 +1,0 @@
-import PropTypes from 'prop-types';
-
-export const componentShape = PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]);

--- a/packages/react-docs/src/pages/index.js
+++ b/packages/react-docs/src/pages/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
 import { Title } from '@patternfly/react-core/dist/js/components/Title/Title';
 import { PageSection, PageSectionVariants } from '@patternfly/react-core/dist/js/components/Page/PageSection';
@@ -48,11 +47,6 @@ const IndexPage = ({ data, location }) => {
       </div>
     </SideNavLayout>
   );
-};
-
-IndexPage.propTypes = {
-  data: PropTypes.any.isRequired,
-  location: PropTypes.Object
 };
 
 export const pageQuery = graphql`

--- a/packages/react-integration/demo-app-ts/src/components/AppSidebar/AppSidebar.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/AppSidebar/AppSidebar.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { PageSidebar, PageSidebarProps } from '@patternfly/react-core';
 
 export const AppSidebar: React.FunctionComponent<PageSidebarProps> = props => <PageSidebar nav={props.nav} />;
-
-AppSidebar.propTypes = {
-  nav: PropTypes.node
-};
 
 export default AppSidebar;

--- a/scripts/generators/patternfly-4-component/templates/component/component.tsx.hbs
+++ b/scripts/generators/patternfly-4-component/templates/component/component.tsx.hbs
@@ -1,24 +1,19 @@
-import React, { DetailedHTMLProps } from 'react';
+import * as React from 'react';
 import styles from '@patternfly/react-styles/css/{{typeDir}}/{{componentName}}';
 import { css } from '@patternfly/react-styles';
-import PropTypes from 'prop-types';
-
-const defaultProps = {
-children: null,
-className: ''
-};
 
 interface {{ componentName }}Props {
-children?: any;
-className?: string;
+  children?: any;
+  className?: string;
 }
 
-const {{componentName}}: React.SFC<{{componentName}}Props> = (props) => (
-  <div {...props} className={css(styles.{{ camelCase componentName }}, props.className)}>
-    {props.children}
-  </div>
+export const {{componentName}}: React.SFC<{{componentName}}Props> = ({
+  className,
+  children
+}) => {
+  return (
+    <div {...props} className={css(styles.{{ camelCase componentName }}, props.className)}>
+      {props.children}
+    </div>
   );
-
-  {{ componentName }}.defaultProps = defaultProps;
-
-  export default {{ componentName }};
+}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Towards #3836 . Biggest need is to remove `componentShape`, rest is just small cleanup.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
