### PR TITLE
Select/context selector - update search box element name

### DIFF
--- a/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
+++ b/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
@@ -108,7 +108,7 @@ export class ContextSelector extends React.Component<ContextSelectorProps> {
           <div className={css(styles.contextSelectorMenu)}>
             {isOpen && (
               <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
-                <div>
+                <div className={css(styles.contextSelectorMenuSearch)}>
                   <InputGroup>
                     <TextInput
                       value={searchInputValue}

--- a/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelector.test.tsx.snap
+++ b/packages/react-core/src/components/ContextSelector/__tests__/__snapshots__/ContextSelector.test.tsx.snap
@@ -49,7 +49,9 @@ exports[`Renders ContextSelector open 1`] = `
       }
       paused={false}
     >
-      <div>
+      <div
+        className="pf-c-context-selector__menu-search"
+      >
         <InputGroup>
           <ForwardRef
             aria-labelledby="pf-context-selector-search-button-id-0"


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #3948 

## Breaking changes
- `.pf-c-context-selector__menu-input` updated to `.pf-c-context-selector__menu-search`
- `.pf-c-select__menu-input` updated to `.pf-c-select__menu-search`