### PR TITLE
fix(popover): update default popover header size

### DIFF
--- a/packages/react-core/src/components/Popover/PopoverHeader.tsx
+++ b/packages/react-core/src/components/Popover/PopoverHeader.tsx
@@ -6,7 +6,7 @@ export const PopoverHeader: React.FunctionComponent<PopoverHeaderProps> = ({
   id,
   ...props
 }: PopoverHeaderProps) => (
-  <Title headingLevel="h6" size={TitleSizes.xl} id={id} {...props}>
+  <Title headingLevel="h6" size={TitleSizes.md} id={id} {...props}>
     {children}
   </Title>
 );

--- a/packages/react-core/src/components/Popover/__tests__/Generated/__snapshots__/PopoverHeader.test.tsx.snap
+++ b/packages/react-core/src/components/Popover/__tests__/Generated/__snapshots__/PopoverHeader.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`PopoverHeader should match snapshot (auto-generated) 1`] = `
 <Title
   headingLevel="h6"
   id="string"
-  size="xl"
+  size="md"
 >
   <div>
     ReactNode

--- a/packages/react-integration/cypress/integration/popover.spec.ts
+++ b/packages/react-integration/cypress/integration/popover.spec.ts
@@ -19,4 +19,12 @@ describe('Popover Demo Test', () => {
       });
     });
   });
+
+  it('Popover header has correct default size', () => {
+    cy.get('div[id="popoverTarget"]').then((popoverLink: JQuery<HTMLDivElement>) => {
+      cy.wrap(popoverLink).click();
+      cy.get('.tippy-popper').should('exist');
+      cy.get('h6').should('have.class', 'pf-m-md');
+    });
+  });
 });


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/3986

This PR updates the default size of the popover header to be medium instead of extra-large.

## Breaking changes
1. **Popover**: PopoverHeader title now has a default size of medium. Extra large is no longer the default size.
