### PR TITLE
feat(title): supply defaults for title size property

### DIFF
--- a/packages/react-core/src/components/Title/Title.tsx
+++ b/packages/react-core/src/components/Title/Title.tsx
@@ -11,11 +11,20 @@ export enum TitleSizes {
   '4xl' = '4xl'
 }
 
+enum headingLevelSizeMap {
+  h1 = '2xl',
+  h2 = 'xl',
+  h3 = 'lg',
+  h4 = 'md',
+  h5 = 'md',
+  h6 = 'md'
+}
+
 type Size = 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl';
 
 export interface TitleProps extends Omit<React.HTMLProps<HTMLHeadingElement>, 'size' | 'className'> {
   /** The size of the Title  */
-  size: Size;
+  size?: Size;
   /** Content rendered inside the Title */
   children?: React.ReactNode;
   /** Additional classes added to the Title */
@@ -25,13 +34,13 @@ export interface TitleProps extends Omit<React.HTMLProps<HTMLHeadingElement>, 's
 }
 
 export const Title: React.FunctionComponent<TitleProps> = ({
-  size,
   className = '',
   children = '',
   headingLevel: HeadingLevel,
+  size = headingLevelSizeMap[HeadingLevel],
   ...props
 }: TitleProps) => (
-  <HeadingLevel {...props} className={css(styles.title, styles.modifiers[size as Size], className)}>
+  <HeadingLevel {...props} className={css(styles.title, size && styles.modifiers[size as Size], className)}>
     {children}
   </HeadingLevel>
 );

--- a/packages/react-core/src/components/Title/__tests__/Generated/Title.test.tsx
+++ b/packages/react-core/src/components/Title/__tests__/Generated/Title.test.tsx
@@ -8,6 +8,6 @@ import { Title } from '../../Title';
 import {} from '../..';
 
 it('Title should match snapshot (auto-generated)', () => {
-  const view = shallow(<Title size={'xs'} children={''} className={"''"} headingLevel={'h1'} />);
+  const view = shallow(<Title size={'md'} children={''} className={"''"} headingLevel={'h1'} />);
   expect(view).toMatchSnapshot();
 });

--- a/packages/react-core/src/components/Title/__tests__/Generated/__snapshots__/Title.test.tsx.snap
+++ b/packages/react-core/src/components/Title/__tests__/Generated/__snapshots__/Title.test.tsx.snap
@@ -2,6 +2,6 @@
 
 exports[`Title should match snapshot (auto-generated) 1`] = `
 <h1
-  className="pf-c-title ''"
+  className="pf-c-title pf-m-md ''"
 />
 `;

--- a/packages/react-core/src/components/Title/examples/Title.md
+++ b/packages/react-core/src/components/Title/examples/Title.md
@@ -34,3 +34,29 @@ import { Title } from '@patternfly/react-core';
   </Title>
 </React.Fragment>
 ```
+
+```js title=Default-size-mappings
+import React from 'react';
+import { Title } from '@patternfly/react-core';
+
+<React.Fragment>
+  <Title headingLevel="h1">
+    h1 default to 2xl
+  </Title>
+  <Title headingLevel="h2">
+    h2 defaults to xl
+  </Title>
+  <Title headingLevel="h3">
+    h3 defaults to lg
+  </Title>
+  <Title headingLevel="h4">
+    h4 defaults to md
+  </Title>
+  <Title headingLevel="h5">
+    h5 defaults to md
+  </Title>
+  <Title headingLevel="h6">
+    h6 defaults to md
+  </Title>
+</React.Fragment>
+```

--- a/packages/react-integration/cypress/integration/title.spec.ts
+++ b/packages/react-integration/cypress/integration/title.spec.ts
@@ -1,0 +1,39 @@
+describe('Title Demo Test', () => {
+  it('Navigate to demo section', () => {
+    cy.visit('http://localhost:3000/');
+    cy.get('#title-demo-nav-item-link').click();
+    cy.url().should('eq', 'http://localhost:3000/title-demo-nav-link');
+  });
+
+  it('Verify h1 receives correct default size', () => {
+    cy.get('h1#example1').should('have.class', 'pf-m-2xl');
+  });
+
+  it('Verify h2 receives correct default size', () => {
+    cy.get('h2#example2').should('have.class', 'pf-m-xl');
+  });
+
+  it('Verify h3 receives correct default size', () => {
+    cy.get('h3#example3').should('have.class', 'pf-m-lg');
+  });
+
+  it('Verify h4 receives correct default size', () => {
+    cy.get('h4#example4').should('have.class', 'pf-m-md');
+  });
+
+  it('Verify h5 receives correct default size', () => {
+    cy.get('h5#example5').should('have.class', 'pf-m-md');
+  });
+
+  it('Verify h6 receives correct default size', () => {
+    cy.get('h6#example6').should('have.class', 'pf-m-md');
+  });
+
+  it('Verify ability to override default h2 size of "xl" to "md"', () => {
+    cy.get('h2#example7').should('have.class', 'pf-m-md');
+  });
+
+  it('Verify setting title size to "4xl" using TitleSizes', () => {
+    cy.get('h3#example8').should('have.class', 'pf-m-4xl');
+  });
+});

--- a/packages/react-integration/demo-app-ts/src/components/demos/TitleDemo/TitleDemo.tsx
+++ b/packages/react-integration/demo-app-ts/src/components/demos/TitleDemo/TitleDemo.tsx
@@ -1,10 +1,5 @@
-import { Title, TitleProps, TitleSizes } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 import React, { Component } from 'react';
-
-const myProps: TitleProps = {
-  size: 'md',
-  headingLevel: 'h1'
-};
 
 export class TitleDemo extends Component {
   componentDidMount() {
@@ -14,11 +9,29 @@ export class TitleDemo extends Component {
   render() {
     return (
       <React.Fragment>
-        <Title size={myProps.size} headingLevel={myProps.headingLevel}>
-          Integration Demo App
+        <Title headingLevel="h1" id="example1">
+          h1 default to 2xl
         </Title>
-        <Title size={TitleSizes.md} headingLevel="h2">
-          Setting title size using TitleSizes
+        <Title headingLevel="h2" id="example2">
+          h2 defaults to xl
+        </Title>
+        <Title headingLevel="h3" id="example3">
+          h3 defaults to lg
+        </Title>
+        <Title headingLevel="h4" id="example4">
+          h4 defaults to md
+        </Title>
+        <Title headingLevel="h5" id="example5">
+          h5 defaults to md
+        </Title>
+        <Title headingLevel="h6" id="example6">
+          h6 defaults to md
+        </Title>
+        <Title size="md" headingLevel="h2" id="example7">
+          Overrides default h2 size of "xl" to "md"
+        </Title>
+        <Title size={TitleSizes['4xl']} headingLevel="h3" id="example8">
+          Setting title size to "4xl" using TitleSizes
         </Title>
       </React.Fragment>
     );


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Closes https://github.com/patternfly/patternfly-react/issues/4079

This PR makes `size` optional and generates a default value for it (when not supplied by user) that corresponds to to closest likely size given the heading level. This should not only simplify Title usage, but also ease upgrade pains in some cases.

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**: https://github.com/patternfly/patternfly-react/pull/3922

