### PR TITLE
Feat/Drawer - add width props, update demo & cypress tests

### DIFF
--- a/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
+++ b/packages/react-core/src/components/Drawer/DrawerPanelContent.tsx
@@ -10,18 +10,38 @@ export interface DrawerPanelContentProps extends React.HTMLProps<HTMLDivElement>
   children?: React.ReactNode;
   /* Flag indicating that the drawer panel should have a border. */
   hasBorder?: boolean;
+  /* Default width for drawer panel */
+  width?: 25 | 33 | 50 | 66 | 75 | 100;
+  /* Drawer panel width on large viewports */
+  widthOnLg?: 25 | 33 | 50 | 66 | 75 | 100;
+  /* Drawer panel width on xl viewports */
+  widthOnXl?: 25 | 33 | 50 | 66 | 75 | 100;
+  /* Drawer panel width on 2xl viewports */
+  widthOn2Xl?: 25 | 33 | 50 | 66 | 75 | 100;
 }
 
 export const DrawerPanelContent: React.SFC<DrawerPanelContentProps> = ({
   className = '',
   children,
   hasBorder = false,
+  width,
+  widthOnLg,
+  widthOnXl,
+  widthOn2Xl,
   ...props
 }: DrawerPanelContentProps) => (
   <DrawerContext.Consumer>
     {({ isExpanded }) => (
       <div
-        className={css(styles.drawerPanel, hasBorder && styles.modifiers.border, className)}
+        className={css(
+          styles.drawerPanel,
+          hasBorder && styles.modifiers.border,
+          width && styles.modifiers[`width_${width}` as keyof typeof styles.modifiers],
+          widthOnLg && styles.modifiers[`width_${widthOnLg}OnLg` as keyof typeof styles.modifiers],
+          widthOnXl && styles.modifiers[`width_${widthOnXl}OnXl` as keyof typeof styles.modifiers],
+          widthOn2Xl && styles.modifiers[`width_${widthOn2Xl}On_2xl` as keyof typeof styles.modifiers],
+          className
+        )}
         hidden={!isExpanded}
         aria-hidden={!isExpanded}
         aria-expanded={isExpanded}

--- a/packages/react-integration/cypress/integration/drawer.spec.ts
+++ b/packages/react-integration/cypress/integration/drawer.spec.ts
@@ -17,4 +17,23 @@ describe('Drawer Demo Test', () => {
     cy.get('#toggleButton').click();
     cy.get('.pf-c-drawer').should('have.class', 'pf-m-expanded');
   });
+
+  it('Verify panel widths', () => {
+    // Large viewport
+    const $drawerPanel = cy.get('.pf-c-drawer__panel');
+    $drawerPanel.should('have.class', 'pf-m-width-100');
+    $drawerPanel.should('have.class', 'pf-m-width-50-on-lg');
+    $drawerPanel.should('have.class', 'pf-m-width-33-on-xl');
+    $drawerPanel.should('have.class', 'pf-m-width-25-on-2xl');
+    $drawerPanel.should('have.css', 'flex-basis', '50%');
+    // Medium viewport
+    cy.viewport(800, 660);
+    cy.get('.pf-c-drawer__panel').should('have.css', 'flex-basis', '100%');
+    // Xl viewport
+    cy.viewport(1200, 660);
+    cy.get('.pf-c-drawer__panel').should('have.css', 'flex-basis', '33%');
+    // 2Xl viewport
+    cy.viewport(1450, 660);
+    cy.get('.pf-c-drawer__panel').should('have.css', 'flex-basis', '25%');
+  });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DrawerDemo/DrawerDemo.tsx
@@ -40,7 +40,7 @@ export class DrawerDemo extends React.Component<DrawerProps, DrawerDemoState> {
   render() {
     const { isExpanded } = this.state;
     const panelContent = (
-      <DrawerPanelContent>
+      <DrawerPanelContent width={100} widthOnLg={50} widthOnXl={33} widthOn2Xl={25}>
         <DrawerHead>
           <span>drawer-panel</span>
           <DrawerActions>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #3888

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Follow-up work from #3884 

This PR adds functionality for setting panel width with new props on `DrawerPanelContent`, and updates the corresponding demo & tests.
