### PR TITLE
fix(empty-state): add isFullHeight prop support

### DIFF
--- a/packages/react-core/src/components/EmptyState/EmptyState.tsx
+++ b/packages/react-core/src/components/EmptyState/EmptyState.tsx
@@ -16,17 +16,21 @@ export interface EmptyStateProps extends React.HTMLProps<HTMLDivElement> {
   children: React.ReactNode;
   /** Modifies EmptyState max-width */
   variant?: 'full' | 'small' | 'large' | 'xl';
+  /** Cause component to consume the available height of its container */
+  isFullHeight?: boolean;
 }
 
 export const EmptyState: React.FunctionComponent<EmptyStateProps> = ({
   children,
   className = '',
   variant = EmptyStateVariant.full,
+  isFullHeight,
   ...props
 }: EmptyStateProps) => (
   <div
     className={css(
       styles.emptyState,
+      isFullHeight && styles.modifiers.fullHeight,
       variant === 'small' && styles.modifiers.sm,
       variant === 'large' && styles.modifiers.lg,
       variant === 'xl' && styles.modifiers.xl,
@@ -34,6 +38,6 @@ export const EmptyState: React.FunctionComponent<EmptyStateProps> = ({
     )}
     {...props}
   >
-    {children}
+    <div className={css(styles.emptyStateContent)}>{children}</div>
   </div>
 );

--- a/packages/react-core/src/components/EmptyState/__tests__/EmptyState.test.tsx
+++ b/packages/react-core/src/components/EmptyState/__tests__/EmptyState.test.tsx
@@ -32,7 +32,7 @@ describe('EmptyState', () => {
 
   test('Main variant large', () => {
     const view = shallow(
-      <EmptyState variant={EmptyStateVariant.lg}>
+      <EmptyState variant={EmptyStateVariant.large}>
         <Title headingLevel="h3" size={TitleSizes.md}>EmptyState large</Title>
       </EmptyState>
     );
@@ -41,7 +41,7 @@ describe('EmptyState', () => {
 
   test('Main variant small', () => {
     const view = shallow(
-      <EmptyState variant={EmptyStateVariant.sm}>
+      <EmptyState variant={EmptyStateVariant.small}>
         <Title headingLevel="h3" size={TitleSizes.md}>EmptyState small</Title>
       </EmptyState>
     );
@@ -90,4 +90,14 @@ describe('EmptyState', () => {
     expect(view.props().className).toBe('pf-c-empty-state__primary custom-empty-state-prim-cls');
     expect(view.props().id).toBe('empty-state-prim-id');
   });
+
+  test('Full height', () => {
+    const view = shallow(
+      <EmptyState isFullHeight variant={EmptyStateVariant.large}>
+        <Title headingLevel="h3" size={TitleSizes.md}>EmptyState large</Title>
+      </EmptyState>
+    );
+    expect(view).toMatchSnapshot();
+  });
+
 });

--- a/packages/react-core/src/components/EmptyState/__tests__/Generated/__snapshots__/EmptyState.test.tsx.snap
+++ b/packages/react-core/src/components/EmptyState/__tests__/Generated/__snapshots__/EmptyState.test.tsx.snap
@@ -4,8 +4,12 @@ exports[`EmptyState should match snapshot (auto-generated) 1`] = `
 <div
   className="pf-c-empty-state ''"
 >
-  <div>
-    ReactNode
+  <div
+    className="pf-c-empty-state__content"
+  >
+    <div>
+      ReactNode
+    </div>
   </div>
 </div>
 `;

--- a/packages/react-core/src/components/EmptyState/__tests__/__snapshots__/EmptyState.test.tsx.snap
+++ b/packages/react-core/src/components/EmptyState/__tests__/__snapshots__/EmptyState.test.tsx.snap
@@ -1,56 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EmptyState Full height 1`] = `
+<div
+  className="pf-c-empty-state pf-m-full-height pf-m-lg"
+>
+  <div
+    className="pf-c-empty-state__content"
+  >
+    <Title
+      headingLevel="h3"
+      size="md"
+    >
+      EmptyState large
+    </Title>
+  </div>
+</div>
+`;
+
 exports[`EmptyState Main 1`] = `
 <div
   className="pf-c-empty-state"
 >
-  <Title
-    headingLevel="h5"
-    size="lg"
+  <div
+    className="pf-c-empty-state__content"
   >
-    HTTP Proxies
-  </Title>
-  <EmptyStateBody>
-    Defining HTTP Proxies that exist on your network allows you to perform various actions through those proxies.
-  </EmptyStateBody>
-  <Button
-    variant="primary"
-  >
-    New HTTP Proxy
-  </Button>
-  <EmptyStateSecondaryActions>
-    <Button
-      aria-label="learn more action"
-      variant="link"
+    <Title
+      headingLevel="h5"
+      size="lg"
     >
-      Learn more about this in the documentation.
+      HTTP Proxies
+    </Title>
+    <EmptyStateBody>
+      Defining HTTP Proxies that exist on your network allows you to perform various actions through those proxies.
+    </EmptyStateBody>
+    <Button
+      variant="primary"
+    >
+      New HTTP Proxy
     </Button>
-  </EmptyStateSecondaryActions>
+    <EmptyStateSecondaryActions>
+      <Button
+        aria-label="learn more action"
+        variant="link"
+      >
+        Learn more about this in the documentation.
+      </Button>
+    </EmptyStateSecondaryActions>
+  </div>
 </div>
 `;
 
 exports[`EmptyState Main variant large 1`] = `
 <div
-  className="pf-c-empty-state"
+  className="pf-c-empty-state pf-m-lg"
 >
-  <Title
-    headingLevel="h3"
-    size="md"
+  <div
+    className="pf-c-empty-state__content"
   >
-    EmptyState large
-  </Title>
+    <Title
+      headingLevel="h3"
+      size="md"
+    >
+      EmptyState large
+    </Title>
+  </div>
 </div>
 `;
 
 exports[`EmptyState Main variant small 1`] = `
 <div
-  className="pf-c-empty-state"
+  className="pf-c-empty-state pf-m-sm"
 >
-  <Title
-    headingLevel="h3"
-    size="md"
+  <div
+    className="pf-c-empty-state__content"
   >
-    EmptyState small
-  </Title>
+    <Title
+      headingLevel="h3"
+      size="md"
+    >
+      EmptyState small
+    </Title>
+  </div>
 </div>
 `;

--- a/packages/react-core/src/components/EmptyState/examples/EmptyState.md
+++ b/packages/react-core/src/components/EmptyState/examples/EmptyState.md
@@ -32,7 +32,7 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 
 SimpleEmptyState = () => (
-  <EmptyState variant={EmptyStateVariant.sm}>
+  <EmptyState variant={EmptyStateVariant.small}>
     <EmptyStateIcon icon={CubesIcon} />
     <Title headingLevel="h4" size="lg">
       Empty State
@@ -68,7 +68,7 @@ import {
 import { CubesIcon } from '@patternfly/react-icons';
 
 SimpleEmptyState = () => (
-  <EmptyState variant={EmptyStateVariant.lg}>
+  <EmptyState variant={EmptyStateVariant.large}>
     <EmptyStateIcon icon={CubesIcon} />
     <Title headingLevel="h4" size="lg">
       Empty State
@@ -96,7 +96,6 @@ import {
   Title,
   Button,
   EmptyState,
-  EmptyStateVariant,
   EmptyStateIcon,
   EmptyStateBody,
   EmptyStateSecondaryActions
@@ -204,7 +203,6 @@ import {
   Title,
   Button,
   EmptyState,
-  EmptyStateVariant,
   EmptyStateIcon,
   EmptyStateBody,
   EmptyStateSecondaryActions
@@ -237,7 +235,6 @@ import {
   Button,
   EmptyState,
   EmptyStatePrimary,
-  EmptyStateVariant,
   EmptyStateIcon,
   EmptyStateBody,
   EmptyStateSecondaryActions

--- a/packages/react-integration/cypress/integration/emptystate.spec.ts
+++ b/packages/react-integration/cypress/integration/emptystate.spec.ts
@@ -16,4 +16,8 @@ describe('Empty State Demo Test', () => {
   it('Verify small empty state', () => {
     cy.get('.pf-c-empty-state').contains('Small Empty State');
   });
+
+  it('Verify full height example carries modifier class', () => {
+    cy.get('.pf-c-empty-state#full-height-example').should('have.class', 'pf-m-full-height');
+  });
 });

--- a/packages/react-integration/demo-app-ts/src/components/demos/EmptyStateDemo/EmptyStateDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/EmptyStateDemo/EmptyStateDemo.tsx
@@ -82,6 +82,18 @@ export class EmptyStateDemo extends Component {
       </React.Fragment>
     )
   };
+  myFullHeightEmptyStateProps: EmptyStateProps = {
+    id: 'full-height-example',
+    children: (
+      <React.Fragment>
+        <EmptyStateIcon icon={CubesIcon} />
+        <Title headingLevel="h5" size="lg">
+          Full height empty state
+        </Title>
+        <EmptyStateBody>This represents a full height empty state pattern in Patternfly 4</EmptyStateBody>
+      </React.Fragment>
+    )
+  };
 
   componentDidMount() {
     window.scrollTo(0, 0);
@@ -93,6 +105,9 @@ export class EmptyStateDemo extends Component {
         <EmptyState variant={this.myLargeEmptyStateProps.variant}>{this.myLargeEmptyStateProps.children}</EmptyState>
         <EmptyState variant={this.mySmallEmptyStateProps.variant}>{this.mySmallEmptyStateProps.children}</EmptyState>
         <EmptyState>{this.myFullEmptyStateProps.children}</EmptyState>
+        <EmptyState isFullHeight id={this.myFullHeightEmptyStateProps.id}>
+          {this.myFullHeightEmptyStateProps.children}
+        </EmptyState>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/3673

This PR adds a new prop `isFullHeight` to EmptyState component, along with corresponding tests.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: https://github.com/patternfly/patternfly/issues/2568
