### PR TITLE
fix(page): use xl breakpoint instead of md

### DIFF
--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -100,15 +100,11 @@ export class Page extends React.Component<PageProps, PageState> {
   handleResize = () => {
     const { onPageResize } = this.props;
     const windowSize = window.innerWidth;
-    // eslint-disable-next-line radix
-    const mobileView = windowSize < Number.parseInt(globalBreakpointXl.value, 10);
+    const mobileView = windowSize < Number.parseInt(globalBreakpointXl.value);
     if (onPageResize) {
       onPageResize({ mobileView, windowSize });
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    this.setState(prevState => ({
-      mobileView
-    }));
+    this.setState({ mobileView });
   };
 
   onNavToggleMobile = () => {

--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Page/page';
 import { css } from '@patternfly/react-styles';
-import globalBreakpointMd from '@patternfly/react-tokens/dist/js/global_breakpoint_md';
+import globalBreakpointLg from '@patternfly/react-tokens/dist/js/global_breakpoint_lg';
 import { debounce } from '../../helpers/util';
 
 export enum PageLayouts {
@@ -101,7 +101,7 @@ export class Page extends React.Component<PageProps, PageState> {
     const { onPageResize } = this.props;
     const windowSize = window.innerWidth;
     // eslint-disable-next-line radix
-    const mobileView = windowSize < Number.parseInt(globalBreakpointMd.value, 10);
+    const mobileView = windowSize < Number.parseInt(globalBreakpointLg.value, 10);
     if (onPageResize) {
       onPageResize({ mobileView, windowSize });
     }

--- a/packages/react-core/src/components/Page/Page.tsx
+++ b/packages/react-core/src/components/Page/Page.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styles from '@patternfly/react-styles/css/components/Page/page';
 import { css } from '@patternfly/react-styles';
-import globalBreakpointLg from '@patternfly/react-tokens/dist/js/global_breakpoint_lg';
+import globalBreakpointXl from '@patternfly/react-tokens/dist/js/global_breakpoint_xl';
 import { debounce } from '../../helpers/util';
 
 export enum PageLayouts {
@@ -101,7 +101,7 @@ export class Page extends React.Component<PageProps, PageState> {
     const { onPageResize } = this.props;
     const windowSize = window.innerWidth;
     // eslint-disable-next-line radix
-    const mobileView = windowSize < Number.parseInt(globalBreakpointLg.value, 10);
+    const mobileView = windowSize < Number.parseInt(globalBreakpointXl.value, 10);
     if (onPageResize) {
       onPageResize({ mobileView, windowSize });
     }

--- a/packages/react-core/src/components/Page/__tests__/Generated/__snapshots__/Page.test.tsx.snap
+++ b/packages/react-core/src/components/Page/__tests__/Generated/__snapshots__/Page.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Page should match snapshot (auto-generated) 1`] = `
   value={
     Object {
       "isManagedSidebar": false,
-      "isNavOpen": true,
+      "isNavOpen": false,
       "onNavToggle": [Function],
     }
   }


### PR DESCRIPTION
<!-- What changes are being made? Please link the issue being addressed. -->
**What**: Core has updated when to hide the Page sidenav in their media queries. Towards #1801. New breakpoint is *1200px, demo can be seen here: https://patternfly-react-pr-4090.surge.sh/documentation/react/demos/pagelayout/default-nav

<!-- Are there any upstream issues or separate issues you need to reference? -->
**Additional issues**:
