### PR TITLE
(fix): Table actions cursor

### DIFF
--- a/packages/react-table/src/components/Table/ActionsColumn.tsx
+++ b/packages/react-table/src/components/Table/ActionsColumn.tsx
@@ -79,7 +79,7 @@ export class ActionsColumn extends React.Component<ActionsColumnProps, ActionsCo
               <DropdownSeparator {...props} key={itemKey || key} data-key={itemKey || key} />
             ) : (
               <DropdownItem
-                component="div"
+                component="button"
                 onClick={event => this.onSelect(event, onClick)}
                 {...props}
                 key={itemKey || key}

--- a/packages/react-table/src/components/Table/utils/transformers.test.tsx
+++ b/packages/react-table/src/components/Table/utils/transformers.test.tsx
@@ -69,7 +69,7 @@ const testCellActions = ({
       .find('.pf-c-dropdown button')
       .first()
       .simulate('click');
-    expect(view.find('.pf-c-dropdown__menu li div')).toHaveLength(expectDisabled ? 0 : 1);
+    expect(view.find('.pf-c-dropdown__menu li button')).toHaveLength(expectDisabled ? 0 : 1);
   }
 };
 
@@ -189,11 +189,13 @@ describe('Transformer functions', () => {
     actionConfigs.forEach(testCellActions);
   });
 
+  type widthType = 10 | 15 | 20 | 25 | 30 | 35 | 40 | 45 | 50 | 60 | 70 | 80 | 90 | 'max';
+
   describe('cellWidth', () => {
     const widths = [10, 15, 20, 25, 30, 35, 40, 45, 50, 60, 70, 80, 90, 'max'];
     widths.forEach(width =>
       test(`${width}`, () => {
-        expect(cellWidth(width as string)()).toEqual({ className: `pf-m-width-${width}` });
+        expect(cellWidth(width as widthType)()).toEqual({ className: `pf-m-width-${width}` });
       })
     );
   });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/4005

This PR updates the table actions dropdown to use `button` elements by default as we do in core. I noticed this was adjusted recently, would be good to verify this doesn't introduce any problems.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: https://github.com/patternfly/patternfly-react/issues/3559

@SpyTec ping
