### PR TITLE
fix(DataToolbar): fix filter context from updating unnecessarily

### DIFF
--- a/packages/react-core/src/components/DataToolbar/DataToolbarFilter.tsx
+++ b/packages/react-core/src/components/DataToolbar/DataToolbarFilter.tsx
@@ -56,15 +56,19 @@ export class DataToolbarFilter extends React.Component<DataToolbarFilterProps, D
     this.setState({ isMounted: true });
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: DataToolbarFilterProps) {
     const { categoryName, chips } = this.props;
-    this.context.updateNumberFilters(typeof categoryName === 'string' ? categoryName : categoryName.name, chips.length);
+    if (prevProps.chips.length !== chips.length) {
+      this.context.updateNumberFilters(
+        typeof categoryName === 'string' ? categoryName : categoryName.name,
+        chips.length
+      );
+    }
   }
 
   render() {
     const { children, chips, deleteChip, categoryName, showToolbarItem, ...props } = this.props;
     const { isExpanded, chipGroupContentRef } = this.context;
-
     const chipGroup = chips.length ? (
       <DataToolbarItem variant="chip-group">
         <ChipGroup withToolbar>

--- a/packages/react-core/src/components/DataToolbar/__tests__/__snapshots__/DataToolbar.test.tsx.snap
+++ b/packages/react-core/src/components/DataToolbar/__tests__/__snapshots__/DataToolbar.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                 className="pf-c-data-toolbar__toggle"
               >
                 <Component
-                  aria-controls="data-toolbar-expandable-content-7"
+                  aria-controls="data-toolbar-expandable-content-6"
                   aria-haspopup={false}
                   aria-label="Show Filters"
                   onClick={[Function]}
@@ -54,7 +54,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                     component={[Function]}
                     componentProps={
                       Object {
-                        "aria-controls": "data-toolbar-expandable-content-7",
+                        "aria-controls": "data-toolbar-expandable-content-6",
                         "aria-haspopup": false,
                         "aria-label": "Show Filters",
                         "children": <FilterIcon
@@ -70,7 +70,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                     consumerContext={null}
                   >
                     <Button
-                      aria-controls="data-toolbar-expandable-content-7"
+                      aria-controls="data-toolbar-expandable-content-6"
                       aria-haspopup={false}
                       aria-label="Show Filters"
                       onClick={[Function]}
@@ -83,7 +83,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                       variant="plain"
                     >
                       <button
-                        aria-controls="data-toolbar-expandable-content-7"
+                        aria-controls="data-toolbar-expandable-content-6"
                         aria-disabled={null}
                         aria-haspopup={false}
                         aria-label="Show Filters"
@@ -1455,7 +1455,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
             Object {
               "current": <div
                 class="pf-c-data-toolbar__expandable-content"
-                id="data-toolbar-expandable-content-7"
+                id="data-toolbar-expandable-content-6"
               >
                 <div
                   class="pf-c-data-toolbar__group"
@@ -1484,13 +1484,13 @@ exports[`data toolbar DataToolbarFilter 1`] = `
               </div>,
             }
           }
-          id="data-toolbar-expandable-content-7"
+          id="data-toolbar-expandable-content-6"
           isExpanded={false}
           showClearFiltersButton={true}
         >
           <div
             className="pf-c-data-toolbar__expandable-content"
-            id="data-toolbar-expandable-content-7"
+            id="data-toolbar-expandable-content-6"
           >
             <ForwardRef>
               <DataToolbarGroupWithRef
@@ -1757,7 +1757,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
       clearFiltersButtonText="Clear all filters"
       collapseListedFiltersBreakpoint="lg"
       isExpanded={false}
-      numberOfFilters={3}
+      numberOfFilters={1}
       showClearFiltersButton={true}
     >
       <div


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #3770

DataToolbar's state was getting updated by each DataToolbarFilter even when nothing was changed, so I added a check to only kick off the update when a filter's chips got updated.

Moving DataToolbar's internal `filterInfo` object out of its state, to a private variable, would be another way to resolve the bug.