### PR TITLE
fix(DataToolbarFilter): Add prop to enable removal of all chips in a filter category.

### DIFF
--- a/packages/react-core/src/components/DataToolbar/DataToolbarFilter.tsx
+++ b/packages/react-core/src/components/DataToolbar/DataToolbarFilter.tsx
@@ -22,6 +22,8 @@ export interface DataToolbarChip {
 export interface DataToolbarFilterProps extends DataToolbarItemProps {
   /** An array of strings to be displayed as chips in the expandable content */
   chips?: (string | DataToolbarChip)[];
+  /** Callback passed by consumer used to close the entire chip group */
+  deleteChipGroup?: (category: string | DataToolbarChipGroup) => void;
   /** Callback passed by consumer used to delete a chip from the chips[] */
   deleteChip?: (category: string | DataToolbarChipGroup, chip: DataToolbarChip | string) => void;
   /** Content to be rendered inside the data toolbar item associated with the chip group */
@@ -62,7 +64,7 @@ export class DataToolbarFilter extends React.Component<DataToolbarFilterProps, D
   }
 
   render() {
-    const { children, chips, deleteChip, categoryName, showToolbarItem, ...props } = this.props;
+    const { children, chips, deleteChipGroup, deleteChip, categoryName, showToolbarItem, ...props } = this.props;
     const { isExpanded, chipGroupContentRef } = this.context;
 
     const chipGroup = chips.length ? (
@@ -71,6 +73,8 @@ export class DataToolbarFilter extends React.Component<DataToolbarFilterProps, D
           <ChipGroupToolbarItem
             key={typeof categoryName === 'string' ? categoryName : categoryName.key}
             categoryName={typeof categoryName === 'string' ? categoryName : categoryName.name}
+            isClosable={deleteChipGroup !== undefined}
+            onClick={() => deleteChipGroup(categoryName)}
           >
             {chips.map(chip =>
               typeof chip === 'string' ? (

--- a/packages/react-core/src/components/DataToolbar/examples/DataToolbar.md
+++ b/packages/react-core/src/components/DataToolbar/examples/DataToolbar.md
@@ -574,7 +574,7 @@ class DataToolbarConsumerMangedToggleGroup extends React.Component {
 }
 ```
 
-The DataToolbarFilter component expects a consumer managed list of applied filters and a delete chip handler to be passed as props. Then the rendering of chips will be handled responsively by the Toolbar
+The DataToolbarFilter component expects a consumer managed list of applied filters and a delete chip handler to be passed as props. Pass a deleteChipGroup prop to provide both a handler and visual styling to remove all chips in a group. Then the rendering of chips will be handled responsively by the Toolbar
 When filters are applied, the toolbar will expand in height to make space for a row of filter chips. Upon clearing the applied filters, the toolbar will collapse to its default height.
 
 ```js title=Data-toolbar-with-filters beta
@@ -670,6 +670,15 @@ class DataToolbarWithFilterExample extends React.Component {
       }
     };
 
+    this.onDeleteGroup = (type) => {
+      this.setState((prevState) => {
+        prevState.filters[type.toLowerCase()] = [];
+        return {
+          filters: prevState.filters,
+        }
+      });
+    };
+
     this.onStatusToggle = isExpanded => {
       this.setState({
         statusIsExpanded: isExpanded
@@ -730,7 +739,7 @@ class DataToolbarWithFilterExample extends React.Component {
         </InputGroup>
       </DataToolbarItem>
       <DataToolbarGroup variant="filter-group">
-          <DataToolbarFilter chips={filters.status} deleteChip={this.onDelete} categoryName="Status">
+          <DataToolbarFilter chips={filters.status} deleteChip={this.onDelete} deleteChipGroup={this.onDeleteGroup} categoryName="Status">
             <Select
               variant={SelectVariant.checkbox}
               aria-label="Status"

--- a/packages/react-integration/cypress/integration/datatoolbar.spec.ts
+++ b/packages/react-integration/cypress/integration/datatoolbar.spec.ts
@@ -21,6 +21,7 @@ describe('Data Toolbar Demo Test', () => {
         cy.get('.pf-m-chip-group').should('be.visible');
         cy.get('.pf-m-filters-applied-message').should('not.be.visible');
         cy.get('.pf-c-data-toolbar__item .pf-c-button').should('be.visible');
+        cy.get('.pf-c-data-toolbar__item .pf-c-chip-group__close').should('be.visible');
         cy.get('.pf-c-data-toolbar__item .pf-c-button').contains('Clear filters');
       });
     });
@@ -41,6 +42,7 @@ describe('Data Toolbar Demo Test', () => {
         cy.get('.pf-m-chip-container .pf-m-chip-group').should('not.be.visible');
         cy.get('.pf-m-filters-applied-message').should('be.visible');
         cy.get('.pf-c-data-toolbar__item .pf-c-button').should('be.visible');
+        cy.get('.pf-c-data-toolbar__item .pf-c-chip-group__close').should('not.be.visible');
         cy.get('.pf-c-data-toolbar__item .pf-c-button').contains('Clear filters');
       });
     });
@@ -63,6 +65,7 @@ describe('Data Toolbar Demo Test', () => {
       cy.get('.pf-c-data-toolbar__expandable-content').should('be.visible');
       cy.get('.pf-m-chip-container').should('be.visible');
       cy.get('.pf-c-data-toolbar__item .pf-c-button').should('be.visible');
+      cy.get('.pf-c-data-toolbar__item .pf-c-chip-group__close').should('be.visible');
       cy.get('.pf-c-data-toolbar__item .pf-c-button').contains('Clear filters');
       cy.get('#demo-toggle-group .pf-c-data-toolbar__toggle button')
         .last()
@@ -71,6 +74,7 @@ describe('Data Toolbar Demo Test', () => {
       cy.get('.pf-c-data-toolbar__expandable-content').should('not.be.visible');
       cy.get('.pf-m-chip-container').should('not.be.visible');
       cy.get('.pf-c-data-toolbar__item .pf-c-button').should('be.visible');
+      cy.get('.pf-c-data-toolbar__item .pf-c-chip-group__close').should('not.be.visible');
       cy.get('.pf-c-data-toolbar__item .pf-c-button').contains('Clear filters');
     });
   });

--- a/packages/react-integration/demo-app-ts/src/components/demos/DataToolbarDemo/DataToolbarDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/DataToolbarDemo/DataToolbarDemo.tsx
@@ -110,6 +110,17 @@ export class DataToolbarDemo extends React.Component<DataToolbarProps, DataToolb
     }
   };
 
+  onDeleteGroup = (type = '') => {
+    if (type) {
+      this.setState(prevState => {
+        prevState.filters[type.toLowerCase()] = [];
+        return {
+          filters: prevState.filters
+        };
+      });
+    }
+  };
+
   onStatusToggle = isExpanded => {
     this.setState({
       statusIsExpanded: isExpanded
@@ -179,7 +190,12 @@ export class DataToolbarDemo extends React.Component<DataToolbarProps, DataToolb
               {statusMenuItems}
             </Select>
           </DataToolbarFilter>
-          <DataToolbarFilter chips={filters.risk} deleteChip={this.onDelete} categoryName="Risk">
+          <DataToolbarFilter
+            chips={filters.risk}
+            deleteChip={this.onDelete}
+            deleteChipGroup={this.onDeleteGroup}
+            categoryName="Risk"
+          >
             <Select
               variant={SelectVariant.checkbox}
               aria-label="Risk"


### PR DESCRIPTION
Add optional prop: deleteChipGroup to remove all chips in a category as well as provide visual treatment for
the DataToolbarFilter.

fix #4059

<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes #

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
