### PR TITLE
fix(dropdown): respect already passed props

### DIFF
--- a/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
+++ b/packages/react-core/src/components/Dropdown/InternalDropdownItem.tsx
@@ -203,10 +203,9 @@ export class InternalDropdownItem extends React.Component<InternalDropdownItemPr
               {renderWithTooltip(
                 React.isValidElement(component) ? (
                   React.cloneElement(component as React.ReactElement<any>, {
-                    href,
                     id: componentID,
-                    className: classes,
-                    ...additionalProps
+                    ...component.props,
+                    className: css(component.props.className, classes)
                   })
                 ) : (
                   <Component {...additionalProps} href={href} ref={this.ref} className={classes} id={componentID}>


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: #3995 introduced a regression where the `href` or `id` props passed like this:

```tsx
<DropdownItem component={<a href="href" id="id" />} />
```

would be ignored. This PR makes it so that only `className` is overridden when cloning the `component` prop.