### PR TITLE
fix(Datatoolbar): Revert change that breaks chips associated with filters in toolbar

### DIFF
--- a/packages/react-core/src/components/DataToolbar/DataToolbarFilter.tsx
+++ b/packages/react-core/src/components/DataToolbar/DataToolbarFilter.tsx
@@ -58,14 +58,9 @@ export class DataToolbarFilter extends React.Component<DataToolbarFilterProps, D
     this.setState({ isMounted: true });
   }
 
-  componentDidUpdate(prevProps: DataToolbarFilterProps) {
+  componentDidUpdate() {
     const { categoryName, chips } = this.props;
-    if (prevProps.chips.length !== chips.length) {
-      this.context.updateNumberFilters(
-        typeof categoryName === 'string' ? categoryName : categoryName.name,
-        chips.length
-      );
-    }
+    this.context.updateNumberFilters(typeof categoryName === 'string' ? categoryName : categoryName.name, chips.length);
   }
 
   render() {

--- a/packages/react-core/src/components/DataToolbar/__tests__/__snapshots__/DataToolbar.test.tsx.snap
+++ b/packages/react-core/src/components/DataToolbar/__tests__/__snapshots__/DataToolbar.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                 className="pf-c-data-toolbar__toggle"
               >
                 <Component
-                  aria-controls="data-toolbar-expandable-content-6"
+                  aria-controls="data-toolbar-expandable-content-7"
                   aria-haspopup={false}
                   aria-label="Show Filters"
                   onClick={[Function]}
@@ -54,7 +54,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                     component={[Function]}
                     componentProps={
                       Object {
-                        "aria-controls": "data-toolbar-expandable-content-6",
+                        "aria-controls": "data-toolbar-expandable-content-7",
                         "aria-haspopup": false,
                         "aria-label": "Show Filters",
                         "children": <FilterIcon
@@ -70,7 +70,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                     consumerContext={null}
                   >
                     <Button
-                      aria-controls="data-toolbar-expandable-content-6"
+                      aria-controls="data-toolbar-expandable-content-7"
                       aria-haspopup={false}
                       aria-label="Show Filters"
                       onClick={[Function]}
@@ -83,7 +83,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
                       variant="plain"
                     >
                       <button
-                        aria-controls="data-toolbar-expandable-content-6"
+                        aria-controls="data-toolbar-expandable-content-7"
                         aria-disabled={null}
                         aria-haspopup={false}
                         aria-label="Show Filters"
@@ -1455,7 +1455,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
             Object {
               "current": <div
                 class="pf-c-data-toolbar__expandable-content"
-                id="data-toolbar-expandable-content-6"
+                id="data-toolbar-expandable-content-7"
               >
                 <div
                   class="pf-c-data-toolbar__group"
@@ -1484,13 +1484,13 @@ exports[`data toolbar DataToolbarFilter 1`] = `
               </div>,
             }
           }
-          id="data-toolbar-expandable-content-6"
+          id="data-toolbar-expandable-content-7"
           isExpanded={false}
           showClearFiltersButton={true}
         >
           <div
             className="pf-c-data-toolbar__expandable-content"
-            id="data-toolbar-expandable-content-6"
+            id="data-toolbar-expandable-content-7"
           >
             <ForwardRef>
               <DataToolbarGroupWithRef
@@ -1757,7 +1757,7 @@ exports[`data toolbar DataToolbarFilter 1`] = `
       clearFiltersButtonText="Clear all filters"
       collapseListedFiltersBreakpoint="lg"
       isExpanded={false}
-      numberOfFilters={1}
+      numberOfFilters={3}
       showClearFiltersButton={true}
     >
       <div


### PR DESCRIPTION
 Revert change that prevents the current state of the toolbar filters to display in chip groups, as well as
 reflect clear all action.

fix #[4096](https://github.com/patternfly/patternfly-react/issues/4096) and maybe #[4094](https://github.com/patternfly/patternfly-react/pull/4094)


