### PR TITLE
fix(eslint): update config to run in 1 minute instead of over 1 hour

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,6 @@
         "plugin:jsdoc/recommended"
     ],
     "parserOptions": {
-        "project": "packages/tsconfig.base.json",
         "sourceType": "module",
         "ecmaFeatures": {
             "jsx": true
@@ -90,6 +89,7 @@
         "no-empty": "error",
         "no-eval": "error",
         "no-new-wrappers": "error",
+        "no-prototype-builtins": "off",
         "no-shadow": "error",
         "no-throw-literal": "error",
         "no-trailing-spaces": "off",

--- a/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSortableForCompoundExpandableDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TableDemo/TableSortableForCompoundExpandableDemo.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {
   Table,
   TableHeader,

--- a/packages/react-table/src/components/Table/demo/DemoSortableTable.js
+++ b/packages/react-table/src/components/Table/demo/DemoSortableTable.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Table, TableHeader, TableBody, TableVariant, sortable, SortByDirection } from '@patternfly/react-table';
 
 export default class DemoSortableTable extends React.Component {


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #4042 

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: Towards #3972 . It's not really our fault setting `project`: makes eslint take forever, see https://github.com/typescript-eslint/typescript-eslint/issues/1192 for resolution (Typescript 3.9 should fix this issue)
