### PR TITLE
fix(DropdownToggleCheckbox): fix ref to show indeterminate checkbox 

### DIFF
--- a/packages/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
+++ b/packages/react-core/src/components/Dropdown/DropdownToggleCheckbox.tsx
@@ -44,7 +44,7 @@ export class DropdownToggleCheckbox extends React.Component<DropdownToggleCheckb
 
   render() {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { className, onChange, isValid, isDisabled, isChecked, ref, checked, children, ...props } = this.props;
+    const { className, onChange, isValid, isDisabled, isChecked, checked, children, ...props } = this.props;
     const text = children && (
       <span className={css(styles.dropdownToggleText, className)} aria-hidden="true" id={`${props.id}-text`}>
         {children}
@@ -56,7 +56,7 @@ export class DropdownToggleCheckbox extends React.Component<DropdownToggleCheckb
           {...props}
           {...(this.calculateChecked() !== undefined && { onChange: this.handleChange })}
           type="checkbox"
-          ref={ref as any}
+          ref={elem => elem && (elem.indeterminate = isChecked === null)}
           aria-invalid={!isValid}
           disabled={isDisabled}
           checked={this.calculateChecked()}


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**Closes**: #3994 indeterminate state `-` in dropdown toggle checkbox was not displaying

@tlabaj I'm unsure why there was a `ref` property being passed in and set, so are there any issues with changing it to this?
