### PR TITLE
fix(gutter): fix type for gutter support

### DIFF
--- a/packages/react-core/src/demos/CardView/examples/CardView.md
+++ b/packages/react-core/src/demos/CardView/examples/CardView.md
@@ -715,7 +715,7 @@ class CardViewBasic extends React.Component {
             </DataToolbar>
           </PageSection>
           <PageSection>
-            <Gallery gutter="md">
+            <Gallery hasGutter>
               {filtered.map((product, key) => (
                 <React.Fragment>
                   <Card isHoverable key={key}>

--- a/packages/react-core/src/demos/PageLayout/examples/PageLayout.md
+++ b/packages/react-core/src/demos/PageLayout/examples/PageLayout.md
@@ -258,7 +258,7 @@ class PageLayoutDefaultNav extends React.Component {
             </TextContent>
           </PageSection>
           <PageSection>
-            <Gallery gutter="md">
+            <Gallery hasGutter>
               {Array.apply(0, Array(10)).map((x, i) => (
                 <GalleryItem key={i}>
                   <Card>
@@ -504,7 +504,7 @@ class PageLayoutExpandableNav extends React.Component {
             </TextContent>
           </PageSection>
           <PageSection>
-            <Gallery gutter="md">
+            <Gallery hasGutter>
               {Array.apply(0, Array(10)).map((x, i) => (
                 <GalleryItem key={i}>
                   <Card>
@@ -931,7 +931,7 @@ class PageLayoutHorizontalNav extends React.Component {
             </TextContent>
           </PageSection>
           <PageSection>
-            <Gallery gutter="md">
+            <Gallery hasGutter>
               {Array.apply(0, Array(10)).map((x, i) => (
                 <GalleryItem key={i}>
                   <Card>
@@ -1172,7 +1172,7 @@ class PageLayoutManualNav extends React.Component {
             </TextContent>
           </PageSection>
           <PageSection>
-            <Gallery gutter="md">
+            <Gallery hasGutter>
               {Array.apply(0, Array(10)).map((x, i) => (
                 <GalleryItem key={i}>
                   <Card>
@@ -1381,7 +1381,7 @@ class PageLayoutLightNav extends React.Component {
             </TextContent>
           </PageSection>
           <PageSection>
-            <Gallery gutter="md">
+            <Gallery hasGutter>
               {Array.apply(0, Array(10)).map((x, i) => (
                 <GalleryItem key={i}>
                   <Card>

--- a/packages/react-core/src/layouts/Gallery/Gallery.tsx
+++ b/packages/react-core/src/layouts/Gallery/Gallery.tsx
@@ -8,15 +8,15 @@ export interface GalleryProps extends React.HTMLProps<HTMLDivElement> {
   /** additional classes added to the Gallery layout */
   className?: string;
   /** Adds space between children. */
-  gutter?: 'sm' | 'md' | 'lg';
+  hasGutter?: boolean;
 }
 export const Gallery: React.FunctionComponent<GalleryProps> = ({
   children = null,
   className = '',
-  gutter = null,
+  hasGutter,
   ...props
 }: GalleryProps) => (
-  <div className={css(styles.gallery, gutter && styles.modifiers.gutter, className)} {...props}>
+  <div className={css(styles.gallery, hasGutter && styles.modifiers.gutter, className)} {...props}>
     {children}
   </div>
 );

--- a/packages/react-core/src/layouts/Gallery/__tests__/Gallery.test.tsx
+++ b/packages/react-core/src/layouts/Gallery/__tests__/Gallery.test.tsx
@@ -3,7 +3,7 @@ import { Gallery } from '../Gallery';
 import { shallow } from 'enzyme';
 
 test('gutter', () => {
-  const view = shallow(<Gallery gutter="md" />);
+  const view = shallow(<Gallery hasGutter />);
   expect(view).toMatchSnapshot();
 });
 

--- a/packages/react-core/src/layouts/Gallery/__tests__/Generated/Gallery.test.tsx
+++ b/packages/react-core/src/layouts/Gallery/__tests__/Generated/Gallery.test.tsx
@@ -8,6 +8,6 @@ import { Gallery } from '../../Gallery';
 import {} from '../..';
 
 it('Gallery should match snapshot (auto-generated)', () => {
-  const view = shallow(<Gallery children={<>ReactNode</>} className={"''"} gutter={null} />);
+  const view = shallow(<Gallery children={<>ReactNode</>} className={"''"} hasGutter />);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/layouts/Gallery/__tests__/Generated/__snapshots__/Gallery.test.tsx.snap
+++ b/packages/react-core/src/layouts/Gallery/__tests__/Generated/__snapshots__/Gallery.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Gallery should match snapshot (auto-generated) 1`] = `
 <div
-  className="pf-l-gallery ''"
+  className="pf-l-gallery pf-m-gutter ''"
 >
   ReactNode
 </div>

--- a/packages/react-core/src/layouts/Gallery/examples/Gallery.md
+++ b/packages/react-core/src/layouts/Gallery/examples/Gallery.md
@@ -33,7 +33,7 @@ import React from 'react';
 import { Gallery, GalleryItem } from '@patternfly/react-core';
 
 GalleryWithGuttersExample = () => (
-  <Gallery gutter="md">
+  <Gallery hasGutter>
     <GalleryItem>Gallery Item</GalleryItem>
     <GalleryItem>Gallery Item</GalleryItem>
     <GalleryItem>Gallery Item</GalleryItem>

--- a/packages/react-core/src/layouts/Grid/Grid.tsx
+++ b/packages/react-core/src/layouts/Grid/Grid.tsx
@@ -11,7 +11,7 @@ export interface GridProps extends React.HTMLProps<HTMLDivElement> {
   /** additional classes added to the Grid layout */
   className?: string;
   /** Adds space between children. */
-  gutter?: 'sm' | 'md' | 'lg';
+  hasGutter?: boolean;
   /** The number of rows a column in the grid should span.  Value should be a number 1-12 */
   span?: gridItemSpanValueShape;
   /** the number of columns all grid items should span on a small device */
@@ -29,7 +29,7 @@ export interface GridProps extends React.HTMLProps<HTMLDivElement> {
 export const Grid: React.FunctionComponent<GridProps> = ({
   children = null,
   className = '',
-  gutter = null,
+  hasGutter,
   span = null,
   ...props
 }: GridProps) => {
@@ -45,7 +45,7 @@ export const Grid: React.FunctionComponent<GridProps> = ({
   });
 
   return (
-    <div className={css(...classes, gutter && styles.modifiers.gutter, className)} {...props}>
+    <div className={css(...classes, hasGutter && styles.modifiers.gutter, className)} {...props}>
       {children}
     </div>
   );

--- a/packages/react-core/src/layouts/Grid/__tests__/Generated/Grid.test.tsx
+++ b/packages/react-core/src/layouts/Grid/__tests__/Generated/Grid.test.tsx
@@ -9,7 +9,7 @@ import {} from '../..';
 
 it('Grid should match snapshot (auto-generated)', () => {
   const view = shallow(
-    <Grid children={<>ReactNode</>} className={"''"} gutter={null} span={null} sm={1} md={1} lg={1} xl={1} xl2={1} />
+    <Grid children={<>ReactNode</>} className={"''"} hasGutter span={null} sm={1} md={1} lg={1} xl={1} xl2={1} />
   );
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/layouts/Grid/__tests__/Generated/__snapshots__/Grid.test.tsx.snap
+++ b/packages/react-core/src/layouts/Grid/__tests__/Generated/__snapshots__/Grid.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Grid should match snapshot (auto-generated) 1`] = `
 <div
-  className="pf-l-grid pf-m-all-1-col-on-sm pf-m-all-1-col-on-md pf-m-all-1-col-on-lg pf-m-all-1-col-on-xl pf-m-all-1-col-on-2xl ''"
+  className="pf-l-grid pf-m-all-1-col-on-sm pf-m-all-1-col-on-md pf-m-all-1-col-on-lg pf-m-all-1-col-on-xl pf-m-all-1-col-on-2xl pf-m-gutter ''"
 >
   ReactNode
 </div>

--- a/packages/react-core/src/layouts/Grid/__tests__/Grid.test.tsx
+++ b/packages/react-core/src/layouts/Grid/__tests__/Grid.test.tsx
@@ -3,6 +3,6 @@ import { Grid } from '../Grid';
 import { shallow } from 'enzyme';
 
 test('gutter', () => {
-  const view = shallow(<Grid gutter="md" />);
+  const view = shallow(<Grid hasGutter />);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/layouts/Grid/examples/Grid.md
+++ b/packages/react-core/src/layouts/Grid/examples/Grid.md
@@ -40,7 +40,7 @@ import React from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
 
 GridWithGuttersExample = () => (
-  <Grid gutter="md">
+  <Grid hasGutter>
     <GridItem span={8}>span = 8</GridItem>
     <GridItem span={4} rowSpan={2}>
       span = 4, rowSpan = 2

--- a/packages/react-core/src/layouts/Level/Level.tsx
+++ b/packages/react-core/src/layouts/Level/Level.tsx
@@ -4,7 +4,7 @@ import styles from '@patternfly/react-styles/css/layouts/Level/level';
 
 export interface LevelProps extends React.HTMLProps<HTMLDivElement> {
   /** Adds space between children. */
-  gutter?: 'sm' | 'md' | 'lg';
+  hasGutter?: boolean;
   /** additional classes added to the Level layout */
   className?: string;
   /** content rendered inside the Level layout */
@@ -12,12 +12,12 @@ export interface LevelProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 export const Level: React.FunctionComponent<LevelProps> = ({
-  gutter = null,
+  hasGutter,
   className = '',
   children = null,
   ...props
 }: LevelProps) => (
-  <div {...props} className={css(styles.level, gutter && styles.modifiers.gutter, className)}>
+  <div {...props} className={css(styles.level, hasGutter && styles.modifiers.gutter, className)}>
     {children}
   </div>
 );

--- a/packages/react-core/src/layouts/Level/__tests__/Generated/Level.test.tsx
+++ b/packages/react-core/src/layouts/Level/__tests__/Generated/Level.test.tsx
@@ -8,6 +8,6 @@ import { Level } from '../../Level';
 import {} from '../..';
 
 it('Level should match snapshot (auto-generated)', () => {
-  const view = shallow(<Level gutter={null} className={"''"} children={<>ReactNode</>} />);
+  const view = shallow(<Level hasGutter className={"''"} children={<>ReactNode</>} />);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/layouts/Level/__tests__/Generated/__snapshots__/Level.test.tsx.snap
+++ b/packages/react-core/src/layouts/Level/__tests__/Generated/__snapshots__/Level.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Level should match snapshot (auto-generated) 1`] = `
 <div
-  className="pf-l-level ''"
+  className="pf-l-level pf-m-gutter ''"
 >
   ReactNode
 </div>

--- a/packages/react-core/src/layouts/Level/__tests__/Level.test.tsx
+++ b/packages/react-core/src/layouts/Level/__tests__/Level.test.tsx
@@ -4,7 +4,7 @@ import { LevelItem } from '../LevelItem';
 import { shallow } from 'enzyme';
 
 test('Gutter', () => {
-  const view = shallow(<Level gutter="md" />);
+  const view = shallow(<Level hasGutter />);
   expect(view).toMatchSnapshot();
 });
 

--- a/packages/react-core/src/layouts/Level/examples/Level.md
+++ b/packages/react-core/src/layouts/Level/examples/Level.md
@@ -28,7 +28,7 @@ import React from 'react';
 import { Level, LevelItem } from '@patternfly/react-core';
 
 LevelWithGuttersExample = () => (
-  <Level gutter="md">
+  <Level hasGutter>
     <LevelItem>Level Item</LevelItem>
     <LevelItem>Level Item</LevelItem>
     <LevelItem>Level Item</LevelItem>

--- a/packages/react-core/src/layouts/Split/Split.tsx
+++ b/packages/react-core/src/layouts/Split/Split.tsx
@@ -4,7 +4,7 @@ import { css } from '@patternfly/react-styles';
 
 export interface SplitProps extends React.HTMLProps<HTMLDivElement> {
   /** Adds space between children. */
-  gutter?: 'sm' | 'md' | 'lg';
+  hasGutter?: boolean;
   /** content rendered inside the Split layout */
   children?: React.ReactNode;
   /** additional classes added to the Split layout */
@@ -14,7 +14,7 @@ export interface SplitProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 export const Split: React.FunctionComponent<SplitProps> = ({
-  gutter = null,
+  hasGutter,
   className = '',
   children = null,
   component = 'div',
@@ -22,7 +22,7 @@ export const Split: React.FunctionComponent<SplitProps> = ({
 }: SplitProps) => {
   const Component = component as any;
   return (
-    <Component {...props} className={css(styles.split, gutter && styles.modifiers.gutter, className)}>
+    <Component {...props} className={css(styles.split, hasGutter && styles.modifiers.gutter, className)}>
       {children}
     </Component>
   );

--- a/packages/react-core/src/layouts/Split/__tests__/Generated/Split.test.tsx
+++ b/packages/react-core/src/layouts/Split/__tests__/Generated/Split.test.tsx
@@ -8,6 +8,6 @@ import { Split } from '../../Split';
 import {} from '../..';
 
 it('Split should match snapshot (auto-generated)', () => {
-  const view = shallow(<Split gutter={null} children={<>ReactNode</>} className={"''"} component={'div'} />);
+  const view = shallow(<Split hasGutter children={<>ReactNode</>} className={"''"} component={'div'} />);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/layouts/Split/__tests__/Generated/__snapshots__/Split.test.tsx.snap
+++ b/packages/react-core/src/layouts/Split/__tests__/Generated/__snapshots__/Split.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Split should match snapshot (auto-generated) 1`] = `
 <div
-  className="pf-l-split ''"
+  className="pf-l-split pf-m-gutter ''"
 >
   ReactNode
 </div>

--- a/packages/react-core/src/layouts/Split/__tests__/Split.test.tsx
+++ b/packages/react-core/src/layouts/Split/__tests__/Split.test.tsx
@@ -23,7 +23,7 @@ test('isFilled defaults to false', () => {
 
 test('Gutter', () => {
   const view = mount(
-    <Split gutter="md">
+    <Split hasGutter>
       <SplitItem>Basic Content</SplitItem>
     </Split>
   );

--- a/packages/react-core/src/layouts/Split/__tests__/__snapshots__/Split.test.tsx.snap
+++ b/packages/react-core/src/layouts/Split/__tests__/__snapshots__/Split.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Gutter 1`] = `
 <Split
-  gutter="md"
+  hasGutter={true}
 >
   <div
     className="pf-l-split pf-m-gutter"

--- a/packages/react-core/src/layouts/Split/examples/Split.md
+++ b/packages/react-core/src/layouts/Split/examples/Split.md
@@ -28,7 +28,7 @@ import React from 'react';
 import { Split, SplitItem } from '@patternfly/react-core';
 
 SplitWithGutterExample = () => (
-  <Split gutter="md">
+  <Split hasGutter>
     <SplitItem>content</SplitItem>
     <SplitItem isFilled>pf-m-fill</SplitItem>
     <SplitItem>content</SplitItem>

--- a/packages/react-core/src/layouts/Stack/Stack.tsx
+++ b/packages/react-core/src/layouts/Stack/Stack.tsx
@@ -4,7 +4,7 @@ import { css } from '@patternfly/react-styles';
 
 export interface StackProps extends React.HTMLProps<HTMLDivElement> {
   /** Adds space between children. */
-  gutter?: 'sm' | 'md' | 'lg';
+  hasGutter?: boolean;
   /** content rendered inside the Stack layout */
   children?: React.ReactNode;
   /** additional classes added to the Stack layout */
@@ -14,7 +14,7 @@ export interface StackProps extends React.HTMLProps<HTMLDivElement> {
 }
 
 export const Stack: React.FunctionComponent<StackProps> = ({
-  gutter = null,
+  hasGutter,
   className = '',
   children = null,
   component = 'div',
@@ -22,7 +22,7 @@ export const Stack: React.FunctionComponent<StackProps> = ({
 }: StackProps) => {
   const Component = component as any;
   return (
-    <Component {...props} className={css(styles.stack, gutter && styles.modifiers.gutter, className)}>
+    <Component {...props} className={css(styles.stack, hasGutter && styles.modifiers.gutter, className)}>
       {children}
     </Component>
   );

--- a/packages/react-core/src/layouts/Stack/__tests__/Generated/Stack.test.tsx
+++ b/packages/react-core/src/layouts/Stack/__tests__/Generated/Stack.test.tsx
@@ -8,6 +8,6 @@ import { Stack } from '../../Stack';
 import {} from '../..';
 
 it('Stack should match snapshot (auto-generated)', () => {
-  const view = shallow(<Stack gutter={null} children={<>ReactNode</>} className={"''"} component={'div'} />);
+  const view = shallow(<Stack hasGutter children={<>ReactNode</>} className={"''"} component={'div'} />);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/layouts/Stack/__tests__/Generated/__snapshots__/Stack.test.tsx.snap
+++ b/packages/react-core/src/layouts/Stack/__tests__/Generated/__snapshots__/Stack.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Stack should match snapshot (auto-generated) 1`] = `
 <div
-  className="pf-l-stack ''"
+  className="pf-l-stack pf-m-gutter ''"
 >
   ReactNode
 </div>

--- a/packages/react-core/src/layouts/Stack/__tests__/Stack.test.tsx
+++ b/packages/react-core/src/layouts/Stack/__tests__/Stack.test.tsx
@@ -23,7 +23,7 @@ test('isMain defaults to false', () => {
 
 test('gutter', () => {
   const view = mount(
-    <Stack gutter="md">
+    <Stack hasGutter>
       <StackItem>Basic content</StackItem>
     </Stack>
   );

--- a/packages/react-core/src/layouts/Stack/__tests__/__snapshots__/Stack.test.tsx.snap
+++ b/packages/react-core/src/layouts/Stack/__tests__/__snapshots__/Stack.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`gutter 1`] = `
 <Stack
-  gutter="md"
+  hasGutter={true}
 >
   <div
     className="pf-l-stack pf-m-gutter"

--- a/packages/react-core/src/layouts/Stack/examples/Stack.md
+++ b/packages/react-core/src/layouts/Stack/examples/Stack.md
@@ -3,7 +3,7 @@ title: 'Stack'
 cssPrefix: 'pf-l-stack'
 section: 'layouts'
 propComponents: ['Stack', 'StackItem']
-typescript: true 
+typescript: true
 ---
 
 import { Stack, StackItem } from '@patternfly/react-core';
@@ -28,7 +28,7 @@ import React from 'react';
 import { Stack, StackItem } from '@patternfly/react-core';
 
 StackWithGutterExample = () => (
-  <Stack gutter="md">
+  <Stack hasGutter>
     <StackItem>content</StackItem>
     <StackItem isFilled>pf-m-fill</StackItem>
     <StackItem>content</StackItem>

--- a/packages/react-integration/demo-app-ts/src/components/demos/DropdownDemo/DropdownDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DropdownDemo/DropdownDemo.tsx
@@ -238,7 +238,7 @@ export class DropdownDemo extends React.Component<{}, DropdownState> {
 
   render() {
     return (
-      <Stack gutter="md">
+      <Stack hasGutter>
         {this.renderDropdown()}
         {this.renderActionDropdown()}
       </Stack>

--- a/packages/react-integration/demo-app-ts/src/components/demos/GalleryDemo/GalleryDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/GalleryDemo/GalleryDemo.tsx
@@ -4,7 +4,7 @@ import { Gallery, GalleryItem } from '@patternfly/react-core';
 export class GalleryDemo extends React.Component {
   render() {
     return (
-      <Gallery gutter="md">
+      <Gallery hasGutter>
         <GalleryItem>Gallery Item</GalleryItem>
         <GalleryItem>Gallery Item</GalleryItem>
         <GalleryItem>Gallery Item</GalleryItem>

--- a/packages/react-integration/demo-app-ts/src/components/demos/LevelDemo/LevelDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/LevelDemo/LevelDemo.tsx
@@ -4,7 +4,7 @@ import { Level, LevelItem } from '@patternfly/react-core';
 export class LevelDemo extends React.Component {
   render() {
     return (
-      <Level gutter="md">
+      <Level hasGutter>
         <LevelItem>Level Item</LevelItem>
         <LevelItem>Level Item</LevelItem>
         <LevelItem>Level Item</LevelItem>

--- a/packages/react-integration/demo-app-ts/src/components/demos/NavDemo/NavDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/NavDemo/NavDemo.tsx
@@ -268,7 +268,7 @@ export class NavDemo extends Component {
     // Nav onToggle and onSelect should be optional
     // https://github.com/patternfly/patternfly-react/issues/1234
     return (
-      <Stack gutter="md">
+      <Stack hasGutter>
         {this.renderDefaultNav()}
         {this.renderExpandableNav()}
         {this.renderHorizontalNav()}

--- a/packages/react-integration/demo-app-ts/src/components/demos/PaginationDemo/PaginationDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/PaginationDemo/PaginationDemo.tsx
@@ -117,7 +117,7 @@ export class PaginationDemo extends React.Component<React.HTMLProps<HTMLDivEleme
 
   render() {
     return (
-      <Stack gutter="md">
+      <Stack hasGutter>
         {this.renderPagination()}
         {this.renderDisabled()}
       </Stack>

--- a/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SelectDemo/SelectDemo.tsx
@@ -877,7 +877,7 @@ export class SelectDemo extends Component<SelectDemoState> {
 
   render() {
     return (
-      <Stack gutter="md">
+      <Stack hasGutter>
         {this.renderSingleSelect()}
         {this.renderCustomSingleSelect()}
         {this.renderDisabledSingleSelect()}

--- a/packages/react-integration/demo-app-ts/src/components/demos/SplitDemo/SplitDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/SplitDemo/SplitDemo.tsx
@@ -4,7 +4,7 @@ import { Split, SplitItem } from '@patternfly/react-core';
 export class SplitDemo extends React.Component {
   render() {
     return (
-      <Split gutter="md" component="article">
+      <Split hasGutter component="article">
         <SplitItem>content</SplitItem>
         <SplitItem isFilled>pf-m-fill</SplitItem>
         <SplitItem>content</SplitItem>

--- a/packages/react-integration/demo-app-ts/src/components/demos/StackDemo/StackDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/StackDemo/StackDemo.tsx
@@ -7,7 +7,7 @@ export class StackDemo extends Component {
       <React.Fragment>
         <Badge>3</Badge>
         <Badge isRead>13</Badge>
-        <Stack component="article" gutter="sm">
+        <Stack component="article" hasGutter>
           <StackItem>content</StackItem>
           <StackItem isFilled>pf-m-fill</StackItem>
           <StackItem>content</StackItem>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/1982

This PR replaces `gutter` props with `hasGutter` and modifies the type to boolean.

## Breaking changes
1. **Gallery**: Removes prop `gutter`. The prop `hasGutter` should be used instead.
2. **Grid**: Removes prop `gutter`. The prop `hasGutter` should be used instead.
3. **Level**: Removes prop `gutter`. The prop `hasGutter` should be used instead.
4. **Split**: Removes prop `gutter`. The prop `hasGutter` should be used instead.
5. **Stack**: Removes prop `gutter`. The prop `hasGutter` should be used instead.

Additional issues: https://github.com/patternfly/patternfly/issues/2725
