### PR TITLE
Fix compound expandable table example spelling

### DIFF
--- a/packages/react-table/src/components/Table/Table.md
+++ b/packages/react-table/src/components/Table/Table.md
@@ -1000,7 +1000,7 @@ class CollapsibleTable extends React.Component {
 }
 ```
 
-```js title=Compound-exandable
+```js title=Compound-expandable
 import React from 'react';
 import {
   Table,


### PR DESCRIPTION
**What**: Adds a missing `p` to the title of the "Compound expandable" example of the Table documentation, which also affects the anchor on the site (I think).